### PR TITLE
add CI workflow for typecheck and lint

### DIFF
--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -1,0 +1,35 @@
+name: 'Setup Environment'
+description: '開発環境の共通セットアップ（mise、pnpm、依存関係）'
+
+runs:
+  using: 'composite'
+  steps:
+    # mise によるランタイム環境のセットアップ
+    # Node.js、Bun などのバージョン管理
+    - name: Set up by mise
+      uses: jdx/mise-action@e79ddf65a11cec7b0e882bedced08d6e976efb2d # v3
+      with:
+        install: true
+        cache: true
+
+    # pnpm ストアディレクトリのパスを取得
+    - name: Get pnpm store directory
+      id: pnpm-cache
+      shell: bash
+      run: |
+        echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+    # pnpm ストアのキャッシュ
+    # node_modules の代わりにグローバルストアをキャッシュすることで
+    # 重複を排除し、キャッシュサイズを削減
+    - name: Cache pnpm store
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+      with:
+        path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+    # 依存関係のインストール
+    # frozen-lockfile: lock ファイルを更新せず、正確なバージョンをインストール
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/workflows/code_validation.yml
+++ b/.github/workflows/code_validation.yml
@@ -1,0 +1,85 @@
+# コードバリデーションワークフロー
+name: code_validation
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ==============================================================
+  # コードバリデーション（Matrix実行）
+  #
+  # PRで差分のあるパッケージとその依存先に限定してチェックする
+  # ルート設定ファイル（pnpm-workspace.yaml, mise.toml）が変更された場合は
+  # 全ワークスペースを対象にチェックする
+  # ==============================================================
+  validation:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: typecheck
+            diff_command: pnpm --filter '...[origin/${{ github.base_ref }}]' --if-present --no-bail --aggregate-output --reporter=append-only typecheck
+            full_command: pnpm run typecheck:all
+
+          - name: lint
+            diff_command: pnpm --filter '...[origin/${{ github.base_ref }}]' --if-present --no-bail --aggregate-output --reporter=append-only lint
+            full_command: pnpm run lint:all
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          filter: blob:none
+          fetch-depth: 0
+          show-progress: false
+
+      - uses: ./.github/actions/setup-environment
+
+      # ルート設定ファイルの変更を検出
+      # pnpm-workspace.yaml: catalog でバージョン管理、各 package.json は catalog: 参照のため差分が出ない
+      # mise.toml: Node.js/pnpm/Bun バージョン
+      - uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+        id: root-config
+        with:
+          files: |
+            pnpm-workspace.yaml
+            mise.toml
+
+      # ルート設定ファイルが変更された場合は全体チェック、それ以外は差分フィルタ
+      - name: Run ${{ matrix.name }}
+        run: |
+          if [[ "${{ steps.root-config.outputs.any_changed }}" == "true" ]]; then
+            echo "ルート設定ファイルが変更されたため、全ワークスペースをチェックします"
+            ${{ matrix.full_command }}
+          else
+            ${{ matrix.diff_command }}
+          fi
+
+  # ==============================================================
+  # CI全体のステータス集約
+  # Branch Protectionルールでこのジョブのみを必須チェックに設定
+  # これにより内部のジョブ構成を自由に変更可能
+  # ==============================================================
+  all-green:
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - validation
+    steps:
+      - name: Check all CI jobs status
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
+        with:
+          jobs: ${{ toJSON(needs) }}
+          allowed-skips: validation


### PR DESCRIPTION
## 概要

PR に対して typecheck と lint を自動実行する GitHub Actions ワークフローを追加する。

## 背景

lefthook で pre-commit 時に typecheck と lint を実行しているが、CI でも検証することで漏れを防ぐ。studio-front の code_validation ワークフローを参考に、orkis に必要な部分だけを抽出した構成にしている。

## 変更内容

- `.github/workflows/code_validation.yml`: typecheck / lint の matrix 実行ワークフロー
  - `pnpm --filter '...[origin/base]'` で差分パッケージに限定
  - ルート設定ファイル（pnpm-workspace.yaml, mise.toml）変更時は全ワークスペースをチェック
  - `all-green` ジョブで Branch Protection 用のステータス集約
- `.github/actions/setup-environment/action.yml`: mise + pnpm キャッシュの共通セットアップ

## 確認事項

- [ ] PR マージ後、次の PR で CI が正しく動作するか確認