### PR TITLE
fix lint warnings in scripts/watch.ts

### DIFF
--- a/scripts/watch.ts
+++ b/scripts/watch.ts
@@ -3,7 +3,10 @@ import type { ViteDevServer } from "vite";
 import { spawn } from "node:child_process";
 import path from "node:path";
 import { build, createServer } from "vite";
+// electron パッケージは実行時にバイナリパス（string）を返すが、
+// 型定義は Electron API オブジェクトになっている（electron/electron#33412）
 import electron from "electron";
+const electronPath = electron as unknown as string;
 
 const ROOT = path.resolve(import.meta.dirname, "..");
 
@@ -11,6 +14,7 @@ function setupMainWatcher({ resolvedUrls }: ViteDevServer) {
   process.env.VITE_DEV_SERVER_URL = resolvedUrls?.local[0];
 
   let electronApp: ChildProcess | null = null;
+  const exitProcess = () => process.exit();
 
   return build({
     root: path.resolve(ROOT, "apps/electron"),
@@ -21,12 +25,12 @@ function setupMainWatcher({ resolvedUrls }: ViteDevServer) {
         name: "reload-electron",
         writeBundle() {
           if (electronApp !== null) {
-            electronApp.removeListener("exit", process.exit);
+            electronApp.removeListener("exit", exitProcess);
             electronApp.kill("SIGINT");
             electronApp = null;
           }
 
-          electronApp = spawn(String(electron), ["."], {
+          electronApp = spawn(electronPath, ["."], {
             cwd: path.resolve(ROOT, "apps/electron"),
           });
 
@@ -45,7 +49,7 @@ function setupMainWatcher({ resolvedUrls }: ViteDevServer) {
             console.error(str);
           });
 
-          electronApp.addListener("exit", process.exit);
+          electronApp.addListener("exit", exitProcess);
         },
       },
     ],


### PR DESCRIPTION
## 概要

`scripts/watch.ts` の lint 警告 3 件を修正する。

## 背景

`pnpm run lint:all` で `scripts/watch.ts` に以下の警告が検出されていた。

- `no-base-to-string`: `String(electron)` が型上オブジェクトの文字列化と判定される
- `unbound-method` (2件): `process.exit` をイベントリスナーに直接渡すと `this` バインドが失われる

`no-base-to-string` の根本原因は、`electron` パッケージが実行時にはバイナリパス（string）を返すにもかかわらず、型定義は Electron API オブジェクト（`Electron.CrossProcessExports`）になっている点にある。これは `electron/electron#33412` で報告済みだが、TypeScript の制約により修正できないとされている。

## 変更内容

- `electron` の import に `as unknown as string` を適用し、型安全なバイナリパス変数 `electronPath` を作成
- `process.exit` をアロー関数 `exitProcess` でラップし、`addListener`/`removeListener` で同じ参照を使用

## 確認事項

- [ ] `pnpm run dev` で Electron アプリが正常に起動・リロードされること