### PR TITLE
watcher の ignore に .git と node_modules を追加

### DIFF
--- a/apps/electron/src/index.ts
+++ b/apps/electron/src/index.ts
@@ -105,23 +105,27 @@ async function startWatching(windowId: number, root: string) {
   const win = BrowserWindow.fromId(windowId);
   if (!win) return;
 
-  const subscription = await watcher.subscribe(root, (err, events) => {
-    if (err) {
-      console.error("[orkis] watcher error:", err);
-      return;
-    }
-    if (win.isDestroyed()) return;
+  const subscription = await watcher.subscribe(
+    root,
+    (err, events) => {
+      if (err) {
+        console.error("[orkis] watcher error:", err);
+        return;
+      }
+      if (win.isDestroyed()) return;
 
-    // 変更のあったディレクトリパスを重複排除して通知
-    const changedDirs = new Set<string>();
-    for (const event of events) {
-      const rel = path.relative(root, path.dirname(event.path));
-      changedDirs.add(rel);
-    }
-    for (const relDir of changedDirs) {
-      win.webContents.send("fs:change", relDir);
-    }
-  });
+      // 変更のあったディレクトリパスを重複排除して通知
+      const changedDirs = new Set<string>();
+      for (const event of events) {
+        const rel = path.relative(root, path.dirname(event.path));
+        changedDirs.add(rel);
+      }
+      for (const relDir of changedDirs) {
+        win.webContents.send("fs:change", relDir);
+      }
+    },
+    { ignore: [".git", "**/node_modules"] },
+  );
 
   windowWatchers.set(windowId, subscription);
 }


### PR DESCRIPTION
## 概要

@parcel/watcher の監視対象から `.git` ディレクトリと `node_modules` を除外する。

## 背景

#19 で @parcel/watcher によるファイル監視を追加したが、`.git` 内の変更も検知されていた。アプリ内のターミナルで `git switch` するとファイルが大量に変更され、Vite の dev サーバーがリビルド → Electron が再起動する問題が発生していた。

@parcel/watcher の `ignore` オプションは C++ レベルでフィルタリングされるため、JS のコールバックに到達する前に除外でき、パフォーマンス面でも最善。

## 変更内容

- `watcher.subscribe` の第3引数に `{ ignore: [".git", "**/node_modules"] }` を追加

## 確認事項

- [x] ターミナルで `git switch` してもアプリが再起動されないこと