### PR TITLE
ghostty-web の Renovate 設定で next チャンネルを追うようにする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,11 @@
       "description": "auto-merge tsgo dev preview daily releases",
       "matchPackageNames": ["@typescript/native-preview"],
       "automerge": true
+    },
+    {
+      "description": "track next channel for ghostty-web pre-releases",
+      "matchPackageNames": ["ghostty-web"],
+      "followTag": "next"
     }
   ]
 }


### PR DESCRIPTION
## 概要

ghostty-web の Renovate packageRule に `followTag: "next"` を追加する。

## 背景

ghostty-web は正式版 `0.4.0`（2025-12-09）の後も next チャンネルでプレリリースが継続しており、現在 `0.4.0-next.10`（2026-02-24）を使用している。

Renovate は semver の大小比較で `prerelease < release` と判定するため、実際にはより古い正式版 `0.4.0` へのダウングレードを「アップグレード」として提案してしまう（ #28 ）。

`followTag: "next"` を設定することで、Renovate が npm の `next` dist-tag を基準にバージョンを追うようになり、正しく next 版同士の更新を提案するようになる。

## 変更内容

- `renovate.json` に ghostty-web 用の packageRule を追加（`followTag: "next"`）

## 確認事項

- [ ] Renovate が次回実行時に #28 を自動クローズまたは更新するか確認