### PR TITLE
catalog のバージョン pin 留めと electrobun の catalog 化

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,7 +13,7 @@
     "@orkis/renderer": "workspace:*",
     "@orkis/rpc": "workspace:*",
     "@orkis/shared": "workspace:*",
-    "electrobun": "1.14.4"
+    "electrobun": "catalog:"
   },
   "devDependencies": {
     "@types/bun": "catalog:"

--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -16,7 +16,7 @@
     "@orkis/shared": "workspace:*",
     "diff": "8.0.3",
     "dompurify": "3.3.2",
-    "electrobun": "1.14.4",
+    "electrobun": "catalog:",
     "ghostty-web": "0.4.0-next.14.g6a1a50d",
     "marked": "17.0.4",
     "material-icon-theme": "5.32.0",

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -10,6 +10,6 @@
     "typecheck": "tsgo --noEmit"
   },
   "devDependencies": {
-    "electrobun": "1.14.4"
+    "electrobun": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,43 +7,46 @@ settings:
 catalogs:
   default:
     '@tailwindcss/vite':
-      specifier: ^4.2.1
+      specifier: 4.2.1
       version: 4.2.1
     '@types/bun':
       specifier: 1.3.10
       version: 1.3.10
     '@types/node':
-      specifier: ^24.11.0
+      specifier: 24.11.0
       version: 24.11.0
     '@typescript/native-preview':
       specifier: 7.0.0-dev.20260305.1
       version: 7.0.0-dev.20260305.1
+    electrobun:
+      specifier: 1.14.4
+      version: 1.14.4
     eslint:
-      specifier: ^10.0.2
+      specifier: 10.0.2
       version: 10.0.2
     eslint-plugin-import-x:
-      specifier: ^4.16.1
+      specifier: 4.16.1
       version: 4.16.1
     eslint-plugin-unused-imports:
-      specifier: ^4.4.1
+      specifier: 4.4.1
       version: 4.4.1
     lefthook:
-      specifier: ^2.1.2
+      specifier: 2.1.2
       version: 2.1.2
     oxfmt:
-      specifier: ^0.36.0
+      specifier: 0.36.0
       version: 0.36.0
     oxlint:
-      specifier: ^1.51.0
+      specifier: 1.51.0
       version: 1.51.0
     oxlint-tsgolint:
-      specifier: ^0.16.0
+      specifier: 0.16.0
       version: 0.16.0
     tailwindcss:
-      specifier: ^4.2.1
+      specifier: 4.2.1
       version: 4.2.1
     typescript:
-      specifier: ^5.9.3
+      specifier: 5.9.3
       version: 5.9.3
     vite:
       specifier: 8.0.0-beta.16
@@ -118,7 +121,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       electrobun:
-        specifier: 1.14.4
+        specifier: 'catalog:'
         version: 1.14.4
     devDependencies:
       '@types/bun':
@@ -140,7 +143,7 @@ importers:
         specifier: 3.3.2
         version: 3.3.2
       electrobun:
-        specifier: 1.14.4
+        specifier: 'catalog:'
         version: 1.14.4
       ghostty-web:
         specifier: 0.4.0-next.14.g6a1a50d
@@ -213,7 +216,7 @@ importers:
   packages/rpc:
     devDependencies:
       electrobun:
-        specifier: 1.14.4
+        specifier: 'catalog:'
         version: 1.14.4
 
   packages/shared:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,19 +10,20 @@ allowBuilds:
   unrs-resolver: true
 
 catalog:
-  '@tailwindcss/vite': ^4.2.1
+  '@tailwindcss/vite': 4.2.1
   '@types/bun': 1.3.10
-  '@types/node': ^24.11.0
+  '@types/node': 24.11.0
   '@typescript/native-preview': 7.0.0-dev.20260305.1
-  eslint: ^10.0.2
-  eslint-plugin-import-x: ^4.16.1
-  eslint-plugin-unused-imports: ^4.4.1
-  lefthook: ^2.1.2
-  oxfmt: ^0.36.0
-  oxlint: ^1.51.0
-  oxlint-tsgolint: ^0.16.0
-  tailwindcss: ^4.2.1
-  typescript: ^5.9.3
+  electrobun: 1.14.4
+  eslint: 10.0.2
+  eslint-plugin-import-x: 4.16.1
+  eslint-plugin-unused-imports: 4.4.1
+  lefthook: 2.1.2
+  oxfmt: 0.36.0
+  oxlint: 1.51.0
+  oxlint-tsgolint: 0.16.0
+  tailwindcss: 4.2.1
+  typescript: 5.9.3
   vite: 8.0.0-beta.16
 
 minimumReleaseAge: 4320


### PR DESCRIPTION
## 概要

- pnpm catalog のバージョン指定からキャレット（`^`）を除去し、exact version に pin 留め
- 3 つの workspace で直書きされていた `electrobun` を catalog に一元化

## 背景

catalog にキャレット付きのバージョン（`^4.2.1` 等）が指定されており、`pnpm update` 実行時に意図しないバージョンアップが発生する可能性があった。exact version にすることで、バージョン更新を明示的な操作（`pnpm update -r --latest <pkg>`）に限定する。

また `electrobun` が desktop / renderer / rpc の 3 箇所でバージョン `1.14.4` を直書きしていたため、catalog で一元管理するよう変更した。

## 変更内容

### pnpm-workspace.yaml

- 既存 catalog エントリから `^` を除去（10 パッケージ）
- `electrobun: 1.14.4` を catalog に追加

### package.json（3 ファイル）

- `apps/desktop`, `apps/renderer`, `packages/rpc` の `electrobun` を `"catalog:"` 参照に変更

## 確認事項

- [ ] `pnpm install` が正常に完了すること