### PR TITLE
Vue SFC に `<doc>` ブロックを導入

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,11 +72,6 @@ orkis/
 
 ## コーディング規約
 
-### CSS クラス名
-
-- Tailwind ユーティリティ以外のカスタム CSS クラスには `_` プレフィックスを付ける（例: `_markdown-body`, `_line-numbered`）
-- ESLint の `better-tailwindcss/no-unknown-classes` ルールで `_.*` パターンが除外設定されている
-
 ### エラーハンドリング
 
 - try-catch は使わず、`@orkis/shared` の `tryCatch` を使って Result 型で処理する

--- a/apps/renderer/CLAUDE.md
+++ b/apps/renderer/CLAUDE.md
@@ -1,0 +1,26 @@
+## CSS クラス名
+
+- Tailwind ユーティリティ以外のカスタム CSS クラスには `_` プレフィックスを付ける（例: `_markdown-body`, `_line-numbered`）
+- ESLint の `better-tailwindcss/no-unknown-classes` ルールで `_.*` パターンが除外設定されている
+
+## `<doc>` ブロック
+
+Vue SFC にコンポーネントのドキュメントを同居させるカスタムブロック。
+`@miyaoka/vite-plugin-doc-block` がビルド時に除去するため、バンドルサイズに影響しない。
+
+### 書き方
+
+- 冒頭にコンポーネントの概要を一文で書く
+- 必要に応じて `##` セクション + 箇条書きで補足する
+- ファイル名から自明なタイトル（`# ComponentName`）は書かない
+- Props など実装から読み取れる情報は書かない
+
+```vue
+<doc lang="md">
+概要の一文。
+
+## セクション名
+
+- 箇条書きで補足
+</doc>
+```

--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@iconify-json/lucide": "1.2.95",
     "@iconify/tailwind4": "1.2.3",
+    "@miyaoka/vite-plugin-doc-block": "^0.0.2",
     "@tailwindcss/vite": "catalog:",
     "@types/bun": "catalog:",
     "@vitejs/plugin-vue": "6.0.4",

--- a/apps/renderer/src/App.vue
+++ b/apps/renderer/src/App.vue
@@ -1,3 +1,12 @@
+<doc lang="md">
+アプリケーションのルートコンポーネント。
+
+## 責務
+
+- RPC 経由で `orkisOpen` イベントを受信し、ワークスペース（ディレクトリ・ファイル）を設定する
+- マウント時に `rendererReady` を送信してメインプロセスに準備完了を通知する
+</doc>
+
 <script setup lang="ts">
 import { onMounted, onUnmounted } from "vue";
 import { useWorkspace } from "./features/filer/useWorkspace";

--- a/apps/renderer/src/features/debug/DebugPane.vue
+++ b/apps/renderer/src/features/debug/DebugPane.vue
@@ -1,3 +1,13 @@
+<doc lang="md">
+開発用デバッグ情報パネル。
+
+## 表示内容
+
+- 現在のモード（dev / build）
+- 開いているディレクトリ・ファイル
+- git status（staged / unstaged）を変更種別ごとに色分けして一覧表示
+</doc>
+
 <script setup lang="ts">
 import { computed } from "vue";
 import { resolveGitChangeKind } from "../filer/filer-utils";

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -1,3 +1,17 @@
+<doc lang="md">
+ファイルツリーの再帰的なノード。
+
+## 動作
+
+- ディレクトリは展開/折りたたみ可能で、初回展開時に RPC で子エントリを遅延読み込み
+- material-icon-theme のアイコンを表示
+- git status に応じた色分け（modified=黄、added=緑、deleted=赤、renamed=青）と削除ファイルの打ち消し線
+
+## 更新
+
+- 親から `notifyChange` / `notifyGitStatusChange` を呼ばれてツリーを差分更新
+</doc>
+
 <script setup lang="ts">
 import { computed, ref } from "vue";
 import { useRpc } from "../rpc/useRpc";

--- a/apps/renderer/src/features/filer/FilerPane.vue
+++ b/apps/renderer/src/features/filer/FilerPane.vue
@@ -1,3 +1,13 @@
+<doc lang="md">
+ファイルツリーのルートコンテナ。
+
+## 動作
+
+- ワークスペースのディレクトリが設定されるとルートエントリを読み込み、FileTreeItem を再帰的にレンダリング
+- fsChange / gitStatusChange の RPC メッセージを購読し、変更があったディレクトリのみ差分更新
+- git 削除ファイルは仮想エントリとしてツリーに挿入
+</doc>
+
 <script setup lang="ts">
 import { onUnmounted, ref, watch } from "vue";
 import { useRpc } from "../rpc/useRpc";

--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -1,3 +1,12 @@
+<doc lang="md">
+アプリ全体のレイアウトを構成するコンテナ。
+
+## 構成
+
+- 水平方向: SidebarPane → FilerPane → PreviewPane → TerminalPane
+- 最下部: DebugPane
+</doc>
+
 <script setup lang="ts">
 import DebugPane from "../debug/DebugPane.vue";
 import FilerPane from "../filer/FilerPane.vue";

--- a/apps/renderer/src/features/layout/SidebarPane.vue
+++ b/apps/renderer/src/features/layout/SidebarPane.vue
@@ -1,3 +1,7 @@
+<doc lang="md">
+左端のサイドバー。アプリロゴと今後実装予定の Todos セクションを表示する。
+</doc>
+
 <template>
   <div class="flex w-56 shrink-0 flex-col border-r border-zinc-700 p-4">
     <h1 class="mb-4 text-lg font-bold">

--- a/apps/renderer/src/features/preview/CodePreview.vue
+++ b/apps/renderer/src/features/preview/CodePreview.vue
@@ -1,3 +1,10 @@
+<doc lang="md">
+Shiki によるシンタックスハイライト付きコード表示。
+
+- 非同期ハイライト完了までは行番号付きプレーンテキストをフォールバック表示
+- バージョンカウンターで非同期レースを防止
+</doc>
+
 <script setup lang="ts">
 import { watch, ref } from "vue";
 import { highlight } from "./useHighlight";

--- a/apps/renderer/src/features/preview/DiffPreview.vue
+++ b/apps/renderer/src/features/preview/DiffPreview.vue
@@ -1,3 +1,8 @@
+<doc lang="md">
+jsdiff の `diffLines` による行単位の unified diff ビュー。
+追加行（緑）/ 削除行（赤）/ 変更なし行を旧行番号・新行番号付きで表示する。
+</doc>
+
 <script setup lang="ts">
 import { diffLines } from "diff";
 import { computed } from "vue";

--- a/apps/renderer/src/features/preview/ImagePreview.vue
+++ b/apps/renderer/src/features/preview/ImagePreview.vue
@@ -1,3 +1,8 @@
+<doc lang="md">
+画像ファイルのプレビュー。ファイルサーバー経由の URL を `src` として受け取り、
+アスペクト比を保ったまま中央に表示する。
+</doc>
+
 <script setup lang="ts">
 defineProps<{
   /** 画像の data: URL */

--- a/apps/renderer/src/features/preview/MarkdownPreview.vue
+++ b/apps/renderer/src/features/preview/MarkdownPreview.vue
@@ -1,3 +1,10 @@
+<doc lang="md">
+marked で Markdown → HTML 変換し、DOMPurify でサニタイズして表示する。
+
+- YAML frontmatter はコードブロックとして描画
+- ` ```mermaid ` コードブロックは mermaid ライブラリで SVG にレンダリング
+</doc>
+
 <script setup lang="ts">
 import DOMPurify from "dompurify";
 import { marked, type MarkedExtension } from "marked";

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -1,3 +1,25 @@
+<doc lang="md">
+ファイルプレビューの統合コンテナ。選択ファイルの拡張子に応じて子コンポーネントを切り替える。
+
+## プレビュー種別
+
+- コード → CodePreview（Shiki ハイライト）
+- 差分 → DiffPreview（jsdiff 行単位）
+- 画像 / SVG → ImagePreview（ファイルサーバー URL）
+- Markdown → MarkdownPreview（marked + mermaid）
+
+## モード切替
+
+- git 変更があるファイルでは Current / Diff / Original タブを表示
+- SVG・Markdown・画像は Preview チェックボックスでレンダリング/ソース表示を切替可能
+
+## データ取得
+
+- ファイル選択・git status 変化時に current / original を並列取得
+- fsChange メッセージで選択中ファイルをリアクティブに再取得
+- バージョンカウンターで非同期レースを防止
+</doc>
+
 <script setup lang="ts">
 import { computed, onUnmounted, ref, watch } from "vue";
 import type { GitChangeKind } from "../filer/filer-utils";

--- a/apps/renderer/src/features/terminal/TerminalPane.vue
+++ b/apps/renderer/src/features/terminal/TerminalPane.vue
@@ -1,3 +1,14 @@
+<doc lang="md">
+ghostty-web ベースのターミナルエミュレータ。
+
+## ライフサイクル
+
+- マウント時に WASM パーサーを初期化し、RPC 経由で PTY を生成
+- FitAddon + ResizeObserver でコンテナサイズに自動追従
+- PTY ↔ Terminal 間のデータを双方向にブリッジ
+- アンマウント時に PTY を kill し Terminal を dispose
+</doc>
+
 <script setup lang="ts">
 import { init, Terminal, FitAddon } from "ghostty-web";
 import { onMounted, onBeforeUnmount, ref } from "vue";

--- a/apps/renderer/vite.config.ts
+++ b/apps/renderer/vite.config.ts
@@ -1,9 +1,10 @@
+import { docBlockPlugin } from "@miyaoka/vite-plugin-doc-block";
 import tailwindcss from "@tailwindcss/vite";
 import vue from "@vitejs/plugin-vue";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  plugins: [tailwindcss(), vue()],
+  plugins: [docBlockPlugin(), tailwindcss(), vue()],
   base: "./",
   build: {
     outDir: "dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
       '@iconify/tailwind4':
         specifier: 1.2.3
         version: 1.2.3(tailwindcss@4.2.1)
+      '@miyaoka/vite-plugin-doc-block':
+        specifier: ^0.0.2
+        version: 0.0.2(vite@8.0.0-beta.16(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0))(vue@3.5.29(typescript@5.9.3))
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.2.1(vite@8.0.0-beta.16(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0))
@@ -545,6 +548,12 @@ packages:
   '@miyaoka/fsss@0.3.1':
     resolution: {integrity: sha512-xy2BEuHJDe8fQJMVWrqIUnE8AQpl15/hzB68R/xBlJiLMkVF58KUBV28s6fCVQtC5BKSS3qGsdLfoY/mm50aMA==}
     hasBin: true
+
+  '@miyaoka/vite-plugin-doc-block@0.0.2':
+    resolution: {integrity: sha512-YRw8jgPIo1RyXNN4GY1lGOSrzillJzbor5gm2FT//cy3Xher069HoaZS7IMN9r2trpzfY3PkE14wEw9s/CGx+A==}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vue: ^3.0.0
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -3390,6 +3399,11 @@ snapshots:
   '@miyaoka/fsss@0.3.1':
     dependencies:
       zod: 4.3.6
+
+  '@miyaoka/vite-plugin-doc-block@0.0.2(vite@8.0.0-beta.16(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0))(vue@3.5.29(typescript@5.9.3))':
+    dependencies:
+      vite: 8.0.0-beta.16(@types/node@25.3.3)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)
+      vue: 3.5.29(typescript@5.9.3)
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:


### PR DESCRIPTION
## 概要

`@miyaoka/vite-plugin-doc-block` を導入し、全 Vue コンポーネントに `<doc>` カスタムブロックでドキュメントを追加する。

## 背景

コンポーネントの役割や動作を SFC 内に同居させることで、コードを読む際にすぐ概要を把握できるようにする。`<doc>` ブロックはビルド時に除去されるため、バンドルサイズに影響しない。

## 変更内容

### プラグイン導入

- `@miyaoka/vite-plugin-doc-block` を devDependencies に追加
- `vite.config.ts` の plugins 先頭に `docBlockPlugin()` を配置

### doc ブロック追加

- 全12コンポーネントに `<doc lang="md">` ブロックを追加
- 冒頭に概要文、必要に応じて `##` セクション + 箇条書きで構造化

### CLAUDE.md 整理

- `apps/renderer/CLAUDE.md` を新規作成し、doc ブロックの運用ルールを記載
- CSS クラス名の規約をルート CLAUDE.md から `apps/renderer/CLAUDE.md` に移動

## 確認事項

- [ ] `pnpm dev` でビルドエラーが出ないこと
- [ ] `<doc>` ブロックがバンドルに含まれていないこと