### PR TITLE
ターミナルバックエンドを xterm.js / ghostty-web で切り替え可能にする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ AI エージェントの Plan-Implement-Review ループを管理するデスク
 | [rpc.md](docs/rpc.md)               | RPC スキーマ（request / message の全定義）                                 |
 | [filer.md](docs/filer.md)           | ファイラー（ツリー表示、git status 色分け、アイコン、ファイル監視）        |
 | [preview.md](docs/preview.md)       | プレビュー（コード、diff、画像、SVG、Markdown、リアクティブ更新）          |
-| [terminal.md](docs/terminal.md)     | ターミナル（ghostty-web、PTY ライフサイクル）                              |
+| [terminal.md](docs/terminal.md)     | ターミナル（xterm.js / ghostty-web 切り替え、PTY ライフサイクル）          |
 
 ## 技術スタック
 
@@ -27,7 +27,7 @@ AI エージェントの Plan-Implement-Review ループを管理するデスク
 | アイコン         | Iconify（@iconify/tailwind4 + Lucide）        |
 | フォーマッタ     | oxfmt                                         |
 | リンター         | oxlint（TypeScript）/ ESLint（Vue）           |
-| ターミナル       | ghostty-web                                   |
+| ターミナル       | xterm.js / ghostty-web（切り替え可）          |
 | PTY              | Bun.spawn({ terminal })                       |
 | ファイル監視     | node:fs.watch（recursive）                    |
 | RPC              | Electrobun RPC（型安全な bun ↔ webview 通信） |

--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -14,6 +14,8 @@
   "dependencies": {
     "@orkis/rpc": "workspace:*",
     "@orkis/shared": "workspace:*",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "diff": "8.0.3",
     "dompurify": "3.3.2",
     "electrobun": "catalog:",

--- a/apps/renderer/src/features/terminal/GhosttyTerminal.vue
+++ b/apps/renderer/src/features/terminal/GhosttyTerminal.vue
@@ -1,0 +1,86 @@
+<doc lang="md">
+ghostty-web ベースのターミナルエミュレータ。
+WASM パーサーで高速描画し、FitAddon の observeResize で自動リサイズする。
+</doc>
+
+<script setup lang="ts">
+import { init, Terminal, FitAddon } from "ghostty-web";
+import { onMounted, onBeforeUnmount, ref } from "vue";
+import { useRpc } from "../rpc/useRpc";
+import { TERMINAL_FONT_FAMILY, TERMINAL_FONT_SIZE, TERMINAL_THEME } from "./terminalConfig";
+
+const containerRef = ref<HTMLElement>();
+const { request, send, onPtyData, onPtyExit } = useRpc();
+
+let terminal: Terminal | undefined;
+let fitAddon: FitAddon | undefined;
+let ptyId: number | undefined;
+let removeDataListener: (() => void) | undefined;
+let removeExitListener: (() => void) | undefined;
+
+onMounted(async () => {
+  const container = containerRef.value;
+  if (!container) return;
+
+  // ghostty WASM パーサーの初期化
+  await init();
+
+  terminal = new Terminal({
+    fontSize: TERMINAL_FONT_SIZE,
+    fontFamily: TERMINAL_FONT_FAMILY,
+    theme: TERMINAL_THEME,
+    cursorBlink: true,
+  });
+
+  fitAddon = new FitAddon();
+  terminal.loadAddon(fitAddon);
+  terminal.open(container);
+
+  fitAddon.fit();
+  // ResizeObserver による自動リサイズ
+  fitAddon.observeResize();
+  terminal.focus();
+
+  ptyId = await request.ptySpawn({ cols: terminal.cols, rows: terminal.rows });
+
+  // PTY → terminal
+  removeDataListener = onPtyData(({ id, data }) => {
+    if (id === ptyId) {
+      terminal?.write(data);
+    }
+  });
+
+  removeExitListener = onPtyExit(({ id, exitCode: _exitCode }) => {
+    if (id === ptyId) {
+      terminal?.write("\r\n[Process exited]\r\n");
+      ptyId = undefined;
+    }
+  });
+
+  terminal.onResize(({ cols, rows }) => {
+    if (ptyId !== undefined) {
+      send.ptyResize({ id: ptyId, cols, rows });
+    }
+  });
+
+  // terminal → PTY
+  terminal.onData((data) => {
+    if (ptyId !== undefined) {
+      send.ptyWrite({ id: ptyId, data });
+    }
+  });
+});
+
+onBeforeUnmount(() => {
+  removeDataListener?.();
+  removeExitListener?.();
+  if (ptyId !== undefined) {
+    send.ptyKill({ id: ptyId });
+  }
+  terminal?.dispose();
+});
+</script>
+
+<template>
+  <div ref="containerRef" class="size-full" />
+</template>

--- a/apps/renderer/src/features/terminal/TerminalPane.vue
+++ b/apps/renderer/src/features/terminal/TerminalPane.vue
@@ -1,95 +1,52 @@
 <doc lang="md">
-ghostty-web ベースのターミナルエミュレータ。
+ターミナルバックエンド切り替えラッパー。
 
-## ライフサイクル
-
-- マウント時に WASM パーサーを初期化し、RPC 経由で PTY を生成
-- FitAddon + ResizeObserver でコンテナサイズに自動追従
-- PTY ↔ Terminal 間のデータを双方向にブリッジ
-- アンマウント時に PTY を kill し Terminal を dispose
+ghostty-web と xterm.js を動的に切り替える。
+バックエンドを変更すると PTY を再生成して新しいターミナルを開く。
 </doc>
 
 <script setup lang="ts">
-import { init, Terminal, FitAddon } from "ghostty-web";
-import { onMounted, onBeforeUnmount, ref } from "vue";
-import { useRpc } from "../rpc/useRpc";
+import { shallowRef } from "vue";
+import type { Component } from "vue";
+import GhosttyTerminal from "./GhosttyTerminal.vue";
+import XtermTerminal from "./XtermTerminal.vue";
 
-const containerRef = ref<HTMLElement>();
-const { request, send, onPtyData, onPtyExit } = useRpc();
+type TerminalBackend = "ghostty" | "xterm";
 
-let terminal: Terminal | undefined;
-let fitAddon: FitAddon | undefined;
-let ptyId: number | undefined;
-let removeDataListener: (() => void) | undefined;
-let removeExitListener: (() => void) | undefined;
+interface BackendEntry {
+  component: Component;
+  label: string;
+}
 
-onMounted(async () => {
-  const container = containerRef.value;
-  if (!container) return;
+const BACKENDS: Record<TerminalBackend, BackendEntry> = {
+  ghostty: { component: GhosttyTerminal, label: "Ghostty" },
+  xterm: { component: XtermTerminal, label: "xterm" },
+};
 
-  // ghostty WASM パーサーの初期化
-  await init();
+const BACKEND_KEYS: TerminalBackend[] = ["xterm", "ghostty"];
 
-  terminal = new Terminal({
-    fontSize: 13,
-    fontFamily: "'JetBrains Mono', 'Fira Code', Menlo, monospace",
-    theme: {
-      background: "#18181b",
-      foreground: "#e4e4e7",
-      cursor: "#e4e4e7",
-    },
-    cursorBlink: true,
-  });
-
-  fitAddon = new FitAddon();
-  terminal.loadAddon(fitAddon);
-  terminal.open(container);
-
-  fitAddon.fit();
-  // ResizeObserver による自動リサイズ
-  fitAddon.observeResize();
-  terminal.focus();
-
-  ptyId = await request.ptySpawn({ cols: terminal.cols, rows: terminal.rows });
-
-  // PTY → terminal
-  removeDataListener = onPtyData(({ id, data }) => {
-    if (id === ptyId) {
-      terminal?.write(data);
-    }
-  });
-
-  removeExitListener = onPtyExit(({ id, exitCode: _exitCode }) => {
-    if (id === ptyId) {
-      terminal?.write("\r\n[Process exited]\r\n");
-      ptyId = undefined;
-    }
-  });
-
-  terminal.onResize(({ cols, rows }) => {
-    if (ptyId !== undefined) {
-      send.ptyResize({ id: ptyId, cols, rows });
-    }
-  });
-
-  // terminal → PTY
-  terminal.onData((data) => {
-    if (ptyId !== undefined) {
-      send.ptyWrite({ id: ptyId, data });
-    }
-  });
-});
-
-onBeforeUnmount(() => {
-  removeDataListener?.();
-  removeExitListener?.();
-  if (ptyId !== undefined) {
-    send.ptyKill({ id: ptyId });
-  }
-  terminal?.dispose();
-});
+const currentBackend = shallowRef<TerminalBackend>("xterm");
 </script>
 
 <template>
-  <div ref="containerRef" class="size-full" />
+  <div class="flex size-full flex-col">
+    <div class="flex shrink-0 gap-1 px-2 py-1">
+      <button
+        v-for="key in BACKEND_KEYS"
+        :key="key"
+        class="rounded-sm px-2 py-0.5 text-xs"
+        :class="
+          currentBackend === key
+            ? 'bg-zinc-600 text-zinc-100'
+            : 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-300'
+        "
+        @click="currentBackend = key"
+      >
+        {{ BACKENDS[key].label }}
+      </button>
+    </div>
+    <div class="min-h-0 flex-1">
+      <component :is="BACKENDS[currentBackend].component" :key="currentBackend" />
+    </div>
+  </div>
 </template>

--- a/apps/renderer/src/features/terminal/XtermTerminal.vue
+++ b/apps/renderer/src/features/terminal/XtermTerminal.vue
@@ -1,0 +1,91 @@
+<doc lang="md">
+xterm.js ベースのターミナルエミュレータ。
+ghostty-web の代替として、日本語入力が安定している環境で使用する。
+</doc>
+
+<script setup lang="ts">
+import { FitAddon } from "@xterm/addon-fit";
+import { Terminal } from "@xterm/xterm";
+import "@xterm/xterm/css/xterm.css";
+import { onMounted, onBeforeUnmount, ref } from "vue";
+import { useRpc } from "../rpc/useRpc";
+import { TERMINAL_FONT_FAMILY, TERMINAL_FONT_SIZE, TERMINAL_THEME } from "./terminalConfig";
+
+const containerRef = ref<HTMLElement>();
+const { request, send, onPtyData, onPtyExit } = useRpc();
+
+let terminal: Terminal | undefined;
+let fitAddon: FitAddon | undefined;
+let ptyId: number | undefined;
+let removeDataListener: (() => void) | undefined;
+let removeExitListener: (() => void) | undefined;
+let resizeObserver: ResizeObserver | undefined;
+
+onMounted(async () => {
+  const container = containerRef.value;
+  if (!container) return;
+
+  terminal = new Terminal({
+    fontSize: TERMINAL_FONT_SIZE,
+    fontFamily: TERMINAL_FONT_FAMILY,
+    theme: TERMINAL_THEME,
+    cursorBlink: true,
+  });
+
+  fitAddon = new FitAddon();
+  terminal.loadAddon(fitAddon);
+  terminal.open(container);
+
+  fitAddon.fit();
+  terminal.focus();
+
+  ptyId = await request.ptySpawn({ cols: terminal.cols, rows: terminal.rows });
+
+  // PTY → terminal
+  removeDataListener = onPtyData(({ id, data }) => {
+    if (id === ptyId) {
+      terminal?.write(data);
+    }
+  });
+
+  removeExitListener = onPtyExit(({ id, exitCode: _exitCode }) => {
+    if (id === ptyId) {
+      terminal?.write("\r\n[Process exited]\r\n");
+      ptyId = undefined;
+    }
+  });
+
+  // xterm → PTY
+  terminal.onData((data) => {
+    if (ptyId !== undefined) {
+      send.ptyWrite({ id: ptyId, data });
+    }
+  });
+
+  // コンテナリサイズ時に xterm と PTY を同期
+  resizeObserver = new ResizeObserver(() => {
+    fitAddon?.fit();
+  });
+  resizeObserver.observe(container);
+
+  terminal.onResize(({ cols, rows }) => {
+    if (ptyId !== undefined) {
+      send.ptyResize({ id: ptyId, cols, rows });
+    }
+  });
+});
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect();
+  removeDataListener?.();
+  removeExitListener?.();
+  if (ptyId !== undefined) {
+    send.ptyKill({ id: ptyId });
+  }
+  terminal?.dispose();
+});
+</script>
+
+<template>
+  <div ref="containerRef" class="size-full" />
+</template>

--- a/apps/renderer/src/features/terminal/terminalConfig.ts
+++ b/apps/renderer/src/features/terminal/terminalConfig.ts
@@ -1,0 +1,11 @@
+/** ターミナル共通設定。ghostty-web / xterm.js 両バックエンドで共有する。 */
+
+export const TERMINAL_FONT_SIZE = 13;
+
+export const TERMINAL_FONT_FAMILY = "'JetBrains Mono', 'Fira Code', Menlo, monospace";
+
+export const TERMINAL_THEME = {
+  background: "#18181b", // zinc-900
+  foreground: "#e4e4e7", // zinc-200
+  cursor: "#e4e4e7",
+};

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -1,12 +1,16 @@
 # Terminal
 
-ghostty-web によるターミナルエミュレータ。Electrobun RPC 経由で desktop 側の PTY プロセスと通信する。
+ターミナルエミュレータ。Electrobun RPC 経由で desktop 側の PTY プロセスと通信する。
+バックエンドとして xterm.js（デフォルト）と ghostty-web を UI から切り替えられる。
 
 ## 構成
 
 ```
 features/terminal/
-└── TerminalPane.vue    # ターミナル UI（ghostty-web + PTY 通信）
+├── TerminalPane.vue       # バックエンド切り替えラッパー
+├── XtermTerminal.vue      # xterm.js バックエンド（デフォルト）
+├── GhosttyTerminal.vue    # ghostty-web バックエンド
+└── terminalConfig.ts      # 共通設定（フォント、テーマ）
 ```
 
 ## PTY ライフサイクル
@@ -45,12 +49,21 @@ sequenceDiagram
 - shell: `process.env.SHELL` または `zsh`
 - cwd: ウィンドウのワークスペースディレクトリ
 
-## ghostty-web 設定
+## バックエンド
+
+| バックエンド | ライブラリ                      | リサイズ方式             | 備考                    |
+| ------------ | ------------------------------- | ------------------------ | ----------------------- |
+| xterm        | @xterm/xterm + @xterm/addon-fit | 手動 ResizeObserver      | 日本語入力が安定        |
+| ghostty      | ghostty-web                     | FitAddon.observeResize() | WASM パーサーで高速描画 |
+
+バックエンド切り替え時は PTY を再生成して新しいターミナルを開く。
+
+## 共通設定（terminalConfig.ts）
 
 - フォント: JetBrains Mono, Fira Code, Menlo, monospace（13px）
 - テーマ: zinc 系ダークテーマ（背景 `#18181b`）
 - カーソル: 点滅有効
-- リサイズ: `FitAddon` + `ResizeObserver` で容器サイズに自動追従
+- ANSI カラーは各バックエンドのデフォルトパレットを使用
 
 ## Desktop 側の PTY 管理
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,12 @@ importers:
       '@orkis/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@xterm/addon-fit':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0
       diff:
         specifier: 8.0.3
         version: 8.0.3
@@ -1323,6 +1329,12 @@ packages:
 
   '@vue/shared@3.5.29':
     resolution: {integrity: sha512-w7SR0A5zyRByL9XUkCfdLs7t9XOHUyJ67qPGQjOou3p6GvBeBW+AVjUUmlxtZ4PIYaRvE+1LmK44O4uajlZwcg==}
+
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -3928,6 +3940,10 @@ snapshots:
       vue: 3.5.29(typescript@5.9.3)
 
   '@vue/shared@3.5.29': {}
+
+  '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/xterm@6.0.0': {}
 
   abort-controller@3.0.0:
     dependencies:


### PR DESCRIPTION
## 概要

ターミナルのバックエンドとして xterm.js と ghostty-web を UI から切り替えられるようにする。デフォルトは xterm.js。

## 背景

ghostty-web に移行後、日本語入力や表示が不安定な状態が続いている。xterm.js では日本語入力が安定しているため、しばらく両方を切り替えて使えるようにする。

## 変更内容

### ターミナルコンポーネントの分割

- `TerminalPane.vue` をバックエンド切り替えラッパーに変更
- `GhosttyTerminal.vue` — ghostty-web バックエンド（既存実装を移動）
- `XtermTerminal.vue` — xterm.js バックエンド（現在の RPC インターフェースに対応）
- `terminalConfig.ts` — フォント・テーマの共通設定を抽出

### 依存追加

- `@xterm/xterm`、`@xterm/addon-fit`

## 確認事項

- [ ] xterm バックエンドで日本語入力が正常に動作する
- [ ] ghostty バックエンドが従来通り動作する
- [ ] バックエンド切り替え時に PTY が正しく再生成される