### PR TITLE
ペインリサイズとコード折り返しトグルを追加

### DIFF
--- a/apps/renderer/package.json
+++ b/apps/renderer/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@orkis/rpc": "workspace:*",
     "@orkis/shared": "workspace:*",
+    "@vueuse/core": "^14.2.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "diff": "8.0.3",

--- a/apps/renderer/src/features/debug/DebugPane.vue
+++ b/apps/renderer/src/features/debug/DebugPane.vue
@@ -57,7 +57,7 @@ const unstagedEntries = computed<GitStatusEntry[]>(() =>
 
 <template>
   <div
-    class="max-h-32 overflow-y-auto rounded-sm border border-zinc-700 bg-zinc-800 p-3 font-mono text-sm text-zinc-300"
+    class="size-full overflow-y-auto rounded-sm border border-zinc-700 bg-zinc-800 p-3 font-mono text-sm text-zinc-300"
   >
     <div class="mb-1 flex items-center gap-2 font-bold text-zinc-400">
       <span class="icon-[lucide--bug]" />

--- a/apps/renderer/src/features/filer/FilerPane.vue
+++ b/apps/renderer/src/features/filer/FilerPane.vue
@@ -120,7 +120,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="flex w-64 shrink-0 flex-col border-r border-zinc-700">
+  <div class="flex size-full flex-col">
     <!-- ヘッダー -->
     <div class="flex items-center gap-2 border-b border-zinc-700 px-3 py-2">
       <span class="icon-[lucide--folder-tree] text-blue-400" />

--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -3,30 +3,108 @@
 
 ## 構成
 
-- 水平方向: SidebarPane → FilerPane → PreviewPane → TerminalPane
-- 最下部: DebugPane
+- 水平方向: SidebarPane → FilerPane → PreviewPane → TerminalPane（各ペイン間にリサイズハンドル）
+- 垂直方向: メインエリア → DebugPane（リサイズハンドル）
+
+## リサイズ
+
+各ハンドルは隣接する左右（上下）のペインだけを連動してリサイズする。
+ハンドルより遠いペインには影響しない。
 </doc>
 
 <script setup lang="ts">
+import { useWindowSize } from "@vueuse/core";
+import { ref, watchEffect } from "vue";
 import DebugPane from "../debug/DebugPane.vue";
 import FilerPane from "../filer/FilerPane.vue";
 import PreviewPane from "../preview/PreviewPane.vue";
 import TerminalPane from "../terminal/TerminalPane.vue";
+import ResizeHandle from "./ResizeHandle.vue";
 import SidebarPane from "./SidebarPane.vue";
+
+const SIDEBAR_MIN_WIDTH = 120;
+const FILER_MIN_WIDTH = 160;
+const PREVIEW_MIN_WIDTH = 200;
+const TERMINAL_MIN_WIDTH = 200;
+const DEBUG_MIN_HEIGHT = 40;
+const MAIN_MIN_HEIGHT = 200;
+
+/** ハンドル幅 w-2 = 8px */
+const HANDLE_WIDTH = 8;
+const HANDLE_COUNT = 3;
+
+const sidebarWidth = ref(224);
+const filerWidth = ref(256);
+const previewWidth = ref(400);
+const terminalWidth = ref(400);
+const mainHeight = ref(600);
+const debugHeight = ref(128);
+
+// ウィンドウサイズからターミナルとメインの初期値を算出
+const { width: windowWidth, height: windowHeight } = useWindowSize();
+
+watchEffect(() => {
+  const usedWidth =
+    sidebarWidth.value + filerWidth.value + previewWidth.value + HANDLE_WIDTH * HANDLE_COUNT;
+  terminalWidth.value = Math.max(TERMINAL_MIN_WIDTH, windowWidth.value - usedWidth);
+});
+
+watchEffect(() => {
+  const usedHeight = debugHeight.value + HANDLE_WIDTH;
+  mainHeight.value = Math.max(MAIN_MIN_HEIGHT, windowHeight.value - usedHeight);
+});
 </script>
 
 <template>
   <div class="flex h-screen flex-col overflow-hidden bg-zinc-900 text-white">
-    <div class="flex min-h-0 flex-1">
-      <SidebarPane />
-      <FilerPane />
-      <div class="min-w-0 flex-1 border-r border-zinc-700">
+    <div class="flex shrink-0 overflow-hidden" :style="{ height: `${mainHeight}px` }">
+      <div class="shrink-0 overflow-hidden" :style="{ width: `${sidebarWidth}px` }">
+        <SidebarPane />
+      </div>
+      <ResizeHandle
+        v-model:before-size="sidebarWidth"
+        v-model:after-size="filerWidth"
+        direction="horizontal"
+        :before-min-size="SIDEBAR_MIN_WIDTH"
+        :after-min-size="FILER_MIN_WIDTH"
+      />
+
+      <div class="shrink-0 overflow-hidden" :style="{ width: `${filerWidth}px` }">
+        <FilerPane />
+      </div>
+      <ResizeHandle
+        v-model:before-size="filerWidth"
+        v-model:after-size="previewWidth"
+        direction="horizontal"
+        :before-min-size="FILER_MIN_WIDTH"
+        :after-min-size="PREVIEW_MIN_WIDTH"
+      />
+
+      <div class="shrink-0 overflow-hidden" :style="{ width: `${previewWidth}px` }">
         <PreviewPane />
       </div>
-      <div class="min-w-0 flex-1 p-2">
+      <ResizeHandle
+        v-model:before-size="previewWidth"
+        v-model:after-size="terminalWidth"
+        direction="horizontal"
+        :before-min-size="PREVIEW_MIN_WIDTH"
+        :after-min-size="TERMINAL_MIN_WIDTH"
+      />
+
+      <div class="shrink-0 overflow-hidden p-2" :style="{ width: `${terminalWidth}px` }">
         <TerminalPane />
       </div>
     </div>
-    <DebugPane />
+
+    <ResizeHandle
+      v-model:before-size="mainHeight"
+      v-model:after-size="debugHeight"
+      direction="vertical"
+      :before-min-size="MAIN_MIN_HEIGHT"
+      :after-min-size="DEBUG_MIN_HEIGHT"
+    />
+    <div class="shrink-0 overflow-hidden" :style="{ height: `${debugHeight}px` }">
+      <DebugPane />
+    </div>
   </div>
 </template>

--- a/apps/renderer/src/features/layout/ResizeHandle.vue
+++ b/apps/renderer/src/features/layout/ResizeHandle.vue
@@ -1,0 +1,47 @@
+<doc lang="md">
+ペイン間のドラッグリサイズハンドル。水平・垂直の両方向に対応する。
+
+ドラッグ操作でハンドル左右（上下）のペインサイズを連動して増減する。
+`v-model:before-size` と `v-model:after-size` で親と同期する。
+</doc>
+
+<script setup lang="ts">
+import { useElementHover } from "@vueuse/core";
+import { useTemplateRef } from "vue";
+import { useResize } from "./useResize";
+
+interface Props {
+  direction: "horizontal" | "vertical";
+  beforeMinSize: number;
+  afterMinSize: number;
+}
+
+const props = defineProps<Props>();
+const beforeSize = defineModel<number>("beforeSize", { required: true });
+const afterSize = defineModel<number>("afterSize", { required: true });
+
+const handleRef = useTemplateRef<HTMLElement>("handle");
+const isHovered = useElementHover(handleRef);
+
+const { isDragging } = useResize(handleRef, beforeSize, afterSize, {
+  direction: props.direction,
+  beforeMinSize: props.beforeMinSize,
+  afterMinSize: props.afterMinSize,
+});
+</script>
+
+<template>
+  <div
+    ref="handle"
+    class="z-10 flex shrink-0 items-center justify-center"
+    :class="direction === 'horizontal' ? 'w-2 cursor-col-resize' : 'h-2 cursor-row-resize'"
+  >
+    <div
+      class="pointer-events-none transition-colors duration-150"
+      :class="[
+        direction === 'horizontal' ? 'h-full w-px' : 'h-px w-full',
+        isDragging || isHovered ? 'bg-blue-500' : 'bg-zinc-700',
+      ]"
+    />
+  </div>
+</template>

--- a/apps/renderer/src/features/layout/SidebarPane.vue
+++ b/apps/renderer/src/features/layout/SidebarPane.vue
@@ -3,7 +3,7 @@
 </doc>
 
 <template>
-  <div class="flex w-56 shrink-0 flex-col border-r border-zinc-700 p-4">
+  <div class="flex size-full flex-col p-4">
     <h1 class="mb-4 text-lg font-bold">
       <span class="mr-2 icon-[lucide--bot] align-middle text-blue-400" />
       orkis

--- a/apps/renderer/src/features/layout/useResize.ts
+++ b/apps/renderer/src/features/layout/useResize.ts
@@ -1,0 +1,77 @@
+import { useEventListener } from "@vueuse/core";
+import { ref } from "vue";
+import type { Ref, ShallowRef } from "vue";
+
+type Direction = "horizontal" | "vertical";
+
+interface UseResizeOptions {
+  direction: Direction;
+  /** 左（上）ペインの最小サイズ（px） */
+  beforeMinSize: number;
+  /** 右（下）ペインの最小サイズ（px） */
+  afterMinSize: number;
+}
+
+/**
+ * ドラッグによるペインリサイズを管理する composable。
+ * ハンドルの左右（上下）のペインサイズを連動して増減する。
+ * delta 分を一方に加え、他方から引くことで他のペインに影響を与えない。
+ */
+export function useResize(
+  handleRef: Readonly<ShallowRef<HTMLElement | null>>,
+  beforeSize: Ref<number>,
+  afterSize: Ref<number>,
+  options: UseResizeOptions,
+) {
+  const isDragging = ref(false);
+
+  let startPos = 0;
+  let startBeforeSize = 0;
+  let startAfterSize = 0;
+
+  // ハンドル要素の mousedown を常時監視
+  useEventListener(handleRef, "mousedown", (e: MouseEvent) => {
+    e.preventDefault();
+    isDragging.value = true;
+    startPos = options.direction === "horizontal" ? e.clientX : e.clientY;
+    startBeforeSize = beforeSize.value;
+    startAfterSize = afterSize.value;
+
+    const cursor = options.direction === "horizontal" ? "col-resize" : "row-resize";
+    document.body.style.cursor = cursor;
+    document.body.style.userSelect = "none";
+
+    // ドラッグ中のみ mousemove を登録
+    const cleanupMove = useEventListener(document, "mousemove", (moveEvent: MouseEvent) => {
+      const rawDelta =
+        options.direction === "horizontal"
+          ? moveEvent.clientX - startPos
+          : moveEvent.clientY - startPos;
+
+      // 両ペインの最小サイズを尊重して delta をクランプ
+      const maxExpand = startAfterSize - options.afterMinSize;
+      const maxShrink = startBeforeSize - options.beforeMinSize;
+      const delta = Math.max(-maxShrink, Math.min(maxExpand, rawDelta));
+
+      beforeSize.value = startBeforeSize + delta;
+      afterSize.value = startAfterSize - delta;
+    });
+
+    // mouseup: once で自動解除、mousemove も解除する
+    useEventListener(
+      document,
+      "mouseup",
+      () => {
+        isDragging.value = false;
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        cleanupMove();
+      },
+      { once: true },
+    );
+  });
+
+  return {
+    isDragging,
+  };
+}

--- a/apps/renderer/src/features/preview/CodePreview.vue
+++ b/apps/renderer/src/features/preview/CodePreview.vue
@@ -12,6 +12,7 @@ import { highlight } from "./useHighlight";
 const props = defineProps<{
   content: string;
   filePath: string;
+  wordWrap: boolean;
 }>();
 
 const highlightedHtml = ref<string>();
@@ -34,10 +35,19 @@ watch(
 
 <template>
   <!-- ハイライト済み HTML -->
-  <div v-if="highlightedHtml" class="_highlighted-code text-sm/tight" v-html="highlightedHtml" />
+  <div
+    v-if="highlightedHtml"
+    class="_highlighted-code text-sm/tight"
+    :class="wordWrap ? '_word-wrap' : ''"
+    v-html="highlightedHtml"
+  />
 
   <!-- フォールバック: プレーンテキスト -->
-  <pre v-else class="_line-numbered p-4 text-sm/tight text-zinc-300"><code><span
+  <pre
+    v-else
+    class="_line-numbered p-4 text-sm/tight text-zinc-300"
+    :class="wordWrap ? '_word-wrap break-all whitespace-pre-wrap' : ''"
+  ><code><span
         v-for="(line, i) in content.split('\n')"
         :key="i"
         class="_line"
@@ -58,13 +68,39 @@ watch(
   user-select: none;
 }
 
+/* 折り返し時: 行番号を absolute で固定し、折り返し行が行番号の右側に揃うよう padding で確保 */
+._line-numbered._word-wrap ._line,
+._highlighted-code._word-wrap :deep(.line) {
+  position: relative;
+  display: block;
+  padding-left: 4.5ch;
+  min-height: 1lh;
+}
+
+._line-numbered._word-wrap ._line::before,
+._highlighted-code._word-wrap :deep(.line::before) {
+  position: absolute;
+  left: 0;
+  margin-right: 0;
+}
+
 ._highlighted-code :deep(pre) {
   padding: 1rem;
   margin: 0;
   background: transparent !important;
 }
 
+._highlighted-code._word-wrap :deep(pre) {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
 ._highlighted-code :deep(code) {
   font-family: inherit;
+}
+
+._highlighted-code._word-wrap :deep(code) {
+  display: flex;
+  flex-direction: column;
 }
 </style>

--- a/apps/renderer/src/features/preview/DiffPreview.vue
+++ b/apps/renderer/src/features/preview/DiffPreview.vue
@@ -10,6 +10,7 @@ import { computed } from "vue";
 const props = defineProps<{
   original: string;
   current: string;
+  wordWrap: boolean;
 }>();
 
 interface DiffLine {
@@ -57,7 +58,7 @@ const LINE_TYPE_CLASSES: Record<DiffLine["type"], string> = {
     >
       <span class="_line-no">{{ line.oldLineNo ?? "" }}</span>
       <span class="_line-no">{{ line.newLineNo ?? "" }}</span>
-      <span class="_line-text">{{ line.text }}</span>
+      <span class="_line-text" :class="wordWrap ? '_word-wrap' : ''">{{ line.text }}</span>
     </div>
   </div>
 </template>
@@ -82,5 +83,11 @@ const LINE_TYPE_CLASSES: Record<DiffLine["type"], string> = {
 
 ._line-text {
   white-space: pre;
+  min-width: 0;
+}
+
+._line-text._word-wrap {
+  white-space: pre-wrap;
+  word-break: break-all;
 }
 </style>

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -75,6 +75,9 @@ const activeMode = ref<PreviewMode>("current");
 /** Preview チェックボックス（SVG / Markdown / 画像で使用） */
 const previewEnabled = ref(true);
 
+/** コード折り返しトグル */
+const wordWrap = ref(true);
+
 /** diff がある変更種別か */
 function hasGitDiff(gitChange: GitChangeKind | undefined): boolean {
   if (gitChange === undefined) return false;
@@ -107,8 +110,6 @@ const availableModes = computed<PreviewMode[]>(() => {
 /** デフォルトモードの決定 */
 function defaultMode(gitChange: GitChangeKind | undefined): PreviewMode {
   if (gitChange === "deleted") return "original";
-  // 画像プレビュー中はデフォルト current
-  if (hasGitDiff(gitChange)) return isImagePreview.value ? "current" : "diff";
   return "current";
 }
 
@@ -273,14 +274,11 @@ const headerIconUrl = computed(() => {
         <span class="truncate text-sm text-zinc-300" :title="selectedPath">{{
           fileName(selectedPath)
         }}</span>
-        <span class="ml-auto text-xs text-zinc-500">{{ selectedPath }}</span>
       </div>
 
-      <!-- モード切替タブ -->
-      <div
-        v-if="availableModes.length > 1 || showPreviewCheckbox"
-        class="flex items-center border-b border-zinc-700"
-      >
+      <!-- ツールバー -->
+      <div class="flex items-center border-b border-zinc-700">
+        <!-- モード切替タブ -->
         <button
           v-for="mode in availableModes"
           :key="mode"
@@ -296,14 +294,28 @@ const headerIconUrl = computed(() => {
           {{ MODE_LABELS[mode].label }}
         </button>
 
-        <!-- Preview チェックボックス -->
-        <label
-          v-if="showPreviewCheckbox"
-          class="ml-auto flex items-center gap-1.5 px-3 py-1.5 text-xs text-zinc-400 select-none"
-        >
-          <input v-model="previewEnabled" type="checkbox" class="accent-blue-400" />
-          Preview
-        </label>
+        <div class="ml-auto flex items-center">
+          <!-- Preview トグル -->
+          <button
+            v-if="showPreviewCheckbox"
+            class="flex items-center gap-1 px-3 py-1.5 text-xs transition-colors"
+            :class="previewEnabled ? 'text-blue-400' : 'text-zinc-500 hover:text-zinc-300'"
+            @click="previewEnabled = !previewEnabled"
+          >
+            <span class="icon-[lucide--eye] size-3.5" />
+            Preview
+          </button>
+
+          <!-- Wrap トグル -->
+          <button
+            class="flex items-center gap-1 px-3 py-1.5 text-xs transition-colors"
+            :class="wordWrap ? 'text-blue-400' : 'text-zinc-500 hover:text-zinc-300'"
+            @click="wordWrap = !wordWrap"
+          >
+            <span class="icon-[lucide--wrap-text] size-3.5" />
+            Wrap
+          </button>
+        </div>
       </div>
 
       <!-- コンテンツ -->
@@ -319,6 +331,7 @@ const headerIconUrl = computed(() => {
           "
           :original="originalContent"
           :current="currentContent"
+          :word-wrap="wordWrap"
         />
 
         <!-- 画像プレビュー（バイナリ画像 + SVG preview モード） -->
@@ -340,6 +353,7 @@ const headerIconUrl = computed(() => {
           v-else-if="displayContent !== undefined"
           :content="displayContent"
           :file-path="selectedPath"
+          :word-wrap="wordWrap"
         />
       </div>
     </template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       '@orkis/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@vueuse/core':
+        specifier: ^14.2.1
+        version: 14.2.1(vue@3.5.29(typescript@5.9.3))
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
@@ -1056,6 +1059,9 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/web-bluetooth@0.0.21':
+    resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
+
   '@typescript-eslint/eslint-plugin@8.56.1':
     resolution: {integrity: sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1329,6 +1335,19 @@ packages:
 
   '@vue/shared@3.5.29':
     resolution: {integrity: sha512-w7SR0A5zyRByL9XUkCfdLs7t9XOHUyJ67qPGQjOou3p6GvBeBW+AVjUUmlxtZ4PIYaRvE+1LmK44O4uajlZwcg==}
+
+  '@vueuse/core@14.2.1':
+    resolution: {integrity: sha512-3vwDzV+GDUNpdegRY6kzpLm4Igptq+GA0QkJ3W61Iv27YWwW/ufSlOfgQIpN6FZRMG0mkaz4gglJRtq5SeJyIQ==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  '@vueuse/metadata@14.2.1':
+    resolution: {integrity: sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw==}
+
+  '@vueuse/shared@14.2.1':
+    resolution: {integrity: sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==}
+    peerDependencies:
+      vue: ^3.5.0
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
@@ -3650,6 +3669,8 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/web-bluetooth@0.0.21': {}
+
   '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@10.0.2(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -3940,6 +3961,19 @@ snapshots:
       vue: 3.5.29(typescript@5.9.3)
 
   '@vue/shared@3.5.29': {}
+
+  '@vueuse/core@14.2.1(vue@3.5.29(typescript@5.9.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 14.2.1
+      '@vueuse/shared': 14.2.1(vue@3.5.29(typescript@5.9.3))
+      vue: 3.5.29(typescript@5.9.3)
+
+  '@vueuse/metadata@14.2.1': {}
+
+  '@vueuse/shared@14.2.1(vue@3.5.29(typescript@5.9.3))':
+    dependencies:
+      vue: 3.5.29(typescript@5.9.3)
 
   '@xterm/addon-fit@0.11.0': {}
 


### PR DESCRIPTION
## 概要

- 全ペイン間にドラッグリサイズハンドルを追加し、レイアウトを自由に調整可能にした
- コードプレビューに折り返し（Word Wrap）トグルを追加した

## 背景

各ペインが固定幅で、ウィンドウサイズやコンテンツに応じた調整ができなかった。
また、長い行のコードが横スクロールでしか確認できず、狭いプレビューペインでは見づらかった。

## 変更内容

### リサイズ機能

- `useResize` composable: ドラッグで隣接する左右（上下）のペインを連動リサイズ。`@vueuse/core` の `useEventListener` で mousedown を常時監視し、mousemove を動的登録、mouseup は once で自動解除
- `ResizeHandle` コンポーネント: 8px の当たり判定 + 1px の境界線表示。hover / ドラッグ中は青色ハイライト
- `MainLayout`: 4カラム（Sidebar / Filer / Preview / Terminal）間と DebugPane 上にハンドルを配置。ハンドルの左右だけが連動し、遠いペインには影響しない
- 各ペイン（SidebarPane, FilerPane, DebugPane）から固定幅/高さを除去し、親がサイズを制御する構造に変更

### コード折り返し

- PreviewPane ツールバーに Wrap トグルボタン（デフォルト ON）を追加
- CodePreview: 折り返し時は行番号を `position: absolute` で固定し、折り返し行が行番号の右側に揃う
- DiffPreview: `wordWrap` props に対応

### ツールバー改善

- Preview チェックボックスをトグルボタンに統一（Wrap と同じスタイル）
- ヘッダーからパス表示を削除
- デフォルトモードを diff から current に変更

### 依存追加

- `@vueuse/core`（useEventListener, useElementHover, useWindowSize）

## 確認事項

- [ ] 各ペインのリサイズが正しく動作するか
- [ ] 折り返しトグルの ON/OFF が正しく切り替わるか
- [ ] ウィンドウリサイズ時にレイアウトが崩れないか