### PR TITLE
Revert oxlint-tsgolint to 0.15.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ catalogs:
       specifier: 1.52.0
       version: 1.52.0
     oxlint-tsgolint:
-      specifier: 0.16.0
-      version: 0.16.0
+      specifier: 0.15.0
+      version: 0.15.0
     tailwindcss:
       specifier: 4.2.1
       version: 4.2.1
@@ -73,10 +73,10 @@ importers:
         version: 0.37.0
       oxlint:
         specifier: 'catalog:'
-        version: 1.52.0(oxlint-tsgolint@0.16.0)
+        version: 1.52.0(oxlint-tsgolint@0.15.0)
       oxlint-tsgolint:
         specifier: 'catalog:'
-        version: 0.16.0
+        version: 0.15.0
       vite:
         specifier: 'catalog:'
         version: 8.0.0-beta.18(@types/node@24.12.0)(jiti@2.6.1)
@@ -104,10 +104,10 @@ importers:
         version: 0.37.0
       oxlint:
         specifier: 'catalog:'
-        version: 1.52.0(oxlint-tsgolint@0.16.0)
+        version: 1.52.0(oxlint-tsgolint@0.15.0)
       oxlint-tsgolint:
         specifier: 'catalog:'
-        version: 0.16.0
+        version: 0.15.0
 
   apps/desktop:
     dependencies:
@@ -135,10 +135,10 @@ importers:
         version: 0.37.0
       oxlint:
         specifier: 'catalog:'
-        version: 1.52.0(oxlint-tsgolint@0.16.0)
+        version: 1.52.0(oxlint-tsgolint@0.15.0)
       oxlint-tsgolint:
         specifier: 'catalog:'
-        version: 0.16.0
+        version: 0.15.0
 
   apps/renderer:
     dependencies:
@@ -253,10 +253,10 @@ importers:
         version: 0.37.0
       oxlint:
         specifier: 'catalog:'
-        version: 1.52.0(oxlint-tsgolint@0.16.0)
+        version: 1.52.0(oxlint-tsgolint@0.15.0)
       oxlint-tsgolint:
         specifier: 'catalog:'
-        version: 0.16.0
+        version: 0.15.0
 
   packages/shared:
     devDependencies:
@@ -274,10 +274,10 @@ importers:
         version: 0.37.0
       oxlint:
         specifier: 'catalog:'
-        version: 1.52.0(oxlint-tsgolint@0.16.0)
+        version: 1.52.0(oxlint-tsgolint@0.15.0)
       oxlint-tsgolint:
         specifier: 'catalog:'
-        version: 0.16.0
+        version: 0.15.0
 
 packages:
 
@@ -606,9 +606,19 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@oxlint-tsgolint/darwin-arm64@0.15.0':
+    resolution: {integrity: sha512-d7Ch+A6hic+RYrm32+Gh1o4lOrQqnFsHi721ORdHUDBiQPea+dssKUEMwIbA6MKmCy6TVJ02sQyi24OEfCiGzw==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@oxlint-tsgolint/darwin-arm64@0.16.0':
     resolution: {integrity: sha512-WQt5lGwRPJBw7q2KNR0mSPDAaMmZmVvDlEEti96xLO7ONhyomQc6fBZxxwZ4qTFedjJnrHX94sFelZ4OKzS7UQ==}
     cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/darwin-x64@0.15.0':
+    resolution: {integrity: sha512-Aoai2wAkaUJqp/uEs1gml6TbaPW4YmyO5Ai/vOSkiizgHqVctjhjKqmRiWTX2xuPY94VkwOLqp+Qr3y/0qSpWQ==}
+    cpu: [x64]
     os: [darwin]
 
   '@oxlint-tsgolint/darwin-x64@0.16.0':
@@ -616,9 +626,19 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@oxlint-tsgolint/linux-arm64@0.15.0':
+    resolution: {integrity: sha512-4og13a7ec4Vku5t2Y7s3zx6YJP6IKadb1uA9fOoRH6lm/wHWoCnxjcfJmKHXRZJII81WmbdJMSPxaBfwN/S68Q==}
+    cpu: [arm64]
+    os: [linux]
+
   '@oxlint-tsgolint/linux-arm64@0.16.0':
     resolution: {integrity: sha512-MPfqRt1+XRHv9oHomcBMQ3KpTE+CSkZz14wUxDQoqTNdUlV0HWdzwIE9q65I3D9YyxEnqpM7j4qtDQ3apqVvbQ==}
     cpu: [arm64]
+    os: [linux]
+
+  '@oxlint-tsgolint/linux-x64@0.15.0':
+    resolution: {integrity: sha512-9b9xzh/1Harn3a+XiKTK/8LrWw3VcqLfYp/vhV5/zAVR2Mt0d63WSp4FL+wG7DKnI2T/CbMFUFHwc7kCQjDMzQ==}
+    cpu: [x64]
     os: [linux]
 
   '@oxlint-tsgolint/linux-x64@0.16.0':
@@ -626,9 +646,19 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@oxlint-tsgolint/win32-arm64@0.15.0':
+    resolution: {integrity: sha512-nNac5hewHdkk5mowOwTqB1ZD76zB/FsUiyUvdCyupq5cG54XyKqSLEp9QGbx7wFJkWCkeWmuwRed4sfpAlKaeA==}
+    cpu: [arm64]
+    os: [win32]
+
   '@oxlint-tsgolint/win32-arm64@0.16.0':
     resolution: {integrity: sha512-EWdlspQiiFGsP2AiCYdhg5dTYyAlj6y1nRyNI2dQWq4Q/LITFHiSRVPe+7m7K7lcsZCEz2icN/bCeSkZaORqIg==}
     cpu: [arm64]
+    os: [win32]
+
+  '@oxlint-tsgolint/win32-x64@0.15.0':
+    resolution: {integrity: sha512-ioAY2XLpy83E2EqOLH9p1cEgj0G2qB1lmAn0a3yFV1jHQB29LIPIKGNsu/tYCClpwmHN79pT5KZAHZOgWxxqNg==}
+    cpu: [x64]
     os: [win32]
 
   '@oxlint-tsgolint/win32-x64@0.16.0':
@@ -2804,6 +2834,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  oxlint-tsgolint@0.15.0:
+    resolution: {integrity: sha512-iwvFmhKQVZzVTFygUVI4t2S/VKEm+Mqkw3jQRJwfDuTcUYI5LCIYzdO5Dbuv4mFOkXZCcXaRRh0m+uydB5xdqw==}
+    hasBin: true
+
   oxlint-tsgolint@0.16.0:
     resolution: {integrity: sha512-4RuJK2jP08XwqtUu+5yhCbxEauCm6tv2MFHKEMsjbosK2+vy5us82oI3VLuHwbNyZG7ekZA26U2LLHnGR4frIA==}
     hasBin: true
@@ -3762,19 +3796,37 @@ snapshots:
   '@oxfmt/binding-win32-x64-msvc@0.37.0':
     optional: true
 
+  '@oxlint-tsgolint/darwin-arm64@0.15.0':
+    optional: true
+
   '@oxlint-tsgolint/darwin-arm64@0.16.0':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-x64@0.15.0':
     optional: true
 
   '@oxlint-tsgolint/darwin-x64@0.16.0':
     optional: true
 
+  '@oxlint-tsgolint/linux-arm64@0.15.0':
+    optional: true
+
   '@oxlint-tsgolint/linux-arm64@0.16.0':
+    optional: true
+
+  '@oxlint-tsgolint/linux-x64@0.15.0':
     optional: true
 
   '@oxlint-tsgolint/linux-x64@0.16.0':
     optional: true
 
+  '@oxlint-tsgolint/win32-arm64@0.15.0':
+    optional: true
+
   '@oxlint-tsgolint/win32-arm64@0.16.0':
+    optional: true
+
+  '@oxlint-tsgolint/win32-x64@0.15.0':
     optional: true
 
   '@oxlint-tsgolint/win32-x64@0.16.0':
@@ -5860,6 +5912,15 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.37.0
       '@oxfmt/binding-win32-x64-msvc': 0.37.0
 
+  oxlint-tsgolint@0.15.0:
+    optionalDependencies:
+      '@oxlint-tsgolint/darwin-arm64': 0.15.0
+      '@oxlint-tsgolint/darwin-x64': 0.15.0
+      '@oxlint-tsgolint/linux-arm64': 0.15.0
+      '@oxlint-tsgolint/linux-x64': 0.15.0
+      '@oxlint-tsgolint/win32-arm64': 0.15.0
+      '@oxlint-tsgolint/win32-x64': 0.15.0
+
   oxlint-tsgolint@0.16.0:
     optionalDependencies:
       '@oxlint-tsgolint/darwin-arm64': 0.16.0
@@ -5868,8 +5929,9 @@ snapshots:
       '@oxlint-tsgolint/linux-x64': 0.16.0
       '@oxlint-tsgolint/win32-arm64': 0.16.0
       '@oxlint-tsgolint/win32-x64': 0.16.0
+    optional: true
 
-  oxlint@1.52.0(oxlint-tsgolint@0.16.0):
+  oxlint@1.52.0(oxlint-tsgolint@0.15.0):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.52.0
       '@oxlint/binding-android-arm64': 1.52.0
@@ -5890,7 +5952,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.52.0
       '@oxlint/binding-win32-ia32-msvc': 1.52.0
       '@oxlint/binding-win32-x64-msvc': 1.52.0
-      oxlint-tsgolint: 0.16.0
+      oxlint-tsgolint: 0.15.0
 
   oxlint@1.53.0(oxlint-tsgolint@0.16.0):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,7 +21,7 @@ catalog:
   lefthook: 2.1.3
   oxfmt: 0.37.0
   oxlint: 1.52.0
-  oxlint-tsgolint: 0.16.0
+  oxlint-tsgolint: 0.15.0
   tailwindcss: 4.2.1
   typescript: 5.9.3
   vite: 8.0.0-beta.18


### PR DESCRIPTION
## 概要

oxlint-tsgolint を 0.16.0 から 0.15.0 に戻す。

## 背景

PR #77 で oxlint を 1.52.0 に戻したが、oxlint-tsgolint 0.16.0 が peer dependency として oxlint 1.53.0 を引き込んでいた。その結果、`apps/renderer/node_modules/.bin/oxlint` が 1.53.0 を指し続け、lefthook から renderer の `.ts` ファイルに対して oxlint を実行した際に `vite.config.ts` 自動検出のエラーが発生していた。

```
Failed to parse oxlint configuration file.
Expected a `lint` field in the default export of vite.config.ts
```

oxlint-tsgolint を 0.15.0 に戻すことで、renderer に oxlint 1.53.0 がインストールされなくなる。

## 確認事項

- [ ] pre-commit hook で renderer の .ts ファイル変更時にエラーが出ないこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development build tooling version for project maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->