### PR TITLE
worktree 選択でビューを切り替える機能を追加

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "ignorePatterns": [".orkis/"]
+}

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -481,6 +481,10 @@ function resolveVueLspPaths(projectRoot: string, packageDir: string): VueLspPath
 /** ウィンドウ → UUID */
 const windowIds = new Map<OrkisWindow, string>();
 const windowDirs = new Map<OrkisWindow, string>();
+/** CLI からの open 時に window を再利用するための repo root → window マッピング */
+const windowRepoRoots = new Map<OrkisWindow, string>();
+/** switchDir の世代管理。stale な非同期結果を捨てるために使う */
+const windowSwitchGen = new Map<OrkisWindow, number>();
 
 // git status デバウンス
 const gitStatusTimers = new Map<OrkisWindow, ReturnType<typeof setTimeout>>();
@@ -490,6 +494,8 @@ const gitStatusNeedsRerun = new Set<OrkisWindow>();
 function scheduleGitStatusUpdate(win: OrkisWindow, root: string) {
   const existing = gitStatusTimers.get(win);
   if (existing) clearTimeout(existing);
+
+  const gen = windowSwitchGen.get(win) ?? 0;
 
   const timer = setTimeout(async () => {
     gitStatusTimers.delete(win);
@@ -502,6 +508,8 @@ function scheduleGitStatusUpdate(win: OrkisWindow, root: string) {
     gitStatusInFlight.add(win);
     try {
       const statuses = await getGitStatus(root);
+      // 世代が変わっていたら stale な結果を捨てる
+      if ((windowSwitchGen.get(win) ?? 0) !== gen) return;
       win.webview.rpc?.send.gitStatusChange({ statuses });
     } finally {
       gitStatusInFlight.delete(win);
@@ -518,6 +526,16 @@ function scheduleGitStatusUpdate(win: OrkisWindow, root: string) {
 // ファイル監視
 const windowFsWatchers = new Map<OrkisWindow, fs.FSWatcher>();
 const windowGitWatchedFiles = new Map<OrkisWindow, string[]>();
+
+/** linked worktree 対応: `.git` がファイル（gitdir: ...）の場合に実際の git ディレクトリを解決 */
+async function resolveGitDir(root: string): Promise<string> {
+  const result = await tryCatch(
+    new Response(Bun.spawn(["git", "rev-parse", "--git-dir"], { cwd: root }).stdout).text(),
+  );
+  if (!result.ok) return path.join(root, ".git");
+  const gitDir = result.value.trim();
+  return path.isAbsolute(gitDir) ? gitDir : path.resolve(root, gitDir);
+}
 
 function startWatching(win: OrkisWindow, root: string) {
   // ワークスペースのファイル監視（recursive, macOS）
@@ -536,9 +554,13 @@ function startWatching(win: OrkisWindow, root: string) {
     if (/\.[tj]sx?$|\.vue$/.test(filename)) {
       const clients = windowLspClients.get(win);
       if (clients) {
+        const gen = windowSwitchGen.get(win) ?? 0;
         void (async () => {
+          // 世代が変わっていたら stale な通知を捨てる
+          if ((windowSwitchGen.get(win) ?? 0) !== gen) return;
           const absPath = path.join(root, filename);
           const fileResult = await tryCatch(fsp.readFile(absPath, "utf-8"));
+          if ((windowSwitchGen.get(win) ?? 0) !== gen) return;
           for (const lsp of clients) {
             // プロジェクトルートからの相対パスを各 LSP の rootDir からの相対パスに変換
             const lspRelPath = path.relative(lsp.rootDir, absPath);
@@ -559,62 +581,64 @@ function startWatching(win: OrkisWindow, root: string) {
 
   windowFsWatchers.set(win, watcher);
 
-  // .git 関連ファイルの監視
-  const gitDir = path.join(root, ".git");
-  const indexPath = path.join(gitDir, "index");
-  const headPath = path.join(gitDir, "HEAD");
+  // .git 関連ファイルの監視（linked worktree では .git がファイルなので git rev-parse で解決）
+  void (async () => {
+    const gitDir = await resolveGitDir(root);
+    const indexPath = path.join(gitDir, "index");
+    const headPath = path.join(gitDir, "HEAD");
 
-  function resolveCurrentRefPath(): string | undefined {
-    try {
-      const headContent = fs.readFileSync(headPath, "utf-8").trim();
-      if (headContent.startsWith("ref: ")) {
-        return path.join(gitDir, headContent.slice(5));
+    function resolveCurrentRefPath(): string | undefined {
+      try {
+        const headContent = fs.readFileSync(headPath, "utf-8").trim();
+        if (headContent.startsWith("ref: ")) {
+          return path.join(gitDir, headContent.slice(5));
+        }
+      } catch {
+        // detached HEAD 等
       }
-    } catch {
-      // detached HEAD 等
+      return undefined;
     }
-    return undefined;
-  }
 
-  let currentRefPath = resolveCurrentRefPath();
+    let currentRefPath = resolveCurrentRefPath();
 
-  function syncGitWatchedFiles() {
-    const files = [indexPath, headPath];
-    if (currentRefPath) files.push(currentRefPath);
-    windowGitWatchedFiles.set(win, files);
-  }
-
-  function updateRefWatch() {
-    const newRefPath = resolveCurrentRefPath();
-    if (newRefPath === currentRefPath) return;
-
-    if (currentRefPath) {
-      fs.unwatchFile(currentRefPath);
+    function syncGitWatchedFiles() {
+      const files = [indexPath, headPath];
+      if (currentRefPath) files.push(currentRefPath);
+      windowGitWatchedFiles.set(win, files);
     }
-    currentRefPath = newRefPath;
+
+    function updateRefWatch() {
+      const newRefPath = resolveCurrentRefPath();
+      if (newRefPath === currentRefPath) return;
+
+      if (currentRefPath) {
+        fs.unwatchFile(currentRefPath);
+      }
+      currentRefPath = newRefPath;
+      if (currentRefPath) {
+        fs.watchFile(currentRefPath, { interval: GIT_WATCH_POLL_MS }, () => {
+          scheduleGitStatusUpdate(win, root);
+        });
+      }
+      syncGitWatchedFiles();
+    }
+
+    fs.watchFile(indexPath, { interval: GIT_WATCH_POLL_MS }, () => {
+      scheduleGitStatusUpdate(win, root);
+    });
+
+    fs.watchFile(headPath, { interval: GIT_WATCH_POLL_MS }, () => {
+      updateRefWatch();
+      scheduleGitStatusUpdate(win, root);
+    });
+
     if (currentRefPath) {
       fs.watchFile(currentRefPath, { interval: GIT_WATCH_POLL_MS }, () => {
         scheduleGitStatusUpdate(win, root);
       });
     }
     syncGitWatchedFiles();
-  }
-
-  fs.watchFile(indexPath, { interval: GIT_WATCH_POLL_MS }, () => {
-    scheduleGitStatusUpdate(win, root);
-  });
-
-  fs.watchFile(headPath, { interval: GIT_WATCH_POLL_MS }, () => {
-    updateRefWatch();
-    scheduleGitStatusUpdate(win, root);
-  });
-
-  if (currentRefPath) {
-    fs.watchFile(currentRefPath, { interval: GIT_WATCH_POLL_MS }, () => {
-      scheduleGitStatusUpdate(win, root);
-    });
-  }
-  syncGitWatchedFiles();
+  })();
 }
 
 function stopWatching(win: OrkisWindow) {
@@ -646,6 +670,8 @@ function cleanupWindow(win: OrkisWindow) {
   if (windowId) fileServerDirs.delete(windowId);
   windowIds.delete(win);
   windowDirs.delete(win);
+  windowRepoRoots.delete(win);
+  windowSwitchGen.delete(win);
   // このウィンドウが所有する PTY をすべて kill
   for (const [id, entry] of ptys) {
     if (entry.win === win) {
@@ -668,12 +694,17 @@ function cleanupWindow(win: OrkisWindow) {
 function createWindowWithRPC(dir: string): OrkisWindow {
   let win: OrkisWindow;
 
+  /** worktree/branch 管理用（固定） */
+  const repoRootDir = dir;
+  /** ファイル操作用（switchDir で切り替え可能） */
+  let currentDir = dir;
+
   const rpc: OrkisRPCInstance = BrowserView.defineRPC<OrkisRPC>({
     handlers: {
       requests: {
-        ptySpawn: ({ cols, rows }) => spawnPty(win, dir, cols, rows),
+        ptySpawn: ({ cols, rows }) => spawnPty(win, currentDir, cols, rows),
         fsReadDir: async ({ relPath }) => {
-          const absolutePath = await resolveSecurePath(dir, relPath);
+          const absolutePath = await resolveSecurePath(currentDir, relPath);
           const entries = await fsp.readdir(absolutePath, { withFileTypes: true });
           const visibleEntries = entries.filter((e) => e.name !== ".git");
           const names = visibleEntries.map((e) => e.name);
@@ -698,7 +729,7 @@ function createWindowWithRPC(dir: string): OrkisWindow {
           );
         },
         fsReadFile: async ({ relPath }) => {
-          const absolutePath = await resolveSecurePath(dir, relPath);
+          const absolutePath = await resolveSecurePath(currentDir, relPath);
           const file = Bun.file(absolutePath);
           const MAX_FILE_SIZE = 1024 * 1024; // 1MB
           if (file.size > MAX_FILE_SIZE) {
@@ -713,8 +744,8 @@ function createWindowWithRPC(dir: string): OrkisWindow {
           return { content, isBinary: false };
         },
         gitShowFile: async ({ relPath }) => {
-          assertInsideRoot(dir, relPath);
-          const proc = Bun.spawn(["git", "show", `HEAD:${relPath}`], { cwd: dir });
+          assertInsideRoot(currentDir, relPath);
+          const proc = Bun.spawn(["git", "show", `HEAD:${relPath}`], { cwd: currentDir });
           const result = await tryCatch(new Response(proc.stdout).arrayBuffer());
           await proc.exited;
           if (!result.ok || proc.exitCode !== 0) {
@@ -727,21 +758,77 @@ function createWindowWithRPC(dir: string): OrkisWindow {
           return { content: new TextDecoder().decode(bytes), isBinary: false };
         },
         gitDiffFile: async ({ relPath }) => {
-          assertInsideRoot(dir, relPath);
+          assertInsideRoot(currentDir, relPath);
           const result = await tryCatch(
             new Response(
-              Bun.spawn(["git", "diff", "HEAD", "--", relPath], { cwd: dir }).stdout,
+              Bun.spawn(["git", "diff", "HEAD", "--", relPath], { cwd: currentDir }).stdout,
             ).text(),
           );
           if (!result.ok) return "";
           return result.value;
         },
-        gitStatus: () => getGitStatus(dir),
-        gitWorktreeList: () => getWorktreeList(dir),
-        gitBranchList: () => getBranchList(dir),
-        gitWorktreeAdd: ({ branch }) => addWorktree(dir, branch),
-        gitWorktreeRemove: ({ path: wtPath, force }) => removeWorktree(dir, wtPath, force),
-        gitBranchDelete: ({ branch }) => deleteBranch(dir, branch),
+        gitStatus: () => getGitStatus(currentDir),
+        gitWorktreeList: () => getWorktreeList(repoRootDir),
+        gitBranchList: () => getBranchList(repoRootDir),
+        gitWorktreeAdd: ({ branch }) => addWorktree(repoRootDir, branch),
+        gitWorktreeRemove: ({ path: wtPath, force }) => removeWorktree(repoRootDir, wtPath, force),
+        gitBranchDelete: ({ branch }) => deleteBranch(repoRootDir, branch),
+        switchDir: async ({ dir: targetDir }) => {
+          // バリデーション: worktree list に含まれるパスのみ許可
+          const worktrees = await getWorktreeList(repoRootDir);
+          const targetReal = await fsp.realpath(targetDir);
+          const validEntry = await (async () => {
+            for (const wt of worktrees) {
+              const wtReal = await tryCatch(fsp.realpath(wt.path));
+              if (wtReal.ok && wtReal.value === targetReal) return wt;
+            }
+            return undefined;
+          })();
+          if (!validEntry) {
+            throw new Error("Access denied: dir is not a known worktree");
+          }
+
+          // 世代を進めて stale event を無効化
+          const gen = (windowSwitchGen.get(win) ?? 0) + 1;
+          windowSwitchGen.set(win, gen);
+
+          // 既存 PTY を kill
+          for (const [id, entry] of ptys) {
+            if (entry.win === win) {
+              entry.proc.kill();
+              ptys.delete(id);
+            }
+          }
+
+          // 既存 LSP を shutdown（再起動はしない）
+          const clients = windowLspClients.get(win);
+          if (clients) {
+            windowLspClients.delete(win);
+            for (const lsp of clients) {
+              void lsp.shutdown();
+            }
+          }
+
+          // ディレクトリを切り替え
+          currentDir = targetReal;
+
+          // ファイル監視を付け替え
+          stopWatching(win);
+          startWatching(win, currentDir);
+
+          // Map を更新
+          const windowId = windowIds.get(win) ?? "";
+          windowDirs.set(win, currentDir);
+          fileServerDirs.set(windowId, currentDir);
+
+          // 初回 git status をプッシュ
+          scheduleGitStatusUpdate(win, currentDir);
+
+          return {
+            dir: currentDir,
+            fileServerBaseUrl: `http://localhost:${fileServer.port}/${windowId}`,
+          };
+        },
       },
       messages: {
         ptyWrite: ({ id, data }) => {
@@ -765,10 +852,10 @@ function createWindowWithRPC(dir: string): OrkisWindow {
           }
         },
         rendererReady: () => {
-          console.log("[orkis] rendererReady received, sending orkisOpen:", dir);
+          console.log("[orkis] rendererReady received, sending orkisOpen:", currentDir);
           const windowId = windowIds.get(win) ?? "";
           win.webview.rpc?.send.orkisOpen({
-            dir,
+            dir: currentDir,
             fileServerBaseUrl: `http://localhost:${fileServer.port}/${windowId}`,
             channel,
           });
@@ -776,11 +863,14 @@ function createWindowWithRPC(dir: string): OrkisWindow {
           // webview 準備完了後に LSP を起動
           void (async () => {
             const clients: LspClient[] = [];
+            const gen = windowSwitchGen.get(win) ?? 0;
             const diagCallback = (
               source: string,
               relPath: string,
               diagnostics: LspDiagnostic[],
             ) => {
+              // 世代が変わっていたら stale な診断を捨てる
+              if ((windowSwitchGen.get(win) ?? 0) !== gen) return;
               if (diagnostics.length > 0) {
                 console.log(`[diag:${source}] ${relPath}: ${diagnostics.length} items`);
               }
@@ -788,11 +878,11 @@ function createWindowWithRPC(dir: string): OrkisWindow {
             };
 
             // tsgo（TS/JS 用）
-            const tsgoPath = await resolveTsgoPath(dir);
+            const tsgoPath = await resolveTsgoPath(repoRootDir);
             if (tsgoPath) {
               clients.push(
                 createLspClient({
-                  rootDir: dir,
+                  rootDir: repoRootDir,
                   server: { kind: "tsgo", binaryPath: tsgoPath },
                   onDiagnostics: (relPath, diags) => diagCallback("tsgo", relPath, diags),
                   onError: (msg) => console.error(`[lsp:tsgo] ${msg}`),
@@ -801,9 +891,9 @@ function createWindowWithRPC(dir: string): OrkisWindow {
             }
 
             // Vue Language Server（Vue SFC 用、apps/renderer をルートにする）
-            const rendererDir = path.join(dir, "apps", "renderer");
+            const rendererDir = path.join(repoRootDir, "apps", "renderer");
             console.log(`[lsp:vue] rendererDir: ${rendererDir}`);
-            const vuePaths = resolveVueLspPaths(dir, rendererDir);
+            const vuePaths = resolveVueLspPaths(repoRootDir, rendererDir);
             console.log(`[lsp:vue] resolved paths:`, vuePaths ?? "not found");
             if (vuePaths) {
               console.log(`[lsp:vue] server: ${vuePaths.serverPath}, tsdk: ${vuePaths.tsdkPath}`);
@@ -869,8 +959,8 @@ interface OpenMessage {
 type OrkisMessage = HookMessage | OpenMessage;
 
 function findWindowByDir(dir: string): OrkisWindow | undefined {
-  for (const [win, windowDir] of windowDirs) {
-    if (windowDir === dir) return win;
+  for (const [win, repoRoot] of windowRepoRoots) {
+    if (repoRoot === dir) return win;
   }
   return undefined;
 }
@@ -907,6 +997,8 @@ function handleSocketMessage(message: OrkisMessage) {
       windowIds.set(newWin, windowId);
       fileServerDirs.set(windowId, message.dir);
       windowDirs.set(newWin, message.dir);
+      windowRepoRoots.set(newWin, message.dir);
+      windowSwitchGen.set(newWin, 0);
       startWatching(newWin, message.dir);
       break;
     }

--- a/apps/renderer/src/features/diagnostics/useDiagnosticsStore.ts
+++ b/apps/renderer/src/features/diagnostics/useDiagnosticsStore.ts
@@ -56,12 +56,18 @@ export const useDiagnosticsStore = defineStore("diagnostics", () => {
     warningFiles.value.reduce((sum, f) => sum + f.diagnostics.length, 0),
   );
 
+  /** worktree 切り替え時に全診断をクリアする */
+  function clear() {
+    diagnosticsMap.value = new Map();
+  }
+
   return {
     diagnosticsMap,
     errorFiles,
     warningFiles,
     errorCount,
     warningCount,
+    clear,
   };
 });
 

--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -18,10 +18,13 @@ import { ref, watchEffect } from "vue";
 import DebugPane from "../debug/DebugPane.vue";
 import DiagnosticsPane from "../diagnostics/DiagnosticsPane.vue";
 import FilerPane from "../filer/FilerPane.vue";
+import { useWorkspaceStore } from "../filer/useWorkspaceStore";
 import PreviewPane from "../preview/PreviewPane.vue";
 import TerminalPane from "../terminal/TerminalPane.vue";
 import ResizeHandle from "./ResizeHandle.vue";
 import SidebarPane from "./SidebarPane.vue";
+
+const workspaceStore = useWorkspaceStore();
 
 const SIDEBAR_MIN_WIDTH = 120;
 const FILER_MIN_WIDTH = 160;
@@ -93,7 +96,7 @@ watchEffect(() => {
       />
 
       <div class="shrink-0 overflow-hidden p-2" :style="{ width: `${terminalWidth}px` }">
-        <TerminalPane />
+        <TerminalPane :key="workspaceStore.dir" />
       </div>
     </div>
 

--- a/apps/renderer/src/features/layout/SidebarPane.vue
+++ b/apps/renderer/src/features/layout/SidebarPane.vue
@@ -3,6 +3,7 @@
 
 ## 操作
 
+- worktree クリック: 表示対象ディレクトリを切り替え
 - worktree の unlink: 解除（まず通常削除を試行、未コミット変更がある場合は確認後 --force）
 - ブランチの link: そのブランチで worktree を作成
 - New worktree: 新規一時ブランチで worktree を作成
@@ -12,16 +13,19 @@
 import type { WorktreeEntry } from "@orkis/rpc";
 import { tryCatch } from "@orkis/shared";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import { useDiagnosticsStore } from "../diagnostics/useDiagnosticsStore";
 import { useWorkspaceStore } from "../filer/useWorkspaceStore";
 import { useRpc } from "../rpc/useRpc";
 
 const workspaceStore = useWorkspaceStore();
+const diagnosticsStore = useDiagnosticsStore();
 const { request, onGitStatusChange } = useRpc();
 
 const worktrees = ref<WorktreeEntry[]>([]);
 /** worktree 化されていないローカルブランチ */
 const freeBranches = ref<string[]>([]);
 const isCreating = ref(false);
+const isSwitching = ref(false);
 
 /** main 先頭、残りはブランチ名のアルファベット順 */
 const sortedWorktrees = computed(() =>
@@ -33,6 +37,11 @@ const sortedWorktrees = computed(() =>
 );
 
 const sortedBranches = computed(() => [...freeBranches.value].sort((a, b) => a.localeCompare(b)));
+
+/** 現在表示中の worktree かどうか */
+function isActive(wt: WorktreeEntry): boolean {
+  return workspaceStore.dir === wt.path;
+}
 
 /** 確認ダイアログ */
 const confirmRef = ref<HTMLDialogElement>();
@@ -75,6 +84,18 @@ async function fetchData() {
   worktrees.value = wtList;
   const wtBranches = new Set(wtList.map((wt) => wt.branch).filter(Boolean));
   freeBranches.value = branchList.filter((b) => !wtBranches.has(b));
+}
+
+/** worktree をクリックして表示対象を切り替える */
+async function handleWorktreeSelect(wt: WorktreeEntry) {
+  if (isActive(wt) || isSwitching.value) return;
+  isSwitching.value = true;
+  const result = await tryCatch(request.switchDir({ dir: wt.path }));
+  if (result.ok) {
+    diagnosticsStore.clear();
+    workspaceStore.setOpen(result.value.dir, undefined, result.value.fileServerBaseUrl);
+  }
+  isSwitching.value = false;
 }
 
 async function addWorktree(branch?: string) {
@@ -144,7 +165,9 @@ onUnmounted(() => {
       <div
         v-for="wt in sortedWorktrees"
         :key="wt.path"
-        class="group/wt grid grid-cols-[auto_1fr_auto] gap-x-2 rounded-sm py-1.5 pl-2 hover:bg-zinc-800"
+        class="group/wt grid cursor-pointer grid-cols-[auto_1fr_auto] gap-x-2 rounded-sm py-1.5 pl-2"
+        :class="isActive(wt) ? 'bg-zinc-700/50' : 'hover:bg-zinc-800'"
+        @click="handleWorktreeSelect(wt)"
       >
         <span
           class="row-span-2 mt-0.5 text-base"
@@ -154,17 +177,31 @@ onUnmounted(() => {
               : 'icon-[lucide--git-branch] text-zinc-400'
           "
         />
-        <span class="truncate text-sm" :class="wt.isMain ? 'text-zinc-400' : 'text-zinc-200'">
+        <span
+          class="truncate text-sm"
+          :class="
+            isActive(wt)
+              ? 'font-medium text-blue-300'
+              : wt.isMain
+                ? 'text-zinc-400'
+                : 'text-zinc-200'
+          "
+        >
           {{ wt.branch ?? "(detached)" }}
         </span>
-        <span v-if="wt.isMain" class="row-span-2 self-center pr-2 text-xs text-zinc-600">ref</span>
+        <span
+          v-if="wt.isMain && !isActive(wt)"
+          class="row-span-2 self-center pr-2 text-xs text-zinc-600"
+          >ref</span
+        >
         <button
-          v-else
+          v-else-if="!wt.isMain && !isActive(wt)"
           class="row-span-2 grid size-10 place-items-center self-center text-zinc-600 opacity-0 transition-opacity group-hover/wt:opacity-100 hover:text-red-400"
-          @click="handleWorktreeRemove(wt)"
+          @click.stop="handleWorktreeRemove(wt)"
         >
           <span class="icon-[lucide--unlink] text-sm" />
         </button>
+        <span v-else class="row-span-2" />
         <span class="font-mono text-xs text-zinc-600">{{ wt.head }}</span>
       </div>
 

--- a/apps/renderer/src/features/terminal/TerminalPane.vue
+++ b/apps/renderer/src/features/terminal/TerminalPane.vue
@@ -1,52 +1,15 @@
 <doc lang="md">
-ターミナルバックエンド切り替えラッパー。
-
-ghostty-web と xterm.js を動的に切り替える。
-バックエンドを変更すると PTY を再生成して新しいターミナルを開く。
+ターミナルペイン。xterm.js ベースのターミナルエミュレータを表示する。
 </doc>
 
 <script setup lang="ts">
-import { shallowRef } from "vue";
-import type { Component } from "vue";
-import GhosttyTerminal from "./GhosttyTerminal.vue";
 import XtermTerminal from "./XtermTerminal.vue";
-
-type TerminalBackend = "ghostty" | "xterm";
-
-interface BackendEntry {
-  component: Component;
-  label: string;
-}
-
-const BACKENDS: Record<TerminalBackend, BackendEntry> = {
-  ghostty: { component: GhosttyTerminal, label: "Ghostty" },
-  xterm: { component: XtermTerminal, label: "xterm" },
-};
-
-const BACKEND_KEYS: TerminalBackend[] = ["xterm", "ghostty"];
-
-const currentBackend = shallowRef<TerminalBackend>("xterm");
 </script>
 
 <template>
   <div class="flex size-full flex-col">
-    <div class="flex shrink-0 gap-1 px-2 py-1">
-      <button
-        v-for="key in BACKEND_KEYS"
-        :key="key"
-        class="rounded-sm px-2 py-0.5 text-xs"
-        :class="
-          currentBackend === key
-            ? 'bg-zinc-600 text-zinc-100'
-            : 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-300'
-        "
-        @click="currentBackend = key"
-      >
-        {{ BACKENDS[key].label }}
-      </button>
-    </div>
     <div class="min-h-0 flex-1">
-      <component :is="BACKENDS[currentBackend].component" :key="currentBackend" />
+      <XtermTerminal />
     </div>
   </div>
 </template>

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -101,6 +101,11 @@ export type OrkisRPC = {
         params: { branch: string };
         response: void;
       };
+      /** 表示対象ディレクトリを切り替える（worktree 選択） */
+      switchDir: {
+        params: { dir: string };
+        response: { dir: string; fileServerBaseUrl: string };
+      };
     };
     messages: {
       ptyWrite: { id: number; data: string };


### PR DESCRIPTION
## 概要

サイドバーの worktree をクリックすると、ファイラー・プレビュー・ターミナルの表示対象ディレクトリが切り替わるようにする。

## 背景

サイドバーに worktree 一覧とブランチ一覧が表示されているが、worktree をクリックしてもビューが切り替わらなかった。CLAUDE.md の「未着手」に記載されている「worktree クリック時のビュー切り替え」を実装する。

Codex（gpt-5.4）によるレビューで以下の設計上の問題が指摘され、対策を組み込んだ:

- `repoRootDir`（固定）と `currentDir`（切り替え可能）の分離が必要
- linked worktree の `.git` がファイル（`gitdir: ...`）になるため `git rev-parse --git-dir` で解決が必要
- `switchDir` に渡される dir のバリデーション（worktree list に含まれるパスのみ許可）
- stale な非同期結果の遮断（世代管理）

## 変更内容

### RPC スキーマ ( `packages/rpc` )

- `switchDir` request を追加（params: `{ dir }`, response: `{ dir, fileServerBaseUrl }`）

### desktop ( `apps/desktop` )

- `createWindowWithRPC` 内で `repoRootDir`（worktree/branch 管理用、固定）と `currentDir`（ファイル操作用、切り替え可能）を分離
- `switchDir` ハンドラ: バリデーション → 世代インクリメント → PTY kill → LSP shutdown → dir 切り替え → ファイル監視付け替え → git status 初回プッシュ
- `resolveGitDir()` を追加し、`startWatching` の git 監視で linked worktree に対応
- `windowSwitchGen` による世代管理で stale な非同期結果（git status、LSP diagnostics）を遮断
- `windowRepoRoots` を新設し、`findWindowByDir` は repo root で window を再利用

### renderer ( `apps/renderer` )

- サイドバー: worktree クリックで `switchDir` → ビュー切り替え、選択中 worktree のハイライト、アクティブ worktree の unlink 無効化
- MainLayout: `TerminalPane` に `:key="workspaceStore.dir"` を付与し、dir 変更で再マウント → 新 PTY spawn
- TerminalPane: ghostty/xterm 切り替え機能を削除し xterm.js 固定に簡素化
- diagnostics store: `clear()` メソッドを追加し、切り替え時に診断をクリア

### oxlint 設定

- `.oxlintrc.json` を追加し、`.orkis/`（worktree ディレクトリ）を lint 除外

## 確認事項

- [ ] サイドバーで worktree をクリックしてファイラー・プレビュー・ターミナルが切り替わること
- [ ] ファイル監視が新しいディレクトリで動作すること
- [ ] worktree 切り替え後も worktree add/remove が正常に動作すること
- [ ] 表示中の worktree の unlink ボタンが表示されないこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to switch between worktrees and directories within the same window from the sidebar without restarting.
  * Improved support for linked worktrees with automatic git directory resolution.

* **Bug Fixes**
  * Enhanced git status management to prevent stale results when switching worktrees.

* **Refactor**
  * Simplified terminal to use a single implementation, removing the alternative backend option.

* **Chores**
  * Added linter configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->