### PR TITLE
xterm.js で Shift+Enter の改行入力に対応する

### DIFF
--- a/apps/renderer/src/features/terminal/XtermTerminal.vue
+++ b/apps/renderer/src/features/terminal/XtermTerminal.vue
@@ -55,6 +55,17 @@ onMounted(async () => {
     }
   });
 
+  // Shift+Enter で Esc+CR を送信する（Claude Code が改行として認識するシーケンス）
+  terminal.attachCustomKeyEventHandler((ev) => {
+    if (ev.type === "keydown" && ev.key === "Enter" && ev.shiftKey) {
+      if (ptyId !== undefined) {
+        send.ptyWrite({ id: ptyId, data: "\x1b\r" });
+      }
+      return false;
+    }
+    return true;
+  });
+
   // xterm → PTY
   terminal.onData((data) => {
     if (ptyId !== undefined) {


### PR DESCRIPTION
## 概要

xterm.js ターミナル上で Shift+Enter を押したとき、Claude Code が改行として認識するエスケープシーケンス（`Esc+CR`）を PTY に送信するようにする。

## 背景

xterm.js はデフォルトで Shift+Enter を通常の Enter（`\r`）と同じデータとして送信するため、Claude Code 上で Shift+Enter による改行入力ができなかった。

Claude Code は Shift+Enter の認識方法をターミナルごとに分けている:
- kitty / ghostty / iTerm / WezTerm / Warp: ネイティブの keyboard protocol で対応済み
- VS Code / Cursor / Alacritty / Zed: キーバインド設定で `\x1b\r`（Esc+CR）を送信

xterm.js v6 は kitty keyboard protocol 未対応（xtermjs/xterm.js#5424 が open）のため、後者と同じアプローチで `attachCustomKeyEventHandler` を使い `\x1b\r` を手動送信する。

## 変更内容

### xterm.js キー入力処理

- `attachCustomKeyEventHandler` で Shift+Enter を検知し、`\x1b\r` を PTY に送信
- デフォルトの Enter 処理（`\r` 送信）を `return false` で抑制

## 確認事項

- [x] xterm.js ターミナル上の Claude Code で Shift+Enter が改行として動作する
- [ ] 通常の Enter が従来どおりコマンド実行として動作する
- [ ] Shift+Enter が Claude Code 以外のシェル操作に悪影響しない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Shift+Enter keyboard shortcut to the terminal that sends an escape sequence, enabling improved command processing and interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->