### PR TITLE
worktree 切り替え時のターミナル幅崩れを修正

### DIFF
--- a/apps/renderer/src/features/terminal/XtermTerminal.vue
+++ b/apps/renderer/src/features/terminal/XtermTerminal.vue
@@ -109,8 +109,13 @@ onMounted(async () => {
   });
 
   // コンテナリサイズ時に xterm と PTY を同期
-  resizeObserver = new ResizeObserver(() => {
-    fitAddon?.fit();
+  // v-show=false（display:none）でサイズが 0 になった時に fit() すると
+  // cols が極小値になり、再表示後もターミナルが狭いままになるため、サイズ 0 はスキップする
+  resizeObserver = new ResizeObserver((entries) => {
+    const entry = entries[0];
+    if (entry && entry.contentRect.width > 0 && entry.contentRect.height > 0) {
+      fitAddon?.fit();
+    }
   });
   resizeObserver.observe(container);
 


### PR DESCRIPTION
## 概要

worktree 間を切り替えた際にターミナルの表示幅が極端に狭くなる問題を修正。

## 背景

複数の TerminalPane を `v-show` で切り替える構造のため、非表示になった TerminalPane の `display` が `none` になり、コンテナサイズが 0 になる。この時 `ResizeObserver` が fire して `fitAddon.fit()` が呼ばれると、cols が極小値（1〜2列）に設定され、再表示後もターミナルが狭いままになるケースがあった。

## 変更内容

### ターミナルリサイズ処理

- `ResizeObserver` のコールバックで `contentRect` の width/height が 0 の場合は `fitAddon.fit()` をスキップするガードを追加

## 確認事項

- [ ] worktree 間を複数回切り替えてターミナル幅が正しく維持されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced terminal display reliability by fixing an issue where the terminal would appear extremely narrow when re-displayed after being hidden. The resize detection mechanism now properly validates element visibility before adjusting the terminal layout, ensuring correct rendering every time the terminal transitions between visible and hidden states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->