### PR TITLE
worktree ID をタイムスタンプ形式に変更

### DIFF
--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -214,7 +214,17 @@ function countChanges(statuses: Record<string, string>): WorktreeChangeCounts {
 const WORKTREE_DIR = ".orkis/worktrees";
 
 function generateWorktreeId(): string {
-  return `wt-${crypto.randomUUID().slice(0, 8)}`;
+  const now = new Date();
+  const timestamp = [
+    now.getFullYear(),
+    String(now.getMonth() + 1).padStart(2, "0"),
+    String(now.getDate()).padStart(2, "0"),
+    "_",
+    String(now.getHours()).padStart(2, "0"),
+    String(now.getMinutes()).padStart(2, "0"),
+    String(now.getSeconds()).padStart(2, "0"),
+  ].join("");
+  return `wt-${timestamp}`;
 }
 
 async function getBranchList(cwd: string): Promise<string[]> {


### PR DESCRIPTION
## 概要

- worktree 作成時に生成されるブランチ名を `wt-{ランダムハッシュ}` から `wt-{yyyymmdd_hhmmss}` 形式に変更

## 背景

従来の worktree ID は `crypto.randomUUID().slice(0, 8)` によるランダムな8文字ハッシュ（例: `wt-2bd731f6`）だったが、作成時期が一目でわからなかった。タイムスタンプ形式（例: `wt-20260315_143052`）にすることで、ブランチ一覧から作成順や時期を直感的に把握できるようにする。

## 変更内容

### `generateWorktreeId()` の変更

- `crypto.randomUUID()` ベースからローカルタイムのタイムスタンプベースに変更
- 出力形式: `wt-yyyymmdd_hhmmss`

## 確認事項

- [ ] 新しい worktree を作成し、ブランチ名が `wt-yyyymmdd_hhmmss` 形式になることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Worktree identifiers now use timestamp-based formatting instead of random generation, improving consistency across sessions and enhancing traceability in system logs and operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->