### PR TITLE
worktree 作成時の一覧重複表示を防止

### DIFF
--- a/apps/renderer/src/features/layout/SidebarPane.vue
+++ b/apps/renderer/src/features/layout/SidebarPane.vue
@@ -28,6 +28,8 @@ const worktrees = ref<WorktreeEntry[]>([]);
 const freeBranches = ref<string[]>([]);
 const isCreating = ref(false);
 const isSwitching = ref(false);
+/** fetchData の世代管理（並行実行で stale なレスポンスを破棄するため） */
+let fetchGen = 0;
 
 /** main 先頭、残りはブランチ名のアルファベット順 */
 const sortedWorktrees = computed(() =>
@@ -85,10 +87,13 @@ function showAlert(message: string) {
 
 async function fetchData() {
   if (!workspaceStore.dir) return;
+  const gen = ++fetchGen;
   const [wtList, branchList] = await Promise.all([
     request.gitWorktreeList(),
     request.gitBranchList(),
   ]);
+  // 並行実行された新しい fetchData が先に完了していたら、この結果は stale なので破棄
+  if (gen !== fetchGen) return;
   worktrees.value = wtList;
   const wtBranches = new Set(wtList.map((wt) => wt.branch).filter(Boolean));
   freeBranches.value = branchList.filter((b) => !wtBranches.has(b));
@@ -114,7 +119,7 @@ async function addWorktree(branch?: string) {
 
   const result = await tryCatch(request.gitWorktreeAdd({ branch }));
   if (result.ok) {
-    worktrees.value.push(result.value);
+    await fetchData();
   } else if (branch) {
     freeBranches.value.push(branch);
   }


### PR DESCRIPTION
## 概要

New worktree ボタンで worktree を作成した際、同じ worktree が一覧に2つ表示されることがある問題を修正。

## 背景

worktree 一覧の更新には2つの経路があった:

- **楽観的UI（push）**: `addWorktree` が RPC レスポンスを受けて `worktrees.value.push(entry)` で即座にローカル追加
- **イベント駆動（fetchData）**: サーバー側の `worktreeChange` / `gitStatusChange` イベントで `fetchData()` が全件再取得し `worktrees.value = wtList` で上書き

タイミングによっては、`fetchData` が先に新エントリを含む一覧で上書きした後に `push` が実行され、同じエントリが重複追加されていた。

また、`fetchData` 自体も複数イベントから並行実行されるため、古いレスポンスが後から返って最新状態を上書きする可能性があった。

## 変更内容

### SidebarPane.vue

- 楽観的な `push` をやめ、`addWorktree` 成功後に `fetchData()` で一覧を再取得するように変更
- `fetchData` に世代カウンタを導入し、並行実行時に stale なレスポンスを破棄するようにした

## 確認事項

- [ ] New worktree ボタンを複数回押して重複表示が発生しないこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale/overwritten worktree data when multiple background refreshes run concurrently, ensuring only the latest fetch updates the list.
  * After adding a worktree, the worktree list is fully refreshed to ensure a consistent, up-to-date display.
  * Error handling for failed adds remains unchanged, preserving rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->