### PR TITLE
worktree 切り替え時のターミナルリセットを修正

### DIFF
--- a/apps/renderer/src/features/terminal/TerminalPane.vue
+++ b/apps/renderer/src/features/terminal/TerminalPane.vue
@@ -7,14 +7,19 @@
 絶対位置（px）を算出。v-for + position: absolute でフラットに配置する。
 ツリー構造が変わっても既存 leaf の key(id) が同じなので Vue がコンポーネントを
 再利用し、xterm インスタンスと PTY のリマウントが起きない。
+
+## leaf の存在と rect の分離
+
+- leaf の存在: ツリー構造（collectLeafIds）で決まる。split/close でのみ変化
+- leaf の rect: コンテナサイズ（flattenTree）で決まる。v-show:false で 0x0 になっても前回値を維持
 </doc>
 
 <script setup lang="ts">
 import { useElementSize } from "@vueuse/core";
-import { computed, ref } from "vue";
+import { computed, ref, shallowRef, watchEffect } from "vue";
 import SplitResizeHandle from "./SplitResizeHandle.vue";
-import type { FlatHandle, FlatLeaf } from "./splitTree";
-import { flattenTree } from "./splitTree";
+import type { FlatElement, FlatHandle, PixelRect } from "./splitTree";
+import { collectLeafIds, flattenTree } from "./splitTree";
 import TerminalLeaf from "./TerminalLeaf.vue";
 import { useTerminalStore } from "./useTerminalStore";
 
@@ -26,24 +31,37 @@ const props = defineProps<{
 const terminalStore = useTerminalStore();
 const layout = computed(() => terminalStore.ensureLayout(props.dir));
 
+// leaf の存在はツリー構造で決まる（split/close でのみ変化）
+const leafIds = computed(() => collectLeafIds(layout.value.root));
+
 const containerRef = ref<HTMLElement>();
 const { width: containerWidth, height: containerHeight } = useElementSize(containerRef);
 
-// コンテナサイズ未確定（初回 0x0）の間は空配列を返し、leaf が 0x0 で mount されるのを防ぐ
-const flatElements = computed(() => {
-  if (containerWidth.value <= 0 || containerHeight.value <= 0) return [];
-  return flattenTree(layout.value.root, containerWidth.value, containerHeight.value);
+// leaf の位置・サイズはコンテナサイズで決まる（リサイズ時に更新）
+// v-show:false でサイズが 0 になっても前回の結果を維持し、leaf の unmount を防ぐ
+const hasMeasuredOnce = ref(false);
+const flatElements = shallowRef<FlatElement[]>([]);
+
+watchEffect(() => {
+  if (containerWidth.value <= 0 || containerHeight.value <= 0) return;
+  hasMeasuredOnce.value = true;
+  flatElements.value = flattenTree(layout.value.root, containerWidth.value, containerHeight.value);
 });
 
-const flatLeaves = computed(() =>
-  flatElements.value.filter((el): el is FlatLeaf => el.type === "leaf"),
-);
+const rectByLeafId = computed(() => {
+  const map = new Map<string, PixelRect>();
+  for (const el of flatElements.value) {
+    if (el.type === "leaf") map.set(el.id, el.rect);
+  }
+  return map;
+});
 
 const flatHandles = computed(() =>
   flatElements.value.filter((el): el is FlatHandle => el.type === "handle"),
 );
 
-function rectStyle(rect: { top: number; left: number; width: number; height: number }) {
+function rectStyle(rect: PixelRect | undefined) {
+  if (rect === undefined) return { position: "absolute" as const };
   return {
     position: "absolute" as const,
     top: `${rect.top}px`,
@@ -56,14 +74,16 @@ function rectStyle(rect: { top: number; left: number; width: number; height: num
 
 <template>
   <div ref="containerRef" class="relative size-full overflow-hidden">
-    <TerminalLeaf
-      v-for="leaf in flatLeaves"
-      :key="leaf.id"
-      :dir="dir"
-      :leaf-id="leaf.id"
-      :fit-suspended="fitSuspended"
-      :style="rectStyle(leaf.rect)"
-    />
+    <template v-if="hasMeasuredOnce">
+      <TerminalLeaf
+        v-for="id in leafIds"
+        :key="id"
+        :dir="dir"
+        :leaf-id="id"
+        :fit-suspended="fitSuspended"
+        :style="rectStyle(rectByLeafId.get(id))"
+      />
+    </template>
 
     <SplitResizeHandle
       v-for="handle in flatHandles"


### PR DESCRIPTION
## 概要

TerminalPane で leaf の存在条件と rect 計算を分離し、worktree 切り替え時にターミナルが unmount されなくなるよう修正

## 背景

PR #103 でターミナル分割をフラットレンダリングに移行した際、`flattenTree()` の結果を `computed` で算出し、コンテナサイズが 0x0 の場合に空配列を返すガードを入れた。このガードは初回マウント時の `useElementSize` 初期値 0x0 対策として必要だった。

しかし、worktree を切り替えると `v-show="false"` により `display: none` が適用され、`useElementSize` が 0x0 を返す。これにより `flatLeaves` が空配列になり、TerminalLeaf が unmount → PTY kill + xterm dispose が実行されてしまう。worktree に戻ると新しいターミナルがゼロから作成され、以前の内容が失われていた。

## 変更内容

### leaf の存在と rect の責務分離

- leaf の存在: `collectLeafIds(layout.root)` でツリー構造から算出。split/close でのみ変化
- leaf の rect: `shallowRef` + `watchEffect` でキャッシュ。サイズが 0 になっても前回値を維持
- 初回ガード: `hasMeasuredOnce` フラグで、一度も non-zero を観測するまでは leaf をマウントしない

## 確認事項

- [ ] worktree を切り替えてターミナルの内容が保持されるか
- [ ] ターミナル分割の動作に影響がないか
- [ ] 初回表示時にターミナルが正しくマウントされるか

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved terminal pane rendering stability when managing terminal instances.

* **Refactor**
  * Restructured terminal pane rendering architecture to enhance reliability during layout updates and state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->