### PR TITLE
レイアウト調整: プレビューのデフォルト closed 化とペイン順序変更

### DIFF
--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -3,7 +3,7 @@
 
 ## 構成
 
-- 水平方向: SidebarPane → FilerPane → TerminalPane → PreviewPane（各ペイン間にリサイズハンドル）
+- 水平方向: SidebarPane → TerminalPane → FilerPane → PreviewPane（各ペイン間にリサイズハンドル）
 - 垂直方向: メインエリア → DebugPane（リサイズハンドル）
 - PreviewPane は右端に配置され、開閉可能
 
@@ -120,20 +120,9 @@ watchEffect(() => {
       </div>
       <ResizeHandle
         v-model:before-size="sidebarWidth"
-        v-model:after-size="filerWidth"
-        direction="horizontal"
-        :before-min-size="SIDEBAR_MIN_WIDTH"
-        :after-min-size="FILER_MIN_WIDTH"
-      />
-
-      <div class="shrink-0 overflow-hidden" :style="{ width: `${filerWidth}px` }">
-        <FilerPane />
-      </div>
-      <ResizeHandle
-        v-model:before-size="filerWidth"
         v-model:after-size="terminalWidth"
         direction="horizontal"
-        :before-min-size="FILER_MIN_WIDTH"
+        :before-min-size="SIDEBAR_MIN_WIDTH"
         :after-min-size="TERMINAL_MIN_WIDTH"
       />
 
@@ -152,11 +141,23 @@ watchEffect(() => {
       </div>
 
       <ResizeHandle
-        v-show="previewOpen && canDockPreview"
         v-model:before-size="terminalWidth"
-        v-model:after-size="previewWidth"
+        v-model:after-size="filerWidth"
         direction="horizontal"
         :before-min-size="TERMINAL_MIN_WIDTH"
+        :after-min-size="FILER_MIN_WIDTH"
+      />
+
+      <div class="shrink-0 overflow-hidden" :style="{ width: `${filerWidth}px` }">
+        <FilerPane />
+      </div>
+
+      <ResizeHandle
+        v-show="previewOpen && canDockPreview"
+        v-model:before-size="filerWidth"
+        v-model:after-size="previewWidth"
+        direction="horizontal"
+        :before-min-size="FILER_MIN_WIDTH"
         :after-min-size="PREVIEW_MIN_WIDTH"
       />
 


### PR DESCRIPTION
## 概要

メインレイアウトのプレビューペインとペイン配置を調整する。

## 背景

プレビューペインが起動時に開いた状態だとターミナルの作業領域が狭くなる。ファイル選択時に自動オープンするため、デフォルトは closed で十分。
また、ターミナルをファイラーより左に配置することで、メインの作業領域をより中央寄りにする。

## 変更内容

### プレビューペインのデフォルト状態

- `previewOpen` の初期値を `true` → `false` に変更
- ファイル選択時の自動オープン動作は維持

### ペイン順序の変更

- 変更前: Sidebar → Filer → Terminal → Preview
- 変更後: Sidebar → Terminal → Filer → Preview
- ResizeHandle の接続先を新しい順序に合わせて更新

## 確認事項

- [ ] 起動時にプレビューが閉じた状態であること
- [ ] ファイル選択でプレビューが自動オープンすること
- [ ] ペイン順序が Sidebar → Terminal → Filer → Preview になっていること
- [ ] 各ペイン間のリサイズハンドルが正しく動作すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a button to open the Preview pane when it's closed or unavailable.

* **Changes**
  * Reordered UI panes for improved workflow layout.
  * Preview pane now starts in a closed state by default.
  * Restructured resizing behavior and panel interaction logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->