### PR TITLE
Terminal の最大化時リサイズ不能を修正

### DIFF
--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -72,35 +72,69 @@ const MAIN_MIN_HEIGHT = 200;
 /** ハンドル幅 w-2 = 8px */
 const HANDLE_WIDTH = 8;
 
+const { width: windowWidth, height: windowHeight } = useWindowSize();
+
 const sidebarWidth = ref(224);
 const filerWidth = ref(256);
-/** ユーザーが決めた幅。開閉では変更しない */
-const terminalWidth = ref(400);
 /** ユーザーが決めた希望幅 */
 const previewWidth = ref(400);
 const previewOpen = ref(false);
 const mainHeight = ref(600);
 const debugHeight = ref(128);
 
-const { width: windowWidth, height: windowHeight } = useWindowSize();
+/** Preview 開閉ボタンの固定幅（px-1 × 2 + size-4 + border-l） */
+const PREVIEW_TOGGLE_WIDTH = 25;
 
-/** Sidebar + Filer + ハンドル2本 + Terminal で消費される固定幅 */
-const leftFixedWidth = computed(
-  () => sidebarWidth.value + filerWidth.value + HANDLE_WIDTH * 2 + terminalWidth.value,
-);
-
-/** Terminal の右側に残る余白 */
-const rightFreeWidth = computed(() => Math.max(0, windowWidth.value - leftFixedWidth.value));
+/** Terminal を最小幅にしたときに Preview に使える最大幅 */
+const availablePreviewWidth = computed(() => {
+  if (!previewOpen.value) return 0;
+  return Math.max(
+    0,
+    windowWidth.value -
+      sidebarWidth.value -
+      filerWidth.value -
+      TERMINAL_MIN_WIDTH -
+      HANDLE_WIDTH * 3,
+  );
+});
 
 /** プレビューに実際に割り当てる幅（余白に収まるようクランプ） */
 const dockedPreviewWidth = computed(() => {
   if (!previewOpen.value) return 0;
-  const max = rightFreeWidth.value - HANDLE_WIDTH;
-  return Math.max(0, Math.min(previewWidth.value, max));
+  return Math.min(previewWidth.value, availablePreviewWidth.value);
 });
 
 /** プレビューを表示できるだけの余白があるか */
 const canDockPreview = computed(() => dockedPreviewWidth.value >= PREVIEW_MIN_WIDTH);
+
+/** Preview セクションが占める幅（ドック時: ハンドル + Preview、非ドック時: 開閉ボタン） */
+const previewSectionWidth = computed(() =>
+  previewOpen.value && canDockPreview.value
+    ? HANDLE_WIDTH + dockedPreviewWidth.value
+    : PREVIEW_TOGGLE_WIDTH,
+);
+
+/** Terminal 幅: ウィンドウ幅から他ペインを引いた残余領域（state ではなく導出値） */
+const terminalWidth = computed(() =>
+  Math.max(
+    TERMINAL_MIN_WIDTH,
+    windowWidth.value -
+      sidebarWidth.value -
+      filerWidth.value -
+      HANDLE_WIDTH * 2 -
+      previewSectionWidth.value,
+  ),
+);
+
+/** ドラッグ開始時に Terminal の DOM 実測幅を取得する */
+const getTerminalWidth = () =>
+  terminalContainerRef.value?.getBoundingClientRect().width ?? terminalWidth.value;
+
+/** デバッグ用 */
+const leftFixedWidth = computed(
+  () => sidebarWidth.value + filerWidth.value + HANDLE_WIDTH * 2 + terminalWidth.value,
+);
+const rightFreeWidth = computed(() => Math.max(0, windowWidth.value - leftFixedWidth.value));
 
 // previewVisible context key を実際の表示状態と同期
 watchEffect(() => {
@@ -144,10 +178,10 @@ watchEffect(() => {
       </div>
       <ResizeHandle
         v-model:before-size="sidebarWidth"
-        v-model:after-size="terminalWidth"
         direction="horizontal"
         :before-min-size="SIDEBAR_MIN_WIDTH"
         :after-min-size="TERMINAL_MIN_WIDTH"
+        :get-after-size="getTerminalWidth"
       />
 
       <div
@@ -165,11 +199,11 @@ watchEffect(() => {
       </div>
 
       <ResizeHandle
-        v-model:before-size="terminalWidth"
         v-model:after-size="filerWidth"
         direction="horizontal"
         :before-min-size="TERMINAL_MIN_WIDTH"
         :after-min-size="FILER_MIN_WIDTH"
+        :get-before-size="getTerminalWidth"
       />
 
       <div class="shrink-0 overflow-hidden" :style="{ width: `${filerWidth}px` }">

--- a/apps/renderer/src/features/layout/ResizeHandle.vue
+++ b/apps/renderer/src/features/layout/ResizeHandle.vue
@@ -14,11 +14,13 @@ interface Props {
   direction: "horizontal" | "vertical";
   beforeMinSize: number;
   afterMinSize: number;
+  getBeforeSize?: () => number;
+  getAfterSize?: () => number;
 }
 
 const props = defineProps<Props>();
-const beforeSize = defineModel<number>("beforeSize", { required: true });
-const afterSize = defineModel<number>("afterSize", { required: true });
+const beforeSize = defineModel<number>("beforeSize");
+const afterSize = defineModel<number>("afterSize");
 
 const handleRef = useTemplateRef<HTMLElement>("handle");
 const isHovered = useElementHover(handleRef);
@@ -27,6 +29,8 @@ const { isDragging } = useResize(handleRef, beforeSize, afterSize, {
   direction: props.direction,
   beforeMinSize: props.beforeMinSize,
   afterMinSize: props.afterMinSize,
+  getBeforeSize: props.getBeforeSize,
+  getAfterSize: props.getAfterSize,
 });
 </script>
 

--- a/apps/renderer/src/features/layout/useResize.ts
+++ b/apps/renderer/src/features/layout/useResize.ts
@@ -10,32 +10,46 @@ interface UseResizeOptions {
   beforeMinSize: number;
   /** 右（下）ペインの最小サイズ（px） */
   afterMinSize: number;
+  /** ドラッグ開始時の左（上）ペインサイズを取得する関数。DOM 実測幅が必要な場合に使う */
+  getBeforeSize?: () => number;
+  /** ドラッグ開始時の右（下）ペインサイズを取得する関数。DOM 実測幅が必要な場合に使う */
+  getAfterSize?: () => number;
 }
 
 /**
  * ドラッグによるペインリサイズを管理する composable。
  * ハンドルの左右（上下）のペインサイズを連動して増減する。
  * delta 分を一方に加え、他方から引くことで他のペインに影響を与えない。
+ *
+ * beforeSize / afterSize の値が undefined の場合（親がモデルをバインドしていない場合）、
+ * そのペインの ref は更新しない。getBeforeSize / getAfterSize で開始サイズだけ取得する。
  */
 export function useResize(
   handleRef: Readonly<ShallowRef<HTMLElement | null>>,
-  beforeSize: Ref<number>,
-  afterSize: Ref<number>,
+  beforeSize: Ref<number | undefined>,
+  afterSize: Ref<number | undefined>,
   options: UseResizeOptions,
 ) {
   const isDragging = ref(false);
 
+  // 親がモデルをバインドしているかを初期値で判定
+  const shouldWriteBefore = beforeSize.value !== undefined;
+  const shouldWriteAfter = afterSize.value !== undefined;
+
   let startPos = 0;
   let startBeforeSize = 0;
   let startAfterSize = 0;
+
+  const readBeforeSize = () => options.getBeforeSize?.() ?? beforeSize.value ?? 0;
+  const readAfterSize = () => options.getAfterSize?.() ?? afterSize.value ?? 0;
 
   // ハンドル要素の mousedown を常時監視
   useEventListener(handleRef, "mousedown", (e: MouseEvent) => {
     e.preventDefault();
     isDragging.value = true;
     startPos = options.direction === "horizontal" ? e.clientX : e.clientY;
-    startBeforeSize = beforeSize.value;
-    startAfterSize = afterSize.value;
+    startBeforeSize = readBeforeSize();
+    startAfterSize = readAfterSize();
 
     const cursor = options.direction === "horizontal" ? "col-resize" : "row-resize";
     document.body.style.cursor = cursor;
@@ -53,8 +67,8 @@ export function useResize(
       const maxShrink = startBeforeSize - options.beforeMinSize;
       const delta = Math.max(-maxShrink, Math.min(maxExpand, rawDelta));
 
-      beforeSize.value = startBeforeSize + delta;
-      afterSize.value = startAfterSize - delta;
+      if (shouldWriteBefore) beforeSize.value = startBeforeSize + delta;
+      if (shouldWriteAfter) afterSize.value = startAfterSize - delta;
     });
 
     // mouseup: once で自動解除、mousemove も解除する


### PR DESCRIPTION
## 概要

ウィンドウ最大化時に Terminal ペインの幅をドラッグで小さくできない問題を修正する。

## 背景

Terminal コンテナは CSS `flex-1` で残りスペースを埋めるため、ウィンドウ最大化時に実描画幅が `terminalWidth` ref（初期値 400px）を大幅に超えて広がる。一方、ドラッグリサイズの `useResize` は ref の値を基準に縮小可能量を計算する（`maxShrink = startBeforeSize - beforeMinSize`）ため、`400 - 200 = 200px` に制限され不十分だった。

Terminal を明示幅にするアプローチ（A）だと、Preview 開閉やウィンドウリサイズの責務をアプリ側で再実装する必要があり、非可逆性の問題が生じた。代わりに、Terminal は `flex-1` の残余領域のまま維持し、ドラッグ時の制約計算だけ DOM 実測幅を使うアプローチ（C）を採用した。

## 変更内容

### useResize.ts

- `getBeforeSize` / `getAfterSize` オプションを追加。ドラッグ開始時のサイズ取得に DOM 実測幅を使える
- `beforeSize` / `afterSize` の値が `undefined`（親がモデルをバインドしていない）の場合、そのペインの ref を更新しない

### ResizeHandle.vue

- `getBeforeSize` / `getAfterSize` props を追加
- `beforeSize` / `afterSize` model を optional に変更

### MainLayout.vue

- `terminalWidth` を `ref` から `computed` に変更（ウィンドウ幅から他ペイン分を引いた導出値）
- Terminal 隣接ハンドルから `v-model` による Terminal 幅のバインドを削除し、`:get-before-size` / `:get-after-size` で `getBoundingClientRect()` を渡す
- Preview 幅の計算を `terminalWidth` に依存しない形に変更（循環参照を回避）

## 確認事項

- [ ] ウィンドウ最大化時に Terminal を自由に縮小できること
- [ ] Sidebar-Terminal / Terminal-Filer のハンドルドラッグが正常に動作すること
- [ ] ウィンドウリサイズ時に Terminal が追従して伸縮すること
- [ ] Preview の開閉が正常に動作すること
- [ ] Preview 開閉の連打でレイアウトが崩れないこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Terminal and pane sizing now adapt to the window and neighboring panes for more consistent layout.
  * Resize handles and dragging behave reliably with dynamic pane sizes, preserving proportions during window resizes.
  * Preview docking now opens/closes based on available space so layout reallocates smoothly without overlap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->