### PR TITLE
xterm リサイズ時にスクロール位置を保持する

### DIFF
--- a/apps/renderer/src/features/terminal/XtermTerminal.vue
+++ b/apps/renderer/src/features/terminal/XtermTerminal.vue
@@ -58,10 +58,15 @@ function scheduleFit() {
     if (width <= 0 || height <= 0) return;
     if (width === lastFitWidth && height === lastFitHeight) return;
 
-    // リサイズ前のスクロール位置を保存
-    const savedViewportY = terminal?.buffer.active.viewportY ?? 0;
-    const wasAtBottom =
-      terminal !== undefined && terminal.buffer.active.viewportY >= terminal.buffer.active.baseY;
+    // alternate buffer（TUI アプリ）は scrollback がないため bottom にリセットする
+    // primary buffer（通常シェル）は Marker で reflow に追従してスクロール位置を保持する
+    const isAlternate = terminal?.buffer.active.type === "alternate";
+    const buf = terminal?.buffer.active;
+    const wasAtBottom = buf !== undefined && buf.viewportY >= buf.baseY;
+    const marker =
+      !isAlternate && !wasAtBottom && terminal !== undefined && buf !== undefined
+        ? terminal.registerMarker(buf.viewportY - buf.baseY - buf.cursorY)
+        : undefined;
 
     lastFitWidth = width;
     lastFitHeight = height;
@@ -69,11 +74,12 @@ function scheduleFit() {
 
     // リサイズ後にスクロール位置を復元
     if (terminal !== undefined) {
-      if (wasAtBottom) {
+      if (isAlternate || wasAtBottom) {
         terminal.scrollToBottom();
-      } else {
-        terminal.scrollToLine(Math.min(savedViewportY, terminal.buffer.active.baseY));
+      } else if (marker !== undefined && !marker.isDisposed) {
+        terminal.scrollToLine(Math.min(marker.line, terminal.buffer.active.baseY));
       }
+      marker?.dispose();
     }
   });
 }


### PR DESCRIPTION
## 概要

xterm.js の `fitAddon.fit()` 呼び出し時にスクロール位置がトップにリセットされる問題を修正する。

## 背景

ターミナルリサイズ時に xterm.js はスクロール位置をトップにリセットしてしまう。スクロールバックでログを読み返している最中にウィンドウサイズを変えると、読んでいた位置を見失う。

ghostty 本体のソース（`PageList.zig`）を調査し、primary buffer と alternate buffer でリサイズ挙動が異なることを確認した:
- primary buffer: `reflow=true`, `scrollback > 0` → スクロール位置保持
- alternate buffer: `reflow=false`, `scrollback=0` → viewport が bottom にリセット

この挙動に合わせて xterm.js 側でも buffer type に応じた処理を実装した。

なお、Claude Code のような normal buffer を使う TUI アプリでは、リサイズ後の再描画データで位置がずれる問題が残る（ #117 ）。

## 変更内容

### スクロール位置の保存・復元

- `scheduleFit()` 内で `fitAddon.fit()` 前後にスクロール位置の保存・復元を追加
- xterm.js の Marker API を使用し、reflow（cols 変更時の折り返し再計算）に追従する
- alternate buffer は `scrollToBottom()` で bottom にリセット（ghostty と同じ挙動）
- primary buffer でボトムにいた場合は `scrollToBottom()` でボトム追従を維持
- primary buffer でスクロールバック中は Marker の `line` で復元（`baseY` で clamp）

## 確認事項

- [ ] 通常シェル: ボトム位置でリサイズしてもボトムを維持すること
- [ ] 通常シェル: スクロールバック中にリサイズしても同じ位置付近を維持すること
- [ ] 通常シェル: cols 変更（縮小→拡大）で元の位置に復帰すること
- [ ] alternate buffer の TUI アプリ: リサイズ時にボトムにリセットされること