### PR TITLE
CLI のソケット探索を stable/dev フォールバックに変更する

### DIFF
--- a/apps/cli/bin/orkis
+++ b/apps/cli/bin/orkis
@@ -18,17 +18,8 @@ APP_BUNDLE="${APP_CONTENTS}/.."
 ## stable → dev の順で探す（socket-client.ts と同じ優先順）
 SOCKET_CANDIDATES=("/tmp/orkis-stable.sock" "/tmp/orkis-dev.sock")
 
-## いずれかの候補ソケットファイルが存在するか
-any_socket_exists() {
-  for sock in "${SOCKET_CANDIDATES[@]}"; do
-    [[ -S "${sock}" ]] && return 0
-  done
-  return 1
-}
-
-## 接続可能なソケットを探して ACTIVE_SOCKET に設定する
-## 接続失敗したソケットは残骸として削除する
-find_active_socket() {
+## 接続可能なソケットを探して ACTIVE_SOCKET に設定する（削除なし）
+try_connect() {
   ACTIVE_SOCKET=""
   for sock in "${SOCKET_CANDIDATES[@]}"; do
     [[ -S "${sock}" ]] || continue
@@ -37,13 +28,23 @@ find_active_socket() {
       ACTIVE_SOCKET="${sock}"
       return 0
     fi
-    rm -f "${sock}"
   done
   return 1
 }
 
+## 起動前の残骸ソケットを掃除してから接続を試みる
 is_app_running() {
-  find_active_socket
+  for sock in "${SOCKET_CANDIDATES[@]}"; do
+    [[ -S "${sock}" ]] || continue
+
+    if nc -zU "${sock}" 2>/dev/null; then
+      ACTIVE_SOCKET="${sock}"
+      return 0
+    fi
+    # 起動前なので接続できないソケットは残骸とみなして削除
+    rm -f "${sock}"
+  done
+  return 1
 }
 
 # open コマンド（デフォルト）以外はアプリ起動不要
@@ -56,16 +57,10 @@ should_launch_app() {
 launch_app() {
   open "${APP_BUNDLE}"
 
-  # ソケットファイルの出現を待つ（削除はしない）
+  # ソケットが接続可能になるまで待つ（起動中なので削除しない）
   local max_wait=10
   local waited=0
-  while ! any_socket_exists && (( waited < max_wait )); do
-    sleep 0.2
-    (( waited++ ))
-  done
-
-  # ファイルが現れたら接続可能になるまで追加で待つ
-  while ! find_active_socket && (( waited < max_wait )); do
+  while ! try_connect && (( waited < max_wait )); do
     sleep 0.2
     (( waited++ ))
   done


### PR DESCRIPTION
## 概要

`apps/cli/bin/orkis` のソケット探索を、`stable.sock` 固定から `stable → dev` のフォールバック方式に変更する。

## 背景

`build:stable` でビルドしたアプリが `Updater.localInfo.channel()` で `"dev"` を返すケースがあり、ソケットが `/tmp/orkis-dev.sock` に作られる。一方、CLI スクリプトは `/tmp/orkis-stable.sock` をハードコードしていたため、接続先が食い違っていた。

この結果、アプリが起動済みでも CLI が「未起動」と判断し、`open` でフォーカスだけ移った後ソケット待ちでタイムアウトしていた。

`socket-client.ts`（bun 側の CLI）は既に `stable → dev` のフォールバックを実装済みだったため、bash スクリプト側も同じ方式に統一した。

## 変更内容

### `apps/cli/bin/orkis`

- `SOCKET_PATH` 単一変数 → `SOCKET_CANDIDATES` 配列に変更（`stable → dev` の優先順）
- ソケット操作を責務ごとに分離
  - `try_connect()`: 接続テストのみ（削除しない）。`launch_app()` の待機ループで使用
  - `is_app_running()`: 残骸ソケットの掃除 + 接続テスト。起動前の判定で1回だけ呼ばれる
- 起動待ち中にソケットを誤削除するレース条件を排除

## 確認事項

- [ ] `build:stable` → アプリ起動 → 別ターミナルで `orkis` 実行し、タイムアウトせず開けること
- [ ] アプリ未起動時に `orkis` 実行でアプリが自動起動すること
- [ ] 残骸ソケットがある状態で `orkis` 実行し、掃除されて正常起動すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CLI now automatically detects and uses any available socket endpoint, improving connection reliability when multiple sockets exist.
  * Startup wait and timeout behavior improved to handle dynamic socket availability more robustly.
  * Periodic cleanup of stale or non-working socket endpoints reduces connection failures and improves stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->