### PR TITLE
Shift+Enter で改行が2行入るバグを修正

### DIFF
--- a/apps/renderer/src/features/terminal/XtermTerminal.vue
+++ b/apps/renderer/src/features/terminal/XtermTerminal.vue
@@ -159,9 +159,9 @@ onMounted(async () => {
   });
 
   // Shift+Enter で Esc+CR を送信する（Claude Code が改行として認識するシーケンス）
-  // keydown で送信し、keypress でも return false して xterm のデフォルト改行を抑止する
+  // keydown で送信、keypress で xterm のデフォルト改行を抑止、keyup は通過させる
   terminal.attachCustomKeyEventHandler((ev) => {
-    if (ev.key === "Enter" && ev.shiftKey) {
+    if (ev.key === "Enter" && ev.shiftKey && ev.type !== "keyup") {
       if (ev.type === "keydown") {
         const session = terminalStore.paneRegistry[props.leafId]?.session;
         if (session !== undefined) {


### PR DESCRIPTION
## 概要

- ターミナルで Shift+Enter を押すと改行が2行分入ってしまうバグを修正

## 背景

`attachCustomKeyEventHandler` は `keydown`・`keypress`・`keyup` の全イベントで呼ばれる。修正前は `ev.type === "keydown"` のみをチェックしていたため、`keypress` イベントでは条件にマッチせず `return true` が返り、xterm がデフォルトの Enter（改行）を処理していた。

結果として「カスタムの `\x1b\r` 送信」と「xterm デフォルトの改行」が両方実行され、2行分の改行が発生していた。

## 変更内容

### XtermTerminal.vue

- `ev.key === "Enter" && ev.shiftKey` を外側の条件に移動し、イベントタイプごとに処理を分岐するようにした
  - `keydown`: PTY に `\x1b\r` を送信し、xterm のデフォルト処理を抑止
  - `keypress`: xterm のデフォルト改行を抑止（`return false`）
  - `keyup`: xterm の後処理（`focus()`、`updateCursorStyle()` 等）のため通過させる

## 確認事項

- [ ] Shift+Enter で改行が1行だけ入ること
- [ ] 通常の Enter は影響を受けないこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal keyboard handling so Shift+Enter is processed only on key press (avoiding duplicate triggers on key release) and prevents unintended default behavior, resulting in more reliable multiline/enter behavior in the terminal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->