### PR TITLE
ファイル更新時にファイルツリーの展開状態がリセットされる問題を修正

### DIFF
--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -280,7 +280,7 @@ function onChildSelect(childPath: string) {
     <!-- 子エントリ -->
     <template v-if="isDirectory && expanded">
       <div
-        v-if="loading"
+        v-if="loading && !children"
         class="py-1 text-xs text-zinc-500"
         :style="{ paddingLeft: `${(depth + 1) * 16 + 4}px` }"
       >
@@ -288,7 +288,6 @@ function onChildSelect(childPath: string) {
       </div>
       <FileTreeItem
         v-for="child in children"
-        v-else
         ref="childRefs"
         :key="child.name"
         :name="child.name"


### PR DESCRIPTION
## 概要

- ファイル変更通知による再読み込み時に、Loading 表示の `v-if/v-else` で子コンポーネントが破棄されて展開状態がリセットされる問題を修正
- `:key` に `isDirectory` を含めて file/directory 入れ替わり時の状態不整合を防止

## 背景

`FileTreeItem` の子エントリ表示部で `v-if="loading"` / `v-else` を使っていたため、`notifyChange` や `notifyGitStatusChange` で `loadChildren()` が再実行されるたびに `loading=true` → 子コンポーネント unmount → `loading=false` → 再生成という流れが発生していた。再生成時に `expanded = ref(false)` の初期値に戻るため、孫以下の全展開状態が失われていた。

親コンポーネント `FilerPane` では `loading && !rootEntries` で既に初回のみに制限されていたが、`FileTreeItem` では無条件だった。

また `:key="child.name"` のままだと、同名で file ↔ directory が入れ替わった場合にコンポーネントが再利用され、古い `expanded` / `children` キャッシュが残る問題があった。

## 変更内容

### FileTreeItem.vue

- `v-if="loading"` → `v-if="loading && !children"` に変更（初回読み込み時のみ Loading 表示）
- `v-else` を削除（再読み込み中も既存の子コンポーネントを維持）
- `:key` に `isDirectory` を含めて型変更時にインスタンスを再生成

### FilerPane.vue

- `:key` に `isDirectory` を含めて FileTreeItem と統一

## 確認事項

- [ ] ディレクトリを展開した状態でファイルを編集し、展開状態が維持されることを確認
- [ ] 初回展開時に Loading... が表示されることを確認