### PR TITLE
ファイルツリーの key に isDirectory を含めて型変更時の状態不整合を防止

### DIFF
--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -289,7 +289,7 @@ function onChildSelect(childPath: string) {
       <FileTreeItem
         v-for="child in children"
         ref="childRefs"
-        :key="child.name"
+        :key="`${child.name}-${child.isDirectory}`"
         :name="child.name"
         :path="`${path}/${child.name}`"
         :is-directory="child.isDirectory"

--- a/apps/renderer/src/features/filer/FilerPane.vue
+++ b/apps/renderer/src/features/filer/FilerPane.vue
@@ -179,7 +179,7 @@ onUnmounted(() => {
         <FileTreeItem
           v-for="entry in rootEntries"
           ref="treeItemRefs"
-          :key="entry.name"
+          :key="`${entry.name}-${entry.isDirectory}`"
           :name="entry.name"
           :path="entry.name"
           :is-directory="entry.isDirectory"


### PR DESCRIPTION
## 概要

- FileTreeItem / FilerPane の `:key` に `isDirectory` を含めて、同名で file ↔ directory が入れ替わった場合にコンポーネントが正しく再生成されるようにする

## 背景

`:key="child.name"` のままだと、同名で file → directory（またはその逆）に変わった場合に Vue が同じインスタンスを再利用し、古い `expanded` / `children` キャッシュが残る。 #124 のレビューで指摘された問題。

## 変更内容

### FileTreeItem.vue / FilerPane.vue

- `:key="child.name"` → `:key="\`${child.name}-${child.isDirectory}\`"` に変更

## 確認事項

- [ ] ファイルツリーの展開・折りたたみが正常に動作することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file tree rendering to correctly display and manage items with the same name when they are different types (files versus directories).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->