### PR TITLE
feat(desktop): ウィンドウタイトルに owner/repo 名を動的設定

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,6 +7,7 @@
     "dev": "ORKIS_PROJECT_ROOT=$PWD pnpm exec electrobun dev",
     "build": "pnpm exec electrobun build --env=stable",
     "typecheck": "tsgo --noEmit",
+    "test": "bun test --run",
     "lint": "oxlint --type-aware",
     "fix": "oxlint --type-aware --fix && oxfmt ."
   },

--- a/apps/desktop/src/git.test.ts
+++ b/apps/desktop/src/git.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { parseOwnerRepo } from "./git";
+
+describe("parseOwnerRepo", () => {
+  test("HTTPS URL から owner/repo を抽出する", () => {
+    expect(parseOwnerRepo("https://github.com/miyaoka/orkis")).toBe("miyaoka/orkis");
+  });
+
+  test("HTTPS URL (.git 付き) から owner/repo を抽出する", () => {
+    expect(parseOwnerRepo("https://github.com/miyaoka/orkis.git")).toBe("miyaoka/orkis");
+  });
+
+  test("SSH URL から owner/repo を抽出する", () => {
+    expect(parseOwnerRepo("git@github.com:miyaoka/orkis.git")).toBe("miyaoka/orkis");
+  });
+
+  test("SSH URL (.git なし) から owner/repo を抽出する", () => {
+    expect(parseOwnerRepo("git@github.com:miyaoka/orkis")).toBe("miyaoka/orkis");
+  });
+
+  test("ssh:// プロトコルから owner/repo を抽出する", () => {
+    expect(parseOwnerRepo("ssh://git@bitbucket.org/team/repo.git")).toBe("team/repo");
+  });
+
+  test("GitLab の HTTPS URL から owner/repo を抽出する", () => {
+    expect(parseOwnerRepo("https://gitlab.com/org/project.git")).toBe("org/project");
+  });
+
+  test("file:// URL は undefined を返す", () => {
+    expect(parseOwnerRepo("file:///home/me/repo.git")).toBeUndefined();
+  });
+
+  test("絶対パスは undefined を返す", () => {
+    expect(parseOwnerRepo("/Users/foo/bar/repo.git")).toBeUndefined();
+  });
+
+  test("空文字は undefined を返す", () => {
+    expect(parseOwnerRepo("")).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/git.ts
+++ b/apps/desktop/src/git.ts
@@ -1,0 +1,9 @@
+/** remote URL から owner/repo を抽出するパターン（HTTPS / SSH / ssh:// 対応、ローカルパスは除外） */
+const REMOTE_OWNER_REPO_RE =
+  /^(?:(?:https?|ssh):\/\/[^/]+\/|[^@]+@[^:]+:)([^/:]+\/[^/]+?)(?:\.git)?$/;
+
+/** remote URL から owner/repo 形式の名前を抽出する。マッチしなければ undefined */
+export function parseOwnerRepo(url: string): string | undefined {
+  const match = url.match(REMOTE_OWNER_REPO_RE);
+  return match?.[1];
+}

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -8,6 +8,7 @@ import { tryCatch } from "@orkis/shared";
 import type { LspDiagnostic, OrkisRPC, WorktreeChangeCounts } from "@orkis/rpc";
 import { createLspClient } from "./lsp";
 import type { LspClient } from "./lsp";
+import { parseOwnerRepo } from "./git";
 import { getShellEnv } from "./shellEnv";
 
 type OrkisRPCInstance = ReturnType<typeof BrowserView.defineRPC<OrkisRPC>>;
@@ -22,11 +23,8 @@ const channel = await Updater.localInfo.channel();
 async function getRepoName(dir: string): Promise<string> {
   const result = await tryCatch(Promise.resolve(Bun.$`git -C ${dir} remote get-url origin`.text()));
   if (result.ok) {
-    const url = result.value.trim();
-    const match = url.match(/[/:]([^/:]+\/[^/]+?)(?:\.git)?$/);
-    if (match) {
-      return match[1];
-    }
+    const ownerRepo = parseOwnerRepo(result.value.trim());
+    if (ownerRepo) return ownerRepo;
   }
   return path.basename(dir);
 }


### PR DESCRIPTION
## 概要

ウィンドウタイトルを固定値 `"orkis"` から、git remote origin URL に基づく `orkis - owner/repo` 形式に動的設定する。

## 背景

複数リポジトリを開く場面で、ウィンドウタイトルが固定値だとどのリポジトリか判別できない。タイトルバーに `orkis - miyaoka/orkis` のように表示されることで識別性が向上する。

## 変更内容

### apps/desktop/src/git.ts（新規）

- `parseOwnerRepo(url)`: remote URL から `owner/repo` を抽出する純粋関数
- HTTPS / SSH / `ssh://` プロトコルに対応、`file://` やローカル絶対パスは除外

### apps/desktop/src/index.ts

- `getRepoName(dir)`: `git remote get-url origin` を実行し `parseOwnerRepo` で解析。失敗時は `path.basename(dir)` にフォールバック
- `updateWindowTitle()`: ウィンドウ作成後に `orkis - {repoName}` をタイトルに設定
- `Bun.$` の `ShellPromise` は `instanceof Promise` が `false` になるため、`Promise.resolve()` でラップして `tryCatch` に渡している

### apps/desktop/src/git.test.ts（新規）

- `parseOwnerRepo` のテスト（HTTPS / SSH / ssh:// / GitLab / file:// / 絶対パス / 空文字）

### apps/desktop/package.json

- `test` スクリプトを追加

## 確認事項

- [ ] ウィンドウタイトルに `orkis - miyaoka/orkis` が表示されること
- [ ] origin remote が未設定のリポジトリでディレクトリ名にフォールバックすること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Window title now dynamically shows the current repository name (updates when a repository is active).
* **Tests**
  * Added unit tests covering repository-remote parsing edge cases.
* **Chores**
  * Added a project script to run the test suite easily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->