### PR TITLE
refactor(sidebar): worktree リストの表示をディレクトリ名に変更

### DIFF
--- a/apps/renderer/src/features/layout/SidebarPane.vue
+++ b/apps/renderer/src/features/layout/SidebarPane.vue
@@ -229,10 +229,11 @@ onUnmounted(() => {
         >
         <div
           v-else-if="!wt.isMain && !isActive(wt)"
-          class="pointer-events-none absolute inset-y-0 right-0 flex items-center bg-linear-to-l from-zinc-800 via-zinc-800/95 to-transparent pr-1 pl-6 opacity-0 transition-opacity group-hover/wt:opacity-100"
+          class="pointer-events-none absolute inset-y-0 right-0 flex items-center bg-linear-to-l from-zinc-800 via-zinc-800/95 to-transparent pr-1 pl-6 opacity-0 transition-opacity group-focus-within/wt:opacity-100 group-hover/wt:opacity-100"
         >
           <button
-            class="pointer-events-auto grid size-8 place-items-center rounded-md bg-white text-zinc-900 transition-colors hover:bg-red-500 hover:text-white"
+            class="pointer-events-auto grid size-8 place-items-center rounded-md bg-white text-zinc-900 transition-colors hover:bg-red-500 hover:text-white focus:outline-2 focus:outline-blue-400"
+            aria-label="worktree を解除"
             @click.stop="handleWorktreeRemove(wt)"
           >
             <span class="icon-[lucide--unlink] text-sm" />


### PR DESCRIPTION
## 概要

サイドバーの worktree リストの表示名をブランチ名からディレクトリ名に変更し、解除ボタンのデザインを改善。

## 背景

worktree のディレクトリ名（`wt-YYYYMMDD_HHMMSS`）の方がブランチ名より識別しやすい。root（main）はブランチ名のまま最上部固定とする。

また、解除ボタンがグリッドの3列目にあったためディレクトリ名が truncate されていた問題を、absolute 配置 + scrim パターンで解決した。

## 変更内容

### 表示名の変更

- root（isMain）以外の worktree をディレクトリ名で表示
- ソートもディレクトリ名ベースに変更
- コミットハッシュの表示を削除

### 解除ボタンのデザイン改善

- グリッド3列目から absolute 配置に変更し、テキスト領域を圧迫しないように
- グラデーション scrim + 白背景ボタンでホバー時の視認性を確保
- git 差分表示領域に min-h-5 を設定し全行の高さを統一

### アクセシビリティ

- `group-focus-within` で Tab フォーカス時にも解除ボタンを表示
- ボタンに `aria-label` とフォーカスアウトラインを追加

## 確認事項

- [ ] worktree リストの表示がディレクトリ名になっていること
- [ ] root が最上部にブランチ名で固定表示されること
- [ ] 解除ボタンのホバー表示と動作