### PR TITLE
fix(sidebar): worktreeリストの表示をブランチ名に統一

### DIFF
--- a/apps/renderer/src/features/layout/SidebarPane.vue
+++ b/apps/renderer/src/features/layout/SidebarPane.vue
@@ -220,7 +220,7 @@ onUnmounted(() => {
                 : 'text-zinc-200'
           "
         >
-          {{ wt.isMain ? (wt.branch ?? "(detached)") : dirName(wt.path) }}
+          {{ wt.branch ?? "(detached)" }}
         </span>
         <span
           v-if="wt.isMain && !isActive(wt)"


### PR DESCRIPTION
## 概要

サイドバーの worktree リストで、非メイン worktree の表示名をディレクトリ名からブランチ名に変更。

## 背景

非メイン worktree がディレクトリ名（`wt-20260318_031345` のような自動生成名）で表示されており、どの作業の worktree か判別できなかった。`WorktreeEntry.branch` にブランチ名が格納されているため、それを表示に使うように修正。

## 変更内容

### サイドバー表示

- メイン・非メイン問わず `wt.branch ?? "(detached)"` で統一
- `isMain` による表示分岐を廃止

## 確認事項

- [ ] worktree リストにブランチ名が表示されること
- [ ] detached HEAD の worktree で "(detached)" と表示されること
- [ ] メイン worktree の表示が変わらないこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Standardized worktree label display in the sidebar. All worktrees now consistently show branch names or detached state, removing directory path information from non-main entries for a cleaner, more uniform appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->