### PR TITLE
fix(preview): 行番号が1000行超で見切れる問題を修正

### DIFF
--- a/apps/renderer/src/features/preview/CodePreview.vue
+++ b/apps/renderer/src/features/preview/CodePreview.vue
@@ -6,7 +6,7 @@ Shiki によるシンタックスハイライト付きコード表示。
 </doc>
 
 <script setup lang="ts">
-import { watch, ref, nextTick } from "vue";
+import { watch, ref, nextTick, computed } from "vue";
 import { highlight } from "./useHighlight";
 
 const props = defineProps<{
@@ -27,6 +27,10 @@ const activeLineNumber = ref<number>();
 let highlightVersion = 0;
 
 const ACTIVE_LINE_CLASS = "_active-line";
+
+/** 行数の桁数（CSS カスタムプロパティ --line-no-width に使用） */
+const lineCount = computed(() => props.content.split("\n").length);
+const lineNoWidth = computed(() => `${String(lineCount.value).length}ch`);
 
 /** 前回のハイライトをクリアする */
 function clearActiveHighlight() {
@@ -93,6 +97,7 @@ watch(
     ref="containerRef"
     class="_highlighted-code text-sm/tight"
     :class="wordWrap ? '_word-wrap' : ''"
+    :style="{ '--line-no-width': lineNoWidth }"
     v-html="highlightedHtml"
   />
 
@@ -102,6 +107,7 @@ watch(
     ref="containerRef"
     class="_line-numbered p-4 text-sm/tight text-zinc-300"
     :class="wordWrap ? '_word-wrap break-all whitespace-pre-wrap' : ''"
+    :style="{ '--line-no-width': lineNoWidth }"
   ><code><span
         v-for="(line, i) in content.split('\n')"
         :key="i"
@@ -116,7 +122,7 @@ watch(
 ._highlighted-code :deep(.line::before) {
   content: attr(data-line);
   display: inline-block;
-  width: 3ch;
+  width: var(--line-no-width, 3ch);
   margin-right: 1.5ch;
   text-align: right;
   color: var(--color-zinc-600);
@@ -128,7 +134,7 @@ watch(
 ._highlighted-code._word-wrap :deep(.line) {
   position: relative;
   display: block;
-  padding-left: 4.5ch;
+  padding-left: calc(var(--line-no-width, 3ch) + 1.5ch);
   min-height: 1lh;
 }
 

--- a/apps/renderer/src/features/preview/DiffPreview.vue
+++ b/apps/renderer/src/features/preview/DiffPreview.vue
@@ -41,6 +41,12 @@ const diffResult = computed<DiffLine[]>(() => {
   return lines;
 });
 
+/** diff 結果の最大行番号から桁数を算出 */
+const lineNoWidth = computed(() => {
+  const maxLine = Math.max(props.original.split("\n").length, props.current.split("\n").length);
+  return `${String(maxLine).length}ch`;
+});
+
 const LINE_TYPE_CLASSES: Record<DiffLine["type"], string> = {
   added: "text-green-400 bg-green-400/10",
   removed: "text-red-400 bg-red-400/10",
@@ -49,7 +55,7 @@ const LINE_TYPE_CLASSES: Record<DiffLine["type"], string> = {
 </script>
 
 <template>
-  <div class="p-4 text-sm/tight">
+  <div class="p-4 text-sm/tight" :style="{ '--line-no-width': lineNoWidth }">
     <div
       v-for="(line, i) in diffResult"
       :key="i"
@@ -70,7 +76,7 @@ const LINE_TYPE_CLASSES: Record<DiffLine["type"], string> = {
 
 ._line-no {
   display: inline-block;
-  width: 3ch;
+  width: var(--line-no-width, 3ch);
   flex-shrink: 0;
   text-align: right;
   color: var(--color-zinc-600);


### PR DESCRIPTION
## 概要

プレビューの行番号表示幅が固定 `3ch` だったため、1000行以上のファイルで行番号が見切れる問題を修正。

## 背景

行番号の列幅が CSS で `width: 3ch`（3文字分）に固定されていたため、4桁以上の行番号が表示領域からはみ出していた。`text-align: right` と合わさり、先頭の桁が切れて「1000」が「100」のように表示される。

## 変更内容

### CodePreview.vue / DiffPreview.vue

- 行数の桁数から `--line-no-width` CSS カスタムプロパティを算出する `computed` を追加
- `width: 3ch` → `width: var(--line-no-width, 3ch)` に変更
- word-wrap 時の `padding-left: 4.5ch` → `calc(var(--line-no-width, 3ch) + 1.5ch)` に変更

## スコープ

- **スコープ内**: CodePreview（Shiki ハイライト + フォールバック）と DiffPreview の行番号幅の動的化
- **スコープ外（対応しない）**: 行番号幅の最小値保証（1行のファイルで `1ch` になるが、実用上問題なし）

## 確認事項

- [ ] 1000行以上のファイルで行番号が正しく表示される
- [ ] word-wrap モードでも行番号とコードの位置がずれない
- [ ] diff 表示で旧行番号・新行番号の幅が揃う

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced line-number layout in code and diff previews to dynamically adjust spacing based on content length, ensuring proper alignment regardless of file size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->