### PR TITLE
fix(terminal): 最後のペインをCmd+Wで閉じたときウィンドウを閉じずにリセット

### DIFF
--- a/apps/renderer/src/features/terminal/registerTerminalCommands.ts
+++ b/apps/renderer/src/features/terminal/registerTerminalCommands.ts
@@ -4,7 +4,6 @@
  */
 import type { Ref, ShallowRef } from "vue";
 import { useCommandRegistry } from "../command/useCommandRegistry";
-import { useRpc } from "../rpc/useRpc";
 import { findNavigationTarget } from "./useSpatialNavigation";
 import { useTerminalStore } from "./useTerminalStore";
 
@@ -20,7 +19,6 @@ export function registerTerminalCommands(
 ): () => void {
   const registry = useCommandRegistry();
   const terminalStore = useTerminalStore();
-  const { send } = useRpc();
 
   /** 現在の dir と layout を取得するヘルパー。無効なら undefined */
   function getActiveLayout() {
@@ -66,9 +64,9 @@ export function registerTerminalCommands(
     registry.register("terminal.closePane", () => {
       const active = getActiveLayout();
       if (active === undefined) return false;
-      // 最後の1ペインでは closePane が false を返すので、ウィンドウを閉じる
+      // 最後の1ペインでは closePane が false を返すので、レイアウトをリセットして新ターミナルを起動
       if (!terminalStore.closePane(active.dir, active.layout.focusedLeafId)) {
-        send.windowClose();
+        terminalStore.resetLayout(active.dir);
       }
       return true;
     }),

--- a/apps/renderer/src/features/terminal/useTerminalStore.ts
+++ b/apps/renderer/src/features/terminal/useTerminalStore.ts
@@ -410,6 +410,32 @@ export const useTerminalStore = defineStore("terminal", () => {
     return true;
   }
 
+  /**
+   * レイアウトをリセットする。現在のPTYをすべてkillし、新しい単一リーフで再構築する。
+   * 最後の1ペインを閉じて新ターミナルを開く用途で使う。
+   */
+  function resetLayout(dir: string) {
+    const layout = layoutsByDir.value[dir];
+    if (layout === undefined) return;
+
+    // 既存の全ペインを破棄
+    for (const [leafId, entry] of Object.entries(paneRegistry.value)) {
+      if (entry.dir !== dir) continue;
+      killPty(leafId);
+      delete paneRegistry.value[leafId];
+    }
+
+    contextKeys.set("terminalFocus", false);
+
+    // 新しい単一リーフで再構築
+    const leaf = createLeaf();
+    layoutsByDir.value[dir] = {
+      root: leaf,
+      focusedLeafId: leaf.id,
+    };
+    paneRegistry.value[leaf.id] = { dir };
+  }
+
   /** branch の ratio を更新する */
   function resizeBranch(dir: string, branchId: string, ratio: number) {
     const layout = layoutsByDir.value[dir];
@@ -471,6 +497,7 @@ export const useTerminalStore = defineStore("terminal", () => {
     visit,
     splitPane,
     closePane,
+    resetLayout,
     resizeBranch,
     focusPane,
     spawnPty,


### PR DESCRIPTION
## 概要

最後のターミナルペインを Cmd+W で閉じたとき、ウィンドウを閉じる代わりにレイアウトをリセットして新しいターミナルを起動するように変更。

## 背景

従来は最後の1ペインを閉じるとウィンドウごと閉じていた。ターミナルを閉じたいだけなのにウィンドウが消えるのは意図しない挙動であり、選択中の worktree を起点にした新ターミナルが開く方が自然。

## 変更内容

### useTerminalStore

- `resetLayout(dir)` メソッドを追加。指定 dir の全ペインの PTY を kill し、新しい単一リーフでレイアウトを再構築する

### registerTerminalCommands

- `terminal.closePane` コマンドで、最後の1ペインのとき `send.windowClose()` → `terminalStore.resetLayout(dir)` に変更
- 不要になった `useRpc` のインポートを削除

## スコープ

- **スコープ内**: 最後のペインを閉じたときの挙動変更（ウィンドウ閉じ → レイアウトリセット）
- **スコープ外（対応しない）**: ウィンドウを閉じる操作は別のキーバインドや UI で提供する想定

## 確認事項

- [ ] Cmd+W で最後の1ペインを閉じたとき、ウィンドウが閉じずに新ターミナルが開くこと
- [ ] 複数ペインがある場合、Cmd+W で1ペインだけ閉じる既存動作が変わらないこと
- [ ] 分割ペインが複数ある状態で最後の1枚まで閉じたとき、正しくリセットされること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal pane closure behavior. When closing the last pane, the terminal layout now properly resets and initializes a fresh session instead of relying on window-close operations, providing a more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->