### PR TITLE
feat(todo): save icon immediately on toggle in edit form

### DIFF
--- a/apps/renderer/src/features/layout/SidebarPane.vue
+++ b/apps/renderer/src/features/layout/SidebarPane.vue
@@ -177,12 +177,13 @@ function startEditing(todo: Todo) {
   });
 }
 
-async function saveEdit(body: string) {
+async function saveEdit(body: string): Promise<boolean> {
   const id = editingTodoId.value;
-  if (!id) return;
+  if (!id) return false;
   const result = await tryCatch(request.todoUpdate({ id, body, icon: editIcon.value }));
-  if (!result.ok) return;
+  if (!result.ok) return false;
   await fetchData();
+  return true;
 }
 
 /** アイコン変更時: 編集前の body とマージして保存 */
@@ -192,7 +193,7 @@ function saveEditIcon() {
 
 /** 保存ボタン / Enter: 編集中の body で保存してパネルを閉じる */
 async function submitEdit() {
-  await saveEdit(editBody.value);
+  if (!(await saveEdit(editBody.value))) return;
   editingTodoId.value = undefined;
 }
 


### PR DESCRIPTION
## 概要

Todo 編集欄でアイコンをクリック（toggle）した際に、保存ボタンを押さなくても即座にバックエンドに反映されるようにする。

## 背景

従来はアイコン変更後に保存ボタンまたは Shift+Enter を押さないとバックエンドに送信されなかった。アイコンはワンクリックで切り替わる性質のため、選択した時点で即保存される方が自然な操作感になる。

## 変更内容

### 保存処理の分離

- `saveEdit(body)` を共通の保存処理とし、引数で body を受け取る設計に変更
- `saveEditIcon` — 編集前の body（`savedBody`）とマージしてアイコンだけ実質変更
- `submitEdit` — 編集中の body で保存し、成功時のみパネルを閉じる（`async` + `await`）

### アイコンの即時保存

- `TodoIconPicker` の `@update:model-value` で `saveEditIcon` を呼び、アイコン変更時に即保存
- 編集中の body ドラフトはアイコン保存に巻き込まれない

## スコープ

- **スコープ内**: 既存 Todo の編集時におけるアイコン即時保存
- **スコープ外（対応しない）**: 新規 Todo 作成時のアイコンは保存ボタンで送信（ID がまだ存在しないため即保存できない）

## 確認事項

- [x] 編集欄でアイコンをクリックすると即座にサイドバーの表示に反映されるか
- [x] アイコンを再クリック（解除）した場合も即反映されるか
- [ ] アイコン保存後、body の編集途中の内容が保持されているか
- [ ] Enter / 保存ボタンで body の変更が保存され、パネルが閉じるか
- [ ] キャンセルで編集パネルが閉じるか