### PR TITLE
fix(desktop): Claude hooks を同期実行に変更

### DIFF
--- a/apps/desktop/src/claudeHooks.ts
+++ b/apps/desktop/src/claudeHooks.ts
@@ -4,7 +4,7 @@ import { tryCatch } from "@orkis/shared";
 /** hooks 設定ファイルを生成する。nc で直接ソケットに通知する */
 export function generateClaudeSettings(settingsPath: string): void {
   const hookCommand = (event: string) =>
-    `echo '{"type":"hook","event":"${event}","payload":{"ptyId":'"$ORKIS_PTY_ID"'}}' | nc -U "$ORKIS_SOCKET_PATH"`;
+    `echo '{"type":"hook","event":"${event}","payload":{"ptyId":'"$ORKIS_PTY_ID"'}}' | nc -w 1 -U "$ORKIS_SOCKET_PATH"`;
 
   const settings = {
     hooks: {


### PR DESCRIPTION
## 概要

Claude Code hooks の `async: true` を削除し、同期実行に変更する。あわせて `nc` にタイムアウトを追加する。

## 背景

orkis のターミナルで Claude Code を使用すると、ツール呼び出しのたびに「Async hook PostToolUse completed」「Async hook UserPromptSubmit completed」などのステータス表示が大量に出力され、ターミナルの可読性が低下していた。

Claude Code は async hook の完了時にこの表示を出すが、同期 hook では表示されない。hook コマンドはローカル Unix ソケットへの `nc -U` 通知のみで一瞬で終わるため、同期実行にしても遅延は無視できる。

ただし同期実行では desktop 側の異常時に Claude Code が無期限ブロックするリスクがあるため、`nc -w 1` で 1 秒のタイムアウトを設定した。

## 変更内容

### hooks 設定生成 (`apps/desktop/src/claudeHooks.ts`)

- 全 hook（UserPromptSubmit, Stop, PermissionRequest, PostToolUse, PostToolUseFailure）から `async: true` を削除
- `nc -U` に `-w 1`（1 秒タイムアウト）を追加

## スコープ

- **スコープ内**: async フラグの削除、nc タイムアウト追加
- **スコープ外（対応しない）**: Claude Code 側の表示抑制オプション対応（現時点で存在しない）

## 確認事項

- [ ] orkis 再起動後、Claude Code 使用時に「Async hook ... completed」の表示が出ないこと
- [ ] hook 通知（running, done, needs-input, tool-done）が従来通り desktop プロセスに届くこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal hook configuration to remove unnecessary async flags for several command hooks.
  * Improved socket notification reliability by adding a short timeout to the notification command.
  * No public APIs or user-facing signatures were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->