### PR TITLE
fix(sidebar): 消失した worktree のターミナルをクリーンアップ

### DIFF
--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -280,13 +280,10 @@ async function fetchData() {
   pendingTodos.value = todoList.filter((t) => !t.worktreeDir);
 
   // 外部で削除された worktree のターミナルをクリーンアップ
-  // remove() が visitedDirs を再代入するため、スナップショットでイテレーションする
   const wtPaths = new Set(wtList.map((wt) => wt.path));
-  const dirsSnapshot = Array.from(terminalStore.visitedDirs);
-  for (const dir of dirsSnapshot) {
-    if (!wtPaths.has(dir)) {
-      terminalStore.remove(dir);
-    }
+  const staleDirs = terminalStore.visitedDirs.filter((dir) => !wtPaths.has(dir));
+  for (const dir of staleDirs) {
+    terminalStore.remove(dir);
   }
 }
 


### PR DESCRIPTION
## 概要

外部で削除された worktree のターミナルがマルチビューに残り続ける問題を修正。

## 背景

orkis のサイドバーから worktree を削除した場合は `removeFromList()` → `terminalStore.remove()` でターミナルが正しくクリーンアップされる。しかし、ターミナルから直接 `git worktree remove` した場合など、orkis 外で worktree が削除されると、サイドバーの一覧は `fetchData()` で更新されて消えるが、ターミナルストアの `visitedDirs` にはエントリが残り続ける。この状態でマルチビュー（showAll）に切り替えると、存在しない worktree のターミナルが表示されてしまう。

Todo は永続データのため誤削除リスクを考慮して起動時のみクリーンアップしているが、ターミナルはセッション内の一時リソースなので、`fetchData()` のタイミングでリアルタイムにクリーンアップする方針とした。

## 変更内容

### SidebarPane.vue

- `fetchData()` で worktree 一覧取得後、`terminalStore.visitedDirs` と突合し、一覧に存在しない dir を `terminalStore.remove()` で除去する処理を追加
- `remove()` が `visitedDirs` を再代入するため、`Array.from()` でスナップショットを取ってからイテレーションする

## スコープ

- **スコープ内**: `fetchData()` 実行時に消失 worktree のターミナルを除去
- **スコープ外（別 issue で対応）**: `getWorktreeList` の返却パスを realpath で正規化する ( #174 )
- **スコープ外（対応しない）**: Todo の同様のリアルタイムクリーンアップ（永続データのため起動時のみの現行方式を維持）

## 確認事項

- [ ] worktree をターミナルから `git worktree remove` で削除後、マルチビューに切り替えてターミナルが残っていないこと
- [ ] orkis サイドバーから worktree を削除した場合の既存動作に影響がないこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal state is now properly cleaned up when worktrees are deleted externally, preventing stale terminal references from persisting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->