### PR TITLE
disable(lsp): LSP 機能を一時的に無効化

### DIFF
--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -886,69 +886,72 @@ function createWindowWithRPC(dir: string, options?: CreateWindowOptions): OrkisW
           // 非アクティブ worktree の監視を開始
           void syncWorktreeWatchers(win, projectDir, currentDir);
 
+          // TODO: LSP 機能を再有効化するときはこのフラグを true にする
+          const lspEnabled = false;
           // webview 準備完了後に LSP を起動
-          void (async () => {
-            const clients: LspClient[] = [];
-            const gen = windowSwitchGen.get(win) ?? 0;
-            const diagCallback = (
-              source: string,
-              relPath: string,
-              diagnostics: LspDiagnostic[],
-            ) => {
-              // 世代が変わっていたら stale な診断を捨てる
-              if ((windowSwitchGen.get(win) ?? 0) !== gen) return;
-              if (diagnostics.length > 0) {
-                console.log(`[diag:${source}] ${relPath}: ${diagnostics.length} items`);
+          if (lspEnabled)
+            void (async () => {
+              const clients: LspClient[] = [];
+              const gen = windowSwitchGen.get(win) ?? 0;
+              const diagCallback = (
+                source: string,
+                relPath: string,
+                diagnostics: LspDiagnostic[],
+              ) => {
+                // 世代が変わっていたら stale な診断を捨てる
+                if ((windowSwitchGen.get(win) ?? 0) !== gen) return;
+                if (diagnostics.length > 0) {
+                  console.log(`[diag:${source}] ${relPath}: ${diagnostics.length} items`);
+                }
+                win.webview.rpc?.send.lspDiagnostics({ relPath, diagnostics });
+              };
+
+              // tsgo（TS/JS 用）
+              const tsgoPath = await resolveTsgoPath(projectDir);
+              if (tsgoPath) {
+                clients.push(
+                  createLspClient({
+                    rootDir: projectDir,
+                    server: { kind: "tsgo", binaryPath: tsgoPath },
+                    onDiagnostics: (relPath, diags) => diagCallback("tsgo", relPath, diags),
+                    onError: (msg) => console.error(`[lsp:tsgo] ${msg}`),
+                  }),
+                );
               }
-              win.webview.rpc?.send.lspDiagnostics({ relPath, diagnostics });
-            };
 
-            // tsgo（TS/JS 用）
-            const tsgoPath = await resolveTsgoPath(projectDir);
-            if (tsgoPath) {
-              clients.push(
-                createLspClient({
-                  rootDir: projectDir,
-                  server: { kind: "tsgo", binaryPath: tsgoPath },
-                  onDiagnostics: (relPath, diags) => diagCallback("tsgo", relPath, diags),
-                  onError: (msg) => console.error(`[lsp:tsgo] ${msg}`),
-                }),
-              );
-            }
+              // Vue Language Server（Vue SFC 用、apps/renderer をルートにする）
+              const rendererDir = path.join(projectDir, "apps", "renderer");
+              console.log(`[lsp:vue] rendererDir: ${rendererDir}`);
+              const vuePaths = resolveVueLspPaths(projectDir, rendererDir);
+              console.log(`[lsp:vue] resolved paths:`, vuePaths ?? "not found");
+              if (vuePaths) {
+                console.log(`[lsp:vue] server: ${vuePaths.serverPath}, tsdk: ${vuePaths.tsdkPath}`);
+                const RENDERER_PREFIX = "apps/renderer/";
+                clients.push(
+                  createLspClient({
+                    rootDir: rendererDir,
+                    server: {
+                      kind: "vue",
+                      serverPath: vuePaths.serverPath,
+                      tsdkPath: vuePaths.tsdkPath,
+                      pluginProbeLocation: vuePaths.pluginProbeLocation,
+                    },
+                    onDiagnostics: (relPath, diagnostics) => {
+                      diagCallback("vue", `${RENDERER_PREFIX}${relPath}`, diagnostics);
+                    },
+                    onError: (msg) => console.error(`[lsp:vue] ${msg}`),
+                  }),
+                );
+              }
 
-            // Vue Language Server（Vue SFC 用、apps/renderer をルートにする）
-            const rendererDir = path.join(projectDir, "apps", "renderer");
-            console.log(`[lsp:vue] rendererDir: ${rendererDir}`);
-            const vuePaths = resolveVueLspPaths(projectDir, rendererDir);
-            console.log(`[lsp:vue] resolved paths:`, vuePaths ?? "not found");
-            if (vuePaths) {
-              console.log(`[lsp:vue] server: ${vuePaths.serverPath}, tsdk: ${vuePaths.tsdkPath}`);
-              const RENDERER_PREFIX = "apps/renderer/";
-              clients.push(
-                createLspClient({
-                  rootDir: rendererDir,
-                  server: {
-                    kind: "vue",
-                    serverPath: vuePaths.serverPath,
-                    tsdkPath: vuePaths.tsdkPath,
-                    pluginProbeLocation: vuePaths.pluginProbeLocation,
-                  },
-                  onDiagnostics: (relPath, diagnostics) => {
-                    diagCallback("vue", `${RENDERER_PREFIX}${relPath}`, diagnostics);
-                  },
-                  onError: (msg) => console.error(`[lsp:vue] ${msg}`),
-                }),
-              );
-            }
+              if (clients.length === 0) {
+                console.log("[lsp] no LSP servers found, skipping");
+                return;
+              }
 
-            if (clients.length === 0) {
-              console.log("[lsp] no LSP servers found, skipping");
-              return;
-            }
-
-            windowLspClients.set(win, clients);
-            await Promise.all(clients.map((lsp) => lsp.scanProject()));
-          })();
+              windowLspClients.set(win, clients);
+              await Promise.all(clients.map((lsp) => lsp.scanProject()));
+            })();
         },
       },
     },


### PR DESCRIPTION
## 概要

LSP 機能（tsgo + Vue Language Server の起動・診断通知）を一時的に無効化する。

## 背景

現時点で LSP 診断パネルを積極的に使用していないため、不要なプロセス起動を避ける。将来的に再有効化する可能性があるため、コード削除ではなくフラグによる無効化とした。

## 変更内容

### desktop

- `rendererReady` 内の LSP 起動ブロックを `if (lspEnabled)` で囲み、`lspEnabled = false` で無効化
- 再有効化時はフラグを `true` に変更するだけで復帰可能

### 変更なし

- renderer 側の diagnostics コード（store, パネル, RPC 購読）はメッセージが来なければ空のまま動作するため変更不要
- RPC スキーマの `lspDiagnostics` メッセージ定義もそのまま残す

## スコープ

- **スコープ内**: LSP 起動の無効化
- **スコープ外（対応しない）**: LSP 関連コード・依存パッケージの削除（再有効化の可能性があるため）

## 確認事項

- [ ] アプリ起動時に LSP プロセスが起動しないこと
- [ ] diagnostics パネルが空のまま表示されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Disabled Language Server Protocol (LSP) diagnostics in the desktop application. Code diagnostics and project scanning features are now inactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->