### PR TITLE
fix(desktop): build スクリプトの unset を env -u に置換する

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "GOZD_DEV_PROJECT_ROOT=$PWD pnpm exec electrobun dev",
-    "build": "unset GOZD_DEV_PROJECT_ROOT && pnpm exec electrobun build --env=stable",
+    "build": "env -u GOZD_DEV_PROJECT_ROOT pnpm exec electrobun build --env=stable",
     "typecheck": "tsgo --noEmit",
     "test": "bun test --run",
     "lint": "oxlint --type-aware",


### PR DESCRIPTION
## 概要

`apps/desktop/package.json` の build スクリプトで `unset GOZD_DEV_PROJECT_ROOT` を `env -u GOZD_DEV_PROJECT_ROOT` に置換する。

## 背景

#186 で build スクリプトに `unset GOZD_DEV_PROJECT_ROOT &&` を追加した。シェルで `export` されていた場合の環境変数リークを防ぐ目的だったが、pnpm v10 の shell-emulator（`pnpm-workspace.yaml` で `shellEmulator: true`）は `unset` をシェルビルトインとして認識せず、`command not found: unset`（exit status 127）で build が失敗する。

`env -u VAR` は `/usr/bin/env` 外部コマンドなので shell-emulator に依存しない。macOS・Linux 両方でサポートされている。

## 変更内容

### `apps/desktop/package.json`

- build スクリプト: `unset GOZD_DEV_PROJECT_ROOT && pnpm exec electrobun build --env=stable` → `env -u GOZD_DEV_PROJECT_ROOT pnpm exec electrobun build --env=stable`

## スコープ

- **スコープ内**: build スクリプトの shell-emulator 互換性修正
- **スコープ外（対応しない）**: pnpm shell-emulator の無効化（プロジェクトのポリシーとして有効にしている）

## 確認事項

- [ ] `pnpm build` が正常に完了すること
- [ ] `export GOZD_DEV_PROJECT_ROOT=/tmp && pnpm build` でも `isDev` が `false` になり dist がコピーされること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build script configuration for improved cross-platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->