### PR TITLE
feat(git-graph): default to Uncommitted Changes when no commit selected

### DIFF
--- a/apps/renderer/src/features/changes/ChangesPane.vue
+++ b/apps/renderer/src/features/changes/ChangesPane.vue
@@ -11,6 +11,7 @@ Changed files list. Shows HEAD vs working directory by default, or a selected co
 
 <script setup lang="ts">
 import type { GitFileChange } from "@gozd/rpc";
+import { tryCatch } from "@gozd/shared";
 import { computed, ref, watch } from "vue";
 import { useRpc } from "../../shared/rpc";
 import { getFileIconName, getIconUrl } from "../filer";
@@ -29,6 +30,8 @@ const gitStatusStore = useGitStatusStore();
 /** コミット選択時に取得した変更ファイル一覧 */
 const commitFiles = ref<GitFileChange[]>([]);
 const loading = ref(false);
+/** in-flight リクエストの無効化用シーケンス番号 */
+let requestSeq = 0;
 
 /** Uncommitted Changes 行が選択されているか */
 const isUncommittedMode = computed(() => gitGraphStore.selectedHash === UNCOMMITTED_HASH);
@@ -106,15 +109,22 @@ function dirPath(filePath: string): string {
 watch(
   () => [gitGraphStore.selectedHash, gitGraphStore.compareHash] as const,
   async ([hash, compareHash]) => {
+    const seq = ++requestSeq;
     if (hash === UNCOMMITTED_HASH && compareHash === null) {
       commitFiles.value = [];
+      loading.value = false;
       return;
     }
     loading.value = true;
-    commitFiles.value = await request.gitCommitFiles({
-      hash,
-      compareHash: compareHash ?? undefined,
-    });
+    const result = await tryCatch(
+      request.gitCommitFiles({
+        hash,
+        compareHash: compareHash ?? undefined,
+      }),
+    );
+    // 別のリクエストが発行済みなら結果を破棄
+    if (seq !== requestSeq) return;
+    commitFiles.value = result.ok ? result.value : [];
     loading.value = false;
   },
   { immediate: true },

--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -83,7 +83,7 @@ async function loadLog() {
     hash !== null && hash !== UNCOMMITTED_HASH && !result.some((c) => c.hash === hash);
 
   if (isStale(selectedHash) || isStale(compareHash)) {
-    gitGraphStore.clearSelection();
+    gitGraphStore.resetSelection();
   }
 }
 
@@ -93,14 +93,14 @@ onMounted(loadLog);
 watch(
   () => worktreeStore.dir,
   () => {
-    gitGraphStore.clearSelection();
+    gitGraphStore.resetSelection();
     void loadLog();
   },
 );
 
 // firstParentOnly 切替時に再取得
 watch(firstParentOnly, () => {
-  gitGraphStore.clearSelection();
+  gitGraphStore.resetSelection();
   void loadLog();
 });
 

--- a/apps/renderer/src/features/git-graph/useGitGraphStore.ts
+++ b/apps/renderer/src/features/git-graph/useGitGraphStore.ts
@@ -18,12 +18,12 @@ export const useGitGraphStore = defineStore("gitGraph", () => {
     compareHash.value = hash;
   }
 
-  function clearSelection() {
+  function resetSelection() {
     selectedHash.value = UNCOMMITTED_HASH;
     compareHash.value = null;
   }
 
-  return { selectedHash, compareHash, select, selectCompare, clearSelection };
+  return { selectedHash, compareHash, select, selectCompare, resetSelection };
 });
 
 if (import.meta.hot) {


### PR DESCRIPTION
## 概要

git graph でコミット未選択時に changes パネルが "No changes" と表示される問題を修正。未選択状態を Uncommitted Changes 選択状態にフォールバックすることで、初期状態から変更ファイルが確認できるようにした。

## 背景

git graph でコミットを選択していない状態では changes パネルが空（"No changes"）になっていた。実際にはワーキングツリーに変更があっても表示されないため、ユーザーが明示的に Uncommitted Changes 行をクリックする必要があった。

## 変更内容

### git-graph store

- `selectedHash` の型を `string | null` → `string` に変更し、初期値を `UNCOMMITTED_HASH` に設定
- `resetSelection()` が `UNCOMMITTED_HASH` にリセットするように変更（旧 `clearSelection` からリネーム）
- `selectCompare()` の null ガードを削除（`selectedHash` が常に非 null のため不要に）

### ChangesPane

- `selectedHash === null` の分岐を削除（到達不能コードの除去）
- `requestSeq` カウンターで in-flight リクエストの stale 応答を破棄するように修正
- UNCOMMITTED_HASH フォールバック時に `loading` を明示的にリセット
- `tryCatch` で RPC エラーハンドリングを追加

### GitGraphPane

- `selectedHash === null` の分岐を削除
- `clearSelection` → `resetSelection` のリネーム対応

## スコープ

- **スコープ内**: 未選択時のデフォルト選択状態の変更、null チェックの除去、in-flight リクエストの stale 防止
- **スコープ外（対応しない）**: git graph UI で Uncommitted Changes 行の選択を解除する操作（もう一度クリックで解除等）。「常に何かが選択されている」設計に統一

## 確認事項

- [ ] 初期表示で Uncommitted Changes が選択状態になり、changes パネルに変更ファイルが表示される
- [ ] worktree 切り替え後も Uncommitted Changes にフォールバックする
- [ ] コミット選択 → resetSelection 後に Uncommitted Changes に戻る
- [ ] shift+クリックの範囲選択が正常に動作する
- [ ] コミットを素早く切り替えた時に古いリクエストの結果が表示されない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changes pane now defaults to showing "Uncommitted Changes" and reliably clears file lists and loading state on failures or when no commit is selected.
* **Improvements**
  * Selection and range behavior in the git graph is more consistent and resilient; concurrent loading is handled so only the latest results are shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->