### PR TITLE
fix(worktree): create parent directories for nested symlink targets

### DIFF
--- a/apps/desktop/src/git/worktree.ts
+++ b/apps/desktop/src/git/worktree.ts
@@ -131,13 +131,21 @@ async function createWorktreeSymlinks(
       const sourceResult = await tryCatch(resolveExistingFsPath(mainRepoDir, target));
       if (!sourceResult.ok) return;
 
-      // 論理パスでトラバーサルを事前チェック（mkdir 前にセキュリティ検証）
-      const logicalResult = tryCatch(() => resolveGitPath(wtPath, target));
-      if (!logicalResult.ok) return;
-
       // ネストされたパスに対応するため、親ディレクトリを作成
-      const destParent = path.dirname(logicalResult.value);
-      await tryCatch(fsp.mkdir(destParent, { recursive: true }));
+      // resolveGitPath で論理パスのトラバーサルを事前チェックし、
+      // mkdir 後に resolveExistingFsPath で実パスが worktree 内に収まることを検証する
+      const targetDir = path.dirname(target);
+      if (targetDir !== ".") {
+        const logicalResult = tryCatch(() => resolveGitPath(wtPath, targetDir));
+        if (!logicalResult.ok) return;
+
+        const mkdirResult = await tryCatch(fsp.mkdir(logicalResult.value, { recursive: true }));
+        if (!mkdirResult.ok) return;
+
+        // mkdir で作成されたパスが symlink 経由で worktree 外に出ていないか実パスで検証
+        const parentCheck = await tryCatch(resolveExistingFsPath(wtPath, targetDir));
+        if (!parentCheck.ok) return;
+      }
 
       // dest: 親ディレクトリの realpath を検証し、worktree 外への書き込みを防止
       const destResult = await tryCatch(resolveCreatableFsPath(wtPath, target));


### PR DESCRIPTION
## 概要

worktree 作成時のシンボリックリンク処理で、ネストしたパス（例: `.claude/settings.local.json`）を指定した場合に親ディレクトリが存在せずリンクが作成されない問題を修正する。

## 背景

PR #206 で worktree symlinks 機能を追加したが、`.claude/settings.local.json` のようなネストしたパスを指定すると静かにスキップされていた。

原因は `resolveCreatableFsPath` が `fsp.realpath(parent)` で親ディレクトリの実パスを取得する設計のため、親ディレクトリ（`.claude/`）が worktree に存在しないとエラーになり、`tryCatch` で握りつぶされていたこと。

`.claude` ディレクトリ全体をシンボリックリンクする方法も検討したが、`.claude` には git 管理下のファイル（`settings.json` 等）も含まれるため、git が untracked として検出してしまう。個別ファイル指定が正しいアプローチであり、そのためにネストパスのサポートが必要。

## 変更内容

### `apps/desktop/src/git/worktree.ts`

- ネストしたパスの場合のみ親ディレクトリを `fsp.mkdir` で作成
- `resolveGitPath` で論理パスのトラバーサルを事前チェック（mkdir 前）
- `resolveExistingFsPath` で mkdir 後の実パスが worktree 内に収まることを検証
- `mkdir` 失敗時に早期リターン（結果を握りつぶさない）
- `resolveGitPath` のインポートを追加

## スコープ

- **スコープ内**: ネストしたパスの symlink 作成時に親ディレクトリを自動作成、セキュリティ検証
- **スコープ外（別 PR で対応）**: 既存 worktree への後からの symlink 適用、prefix 衝突する設定の検出

## 確認事項

- [ ] `.claude/settings.local.json` を worktreeSymlinks に設定し、worktree 作成後にシンボリックリンクが作られること
- [ ] `../` や絶対パスの指定がバリデーションで拒否されること
- [ ] メインリポジトリに存在しないネストパスの指定がエラーにならずスキップされること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced symlink creation for git worktrees: parent directories are now pre-validated, created when needed, and re-checked to ensure paths remain inside the worktree before link creation, reducing failures and improving safety when initializing or updating worktrees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->