### PR TITLE
feat(worktree): auto-select worktree after creation

### DIFF
--- a/apps/renderer/src/features/sidebar/features/worktree/useWorktreeActions.ts
+++ b/apps/renderer/src/features/sidebar/features/worktree/useWorktreeActions.ts
@@ -109,12 +109,11 @@ export function useWorktreeActions({
     );
     if (result.ok) {
       await fetchData();
-      isCreating.value = false;
       await handleWorktreeSelect(result.value);
     } else {
       freeBranches.value.push(branch);
-      isCreating.value = false;
     }
+    isCreating.value = false;
   }
 
   function removeFromList(wt: WorktreeEntry) {
@@ -164,10 +163,10 @@ export function useWorktreeActions({
       request.createWorktreeWithTodo({ id: todo.id, worktreeDir, branch }),
     );
     await fetchData();
-    isCreating.value = false;
     if (result.ok) {
       await handleWorktreeSelect(result.value.worktree);
     }
+    isCreating.value = false;
   }
 
   /** ブランチを worktree 化する */


### PR DESCRIPTION
## 概要

worktree 作成後に自動で新しい worktree を選択（表示切り替え）するようにした。

## 背景

これまで worktree を作成すると、サイドバーのリストに追加されるだけで、表示は切り替わらなかった。ユーザーは作成後に手動でクリックして切り替える必要があった。作成直後は新しい worktree で作業を始めたいのが自然な流れなので、自動選択を追加する。

## 変更内容

### `useWorktreeActions.ts`

- `createWorktree`（ブランチからの worktree 化）: RPC 成功後に `handleWorktreeSelect` を呼び出して自動切り替え
- `createWorktreeWithTodo`（Todo 付き worktree 作成）: 同様に RPC 成功後に自動切り替え
- 両方とも RPC の戻り値に含まれる `WorktreeEntry` をそのまま `handleWorktreeSelect` に渡す
- `isCreating` のリセットを `handleWorktreeSelect` 完了後に移動し、切り替え中に次の作成が走る競合を防止

## スコープ

- **スコープ内**: worktree 作成後の自動選択
- **スコープ外（対応しない）**: worktree 削除後のフォールバック先の自動選択（別の操作なので今回は対象外）

## 確認事項

- [ ] ブランチ一覧から worktree を作成した後、自動で切り替わること
- [ ] サイドバーの新規作成パネルから worktree を作成した後、自動で切り替わること
- [ ] 作成に失敗した場合は切り替えが発生しないこと


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Newly created worktrees are now automatically selected after successful creation (including the "create with todo" flow).
  * Creation flows now correctly check success before selecting and ensure loading state transitions behave consistently on success or failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->