### PR TITLE
feat(navigator): auto-activate Changes tab on git-graph selection

### DIFF
--- a/apps/renderer/src/features/git-graph/useGitGraphStore.ts
+++ b/apps/renderer/src/features/git-graph/useGitGraphStore.ts
@@ -7,15 +7,19 @@ export const useGitGraphStore = defineStore("gitGraph", () => {
   const selectedHash = ref<string>(UNCOMMITTED_HASH);
   /** shift+クリックで指定した比較対象のコミットハッシュ。null は単一選択モード */
   const compareHash = ref<string | null>(null);
+  /** ユーザー操作による選択のバージョン。select / selectCompare でのみインクリメント */
+  const selectionVersion = ref(0);
 
   function select(hash: string) {
     selectedHash.value = hash;
     compareHash.value = null;
+    selectionVersion.value++;
   }
 
   /** shift+クリックで範囲選択の終点を指定する */
   function selectCompare(hash: string) {
     compareHash.value = hash;
+    selectionVersion.value++;
   }
 
   function resetSelection() {
@@ -23,7 +27,7 @@ export const useGitGraphStore = defineStore("gitGraph", () => {
     compareHash.value = null;
   }
 
-  return { selectedHash, compareHash, select, selectCompare, resetSelection };
+  return { selectedHash, compareHash, selectionVersion, select, selectCompare, resetSelection };
 });
 
 if (import.meta.hot) {

--- a/apps/renderer/src/features/navigator/NavigatorPane.vue
+++ b/apps/renderer/src/features/navigator/NavigatorPane.vue
@@ -24,9 +24,11 @@ const worktreeStore = useWorktreeStore();
 const filerPaneRef = useTemplateRef<InstanceType<typeof FilerPane>>("filerPane");
 const activeView = ref<NavigatorView>("files");
 
-/** git-graph でコミットを選択したら Changes タブをアクティブにする */
+/** git-graph でコミットを選択したら Changes タブをアクティブにする。
+ * selectionVersion は select / selectCompare でのみインクリメントされるため、
+ * resetSelection（worktree 切替等）では発火しない */
 watch(
-  () => gitGraphStore.selectedHash,
+  () => gitGraphStore.selectionVersion,
   () => {
     activeView.value = "changes";
   },


### PR DESCRIPTION
## 概要

git-graph でコミットを選択したとき、NavigatorPane の Changes タブを自動的にアクティブにする。

## 背景

git-graph でコミットをクリックすると ChangesPane のファイル一覧は自動更新されるが、Navigator のタブが Files のままだと変更内容をすぐに確認できなかった。コミット選択の意図は変更ファイルの確認であるため、タブも自動で切り替わるのが自然な UX。

## 変更内容

### useGitGraphStore

- `selectionVersion` カウンターを追加。`select` / `selectCompare` でのみインクリメント
- `resetSelection` ではインクリメントしないため、worktree 切替や stale selection 解消では発火しない

### NavigatorPane

- `gitGraphStore.selectionVersion` を watch し、変更時に `activeView` を `"changes"` に切り替え
- `watch` は `immediate` なしのため、初期表示ではトリガーしない

## スコープ

- **スコープ内**: git-graph のコミット選択（通常クリック・shift+クリック範囲選択）時に Changes タブをアクティブにする
- **スコープ外（対応しない）**: Changes タブから Files タブへの自動復帰（手動切り替えで対応）

## 確認事項

- [ ] git-graph でコミットをクリックしたとき Changes タブに切り替わる
- [ ] shift+クリックで範囲選択したとき Changes タブに切り替わる
- [ ] 初回表示時は Files タブのまま
- [ ] worktree 切替時にタブが勝手に切り替わらない
- [ ] firstParentOnly トグル時にタブが勝手に切り替わらない
- [ ] 手動で Files タブに切り替え可能


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The UI now automatically switches to the Changes view when you select or compare a commit in the git graph, making it easier to review modifications. Manual tab selection still works as before; clearing selection does not trigger the automatic view switch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->