### PR TITLE
feat(barrel-import): ネストスコープ修正と barrelFiles / scopes オプション化

### DIFF
--- a/packages/eslint-plugin/src/rules/barrelImport.test.ts
+++ b/packages/eslint-plugin/src/rules/barrelImport.test.ts
@@ -39,11 +39,20 @@ const BASE = "/project/apps/renderer/src";
  * │   │       │       └── feat-B-grandchild/
  * │   │       │           ├── index.ts    ← バレル
  * │   │       │           └── internal.ts
- * │   │       └── feat-B-child-B/
+ * │   │       ├── feat-B-child-B/
+ * │   │       │   ├── index.ts            ← バレル
+ * │   │       │   └── CompBB.vue
+ * │   │       └── common/
  * │   │           ├── index.ts            ← バレル
- * │   │           └── CompBB.vue
- * │   └── feat-C/
- * │       └── storeC.ts
+ * │   │           └── helperB.ts
+ * │   ├── feat-C/
+ * │   │   └── storeC.ts
+ * │   └── feat-D/
+ * │       ├── index.ts                    ← バレル
+ * │       └── features/
+ * │           └── common/                 ← feat-B と同名の子 feature
+ * │               ├── index.ts            ← バレル
+ * │               └── helperD.ts
  * └── shared/
  *     ├── shared-A/
  *     │   ├── index.ts                    ← バレル
@@ -248,6 +257,17 @@ tester.run("barrel-import", rule, {
       name: "NG: 子 feature 間の内部直接 import",
       code: 'import CompBA from "../feat-B-child-A/CompBA.vue";',
       filename: `${BASE}/features/feat-B/features/feat-B-child-B/CompBB.vue`,
+      errors: [{ messageId: "noDirectImport" }],
+    },
+
+    // ─── 同名子 feature の誤判定防止 ────────────────
+    {
+      // feat-B/features/common/helperB.ts → feat-D/features/common/helperD.ts
+      // 同名の子 feature「common」が異なる親（feat-B, feat-D）の下にある場合、
+      // 同一スコープと誤判定してバレルチェックがスキップされてはならない
+      name: "NG: 異なる親の同名子 feature への内部ファイル直接 import",
+      code: 'import { helperD } from "../../../../feat-D/features/common/helperD";',
+      filename: `${BASE}/features/feat-B/features/common/helperB.ts`,
       errors: [{ messageId: "noDirectImport" }],
     },
 

--- a/packages/eslint-plugin/src/rules/barrelImport.ts
+++ b/packages/eslint-plugin/src/rules/barrelImport.ts
@@ -63,19 +63,42 @@ function buildScopePattern(scopes: Record<string, ScopeConfig>): RegExp {
   return new RegExp(`(?:^|/)((?:${dirPattern})/[^/]+)(?:/|$)`);
 }
 
+/** スコープの識別情報 */
+interface ScopeInfo {
+  /** スコープのリーフペア（例: "features/common"）。ディレクトリ名やバレル判定に使用 */
+  scope: string;
+  /** パス先頭からスコープ末尾までのフルパス。同一性判定に使用 */
+  fullPath: string;
+}
+
 /**
  * パス内の全スコープを浅い順に抽出する。
  * 例: "src/features/sidebar/features/worktree/WorktreeItem.vue"
- *     → ["features/sidebar", "features/worktree"]
+ *     → [
+ *         { scope: "features/sidebar", fullPath: "src/features/sidebar" },
+ *         { scope: "features/worktree", fullPath: "src/features/sidebar/features/worktree" },
+ *       ]
+ *
+ * fullPath により、異なる親の下にある同名子スコープを区別できる。
  */
-function extractAllScopes(filePath: string, scopePattern: RegExp): string[] {
-  const scopes: string[] = [];
+function extractAllScopes(
+  filePath: string,
+  scopePattern: RegExp,
+): ScopeInfo[] {
+  const scopes: ScopeInfo[] = [];
   let searchFrom = 0;
   while (searchFrom < filePath.length) {
     const remaining = filePath.slice(searchFrom);
     const match = scopePattern.exec(remaining);
     if (!match) break;
-    scopes.push(match[1]);
+    const matchEnd = searchFrom + match.index + match[1].length;
+    // match[0] の先頭が "/" の場合、match.index + 1 からスコープが始まる
+    const scopeStart =
+      match[0].startsWith("/") ? match.index + 1 : match.index;
+    scopes.push({
+      scope: match[1],
+      fullPath: filePath.slice(0, searchFrom + scopeStart + match[1].length),
+    });
     searchFrom += match.index + match[0].length;
   }
   return scopes;
@@ -84,10 +107,10 @@ function extractAllScopes(filePath: string, scopePattern: RegExp): string[] {
 /**
  * パスから最深スコープを抽出する。
  */
-function extractScope(
+function extractDeepestScope(
   filePath: string,
   scopePattern: RegExp,
-): string | undefined {
+): ScopeInfo | undefined {
   const scopes = extractAllScopes(filePath, scopePattern);
   return scopes[scopes.length - 1];
 }
@@ -274,17 +297,17 @@ const rule: Rule.RuleModule = {
       );
 
       // import 先の全スコープを抽出（浅い順）
-      const toScopes = extractAllScopes(resolvedPath, scopePattern);
-      if (toScopes.length === 0) return;
+      const toScopeInfos = extractAllScopes(resolvedPath, scopePattern);
+      if (toScopeInfos.length === 0) return;
 
-      const toScope = toScopes[toScopes.length - 1]; // 最深スコープ
-      const toRootScope = toScopes[0]; // 最浅スコープ（外部から見える境界）
+      const toDeepest = toScopeInfos[toScopeInfos.length - 1]; // 最深スコープ
+      const toRoot = toScopeInfos[0]; // 最浅スコープ（外部から見える境界）
 
       // スコープ間の依存方向チェック
-      const fromRootScopes = extractAllScopes(filename, scopePattern);
-      if (fromRootScopes.length > 0) {
-        const fromRootDir = getScopeDir(fromRootScopes[0]);
-        const toRootDir = getScopeDir(toRootScope);
+      const fromScopeInfos = extractAllScopes(filename, scopePattern);
+      if (fromScopeInfos.length > 0) {
+        const fromRootDir = getScopeDir(fromScopeInfos[0].scope);
+        const toRootDir = getScopeDir(toRoot.scope);
         if (
           !isDependencyAllowed(fromRootDir, toRootDir, scopes, dirToScope)
         ) {
@@ -303,25 +326,32 @@ const rule: Rule.RuleModule = {
       }
 
       // import 元の最深スコープを抽出
-      const fromScope = extractScope(filename, scopePattern);
+      const fromDeepest = extractDeepestScope(filename, scopePattern);
 
-      // 同じスコープ内のファイル同士は自由
-      if (fromScope === toScope) return;
+      // 同じスコープ内のファイル同士は自由（fullPath で比較し、同名子スコープを区別）
+      if (fromDeepest && fromDeepest.fullPath === toDeepest.fullPath) return;
 
       // 子スコープから親スコープの内部ファイルへのアクセスは自由
-      // import 元のパスに to のスコープが含まれている = to は from の祖先スコープ
-      if (fromScope && fromScope !== toScope && filename.includes(`/${toScope}/`))
+      // import 元のパスに to のスコープの fullPath が含まれている = to は from の祖先スコープ
+      if (
+        fromDeepest &&
+        fromDeepest.fullPath !== toDeepest.fullPath &&
+        filename.includes(`${toDeepest.fullPath}/`)
+      )
         return;
 
       // import 元がルートスコープの内部にいるか判定
       // 内部 = import 元自身がルートスコープ、またはルートスコープの子孫
       const isInsideRootScope =
-        fromScope === toRootScope || filename.includes(`/${toRootScope}/`);
+        (fromDeepest && fromDeepest.fullPath === toRoot.fullPath) ||
+        filename.includes(`${toRoot.fullPath}/`);
 
       // バレル経由のチェック
       // 内部にいる → 子スコープのバレル（最深スコープ）経由ならOK
       // 外部にいる → ルートスコープのバレルのみOK（子スコープは親の内部実装）
-      const allowedScope = isInsideRootScope ? toScope : toRootScope;
+      const allowedScope = isInsideRootScope
+        ? toDeepest.scope
+        : toRoot.scope;
       if (isBarrelImport(importSource, allowedScope, barrelFiles)) return;
 
       // それ以外は禁止


### PR DESCRIPTION
## 概要

barrel-import ESLint ルールで、外部からネストされた子 feature を直接参照できてしまうバグを修正。あわせて、`barrelFiles` と `scopes` オプションを追加し、プロジェクト固有のハードコードを除去して汎用的なプラグインとして使えるようにした。

## 背景

`features/feat-A/` から `features/feat-B/features/feat-B-child-A/` をバレル経由で import した場合、現行ルールはこれを許可していた。子 feature は親 feature の内部実装であり、外部からは親のバレル（`features/feat-B/`）経由でのみアクセス可能にすべき。

原因は2つ:
- `extractScope` が最深スコープのみを返す設計で、import 先のルートスコープ（外部から見える境界）を考慮していなかった
- `isBarrelImport` が `index.ts` を無条件で許可しており、明示指定で制限を迂回できた

また、`features` / `shared` のディレクトリ名と依存方向（`shared → features` 禁止）がハードコードされており、将来の独立プラグイン化に障害があった。eslint-plugin-boundaries の設計を調査したが、`type` ベースのフラット定義では再帰的ネスト構造を扱えないため、自作ルールの拡張で対応した。

## 変更内容

### ネストスコープの修正

- `extractAllScopes` を追加し、パス内の全スコープを浅い順に取得できるようにした
- `check` 関数で `toRootScope`（最浅スコープ）を取得し、import 元がルートスコープの内部にいるかどうかで許可するバレルを切り替える
- `isBarrelImport` で拡張子付き import 時も直前のセグメントが許可スコープ名と一致するか検証

### 同名子スコープの区別

- `ScopeInfo` 型を導入し、`scope`（リーフペア）と `fullPath`（パス先頭からスコープ末尾まで）を保持
- 同一スコープ判定を `fullPath` ベースに変更し、異なる親の下にある同名子スコープ（例: `feat-B/features/common` と `feat-D/features/common`）を正しく区別

### `barrelFiles` オプション

- デフォルト: `["index.ts", "index.tsx"]`
- ユーザーが `index.js` / `index.jsx` 等を追加可能
- 拡張子なしのディレクトリ import は `barrelFiles` に関係なく常に許可

### `scopes` オプション

- `features` / `shared` のハードコードを完全に除去
- 各スコープは `directories`（ディレクトリ名リスト）と `dependsOn`（依存可能なスコープ名リスト）を宣言
- `buildScopePattern` で正規表現を動的構築（メタ文字エスケープ付き）
- デフォルト設定は従来と同じ挙動:
  ```json
  {
    "shared": { "directories": ["shared"], "dependsOn": [] },
    "features": { "directories": ["features"], "dependsOn": ["shared"] }
  }
  ```

### 設定バリデーション

- 空 `scopes`、空 `directories`、重複ディレクトリ名、未定義 `dependsOn` を検出しエラー報告

### テスト（46テスト）

- テストパス名を抽象化（`feat-A`, `feat-B`, `feat-B-child-A` 等）
- カスタム scopes（`core` / `common` / `modules` の3層）のテストスイートを追加
- 設定バリデーションのテスト（空 scopes、空 directories、重複、未定義 dependsOn）
- 同名子スコープの回帰テスト
- 欠けていたテストケースを網羅的に追加

## スコープ

- **スコープ内**: ネストスコープのバグ修正、同名子スコープの区別、`barrelFiles` / `scopes` オプション化、設定バリデーション、テスト整理
- **スコープ外（対応しない）**: 既存コードベースでの違反検出。lint を実行すれば検出される

## 確認事項

- [ ] `pnpm --filter @gozd/eslint-plugin test --run` が全テスト通過すること
- [ ] `pnpm lint:all` で既存コードに新たな違反が出ないか確認
