### PR TITLE
fix(worktree): worktree 作成後のリスト更新を楽観的更新に変更

### DIFF
--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -80,7 +80,7 @@ const {
   handleWorktreeRemove,
   createWorktreeWithTodo,
   handleBranchLink,
-} = useWorktreeActions({ worktrees, freeBranches, fetchData, showConfirm, showAlert });
+} = useWorktreeActions({ worktrees, freeBranches, showConfirm, showAlert });
 
 const {
   editingTodoId,

--- a/apps/renderer/src/features/sidebar/features/worktree/useWorktreeActions.ts
+++ b/apps/renderer/src/features/sidebar/features/worktree/useWorktreeActions.ts
@@ -10,7 +10,6 @@ import { generateTimestamp, worktreeDisplayName } from "../../utils";
 interface UseWorktreeActionsOptions {
   worktrees: Ref<WorktreeEntry[]>;
   freeBranches: Ref<string[]>;
-  fetchData: () => Promise<void>;
   showConfirm: (message: string, action: () => Promise<void>) => void;
   showAlert: (message: string) => void;
 }
@@ -22,7 +21,6 @@ interface UseWorktreeActionsOptions {
 export function useWorktreeActions({
   worktrees,
   freeBranches,
-  fetchData,
   showConfirm,
   showAlert,
 }: UseWorktreeActionsOptions) {
@@ -115,12 +113,11 @@ export function useWorktreeActions({
     branch: string;
   }) {
     isCreating.value = true;
-    // 失敗しても Todo は残る。fetchData で TODOS 欄に反映され、再試行または削除できる
     const result = await tryCatch(
       request.createWorktreeWithTodo({ id: todo.id, worktreeDir, branch }),
     );
-    await fetchData();
     if (result.ok) {
+      worktrees.value = [...worktrees.value, result.value.worktree];
       await handleWorktreeSelect(result.value.worktree);
     }
     isCreating.value = false;


### PR DESCRIPTION
## 概要

worktree 作成後のリスト更新を `fetchData()` から楽観的更新に変更し、新しい worktree が UI に表示されない・切り替わらない問題を修正する。

## 背景

#226 で「New worktree」の即座作成を導入した後、以下の問題が発生していた:

- 「New worktree」ボタンで作成した worktree が表示されず切り替わらないケースがある
- 既存ブランチからの worktree 作成（メニュー経由）では100%表示されない
- worktree 自体は作成されているが、UI に反映されない

原因は `fetchData()` の世代カウンタ（stale 検出）の競合。desktop 側で `createWorktree` RPC が完了すると `void syncWorktreeWatchers()` が発火し、ファイル監視イベント経由で renderer に `gitStatusChange` / `worktreeChange` が届く。これが `addWorktree` / `createWorktree` / `createWorktreeWithTodo` 内の `await fetchData()` と競合し、世代番号が上がることで元の `fetchData` の結果が stale 扱いで破棄される。結果として `worktrees.value` が更新されず、UI にも反映されなかった。

## 変更内容

### 全 worktree 作成経路を楽観的更新に統一

- `createWorktree` / `addWorktree` / `createWorktreeWithTodo` 内の `await fetchData()` を `worktrees.value = [...worktrees.value, result.value]` に置き換え
- `createWorktree` RPC の戻り値は `WorktreeEntry` そのものなので、リストに直接追加すれば即座に UI に反映される
- `handleWorktreeSelect` → `switchDir` → `worktreeStore.setOpen()` で dir が変わり、`useSidebarData` の watcher 経由で `fetchData` が自然に走るため、changeCounts 等の完全なデータも後続で更新される
- `useWorktreeActions` から `fetchData` 引数を除去（不要になったため）

## 確認事項

- [ ] 「New worktree」クリックで worktree がリストに表示されて切り替わること
- [ ] 既存ブランチからの worktree 作成でリストに表示されて切り替わること
- [ ] メニューの「Create worktree」（Todo → worktree 作成）でリストに表示されて切り替わること
- [ ] 作成後、changeCounts（変更ファイル数バッジ）が後続の fetchData で正しく更新されること


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Worktree creation and addition now update the visible list locally (no full refresh), yielding faster, more responsive updates.
  * Newly created worktrees are immediately selected and reflected in the list to ensure consistent UI state after creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->