### PR TITLE
fix(rpc): 大規模リポジトリでの worktree 作成タイムアウトを修正

### DIFF
--- a/apps/renderer/src/shared/rpc/useRpc.ts
+++ b/apps/renderer/src/shared/rpc/useRpc.ts
@@ -16,6 +16,7 @@ const listeners = {
 };
 
 const rpc = Electroview.defineRPC<GozdRPC>({
+  maxRequestTime: 5000,
   handlers: {
     requests: {},
     messages: {


### PR DESCRIPTION
## 概要

Electrobun RPC の `maxRequestTime` を 5000ms に設定し、大規模リポジトリでの worktree 作成時の RPC タイムアウトを解消する。

## 背景

50万ファイル規模のリポジトリで new worktree を作成すると、`git worktree add` に約 1152ms かかる。Electrobun RPC のデフォルトタイムアウトは 1000ms のため、desktop 側は正常に処理完了して return するが、renderer 側では既にタイムアウト reject 済みで応答が破棄される。結果、worktree 作成後の自動選択（`setOpen`）が実行されない。

Electrobun RPC はリクエスト単位のタイムアウト設定を提供していないため、全体の `maxRequestTime` を延長する暫定対応とした。

## 変更内容

### RPC 設定

- `Electroview.defineRPC` に `maxRequestTime: 5000` を追加

## スコープ

- **スコープ内**: タイムアウト値の延長による暫定修正
- **スコープ外（別 PR で対応）**: `createWorktree` を accept + completion event パターン（message ベース）に移行する本対応

## 確認事項

- [ ] 50万ファイル規模のリポジトリで new worktree 作成後に自動選択されること
- [ ] 既存の RPC request（ファイル読み込み、git status 等）が正常に動作すること


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 5-second timeout limit to RPC requests, preventing requests from hanging indefinitely and improving overall application responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->