### PR TITLE
refactor(renderer): バレルファイルの不要な export を整理

### DIFF
--- a/apps/renderer/src/features/changes/ChangesPane.vue
+++ b/apps/renderer/src/features/changes/ChangesPane.vue
@@ -11,11 +11,12 @@ Changed files list. Shows HEAD vs working directory by default, or a selected co
 
 <script setup lang="ts">
 import type { GitFileChange } from "@gozd/rpc";
+import { UNCOMMITTED_HASH } from "@gozd/rpc";
 import { tryCatch } from "@gozd/shared";
 import { computed, ref, watch } from "vue";
 import { useRpc } from "../../shared/rpc";
 import { getFileIconName, getIconUrl } from "../filer";
-import { UNCOMMITTED_HASH, useGitGraphStore } from "../git-graph";
+import { useGitGraphStore } from "../git-graph";
 import { useGitStatusStore, resolveGitChangeKind } from "../worktree";
 import type { GitChangeKind } from "../worktree";
 

--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -10,6 +10,7 @@ Git commit graph showing the current worktree branch and the default branch.
 
 <script setup lang="ts">
 import type { GitCommit } from "@gozd/rpc";
+import { UNCOMMITTED_HASH } from "@gozd/rpc";
 import { storeToRefs } from "pinia";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { useRpc } from "../../shared/rpc";
@@ -17,7 +18,6 @@ import { useGitStatusStore, useWorktreeStore } from "../worktree";
 import { computeGraphLayout } from "./graphLayout";
 import type { GraphLayout } from "./graphLayout";
 import { useGitGraphStore } from "./useGitGraphStore";
-import { UNCOMMITTED_HASH } from ".";
 
 const { request, onGitStatusChange } = useRpc();
 const worktreeStore = useWorktreeStore();

--- a/apps/renderer/src/features/git-graph/index.ts
+++ b/apps/renderer/src/features/git-graph/index.ts
@@ -1,3 +1,2 @@
 export { default as GitGraphPane } from "./GitGraphPane.vue";
 export { useGitGraphStore } from "./useGitGraphStore";
-export { UNCOMMITTED_HASH } from "@gozd/rpc";

--- a/apps/renderer/src/features/settings/index.ts
+++ b/apps/renderer/src/features/settings/index.ts
@@ -1,3 +1,3 @@
 export { globalSettingsDefaults } from "./globalSettingsSchema";
 export { default as SettingsModal } from "./SettingsModal.vue";
-export { registerSettingsCommand, useSettingsModal } from "./useSettingsModal";
+export { registerSettingsCommand } from "./useSettingsModal";

--- a/apps/renderer/src/features/worktree/index.ts
+++ b/apps/renderer/src/features/worktree/index.ts
@@ -6,4 +6,3 @@ export {
   resolveGitChangeKind,
 } from "./gitStatusUtils";
 export type { GitChangeKind } from "./gitStatusUtils";
-export { normalizePath } from "./pathUtils";


### PR DESCRIPTION
## 概要

feature バレルファイル（index.ts）の不要な export を削除し、公開 API を最小化する。

## 背景

各 feature のバレルファイルの export 数を調査したところ、外部から参照されていない export や、他パッケージの定数を中継しているだけの re-export が見つかった。不要な export は feature 間の暗黙的な結合を生み、変更の波及範囲を広げるリスクがある。

## 変更内容

### 外部未使用の export を削除

- `worktree/index.ts`: `normalizePath` を削除（外部使用 0 件、内部専用）
- `settings/index.ts`: `useSettingsModal` を削除（`SettingsModal.vue` 内部でのみ使用）

### re-export を直接参照に変更

- `git-graph/index.ts`: `@gozd/rpc` の `UNCOMMITTED_HASH` re-export を削除
- `changes/ChangesPane.vue`: `UNCOMMITTED_HASH` を `@gozd/rpc` から直接 import
- `git-graph/GitGraphPane.vue`: `UNCOMMITTED_HASH` をバレル自己参照（`"."`）から `@gozd/rpc` に変更

## スコープ

- **スコープ内**: 外部参照のない export の削除、re-export の直接参照化
- **スコープ外（別 PR で対応）**: `terminal` feature の責務分離（`ClaudeStatus` 型の移動等）、`worktree` の `gitStatusUtils` を shared に移動するかの検討

## 確認事項

- [ ] typecheck が通ること（pre-commit hook で確認済み）
- [ ] 各 feature の機能が正常に動作すること


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal module exports and imports to consolidate constant sourcing and simplify the public API surface of feature modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->