### PR TITLE
chore(renderer): ESLint の warn ルールをすべて error に昇格

### DIFF
--- a/apps/renderer/eslint.config.fix.ts
+++ b/apps/renderer/eslint.config.fix.ts
@@ -6,8 +6,8 @@ export default [
   ...baseConfig,
   {
     rules: {
-      "import-x/order": "warn",
-      "better-tailwindcss/enforce-canonical-classes": "warn",
+      "import-x/order": "error",
+      "better-tailwindcss/enforce-canonical-classes": "error",
     },
   },
 ];

--- a/apps/renderer/eslint.config.ts
+++ b/apps/renderer/eslint.config.ts
@@ -27,9 +27,9 @@ export default defineConfigWithVueTs(
     rules: {
       // unused-imports
       "@typescript-eslint/no-unused-vars": "off",
-      "unused-imports/no-unused-imports": "warn",
+      "unused-imports/no-unused-imports": "error",
       "unused-imports/no-unused-vars": [
-        "warn",
+        "error",
         {
           vars: "all",
           varsIgnorePattern: "^_",
@@ -40,7 +40,7 @@ export default defineConfigWithVueTs(
       ],
 
       // import-x
-      "import-x/no-duplicates": "warn",
+      "import-x/no-duplicates": "error",
       // 保存時の自動 lint で並び替えが発生すると編集中に邪魔なので off
       // lint:fix や pre-commit hook では eslint.config.fix.ts で有効化
       "import-x/order": [
@@ -78,7 +78,7 @@ export default defineConfigWithVueTs(
       // 各ルールは独立したワーカーで Tailwind Design System をロードするため、
       // 有効なルール数に比例して初期化コストが増加する（1ルールあたり約1秒）
       "better-tailwindcss/no-unknown-classes": [
-        "warn",
+        "error",
         {
           ignore: ["_.*"],
         },


### PR DESCRIPTION
## 概要

ESLint 設定で `"warn"` になっていた全ルールを `"error"` に昇格させる。

## 背景

warn レベルのルールは CI やエディタ上で表示されるものの、ビルドやチェックをブロックしないため違反が蓄積しやすい。全ルールを error に統一することで、違反を確実に検出・ブロックする。

## 変更内容

### `eslint.config.ts`

- `unused-imports/no-unused-imports`: warn → error
- `unused-imports/no-unused-vars`: warn → error
- `import-x/no-duplicates`: warn → error
- `better-tailwindcss/no-unknown-classes`: warn → error

### `eslint.config.fix.ts`

- `import-x/order`: warn → error
- `better-tailwindcss/enforce-canonical-classes`: warn → error

## 確認事項

- [ ] `pnpm lint:all` でエラーが増えていないこと
