### PR TITLE
feat(desktop): CLI から open 時に既存ウィンドウをアクティブ化

### DIFF
--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -1018,6 +1018,7 @@ function openWindow(req: OpenWindowRequest): void {
   );
   const existing = findWindowByDir(projectDir);
   if (existing) {
+    existing.focus();
     const existingId = windowIds.get(existing) ?? "";
     const currentDir = windowDirs.get(existing) ?? projectDir;
     // 表示中の worktree と異なる場合は switchToDir で切り替えを指示


### PR DESCRIPTION
## 概要

CLI (`gozd <path>`) で既に開いているプロジェクトを指定した際に、既存ウィンドウを前面にアクティブ化する。

## 背景

現状、CLI から既に開いているプロジェクトを `gozd <path>` で開くと、RPC メッセージ（`gozdOpen`）は送信されるがウィンドウは背面のままになる。ユーザーは手動でウィンドウを探す必要がある。

## 変更内容

### desktop

- `openWindow()` の既存ウィンドウ分岐で `existing.focus()` を呼び出し、ウィンドウを前面に持ってくる
- Electrobun の `BrowserWindow.focus()` は内部で `focusWindow` FFI（macOS の `makeKeyAndOrderFront:` 相当）を呼ぶ

## 確認事項

- [ ] CLI から既に開いているプロジェクトを指定してウィンドウが前面に来ること
- [ ] 開いていないプロジェクトを指定した場合は従来通り新規ウィンドウが作成されること
