### PR TITLE
feat(layout): ウィンドウタイトルを左寄せに変更

### DIFF
--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -205,16 +205,11 @@ watchEffect(() => {
       />
       <!-- ドラッグ領域 + タイトル表示 -->
       <div
-        class="electrobun-webkit-app-region-drag flex min-w-0 flex-1 items-center justify-center"
+        class="electrobun-webkit-app-region-drag flex min-w-0 flex-1 items-center"
         style="height: 100%"
       >
         <span class="truncate text-sm text-zinc-400">{{ worktreeStore.repoName ?? "gozd" }}</span>
       </div>
-      <!-- 右側の余白（信号機ボタンと対称） -->
-      <div
-        class="electrobun-webkit-app-region-drag shrink-0"
-        :style="{ width: `${TRAFFIC_LIGHTS_WIDTH}px`, height: '100%' }"
-      />
     </div>
     <div class="flex shrink-0 overflow-hidden" :style="{ height: `${mainHeight}px` }">
       <div class="shrink-0 overflow-hidden" :style="{ width: `${sidebarWidth}px` }">


### PR DESCRIPTION
## 概要

ウィンドウタイトルバーのリポジトリ名表示を中央揃えから左寄せに変更する。

## 背景

タイトルバーのリポジトリ名が中央に配置されていたが、左寄せのほうが自然な見た目になる。

## 変更内容

### タイトルバー（MainLayout.vue）

- `justify-center` を削除してタイトルテキストを左寄せに変更
- 中央揃えのための右側対称余白（信号機ボタンと同じ幅の div）を削除
- ドラッグ可能領域がタイトル右側いっぱいまで広がるようになった

## 確認事項

- [ ] タイトルが信号機ボタンの右隣に左寄せで表示されること
- [ ] タイトルバーのドラッグでウィンドウ移動ができること


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted title bar layout by removing right-side spacing while maintaining left-side alignment, resulting in an asymmetrical title bar design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->