### PR TITLE
feat(git-graph): ref バッジにローカル/リモート同期状態アイコンを表示

### DIFF
--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -43,6 +43,38 @@ const currentBranch = computed(() => {
 });
 
 /**
+ * ローカルとリモートが異なるコミットに存在するブランチ名の Set。
+ * 同じコミットにローカルとリモートが両方あれば synced（computeDisplayRefs で処理）。
+ * 別コミットに分かれていれば out-of-sync としてここで検出する。
+ */
+const outOfSyncBranches = computed(() => {
+  const localCommits = new Map<string, string>();
+  const remoteCommits = new Map<string, string>();
+
+  for (const commit of commits.value) {
+    for (const r of commit.refs) {
+      if (r === "HEAD" || r === "origin/HEAD") continue;
+      if (r.startsWith("tag:")) continue;
+      if (r.startsWith("origin/")) {
+        const name = r.slice("origin/".length);
+        remoteCommits.set(name, commit.hash);
+      } else {
+        localCommits.set(r, commit.hash);
+      }
+    }
+  }
+
+  const result = new Set<string>();
+  for (const [name, localHash] of localCommits) {
+    const remoteHash = remoteCommits.get(name);
+    if (remoteHash && remoteHash !== localHash) {
+      result.add(name);
+    }
+  }
+  return result;
+});
+
+/**
  * コミット一覧の先頭に Uncommitted Changes 仮想行を挿入する。
  * HEAD コミットを親として接続する。
  */
@@ -218,6 +250,8 @@ interface DisplayRef {
   type: "local" | "remote" | "synced" | "tag";
   /** origin と同じコミットにあるか */
   isSynced: boolean;
+  /** ローカルとリモートが別コミットに存在するか */
+  isOutOfSync: boolean;
   /** カレントブランチか */
   isCurrent: boolean;
   /** デフォルトブランチか */
@@ -249,6 +283,7 @@ function computeDisplayRefs(
   refs: string[],
   currentBranchName?: string,
   defaultBranchName?: string,
+  outOfSyncSet?: Set<string>,
 ): DisplayRef[] {
   const filtered = refs.filter((r) => r !== "HEAD" && r !== "origin/HEAD");
   const locals = new Set(filtered.filter((r) => !r.startsWith("origin/") && !r.startsWith("tag:")));
@@ -266,17 +301,20 @@ function computeDisplayRefs(
     const type = isSynced ? "synced" : "local";
     const isCurrent = local === currentBranchName;
     const isDefault = local === defaultBranchName;
-    result.push({ label: local, type, isSynced, isCurrent, isDefault });
+    const isOutOfSync = !isSynced && (outOfSyncSet?.has(local) ?? false);
+    result.push({ label: local, type, isSynced, isOutOfSync, isCurrent, isDefault });
   }
 
   // origin のみ（ローカルに対応がない）
   for (const remote of remotes) {
     const isCurrent = remote === currentBranchName;
     const isDefault = remote === defaultBranchName;
+    const isOutOfSync = outOfSyncSet?.has(remote) ?? false;
     result.push({
       label: `origin/${remote}`,
       type: "remote",
       isSynced: false,
+      isOutOfSync,
       isCurrent,
       isDefault,
     });
@@ -288,6 +326,7 @@ function computeDisplayRefs(
       label: tag.slice("tag:".length),
       type: "tag",
       isSynced: false,
+      isOutOfSync: false,
       isCurrent: false,
       isDefault: false,
     });
@@ -496,6 +535,7 @@ function isInRange(hash: string): boolean {
                 node.commit.refs,
                 currentBranch,
                 defaultBranch,
+                outOfSyncBranches,
               )"
               :key="`${displayRef.type}:${displayRef.label}`"
               class="flex shrink-0 items-center gap-0.5 rounded-sm px-1 py-0.5 text-[10px] leading-none font-medium"
@@ -508,7 +548,8 @@ function isInRange(hash: string): boolean {
                 displayRef.isDefault && DEFAULT_CLASS,
               ]"
             >
-              <span v-if="displayRef.isSynced" class="icon-[lucide--refresh-cw] size-2.5" />
+              <span v-if="displayRef.isSynced" class="icon-[lucide--link] size-3" />
+              <span v-else-if="displayRef.isOutOfSync" class="icon-[lucide--link-2-off] size-3" />
               {{ displayRef.label }}
             </span>
             <span


### PR DESCRIPTION
## 概要

git-graph の ref バッジに、ローカルとリモートの同期状態を示すアイコンを追加する。

## 背景

従来はローカルとリモートが同じコミットにある場合（synced）のみ refresh-cw アイコンを表示していたが、ローカルとリモートが異なるコミットにある場合（push 前や fetch 後）に同期ズレであることが視覚的にわからなかった。

## 変更内容

### 同期ズレ検出

- 全コミットの refs を横断走査し、同名のローカル/リモートブランチが異なるコミットハッシュを持つケースを `outOfSyncBranches` computed で検出
- `DisplayRef` に `isOutOfSync` フラグを追加し、`computeDisplayRefs` に `outOfSyncSet` パラメータを追加

### アイコン変更

- 同期済み（synced）: `refresh-cw` → `link`
- 同期ズレ（out-of-sync）: `link-2-off`（新規追加）

### 表示パターン

| 状態 | アイコン | 説明 |
|------|----------|------|
| synced | link | ローカルとリモートが同じコミット |
| out-of-sync (local) | link-2-off | ローカル側。対応するリモートが別コミットに存在 |
| out-of-sync (remote) | link-2-off | リモート側。対応するローカルが別コミットに存在 |
| local only | なし | リモートに対応するブランチなし |
| remote only | なし | ローカルに対応するブランチなし |

## スコープ

- **スコープ内**: ref バッジの同期/同期ズレ表示
- **スコープ外（対応しない）**: ahead/behind の件数表示や差分方向の区別（push が必要 vs pull が必要）

## 確認事項

- [ ] 同期済みブランチに link アイコンが表示される
- [ ] push 前のブランチにローカル側・リモート側それぞれ link-2-off アイコンが表示される
- [ ] ローカルのみ / リモートのみのブランチにアイコンが表示されない
