### PR TITLE
fix(git-graph): build版でPRバッジが表示されない

### DIFF
--- a/apps/desktop/src/git/pr.ts
+++ b/apps/desktop/src/git/pr.ts
@@ -14,9 +14,15 @@ interface GhPrItem {
   headRepositoryOwner: { login: string };
 }
 
-export async function getPrList(cwd: string): Promise<GitPullRequest[]> {
+export async function getPrList({
+  cwd,
+  env,
+}: {
+  cwd: string;
+  env: Record<string, string>;
+}): Promise<GitPullRequest[]> {
   const ownerResult = await tryCatch(
-    Promise.resolve(Bun.$`gh repo view --json owner --jq '.owner.login'`.cwd(cwd).text()),
+    Promise.resolve(Bun.$`gh repo view --json owner --jq '.owner.login'`.cwd(cwd).env(env).text()),
   );
   if (!ownerResult.ok) return [];
   const repoOwner = ownerResult.value.trim();
@@ -25,6 +31,7 @@ export async function getPrList(cwd: string): Promise<GitPullRequest[]> {
     Promise.resolve(
       Bun.$`gh pr list --state open --json number,url,headRefName,state,isDraft,headRepositoryOwner --limit 100`
         .cwd(cwd)
+        .env(env)
         .text(),
     ),
   );

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -698,7 +698,7 @@ function createWindowWithRPC(dir: string, options?: CreateWindowOptions): GozdWi
         gitCommitFiles: ({ hash, compareHash }) => getGitCommitFiles(currentDir, hash, compareHash),
         gitLog: ({ maxCount, firstParentOnly }) =>
           getGitLog({ cwd: currentDir, maxCount, firstParentOnly }),
-        gitPrList: () => getPrList(projectDir),
+        gitPrList: () => getPrList({ cwd: projectDir, env: shellEnv }),
         gitWorktreeList: async () => {
           const entries = await attachChangeCounts(await getWorktreeList(projectDir));
           // 各 worktree に紐づく Todo を付与


### PR DESCRIPTION
## 概要

build版（.app バンドル）で git-graph の PR バッジが表示されない問題を修正。

## 背景

PR ( #246 ) で PR バッジ表示機能を追加したが、build 版では PR 情報が取得できず表示されない。

macOS で `.app` を Dock/Finder から起動すると、Launch Services が渡す PATH は `/usr/bin:/bin:/usr/sbin:/sbin` のみ。`gh` は通常 `/opt/homebrew/bin/` にインストールされるため PATH で解決できない。

既に `shellEnv.ts` がログインシェルから完全な環境変数を取得して PTY spawn に渡していたが、`pr.ts` の `Bun.$` には渡されていなかった。dev 時はターミナルから起動するため `process.env` にフル PATH が含まれており問題が顕在化していなかった。

## 変更内容

### `apps/desktop/src/git/pr.ts`

- `getPrList` の引数をオブジェクト形式に変更し `env` を受け取る
- `Bun.$` の `.env(env)` チェーンで `shellEnv` を適用

### `apps/desktop/src/index.ts`

- `getPrList` の呼び出しに `shellEnv` を渡す

## スコープ

- **スコープ内**: `gh` コマンドの PATH 解決
- **スコープ外（対応しない）**: 他の git コマンドは `/usr/bin/git` で解決できるため対応不要

## 確認事項

- [ ] build 版で PR バッジが表示されること
