### PR TITLE
fix(git-graph): Bun.$ を Bun.spawn に置き換えて build 版で gh コマンドを実行可能にする

### DIFF
--- a/apps/desktop/src/git/pr.ts
+++ b/apps/desktop/src/git/pr.ts
@@ -35,11 +35,15 @@ async function execGh({
     return { ok: false, stderr: String(spawnResult.error) };
   }
   const proc = spawnResult.value;
-  const [stdout, stderr] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ]);
+  const readResult = await tryCatch(
+    Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]),
+  );
+  // ストリーム読み取り失敗でもプロセス終了を保証する
   await proc.exited;
+  if (!readResult.ok) {
+    return { ok: false, stderr: String(readResult.error) };
+  }
+  const [stdout, stderr] = readResult.value;
   if (proc.exitCode !== 0) {
     return { ok: false, stderr: stderr.trim() };
   }


### PR DESCRIPTION
## 概要

build 版で git-graph の PR バッジが表示されない問題を修正。PR ( #247 ) の修正では不十分だった根本原因に対処。

## 背景

PR ( #247 ) で `getPrList` に `shellEnv` を渡すようにしたが、build 版では依然として `gh` コマンドが `command not found` になっていた。

デバッグログ（ #248 の `errorNotify` を活用）で調査した結果、`Bun.$`（Bun Shell）は `.env()` で渡した `PATH` をコマンドルックアップに使わず、`process.env.PATH` を参照することが判明。build 版は Launch Services 経由で起動されるため `process.env.PATH` が `/usr/bin:/bin:/usr/sbin:/sbin` のみとなり、mise でインストールした `gh` が見つからなかった。

## 変更内容

### `apps/desktop/src/git/pr.ts`

- `Bun.$` を `Bun.spawn` に置き換え。`Bun.spawn` は渡した `env` の `PATH` でコマンド解決を行う
- `execGh` ヘルパー関数を追加し、spawn・stdout/stderr 読み取り・終了コード判定をカプセル化
- ストリーム読み取りを `tryCatch` で包み、非同期エラー時も空配列フォールバックを維持
- `await proc.exited` を成功・失敗どちらでも実行し、子プロセスの後始末を保証

## スコープ

- **スコープ内**: `gh` コマンドの実行を `Bun.$` から `Bun.spawn` に切り替え
- **スコープ外（対応しない）**: 他の `Bun.$` 使用箇所の調査。現時点で `gh` 以外に `shellEnv` の PATH でコマンド解決が必要な箇所はない

## 確認事項

- [x] build 版で PR バッジが表示されること
