### PR TITLE
feat(git-graph): ブランチ切り替え時に HEAD へ自動スクロール

### DIFF
--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -12,7 +12,7 @@ Git commit graph showing the current worktree branch and the default branch.
 import type { GitCommit, GitPullRequest } from "@gozd/rpc";
 import { UNCOMMITTED_HASH } from "@gozd/rpc";
 import { storeToRefs } from "pinia";
-import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
 import { useRpc } from "../../shared/rpc";
 import { ResizeHandle } from "../layout";
 import { useGitStatusStore, useWorktreeStore } from "../worktree";
@@ -122,13 +122,14 @@ let lastUpstream = "";
 /** loadLog の世代管理。並行実行で古いレスポンスが後着して上書きするのを防ぐ */
 let loadLogGen = 0;
 
-async function loadLog() {
+/** @returns 世代チェックを通過して state を更新した場合 true */
+async function loadLog(): Promise<boolean> {
   const gen = ++loadLogGen;
   const result = await request.gitLog({
     maxCount: 200,
     firstParentOnly: firstParentOnly.value || undefined,
   });
-  if (gen !== loadLogGen) return;
+  if (gen !== loadLogGen) return false;
 
   const merged = mergeCommitStreams({
     headCommits: result.headCommits,
@@ -149,6 +150,7 @@ async function loadLog() {
   if (isStale(selectedHash) || isStale(compareHash)) {
     gitGraphStore.resetSelection();
   }
+  return true;
 }
 
 onMounted(loadLog);
@@ -156,9 +158,12 @@ onMounted(loadLog);
 // worktree 切り替え時に再取得し、HEAD にスクロール
 watch(
   () => worktreeStore.dir,
-  () => {
+  async () => {
     gitGraphStore.resetSelection();
-    void loadLog().then(() => scrollToHead());
+    const updated = await loadLog();
+    if (!updated) return;
+    await nextTick();
+    scrollToHead();
   },
 );
 
@@ -186,9 +191,12 @@ const disposeGitStatus = onGitStatusChange(({ head, upstream }) => {
   if (upstreamChanged) lastUpstream = upstreamKey;
 
   if (headChanged || upstreamChanged) {
-    void loadLog().then(() => {
-      if (headChanged) scrollToHead();
-    });
+    void (async () => {
+      const updated = await loadLog();
+      if (!updated || !headChanged) return;
+      await nextTick();
+      scrollToHead();
+    })();
   }
   // upstream 変化（push/fetch）時に PR 一覧も再取得
   if (upstreamChanged) {


### PR DESCRIPTION
## 概要

ブランチ切り替え時に git graph が HEAD コミットまで自動スクロールするようにした。

## 背景

git graph でブランチを切り替えた後、HEAD の位置が画面外にあると手動でスクロールして探す必要があった。特にコミット数が多いブランチでは HEAD を見つけるのに手間がかかる。

## 変更内容

### 自動スクロールの追加

- worktree 切り替え時（サイドバー操作）: `loadLog()` 完了後に `scrollToHead()` を実行
- HEAD 変更検知時（ターミナルでの `git checkout` / `git switch`）: `loadLog()` 完了後に `scrollToHead()` を実行

### スクロール位置の改善

- `scrollToHead()` のスクロール方式を最小スクロール（`scrollToIndex`）からビューポート中央配置（`scrollToCenter`）に変更
- ブランチ切り替えは文脈が完全に変わるため、HEAD 前後のコミットも見渡せる中央配置が適切
- キーボードナビゲーション用の `scrollToIndex` は既存の最小スクロール方式を維持

### 非同期処理の安全性

- `loadLog()` が `boolean` を返すようにし、世代チェック（`loadLogGen`）を通過した場合のみ `true` を返す
- 古い世代の応答では `scrollToHead()` をスキップし、意図しない再スクロールを防止
- `nextTick()` を挟んで Vue の DOM 反映完了後にスクロールを実行（`v-if` 切り替え時の `scrollContainer` 未マウント問題を回避）

## 確認事項

- [ ] サイドバーで worktree を切り替えたとき、git graph が HEAD まで自動スクロールすること
- [ ] ターミナルで `git checkout` / `git switch` したとき、git graph が HEAD まで自動スクロールすること
- [ ] HEAD がビューポートの中央付近に配置されること
- [ ] 手動の「Scroll to HEAD」ボタンも中央配置で動作すること
- [ ] キーボード（上下矢印キー）操作のスクロールは従来通り最小スクロールで動作すること
