### PR TITLE
feat(git-graph): PR 一覧を定期ポーリングで取得する

### DIFF
--- a/apps/desktop/src/git/pr.ts
+++ b/apps/desktop/src/git/pr.ts
@@ -56,13 +56,13 @@ export async function getPrList({
 }: {
   cwd: string;
   env: Record<string, string>;
-}): Promise<GitPullRequest[]> {
+}): Promise<GitPullRequest[] | null> {
   const ownerResult = await execGh({
     args: ["repo", "view", "--json", "owner", "--jq", ".owner.login"],
     cwd,
     env,
   });
-  if (!ownerResult.ok) return [];
+  if (!ownerResult.ok) return null;
   const repoOwner = ownerResult.stdout.trim();
 
   const listResult = await execGh({
@@ -79,10 +79,10 @@ export async function getPrList({
     cwd,
     env,
   });
-  if (!listResult.ok) return [];
+  if (!listResult.ok) return null;
 
   const parsed = tryCatch(() => JSON.parse(listResult.stdout) as GhPrItem[]);
-  if (!parsed.ok) return [];
+  if (!parsed.ok) return null;
 
   // fork 由来の PR を除外（自リポジトリの owner と一致するもののみ）
   return parsed.value

--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -213,17 +213,13 @@ const prByBranch = ref(new Map<string, GitPullRequest>());
 /** loadPrList の世代管理。並行実行で古いレスポンスが後着して上書きするのを防ぐ */
 let loadPrGen = 0;
 
-/**
- * PR 一覧を取得して prByBranch を更新する。
- * keepOnEmpty: true の場合、取得結果が空なら前回値を保持する。
- * ポーリング時は gh の一時的な失敗（認証切れ・タイムアウト等）で
- * PR バッジが消えるのを防ぐために使用する。
- */
-async function loadPrList({ keepOnEmpty = false } = {}) {
+/** PR 一覧を取得して prByBranch を更新する。gh 失敗時（null）は前回値を保持する */
+async function loadPrList() {
   const gen = ++loadPrGen;
   const prs = await request.gitPrList(undefined);
   if (gen !== loadPrGen) return;
-  if (keepOnEmpty && prs.length === 0 && prByBranch.value.size > 0) return;
+  // gh 失敗時は null — 前回値を保持してバッジが消えるのを防ぐ
+  if (!prs) return;
   const map = new Map<string, GitPullRequest>();
   for (const pr of prs) {
     map.set(pr.headRefName, pr);
@@ -234,7 +230,7 @@ async function loadPrList({ keepOnEmpty = false } = {}) {
 // PR 一覧の定期ポーリング（gh pr create 等でリモートのみ変化するケースに対応）
 const PR_POLL_INTERVAL_MS = 60_000;
 const { pause: pausePrPoll, resume: resumePrPoll } = useIntervalFn(
-  () => void loadPrList({ keepOnEmpty: true }),
+  () => void loadPrList(),
   PR_POLL_INTERVAL_MS,
   { immediate: false },
 );

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -195,10 +195,10 @@ export type GozdRPC = {
           defaultBranch?: string;
         };
       };
-      /** GitHub PR 一覧を取得（open のみ、ブランチ名で紐付け） */
+      /** GitHub PR 一覧を取得（open のみ、ブランチ名で紐付け）。gh 失敗時は null */
       gitPrList: {
         params: undefined;
-        response: GitPullRequest[];
+        response: GitPullRequest[] | null;
       };
       /** git worktree list で worktree 一覧を取得 */
       gitWorktreeList: {


### PR DESCRIPTION
## 概要

git-graph の PR 一覧取得に 1 分間隔のポーリングを追加し、gh CLI の失敗時は前回値を保持するようにする。

## 背景

`gh pr create` は GitHub のリモート API を叩くだけでローカルの `.git` ディレクトリに書き込まない。既存の実装ではファイル監視ベースの `gitStatusChange` で upstream 変化を検知して PR 一覧を再取得していたが、`git push` → `gh pr create` の順で操作すると、push 時点では PR が存在せず、create 後はトリガーが発火しないため PR バッジが表示されなかった。

## 変更内容

### PR 一覧のポーリング

- `useIntervalFn` で 60 秒間隔の定期取得を追加
- コンポーネント破棄時に effect scope で自動クリーンアップ
- worktree 切り替え時にタイマーをリセット（即時取得 + インターバル再スタート）
- 既存の upstream 変化時の再取得はそのまま維持

### gh 失敗時の前回値保持

- `getPrList` の戻り値を `GitPullRequest[] | null` に変更（RPC スキーマも同様）
- gh CLI の実行失敗・認証切れ・タイムアウト時は `null` を返す
- renderer 側で `null` の場合は前回値を保持し、PR バッジが消えるのを防止
- 成功時の空配列（PR が本当に 0 件）は正しく反映される

## スコープ

- **スコープ内**: git-graph 表示中の PR 一覧の定期ポーリングと gh 失敗耐性
- **スコープ外（対応しない）**: git-graph 非表示時のポーリング — タブが非表示ならコンポーネントが破棄されるため不要

## 確認事項

- [ ] PR 作成後、1 分以内に RefBadge に PR 番号が表示されること
- [ ] worktree 切り替え時にポーリングがリセットされること
- [ ] gh の認証が切れた状態でも既存の PR バッジが消えないこと
