### PR TITLE
fix(palette): pointerenter による selectedIndex 変更を削除

### DIFF
--- a/apps/renderer/src/features/palette/features/command-palette/CommandPalette.vue
+++ b/apps/renderer/src/features/palette/features/command-palette/CommandPalette.vue
@@ -148,7 +148,6 @@ onUnmounted(disposeShow);
               executeSelected();
             }
           "
-          @pointerenter="selectedIndex = i"
         >
           <span>{{ cmd.label }}</span>
           <kbd

--- a/apps/renderer/src/features/palette/features/pr-picker/PrPickerDialog.vue
+++ b/apps/renderer/src/features/palette/features/pr-picker/PrPickerDialog.vue
@@ -155,7 +155,6 @@ useEventListener(dialogRef, "click", (e: MouseEvent) => {
               acceptSelected();
             }
           "
-          @pointerenter="selectedIndex = i"
         >
           <PrPickerRow :pr="pr" />
         </div>

--- a/apps/renderer/src/features/palette/features/quick-pick/QuickPick.vue
+++ b/apps/renderer/src/features/palette/features/quick-pick/QuickPick.vue
@@ -197,7 +197,6 @@ function handleKeydown(e: KeyboardEvent) {
                 accept();
               }
             "
-            @pointerenter="selectedIndex = i"
           >
             <span>{{ item.label }}</span>
             <span v-if="item.description" class="ml-4 shrink-0 text-xs text-zinc-500">


### PR DESCRIPTION
## 概要

パレット系コンポーネント（CommandPalette, QuickPick, PrPickerDialog）から `@pointerenter="selectedIndex = i"` を削除する。

ホバーは CSS `:hover` による見た目の変更のみとし、選択の変更はクリックとキーボード操作のみで行う。

## 背景

従来の実装では `pointerenter` イベントで `selectedIndex` を更新していたため、以下の問題が発生していた。

- キーボードで選択を移動してスクロールが発生すると、マウスカーソル下の項目に `selectedIndex` が吸われて選択位置がリセットされる
- QuickPick のテーマ選択など `onHighlight` コールバックが `selectedIndex` の `watch` に紐づいているため、マウスが項目上を通過するだけでプレビューが意図せず発火する

VS Code の Quick Input List（コマンドパレット）を調査したところ、`mouseover` でフォーカスを変更せず、ホバーは CSS `:hover:not(.focused)` による見た目のみとしていることが確認された。

## 変更内容

### パレットコンポーネント

- `CommandPalette.vue`: `@pointerenter="selectedIndex = i"` を削除
- `QuickPick.vue`: 同上
- `PrPickerDialog.vue`: 同上

## 挙動の変化

- QuickPick のテーマ選択で、マウスホバーによるリアルタイムプレビューが動作しなくなる（キーボード操作では従来通り）
- マウスで行にホバーして Enter を押した場合、ホバー中の行ではなくキーボードで最後に選択した行が実行される

## スコープ

- **スコープ内**: `pointerenter` による `selectedIndex` 変更の削除
- **スコープ外（別 PR で対応）**: キーボード操作中のスクロールに伴う CSS `:hover` 背景のちらつき抑制。VS Code は仮想スクロール + カスタムスクロールバーで対処しており、別のアプローチが必要

## 確認事項

- [ ] CommandPalette でキーボード移動中にマウスカーソル下の項目に選択が吸われないこと
- [ ] QuickPick（テーマ選択等）でマウスホバーだけでプレビューが発火しないこと
- [ ] クリックによる項目選択が引き続き動作すること
- [ ] CSS `:hover` による視覚的なホバーフィードバックが引き続き表示されること
- [ ] テーマ選択でキーボード操作によるリアルタイムプレビューが動作すること
