### PR TITLE
feat(voicevox): add playback state indicator and stop button

### DIFF
--- a/apps/renderer/src/features/sidebar/VoicevoxPanel.vue
+++ b/apps/renderer/src/features/sidebar/VoicevoxPanel.vue
@@ -25,6 +25,15 @@ async function handleActivate() {
   <div class="border-t border-zinc-700/50 px-4 py-3">
     <template v-if="voicevoxStore.enabled">
       <div class="flex flex-col gap-2">
+        <button
+          v-if="voicevoxStore.playing"
+          class="flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300"
+          title="Stop playback"
+          @click="voicevoxStore.stopAudio()"
+        >
+          <span class="icon-[lucide--volume-2] size-4 shrink-0 animate-pulse" />
+          <span>Playing...</span>
+        </button>
         <div class="flex items-center gap-2 text-xs text-zinc-500">
           <span class="icon-[lucide--gauge] size-4 shrink-0" title="Speed" />
           <input

--- a/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
+++ b/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
@@ -19,6 +19,25 @@ const SPEAK_EVENTS = new Set(["done", "needs-input"]);
 let currentAudio: HTMLAudioElement | undefined;
 let currentObjectUrl: string | undefined;
 
+/**
+ * 再生中かどうか。モジュールスコープの ref で管理し、store から公開する。
+ * Audio イベント（play / ended / pause）で同期する。
+ */
+const playing = ref(false);
+
+/** currentAudio に再生状態の同期リスナーを登録する */
+function attachPlayingListeners(audio: HTMLAudioElement) {
+  audio.addEventListener("play", () => {
+    playing.value = true;
+  });
+  audio.addEventListener("ended", () => {
+    playing.value = false;
+  });
+  audio.addEventListener("pause", () => {
+    playing.value = false;
+  });
+}
+
 /** 現在の Audio と ObjectURL を解放する */
 function releaseAudio() {
   if (currentAudio) {
@@ -137,6 +156,7 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
       const url = URL.createObjectURL(blob);
       currentObjectUrl = url;
       currentAudio = new Audio(url);
+      attachPlayingListeners(currentAudio);
       currentAudio.addEventListener("ended", releaseAudio);
       void currentAudio.play();
     };
@@ -208,6 +228,12 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
     return "VOICEVOX Engine startup timed out. Please start VOICEVOX manually.";
   }
 
+  /** 再生中の音声を停止する */
+  function stopAudio() {
+    speakGeneration++;
+    releaseAudio();
+  }
+
   /** VOICEVOX を無効化する。in-flight の音声合成リクエストも無効化する */
   function deactivate() {
     speakGeneration++;
@@ -231,7 +257,7 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
 
   initHookSubscription();
 
-  return { enabled, speedScale, volumeScale, activating, activate, deactivate };
+  return { enabled, playing, speedScale, volumeScale, activating, activate, deactivate, stopAudio };
 });
 
 if (import.meta.hot) {


### PR DESCRIPTION
## 概要

VOICEVOX パネルに再生中インジケーターと停止ボタンを追加する。

## 背景

VOICEVOX で音声が再生中かどうかの視覚的フィードバックがなく、再生を手動で止める手段もなかった。無効化（deactivate）すれば止まるが、設定がリセットされてしまう。

## 変更内容

### Store（useVoicevoxStore）

- `playing` ref を追加し、HTMLAudioElement の `play` / `ended` / `pause` イベントで同期
- `stopAudio()` 関数を追加（再生停止 + speakGeneration++ で in-flight リクエストもキャンセル）

### UI（VoicevoxPanel）

- パネル最上部に再生中のみ表示されるボタンを追加（`animate-pulse` アニメーション付き）
- クリックで `stopAudio()` を呼び出して再生停止

## 確認事項

- [ ] VOICEVOX 有効化後、音声再生中に「Playing...」ボタンがパルスアニメーションで表示される
- [ ] ボタンクリックで再生が即停止し、ボタンが非表示になる
- [ ] 再生完了時にボタンが自動的に非表示になる
