### PR TITLE
fix(sidebar): skip title sync for generic "Claude Code" title

### DIFF
--- a/apps/renderer/src/features/sidebar/useSidebarData.ts
+++ b/apps/renderer/src/features/sidebar/useSidebarData.ts
@@ -128,6 +128,8 @@ export function useSidebarData() {
       // Claude Code のステータスプレフィックス（✳ + Braille dots）を除去
       const title = update.title.replace(/^[\u2733\u2800-\u28FF] /, "");
       if (!title) return;
+      // セッション開始・レジューム時の汎用タイトル "Claude Code" で Todo を上書きしない
+      if (title === "Claude Code") return;
       void drainTitleSync(dir, title);
     },
   );


### PR DESCRIPTION
## 概要

ターミナルタイトル → Todo タイトル同期で、汎用タイトル "Claude Code" を無視するフィルタを追加する。

## 背景

#270 でターミナルタイトルを worktree の Todo タイトルに同期する機能を実装したが、Claude Code はセッション開始時・レジューム時に OSC 2 で "Claude Code" という汎用タイトルを設定する。これにより、以前設定されていた作業内容のタイトルがリセットされてしまう問題があった。

### 検討した代替案

`claudeState` による判定も試みたが、以下の理由で不採用とした：

- SessionStart フックより OSC 2 タイトルのほうが先に到着するため、セッション開始時は `claudeState` が `undefined`（Claude 未起動）
- レジューム時は `working` 状態で "Claude Code" タイトルが来るため、状態ベースのフィルタでは区別できない

タイトル文字列による判定は状態遷移のタイミングに依存しないため確実。

## 変更内容

### useSidebarData

- プレフィックス除去後のタイトルが "Claude Code" と一致する場合は `drainTitleSync` を呼ばずに早期リターン

## スコープ

- **スコープ内**: "Claude Code" 汎用タイトルによる Todo 上書きの防止
- **スコープ外（対応しない）**: 他の汎用タイトルパターンへの対応（現状 Claude Code 以外に問題となるパターンは確認されていない）

## 確認事項

- [ ] セッション開始時に "Claude Code" タイトルで Todo が上書きされないこと
- [ ] レジューム時にも同様に上書きされないこと
- [ ] 作業中のタイトル更新は従来通り Todo に反映されること
