### PR TITLE
feat(navigator): auto-switch to Changes tab on git status change

### DIFF
--- a/apps/renderer/src/features/navigator/NavigatorPane.vue
+++ b/apps/renderer/src/features/navigator/NavigatorPane.vue
@@ -46,7 +46,7 @@ watch(
     Object.entries(gitStatusStore.gitStatuses)
       .map(([filePath, status]) => `${filePath}\0${status}`)
       .sort()
-      .join("\n"),
+      .join("\0\0"),
   () => {
     activeView.value = "changes";
   },


### PR DESCRIPTION
## 概要

git status の変化に応じて Navigator の Changes タブを自動的にアクティブにする。

## 背景

ファイルを編集して git status に変更が現れても、Navigator が Files タブのままだと変更に気づきにくかった。
既に git-graph でコミット選択時には Changes タブへの自動切り替えが実装されていたが、git status 更新時にはトリガーがなかった。

## 変更内容

### NavigatorPane

changes の内容変化とファイル変化の2つの独立したトリガーで切り替える。

- **changes の内容変化**（watch）: `gitStatusStore.gitStatuses` の内容を文字列化して比較。`git clean`, `git commit`, worktree 切り替え等で変更ファイル一覧が変わったときに発火
- **changes にあるファイルの変化**（RPC イベント）: `onGitStatusChange` で statuses が非空のときに発火。同じファイルの編集（`.M` → `.M`）のように statuses 内容は変わらないがイベントは発火するケースをカバー

単一条件では一部ケースを取りこぼすため2トリガーに分離:
- watch のみ: 同じファイルの編集で statuses 内容が変わらないため発火しない
- RPC イベントのみ: `pnpm install` 等 gitignore 配下の変更でも dirty 状態なら切り替わってしまう

## スコープ

- **スコープ内**: git status 変化時の Changes タブ自動切り替え
- **スコープ外（対応しない）**: ユーザーが Files タブに戻った後の再切り替え抑制。使用感を見てから検討する

## 確認事項

- [x] ファイル編集で Changes タブに切り替わること
- [x] `git clean` で Changes タブに切り替わること
- [x] `git commit` / `git reset --hard` で Changes タブに切り替わること
- [x] `pnpm install`（changes に出ない変更）で切り替わらないこと
- [x] worktree 切り替え時に dirty なら切り替わること
- [x] git-graph でコミット選択時の既存の自動切り替えが動作すること
