### PR TITLE
debug(claude-status): add detectInterrupt debug log

### DIFF
--- a/apps/renderer/src/features/terminal/claudeStatus.ts
+++ b/apps/renderer/src/features/terminal/claudeStatus.ts
@@ -209,11 +209,7 @@ export function createClaudeStatusManager(deps: ClaudeStatusManagerDeps) {
       );
     }
 
-    if (currentState !== "working") {
-      // tail バッファは state に関わらず更新する（次チャンクの combined に必要）
-      ptyTailBuffers.set(ptyId, data.slice(-PTY_TAIL_BUFFER_SIZE));
-      return;
-    }
+    if (currentState !== "working") return;
 
     if (combined.includes(INTERRUPT_MARKER)) {
       cancelAskTimer(ptyId);


### PR DESCRIPTION
## 概要

`detectInterrupt` にデバッグログを追加し、Interrupted で working が解除されないケースの原因を調査する。

## 背景

Claude Code を Ctrl+C / Escape で中断した際に、gozd の Claude ステータスが `working` のまま `idle` に戻らないケースがある。`detectInterrupt` は PTY 出力の `INTERRUPT_MARKER` パターンマッチで中断を検知しているが、マッチしない条件（ANSI エスケープシーケンスの混入、チャンク分割、state mismatch 等）が特定できていない。

## 変更内容

### デバッグログ追加

- `combined`（tail + data）に `"Interrupted"` を含む場合のみログ出力（チャンク分割にも対応）
- ログ内容: `ptyId`、`state`（working 以外も記録）、`markerMatched`、`tailLen`、`dataLen`、marker 周辺 50 文字の preview
- state チェックの前にログを出すことで、working 以外の state で interrupt 文言が来たケースも観測可能
- tail バッファは state に関わらず更新する（次チャンクの combined に必要）

## スコープ

- **スコープ内**: デバッグログの追加のみ
- **スコープ外（別 PR で対応）**: 原因特定後の修正（ANSI ストリップ等）

## 確認事項

- [ ] DevTools コンソールで `[claude-status] detectInterrupt` をフィルタし、Interrupted 操作時のログを確認する
- [ ] `markerMatched=false` のケースで preview の生データから、マーカーがマッチしない原因を特定する
- [ ] `state=asking` 等 working 以外で interrupt 文言が来ているケースがないか確認する
