### PR TITLE
fix(pr-picker): prevent Enter on filter toggles from blocking PR accept

### DIFF
--- a/apps/renderer/src/features/palette/features/pr-picker/PrPickerDialog.vue
+++ b/apps/renderer/src/features/palette/features/pr-picker/PrPickerDialog.vue
@@ -153,26 +153,26 @@ useEventListener(dialogRef, "click", (e: MouseEvent) => {
         />
         <label
           v-if="viewer !== ''"
-          class="shrink-0 cursor-pointer rounded-sm px-2 py-0.5 text-xs select-none"
+          class="shrink-0 cursor-pointer rounded-sm px-2 py-0.5 text-xs select-none has-focus-visible:ring-2 has-focus-visible:ring-blue-400"
           :class="
             filterAssignee
               ? 'bg-blue-600 text-white'
               : 'bg-zinc-700 text-zinc-400 hover:text-zinc-200'
           "
         >
-          <input v-model="filterAssignee" type="checkbox" class="hidden" />
+          <input v-model="filterAssignee" type="checkbox" class="sr-only" />
           assignee:me
         </label>
         <label
           v-if="viewer !== ''"
-          class="shrink-0 cursor-pointer rounded-sm px-2 py-0.5 text-xs select-none"
+          class="shrink-0 cursor-pointer rounded-sm px-2 py-0.5 text-xs select-none has-focus-visible:ring-2 has-focus-visible:ring-blue-400"
           :class="
             filterReviewer
               ? 'bg-blue-600 text-white'
               : 'bg-zinc-700 text-zinc-400 hover:text-zinc-200'
           "
         >
-          <input v-model="filterReviewer" type="checkbox" class="hidden" />
+          <input v-model="filterReviewer" type="checkbox" class="sr-only" />
           reviewer:me
         </label>
       </div>


### PR DESCRIPTION
## 概要

PR ピッカーの assignee:me / reviewer:me フィルターにフォーカスした状態で Enter を押すと、フィルターがトグルされるだけで PR からの worktree 作成が実行されない問題を修正する。

## 背景

`<button>` はブラウザ仕様により、フォーカス中の Enter キーで `click` イベントが発火する。`handleKeydown` では `e.target instanceof HTMLButtonElement` でボタンフォーカス時に Enter を無視していたため、ブラウザの `click` 発火でフィルターがトグルされるだけで `acceptSelected()` が呼ばれなかった。

## 変更内容

### フィルター要素の構造変更

- `<button>` を `<label>` + `<input type="checkbox">` に変更
- checkbox は `sr-only` で視覚的に非表示だがフォーカス可能
- `v-model` で checkbox の状態を直接バインドし、クリック・Space キーによるトグル動作を維持
- `has-focus-visible:ring-2` で Tab フォーカス時にリングを表示

### キーハンドラーの簡素化

- `handleKeydown` の Enter 分岐から `HTMLButtonElement` チェックを削除
- checkbox は Enter で `click` を発火しないため、Enter は常に `acceptSelected()` に到達する

## スコープ

- **スコープ内**: PR ピッカーのフィルターにおける Enter キーの挙動修正、キーボード操作性の維持
- **スコープ外（対応しない）**: 他のダイアログ（command-palette, quick-pick）の調査。現時点でフィルターボタンを含むのは PR ピッカーのみ

## 確認事項

- [ ] フィルターをクリックしてトグルできること
- [ ] Tab でフィルターにフォーカスし、Space でトグルできること
- [ ] フォーカス時にリングが表示されること
- [ ] Enter で PR が選択され worktree が作成されること（フィルターにフォーカス中でも）
