### PR TITLE
feat(worktree): reverse list order and move add button to top

### DIFF
--- a/apps/renderer/src/features/sidebar/features/worktree/WorktreeList.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/WorktreeList.vue
@@ -70,6 +70,20 @@ defineSlots<{
       </div>
     </div>
 
+    <button
+      class="grid grid-cols-[auto_1fr] gap-x-2 rounded-sm py-1.5 pl-2 text-left text-sm text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300 disabled:opacity-50"
+      :disabled="isCreating"
+      @click="$emit('add')"
+    >
+      <span
+        class="text-base"
+        :class="isCreating ? 'icon-[lucide--loader-circle] animate-spin' : 'icon-[lucide--plus]'"
+      />
+      <span>New worktree</span>
+    </button>
+
+    <p v-if="loading" class="py-2 pl-2 text-sm text-zinc-500">Loading...</p>
+
     <div v-for="(wt, i) in worktrees" :key="wt.path">
       <WorktreeItem
         :wt="wt"
@@ -84,19 +98,5 @@ defineSlots<{
       />
       <slot name="after-item" :wt="wt" />
     </div>
-
-    <p v-if="loading" class="py-2 pl-2 text-sm text-zinc-500">Loading...</p>
-
-    <button
-      class="mt-1 grid grid-cols-[auto_1fr] gap-x-2 rounded-sm py-1.5 pl-2 text-left text-sm text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300 disabled:opacity-50"
-      :disabled="isCreating"
-      @click="$emit('add')"
-    >
-      <span
-        class="text-base"
-        :class="isCreating ? 'icon-[lucide--loader-circle] animate-spin' : 'icon-[lucide--plus]'"
-      />
-      <span>New worktree</span>
-    </button>
   </div>
 </template>

--- a/apps/renderer/src/features/sidebar/useSidebarData.ts
+++ b/apps/renderer/src/features/sidebar/useSidebarData.ts
@@ -27,11 +27,11 @@ export function useSidebarData() {
   /** root（main）worktree */
   const rootWorktree = computed(() => worktrees.value.find((wt) => wt.isMain));
 
-  /** main 以外の worktree をディレクトリ名のアルファベット順で */
+  /** main 以外の worktree をディレクトリ名の降順で（新しい worktree が上） */
   const nonMainWorktrees = computed(() =>
     worktrees.value
       .filter((wt) => !wt.isMain)
-      .sort((a, b) => dirName(a.path).localeCompare(dirName(b.path))),
+      .sort((a, b) => dirName(b.path).localeCompare(dirName(a.path))),
   );
 
   const sortedBranches = computed(() => [...freeBranches.value].sort((a, b) => a.localeCompare(b)));


### PR DESCRIPTION
## 概要

サイドバーの worktree 一覧を逆順（降順）に変更し、"New worktree" ボタンを一覧の先頭に移動する。

## 背景

worktree 名は日付ベース（`20260328_042943`）のため、昇順ソートだと古い worktree が上に表示され、新しく作った worktree を見つけるにはスクロールが必要だった。また、"New worktree" ボタンが一覧末尾にあり、worktree が増えるとボタンへのアクセスも遠くなっていた。

## 変更内容

### ソート順の変更

- `useSidebarData.ts` の `nonMainWorktrees` computed を降順ソートに変更（`localeCompare` の引数を入れ替え）

### ボタン位置の変更

- `WorktreeList.vue` の "New worktree" ボタンを worktree 一覧の前（ヘッダー直下）に移動
- 末尾にあった `mt-1` クラスを削除

## スコープ

- **スコープ内**: worktree 一覧の表示順とボタン位置の変更
- **スコープ外（対応しない）**: ソート順の切り替え UI やユーザー設定。現状は日付ベース名の降順で十分

## 確認事項

- [ ] サイドバーの worktree 一覧が新しい順（降順）で表示されること
- [ ] "New worktree" ボタンが一覧の先頭にあること
- [ ] ボタンクリックで worktree 作成が動作すること
