### PR TITLE
chore(deps): update pnpm to 11.0.0-rc.5

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
 [tools]
 node = "24.15.0"
 bun = "1.3.13"
-"npm:pnpm" = "11.0.0-rc.2"
+"npm:pnpm" = "11.0.0-rc.5"


### PR DESCRIPTION
## 概要

mise.toml の pnpm バージョンを 11.0.0-rc.2 から 11.0.0-rc.5 に更新する。

## 背景

pnpm v11 RC の最新リリースに追従するための定期的な依存更新。

## 変更内容

### 依存更新

- `mise.toml` の `npm:pnpm` を `11.0.0-rc.5` に更新

## 確認事項

- [ ] `pnpm install` が正常に完了すること
- [ ] pre-commit hook（knip）が通ること
