### PR TITLE
fix(desktop): git status の index.lock 競合を防止

### DIFF
--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -139,6 +139,8 @@ function spawnPty(win: GozdWindow, cwd: string, cols: number, rows: number): num
     cwd,
     env: {
       ...shellEnv,
+      // desktop プロセスの GIT_OPTIONAL_LOCKS=0 を PTY に持ち込まない
+      GIT_OPTIONAL_LOCKS: undefined,
       // TERM 系は PTY 側で明示設定する（親の値を持ち込まない）
       TERM: "xterm-256color",
       COLORTERM: "truecolor",

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -48,6 +48,9 @@ import {
   cleanupStaleTasks,
 } from "./task";
 
+// gozd のファイル監視が git status を実行する際の index.lock 競合を防止する（ #318 ）
+process.env.GIT_OPTIONAL_LOCKS = "0";
+
 type GozdRPCInstance = ReturnType<typeof BrowserView.defineRPC<GozdRPC>>;
 type GozdWindow = BrowserWindow<GozdRPCInstance>;
 


### PR DESCRIPTION
## 概要

gozd の desktop プロセスに `GIT_OPTIONAL_LOCKS=0` 環境変数を設定し、ファイル監視による `git status` 実行時の `index.lock` 競合を防止する。

## 背景

gozd の worktree 監視中に `git rebase` を実行すると、rebase の初期チェックアウトによるファイル変更を gozd が検知し `git status` を実行する。`git status` は read-only に見えるが、内部でインデックスの stat 情報（mtime, size）をリフレッシュするために `index.lock` を取得する。これが rebase の pick 操作と競合し、`Unable to create 'index.lock': File exists` エラーで rebase が失敗する。

VSCode の Git 拡張も同じ問題のために `GIT_OPTIONAL_LOCKS=0` を使用している。Git 2.15 で導入されたこのオプションは、stat リフレッシュをスキップしロックなしで status を返す。

( #318 )

## 変更内容

### desktop プロセスの環境変数設定

- `apps/desktop/src/index.ts` の初期化段階で `process.env.GIT_OPTIONAL_LOCKS = "0"` を設定
- `Bun.spawn` / `Bun.spawnSync` / `Bun.$` すべてが `process.env` を継承するため、desktop から実行されるすべての git コマンドに自動適用される

### PTY 環境からの除外

- PTY（ユーザーのターミナル）の env で `GIT_OPTIONAL_LOCKS: undefined` を明示設定し、desktop プロセスの設定がユーザーのターミナル環境に伝播しないようにした
- `shellEnv` は `process.env` を継承するケースがあるため、スプレッド後に `undefined` で上書きして除外する

## 確認事項

- [ ] gozd 上で `git rebase` を実行し、`index.lock` 競合が発生しないことを確認
- [ ] ファイル変更時のサイドバー git status 表示が正常に動作することを確認
- [ ] ターミナル内で `echo $GIT_OPTIONAL_LOCKS` が空であることを確認
