### PR TITLE
fix(sidebar): remove task edit toggle on worktree click

### DIFF
--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -104,12 +104,11 @@ useIntervalFn(() => {
 
 const sidebarMenuRef = ref<InstanceType<typeof SidebarMenu>>();
 
-/** worktree クリック: active なら Task 編集トグル、そうでなければ切り替え */
+/** worktree クリック: active なら done クリア、そうでなければ切り替え */
 function onWorktreeSelect(wt: import("@gozd/rpc").WorktreeEntry) {
   terminalStore.viewMode = "wt";
   if (isActive(wt)) {
     terminalStore.clearDoneStates(wt.path);
-    void toggleWorktreeTaskEdit(wt);
     return;
   }
   handleWorktreeSelect(wt);

--- a/docs/task.md
+++ b/docs/task.md
@@ -37,7 +37,7 @@ interface Task {
 
 ### worktree に Task を追加
 
-worktree クリック（アクティブ時）→ Task がなければインライン編集で新規作成。ターミナルタイトル変更時にも Task が自動作成される（`useSidebarData.ts` のタイトル同期）。
+`⋮` メニュー → "Edit task" でインライン編集。Task がなければ新規作成入力欄を表示する。ターミナルタイトル変更時にも Task が自動作成される（`useSidebarData.ts` のタイトル同期）。
 
 ### PR から worktree 作成
 

--- a/docs/task.md
+++ b/docs/task.md
@@ -89,8 +89,8 @@ BRANCHES
 
 **WORKTREES 行:**
 
-- Task を編集
-- wt を削除
+- Edit task
+- Remove worktree
 
 **BRANCHES 行:**
 
@@ -98,7 +98,7 @@ BRANCHES
 
 ### Task 編集
 
-`[⋮]` → "Task を編集" でサイドバー内にインライン展開する。テキストの編集のみ行う。
+`[⋮]` → "Edit task" でサイドバー内にインライン展開する。テキストの編集のみ行う。
 
 ```text
 WORKTREES


### PR DESCRIPTION
## 概要

サイドバーの worktree タイトルをクリックしたときに Task 編集モードに入る挙動を除去する。

## 背景

active な worktree をクリックすると `toggleWorktreeTaskEdit` が呼ばれ、意図せず Task 編集モードに入ってしまう。Task の編集は `⋮` メニューから行えるため、クリックでの編集トグルは不要。

## 変更内容

### SidebarPane

- `onWorktreeSelect` から `toggleWorktreeTaskEdit` の呼び出しを除去
- active な worktree の再クリック時は done 状態のクリアのみ行う
- `⋮` メニュー経由の Task 編集は引き続き利用可能

### ドキュメント

- `docs/task.md` の Task 追加トリガーの記述を、worktree クリックから `⋮` メニュー経由に更新
- メニュー項目の日本語ラベル（"Task を編集" / "wt を削除"）を実装の英語ラベル（"Edit task" / "Remove worktree"）に統一

## 確認事項

- [ ] active な worktree をクリックしても編集モードに入らないこと
- [ ] `⋮` メニューから Task 編集が引き続き動作すること
- [ ] done バッジが worktree クリックでクリアされること
