### PR TITLE
fix(worktree): PR 選択時にリモートブランチのコミットを使用する

### DIFF
--- a/apps/desktop/src/git/worktree.ts
+++ b/apps/desktop/src/git/worktree.ts
@@ -16,7 +16,7 @@ function getWorktreeRoot(projectDir: string): string {
 }
 
 /**
- * リモートブランチを fetch し、ローカルブランチを作成（または更新）して worktree 化する。
+ * リモートブランチを fetch し、ローカルブランチを作成して worktree 化する。
  * リモートに存在しない場合は false を返す。
  */
 async function createWorktreeFromRemote({
@@ -35,46 +35,14 @@ async function createWorktreeFromRemote({
   await fetchProc.exited;
   if (fetchProc.exitCode !== 0) return false;
 
-  // ローカルブランチが既に存在する場合はリモートの最新に合わせる
-  const branchExists =
-    (await Bun.spawn(["git", "show-ref", "--verify", "--quiet", `refs/heads/${branch}`], { cwd })
-      .exited) === 0;
-
-  if (branchExists) {
-    const resetProc = Bun.spawn(["git", "branch", "-f", branch, `origin/${branch}`], {
-      cwd,
-      stderr: "pipe",
-    });
-    await resetProc.exited;
-    if (resetProc.exitCode !== 0) {
-      const stderr = await new Response(resetProc.stderr).text();
-      throw new Error(
-        `git branch reset failed: ${stderr.trim() || `exit code ${resetProc.exitCode}`}`,
-      );
-    }
-    const wtProc = Bun.spawn(["git", "worktree", "add", wtPath, branch], {
-      cwd,
-      stderr: "pipe",
-    });
-    await wtProc.exited;
-    if (wtProc.exitCode !== 0) {
-      const stderr = await new Response(wtProc.stderr).text();
-      throw new Error(
-        `git worktree add failed: ${stderr.trim() || `exit code ${wtProc.exitCode}`}`,
-      );
-    }
-  } else {
-    const wtProc = Bun.spawn(["git", "worktree", "add", "-b", branch, wtPath, `origin/${branch}`], {
-      cwd,
-      stderr: "pipe",
-    });
-    await wtProc.exited;
-    if (wtProc.exitCode !== 0) {
-      const stderr = await new Response(wtProc.stderr).text();
-      throw new Error(
-        `git worktree add failed: ${stderr.trim() || `exit code ${wtProc.exitCode}`}`,
-      );
-    }
+  const wtProc = Bun.spawn(["git", "worktree", "add", "-b", branch, wtPath, `origin/${branch}`], {
+    cwd,
+    stderr: "pipe",
+  });
+  await wtProc.exited;
+  if (wtProc.exitCode !== 0) {
+    const stderr = await new Response(wtProc.stderr).text();
+    throw new Error(`git worktree add failed: ${stderr.trim() || `exit code ${wtProc.exitCode}`}`);
   }
   return true;
 }
@@ -84,15 +52,15 @@ export async function addWorktree({
   worktreeDir,
   branch,
   symlinks,
-  fromRemote,
+  startPoint,
 }: {
   cwd: string;
   worktreeDir: string;
   branch: string;
   /** メインリポジトリからシンボリックリンクする対象パス */
   symlinks?: string[];
-  /** リモートブランチから作成する（PR 選択時など） */
-  fromRemote?: boolean;
+  /** ブランチの起点となる commit-ish（例: `origin/feature-x`） */
+  startPoint?: string;
 }): Promise<WorktreeEntry> {
   const worktreeRoot = getWorktreeRoot(cwd);
   await fsp.mkdir(worktreeRoot, { recursive: true });
@@ -100,10 +68,32 @@ export async function addWorktree({
 
   assertBranchName(branch);
 
-  if (fromRemote) {
-    const remoteResult = await createWorktreeFromRemote({ cwd, branch, wtPath });
-    if (!remoteResult) {
-      throw new Error(`Remote branch not found: origin/${branch}`);
+  if (startPoint) {
+    // origin/ プレフィックスの場合はリモートブランチを fetch して最新にする
+    const ORIGIN_PREFIX = "origin/";
+    if (startPoint.startsWith(ORIGIN_PREFIX)) {
+      const remoteBranch = startPoint.slice(ORIGIN_PREFIX.length);
+      const fetchProc = Bun.spawn(["git", "fetch", "origin", remoteBranch], {
+        cwd,
+        stderr: "pipe",
+      });
+      await fetchProc.exited;
+      if (fetchProc.exitCode !== 0) {
+        const stderr = await new Response(fetchProc.stderr).text();
+        throw new Error(`git fetch failed: ${stderr.trim() || `exit code ${fetchProc.exitCode}`}`);
+      }
+    }
+    // -B: ブランチが存在しなければ作成、存在すれば startPoint にリセットして worktree 化
+    const wtProc = Bun.spawn(["git", "worktree", "add", "-B", branch, wtPath, startPoint], {
+      cwd,
+      stderr: "pipe",
+    });
+    await wtProc.exited;
+    if (wtProc.exitCode !== 0) {
+      const stderr = await new Response(wtProc.stderr).text();
+      throw new Error(
+        `git worktree add failed: ${stderr.trim() || `exit code ${wtProc.exitCode}`}`,
+      );
     }
   } else {
     // まず -b で新規ブランチ作成を試み、既存ブランチなら -b なしでリトライ。

--- a/apps/desktop/src/git/worktree.ts
+++ b/apps/desktop/src/git/worktree.ts
@@ -83,7 +83,31 @@ export async function addWorktree({
         throw new Error(`git fetch failed: ${stderr.trim() || `exit code ${fetchProc.exitCode}`}`);
       }
     }
-    // -B: ブランチが存在しなければ作成、存在すれば startPoint にリセットして worktree 化
+    // ローカルブランチが存在する場合、fast-forward 可能か検証してからリセットする
+    const branchExists =
+      (await Bun.spawn(["git", "show-ref", "--verify", "--quiet", `refs/heads/${branch}`], { cwd })
+        .exited) === 0;
+    if (branchExists) {
+      // 別 worktree で使用中のブランチは -B でもリセットできない
+      const worktrees = await getWorktreeList(cwd);
+      const usedBy = worktrees.find((wt) => wt.branch === branch);
+      if (usedBy) {
+        throw new Error(`Branch "${branch}" is already checked out in worktree: ${usedBy.path}`);
+      }
+
+      const isAncestor =
+        (await Bun.spawn(
+          ["git", "merge-base", "--is-ancestor", `refs/heads/${branch}`, startPoint],
+          { cwd },
+        ).exited) === 0;
+      if (!isAncestor) {
+        throw new Error(
+          `Local branch "${branch}" has diverged from ${startPoint}. Remove the local branch or resolve manually.`,
+        );
+      }
+    }
+
+    // -B: ブランチが存在しなければ作成、存在すれば startPoint にリセット（fast-forward 検証済み）
     const wtProc = Bun.spawn(["git", "worktree", "add", "-B", branch, wtPath, startPoint], {
       cwd,
       stderr: "pipe",

--- a/apps/desktop/src/git/worktree.ts
+++ b/apps/desktop/src/git/worktree.ts
@@ -16,7 +16,7 @@ function getWorktreeRoot(projectDir: string): string {
 }
 
 /**
- * リモートブランチを fetch し、ローカルブランチを作成して worktree 化する。
+ * リモートブランチを fetch し、ローカルブランチを作成（または更新）して worktree 化する。
  * リモートに存在しない場合は false を返す。
  */
 async function createWorktreeFromRemote({
@@ -35,14 +35,46 @@ async function createWorktreeFromRemote({
   await fetchProc.exited;
   if (fetchProc.exitCode !== 0) return false;
 
-  const wtProc = Bun.spawn(["git", "worktree", "add", "-b", branch, wtPath, `origin/${branch}`], {
-    cwd,
-    stderr: "pipe",
-  });
-  await wtProc.exited;
-  if (wtProc.exitCode !== 0) {
-    const stderr = await new Response(wtProc.stderr).text();
-    throw new Error(`git worktree add failed: ${stderr.trim() || `exit code ${wtProc.exitCode}`}`);
+  // ローカルブランチが既に存在する場合はリモートの最新に合わせる
+  const branchExists =
+    (await Bun.spawn(["git", "show-ref", "--verify", "--quiet", `refs/heads/${branch}`], { cwd })
+      .exited) === 0;
+
+  if (branchExists) {
+    const resetProc = Bun.spawn(["git", "branch", "-f", branch, `origin/${branch}`], {
+      cwd,
+      stderr: "pipe",
+    });
+    await resetProc.exited;
+    if (resetProc.exitCode !== 0) {
+      const stderr = await new Response(resetProc.stderr).text();
+      throw new Error(
+        `git branch reset failed: ${stderr.trim() || `exit code ${resetProc.exitCode}`}`,
+      );
+    }
+    const wtProc = Bun.spawn(["git", "worktree", "add", wtPath, branch], {
+      cwd,
+      stderr: "pipe",
+    });
+    await wtProc.exited;
+    if (wtProc.exitCode !== 0) {
+      const stderr = await new Response(wtProc.stderr).text();
+      throw new Error(
+        `git worktree add failed: ${stderr.trim() || `exit code ${wtProc.exitCode}`}`,
+      );
+    }
+  } else {
+    const wtProc = Bun.spawn(["git", "worktree", "add", "-b", branch, wtPath, `origin/${branch}`], {
+      cwd,
+      stderr: "pipe",
+    });
+    await wtProc.exited;
+    if (wtProc.exitCode !== 0) {
+      const stderr = await new Response(wtProc.stderr).text();
+      throw new Error(
+        `git worktree add failed: ${stderr.trim() || `exit code ${wtProc.exitCode}`}`,
+      );
+    }
   }
   return true;
 }
@@ -52,12 +84,15 @@ export async function addWorktree({
   worktreeDir,
   branch,
   symlinks,
+  fromRemote,
 }: {
   cwd: string;
   worktreeDir: string;
   branch: string;
   /** メインリポジトリからシンボリックリンクする対象パス */
   symlinks?: string[];
+  /** リモートブランチから作成する（PR 選択時など） */
+  fromRemote?: boolean;
 }): Promise<WorktreeEntry> {
   const worktreeRoot = getWorktreeRoot(cwd);
   await fsp.mkdir(worktreeRoot, { recursive: true });
@@ -65,40 +100,48 @@ export async function addWorktree({
 
   assertBranchName(branch);
 
-  // まず -b で新規ブランチ作成を試み、既存ブランチなら -b なしでリトライ。
-  // タイムスタンプベースの名前では事実上リトライは発生しない
-  const newBranchProc = Bun.spawn(["git", "worktree", "add", "-b", branch, wtPath], {
-    cwd,
-    stderr: "pipe",
-  });
-  await newBranchProc.exited;
+  if (fromRemote) {
+    const remoteResult = await createWorktreeFromRemote({ cwd, branch, wtPath });
+    if (!remoteResult) {
+      throw new Error(`Remote branch not found: origin/${branch}`);
+    }
+  } else {
+    // まず -b で新規ブランチ作成を試み、既存ブランチなら -b なしでリトライ。
+    // タイムスタンプベースの名前では事実上リトライは発生しない
+    const newBranchProc = Bun.spawn(["git", "worktree", "add", "-b", branch, wtPath], {
+      cwd,
+      stderr: "pipe",
+    });
+    await newBranchProc.exited;
 
-  if (newBranchProc.exitCode !== 0) {
-    // ブランチが既に存在するかをロケール非依存で判定（stderr のメッセージは LANG で変わるため）
-    const branchExists =
-      (await Bun.spawn(["git", "show-ref", "--verify", "--quiet", `refs/heads/${branch}`], { cwd })
-        .exited) === 0;
+    if (newBranchProc.exitCode !== 0) {
+      // ブランチが既に存在するかをロケール非依存で判定（stderr のメッセージは LANG で変わるため）
+      const branchExists =
+        (await Bun.spawn(["git", "show-ref", "--verify", "--quiet", `refs/heads/${branch}`], {
+          cwd,
+        }).exited) === 0;
 
-    if (branchExists) {
-      const existingProc = Bun.spawn(["git", "worktree", "add", wtPath, branch], {
-        cwd,
-        stderr: "pipe",
-      });
-      await existingProc.exited;
-      if (existingProc.exitCode !== 0) {
-        const retryStderr = await new Response(existingProc.stderr).text();
-        throw new Error(
-          `git worktree add failed: ${retryStderr.trim() || `exit code ${existingProc.exitCode}`}`,
-        );
-      }
-    } else {
-      // リモートブランチからローカルブランチを作成して worktree 化する
-      const remoteResult = await createWorktreeFromRemote({ cwd, branch, wtPath });
-      if (!remoteResult) {
-        const stderr = await new Response(newBranchProc.stderr).text();
-        throw new Error(
-          `git worktree add failed: ${stderr.trim() || `exit code ${newBranchProc.exitCode}`}`,
-        );
+      if (branchExists) {
+        const existingProc = Bun.spawn(["git", "worktree", "add", wtPath, branch], {
+          cwd,
+          stderr: "pipe",
+        });
+        await existingProc.exited;
+        if (existingProc.exitCode !== 0) {
+          const retryStderr = await new Response(existingProc.stderr).text();
+          throw new Error(
+            `git worktree add failed: ${retryStderr.trim() || `exit code ${existingProc.exitCode}`}`,
+          );
+        }
+      } else {
+        // リモートブランチからローカルブランチを作成して worktree 化する
+        const remoteResult = await createWorktreeFromRemote({ cwd, branch, wtPath });
+        if (!remoteResult) {
+          const stderr = await new Response(newBranchProc.stderr).text();
+          throw new Error(
+            `git worktree add failed: ${stderr.trim() || `exit code ${newBranchProc.exitCode}`}`,
+          );
+        }
       }
     }
   }

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -846,14 +846,14 @@ function createWindowWithRPC(dir: string, options?: CreateWindowOptions): GozdWi
           return entries;
         },
         gitBranchList: () => getBranchList(projectDir),
-        createWorktree: async ({ worktreeDir, branch, fromRemote }) => {
+        createWorktree: async ({ worktreeDir, branch, startPoint }) => {
           const { worktreeSymlinks } = loadProjectConfig(projectDir);
           const entry = await addWorktree({
             cwd: projectDir,
             worktreeDir,
             branch,
             symlinks: worktreeSymlinks,
-            fromRemote,
+            startPoint,
           });
 
           // switchDir 相当: 作成したパスは自明に正当なので検証不要

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -846,13 +846,14 @@ function createWindowWithRPC(dir: string, options?: CreateWindowOptions): GozdWi
           return entries;
         },
         gitBranchList: () => getBranchList(projectDir),
-        createWorktree: async ({ worktreeDir, branch }) => {
+        createWorktree: async ({ worktreeDir, branch, fromRemote }) => {
           const { worktreeSymlinks } = loadProjectConfig(projectDir);
           const entry = await addWorktree({
             cwd: projectDir,
             worktreeDir,
             branch,
             symlinks: worktreeSymlinks,
+            fromRemote,
           });
 
           // switchDir 相当: 作成したパスは自明に正当なので検証不要

--- a/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
+++ b/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
@@ -58,7 +58,7 @@ export function registerPrCommand(): () => void {
               request.createWorktree({
                 worktreeDir: generateTimestamp(),
                 branch: pr.headRefName,
-                fromRemote: true,
+                startPoint: `origin/${pr.headRefName}`,
               }),
             );
             if (!result.ok) {

--- a/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
+++ b/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
@@ -58,6 +58,7 @@ export function registerPrCommand(): () => void {
               request.createWorktree({
                 worktreeDir: generateTimestamp(),
                 branch: pr.headRefName,
+                fromRemote: true,
               }),
             );
             if (!result.ok) {

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -234,7 +234,7 @@ export type GozdRPC = {
       };
       /** worktree を作成し、表示対象を切り替える */
       createWorktree: {
-        params: { worktreeDir: string; branch: string; fromRemote?: boolean };
+        params: { worktreeDir: string; branch: string; startPoint?: string };
         response: { worktree: WorktreeEntry; dir: string; fileServerBaseUrl: string };
       };
       /** worktree を解除する（ブランチは残る） */

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -234,7 +234,7 @@ export type GozdRPC = {
       };
       /** worktree を作成し、表示対象を切り替える */
       createWorktree: {
-        params: { worktreeDir: string; branch: string };
+        params: { worktreeDir: string; branch: string; fromRemote?: boolean };
         response: { worktree: WorktreeEntry; dir: string; fileServerBaseUrl: string };
       };
       /** worktree を解除する（ブランチは残る） */


### PR DESCRIPTION
## 概要

PR 選択から worktree を作成する際に、ブランチがリモートの正しいコミットではなくデフォルトブランチ（HEAD）のコミットを指してしまうバグを修正する。

## 背景

`addWorktree` は最初に `git worktree add -b <branch> <wtPath>` を start-point なしで実行する。PR のブランチ名がローカルに存在しない場合、このコマンドは成功してしまい、HEAD（デフォルトブランチの最新コミット）を起点にブランチが作られる。本来到達すべき `createWorktreeFromRemote`（fetch してから `origin/<branch>` を起点にする正しいパス）に進まない。

## 変更内容

### RPC スキーマ

- `createWorktree` の params に `startPoint?: string` を追加。呼び出し側がブランチの起点となる commit-ish を明示的に指定できるようにする

### worktree 作成ロジック（`apps/desktop/src/git/worktree.ts`）

- `addWorktree` に `startPoint` パラメータを追加
- `startPoint` 指定時は `git worktree add -B`（create-or-reset）で worktree 化
- `startPoint` が `origin/` プレフィックスの場合、事前に `git fetch` でリモートブランチを最新化
- ローカルブランチが既に存在する場合の安全ガード:
  - 別 worktree で使用中のブランチは事前検知して明確なエラーメッセージを返す
  - `git merge-base --is-ancestor` で fast-forward 可能か検証し、diverge していればエラーにする（未 push のローカルコミットを保護）

### PR picker

- `registerPrCommand.ts` で `startPoint: \`origin/${pr.headRefName}\`` を指定

## スコープ

- **スコープ外（対応しない）**: `startPoint` なしのパス（サイドバーからのブランチ worktree 化）は従来通り変更なし

## 確認事項

- [ ] PR を選択して worktree を作成し、ブランチがリモートの正しいコミットを指しているか確認
- [ ] ローカルに同名ブランチが既に存在する状態で PR から worktree を作成し、リモートの最新に更新されるか確認
- [ ] ローカルブランチが diverge している場合にエラーメッセージが表示されるか確認
- [ ] サイドバーからのブランチ worktree 化（`startPoint` なし）が従来通り動作するか確認
