### PR TITLE
fix(shell-env): shellEnv を process.env にマージして全子プロセスの環境を統一

### DIFF
--- a/apps/desktop/src/git/issue.ts
+++ b/apps/desktop/src/git/issue.ts
@@ -43,14 +43,8 @@ query($owner: String!, $repo: String!, $limit: Int!) {
   }
 }`;
 
-export async function getIssueList({
-  cwd,
-  env,
-}: {
-  cwd: string;
-  env: Record<string, string>;
-}): Promise<GitIssue[] | null> {
-  const ownerRepo = await getOwnerRepo({ cwd, env });
+export async function getIssueList({ cwd }: { cwd: string }): Promise<GitIssue[] | null> {
+  const ownerRepo = await getOwnerRepo({ cwd });
   if (!ownerRepo) return null;
   const { owner, repo } = ownerRepo;
 
@@ -69,7 +63,6 @@ export async function getIssueList({
       `query=${ISSUE_QUERY}`,
     ],
     cwd,
-    env,
   });
   if (!result.ok) return null;
 

--- a/apps/desktop/src/git/pr.ts
+++ b/apps/desktop/src/git/pr.ts
@@ -54,22 +54,16 @@ query($owner: String!, $repo: String!, $limit: Int!) {
   }
 }`;
 
-/**
- * Bun.spawn で gh コマンドを実行し、stdout を文字列で返す。
- * Bun.$ は .env() で渡した PATH をコマンド解決に使わない（process.env.PATH を参照する）ため、
- * build 版で gh が見つからない問題がある。Bun.spawn なら env.PATH でコマンド解決される。
- */
+/** Bun.spawn で gh コマンドを実行し、stdout を文字列で返す */
 export async function execGh({
   args,
   cwd,
-  env,
 }: {
   args: string[];
   cwd: string;
-  env: Record<string, string>;
 }): Promise<{ ok: true; stdout: string } | { ok: false; stderr: string }> {
   const spawnResult = tryCatch(() =>
-    Bun.spawn(["gh", ...args], { cwd, env, stdout: "pipe", stderr: "pipe" }),
+    Bun.spawn(["gh", ...args], { cwd, stdout: "pipe", stderr: "pipe" }),
   );
   if (!spawnResult.ok) {
     return { ok: false, stderr: String(spawnResult.error) };
@@ -93,15 +87,9 @@ export async function execGh({
 /** 自アカウントのログイン名キャッシュ（成功時のみ保持） */
 let cachedViewer: string | undefined;
 
-export async function getViewer({
-  cwd,
-  env,
-}: {
-  cwd: string;
-  env: Record<string, string>;
-}): Promise<string | null> {
+export async function getViewer({ cwd }: { cwd: string }): Promise<string | null> {
   if (cachedViewer !== undefined) return cachedViewer;
-  const result = await execGh({ args: ["api", "user", "--jq", ".login"], cwd, env });
+  const result = await execGh({ args: ["api", "user", "--jq", ".login"], cwd });
   if (!result.ok) return null;
   const login = result.stdout.trim();
   cachedViewer = login;
@@ -111,15 +99,12 @@ export async function getViewer({
 /** リポジトリの owner/repo を取得する。gh 失敗時は null */
 export async function getOwnerRepo({
   cwd,
-  env,
 }: {
   cwd: string;
-  env: Record<string, string>;
 }): Promise<{ owner: string; repo: string } | null> {
   const nameResult = await execGh({
     args: ["repo", "view", "--json", "owner,name", "--jq", '.owner.login + "/" + .name'],
     cwd,
-    env,
   });
   if (!nameResult.ok) return null;
   const [owner, repo] = nameResult.stdout.trim().split("/");
@@ -127,14 +112,8 @@ export async function getOwnerRepo({
   return { owner, repo };
 }
 
-export async function getPrList({
-  cwd,
-  env,
-}: {
-  cwd: string;
-  env: Record<string, string>;
-}): Promise<GitPullRequest[] | null> {
-  const ownerRepo = await getOwnerRepo({ cwd, env });
+export async function getPrList({ cwd }: { cwd: string }): Promise<GitPullRequest[] | null> {
+  const ownerRepo = await getOwnerRepo({ cwd });
   if (!ownerRepo) return null;
   const { owner, repo } = ownerRepo;
 
@@ -153,7 +132,6 @@ export async function getPrList({
       `query=${PR_QUERY}`,
     ],
     cwd,
-    env,
   });
   if (!result.ok) return null;
 

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -135,10 +135,10 @@ function spawnPty(win: GozdWindow, cwd: string, cols: number, rows: number): num
   // stream: true で途中切れの UTF-8 バイト列を次のチャンクに繰り越す
   const decoder = new TextDecoder("utf-8", { fatal: false });
 
-  const proc = Bun.spawn([shellEnv.SHELL ?? "/bin/zsh"], {
+  const proc = Bun.spawn([process.env.SHELL ?? "/bin/zsh"], {
     cwd,
     env: {
-      ...shellEnv,
+      ...process.env,
       // desktop プロセスの GIT_OPTIONAL_LOCKS=0 を PTY に持ち込まない
       GIT_OPTIONAL_LOCKS: undefined,
       // TERM 系は PTY 側で明示設定する（親の値を持ち込まない）
@@ -147,11 +147,11 @@ function spawnPty(win: GozdWindow, cwd: string, cols: number, rows: number): num
       TERM_PROGRAM: "gozd",
       // CLI ツール（Claude Code 等）に OSC 8 ハイパーリンクの出力を許可する
       FORCE_HYPERLINK: "1",
-      LANG: shellEnv.LANG ?? "en_US.UTF-8",
+      LANG: process.env.LANG ?? "en_US.UTF-8",
       // Claude Code hooks がどの PTY から発火したか特定するための識別子
       GOZD_PTY_ID: String(id),
       // ZDOTDIR 差し替えで gozd の zsh 初期化を注入する
-      GOZD_ORIG_ZDOTDIR: shellEnv.ZDOTDIR ?? homedir(),
+      GOZD_ORIG_ZDOTDIR: process.env.ZDOTDIR ?? homedir(),
       GOZD_ZDOTDIR,
       ZDOTDIR: GOZD_ZDOTDIR,
       // claude() 関数が参照する hooks 設定ファイルパス
@@ -834,9 +834,9 @@ function createWindowWithRPC(dir: string, options?: CreateWindowOptions): GozdWi
         },
         gitLog: ({ maxCount, firstParentOnly }) =>
           getGitLog({ cwd: currentDir, maxCount, firstParentOnly }),
-        gitPrList: () => getPrList({ cwd: projectDir, env: shellEnv }),
-        gitIssueList: () => getIssueList({ cwd: projectDir, env: shellEnv }),
-        gitViewer: () => getViewer({ cwd: projectDir, env: shellEnv }),
+        gitPrList: () => getPrList({ cwd: projectDir }),
+        gitIssueList: () => getIssueList({ cwd: projectDir }),
+        gitViewer: () => getViewer({ cwd: projectDir }),
         gitWorktreeList: async () => {
           const entries = await attachGitStatuses(await getWorktreeList(projectDir));
           // 各 worktree に紐づく Task を付与
@@ -1331,7 +1331,10 @@ if (await isAlreadyRunning()) {
   process.exit(0);
 }
 
-const shellEnv = await getShellEnv();
+// shellEnv を process.env にマージし、全ての Bun.spawn が正しい PATH・環境で動作するようにする。
+// Launch Services 経由の起動時は PATH が /usr/bin:/bin:/usr/sbin:/sbin のみで、
+// Homebrew の git/gh が解決できず Apple 版 git が使われてしまう問題を防ぐ。
+Object.assign(process.env, await getShellEnv());
 
 // --- アプリメニュー ---
 


### PR DESCRIPTION
## 概要

`shellEnv` を `process.env` にマージする方式に変更し、全ての `Bun.spawn` が正しい PATH・環境変数で動作するようにする。

## 背景

#377 で PR 選択からの worktree 作成時に `git fetch` を追加したところ、macOS の「git-credential-osxkeychain がキーチェーン内の github.com に保存されている機密情報を使用しようとしています」ダイアログが毎回表示されるようになった。

原因は、`.app` バンドルが Launch Services 経由で起動されると `PATH` が `/usr/bin:/bin:/usr/sbin:/sbin` のみになり、`Bun.spawn(["git", ...])` が `/usr/bin/git`（Xcode CLT 版）を使うこと。ターミナルでは `/opt/homebrew/bin/git`（Homebrew 版）が使われており、`credential.helper=osxkeychain` は git の `--exec-path` 配下から解決されるため、異なる git バイナリ = 異なる credential helper = 異なるキーチェーン ACL エントリとなり、毎回確認が出る。

`gh` コマンドについては #247 で同じ問題（PATH 不足で gh が見つからない）に対処済みだったが、`git` は `/usr/bin/git` が存在するため「コマンドが見つからない」エラーにならず、認証不要のローカル操作（`git worktree add`, `git status` 等）では問題が顕在化しなかった。

## 変更内容

### shellEnv の適用方式を変更

- `shellEnv` を個別の関数に `env` 引数で渡す方式から、`process.env` にマージする方式に変更
- `Bun.spawn` は `env` オプション省略時に `process.env` を継承するため、全ての子プロセスが自動的に正しい環境を使う

### gh 系モジュールから env パラメータを削除

- `execGh`, `getViewer`, `getOwnerRepo`, `getPrList`（pr.ts）から `env` パラメータを削除
- `getIssueList`（issue.ts）から `env` パラメータを削除
- `index.ts` の呼び出し元から `env: shellEnv` を削除

### spawnPty の環境変数参照を統一

- `shellEnv.SHELL`, `shellEnv.LANG`, `shellEnv.ZDOTDIR` → `process.env.*` に変更
- `...shellEnv` → `...process.env` に変更

## 確認事項

- [ ] PR を選択して worktree を作成し、キーチェーン確認ダイアログが出ないことを確認
- [ ] ターミナルが正常に起動し、環境変数（PATH, SHELL, LANG 等）が正しいことを確認
- [ ] PR バッジ・issue 一覧が正常に表示されることを確認
- [ ] build 版（`pnpm build`）でも同様に動作することを確認
