### PR TITLE
fix(spawn): add spawn/spawnSync wrapper to pass process.env to child processes

### DIFF
--- a/apps/desktop/src/git/branch.ts
+++ b/apps/desktop/src/git/branch.ts
@@ -1,4 +1,5 @@
 import { tryCatch } from "@gozd/shared";
+import { spawn } from "../spawn";
 
 /** ブランチ名にシェルメタ文字が含まれていないことを検証する */
 export function assertBranchName(branch: string): void {
@@ -9,7 +10,7 @@ export function assertBranchName(branch: string): void {
 
 export async function getBranchList(cwd: string): Promise<string[]> {
   const result = await tryCatch(
-    new Response(Bun.spawn(["git", "branch", "--format=%(refname:short)"], { cwd }).stdout).text(),
+    new Response(spawn(["git", "branch", "--format=%(refname:short)"], { cwd }).stdout).text(),
   );
   if (!result.ok) return [];
   return result.value.trim().split("\n").filter(Boolean);
@@ -18,7 +19,7 @@ export async function getBranchList(cwd: string): Promise<string[]> {
 export async function deleteBranch(cwd: string, branch: string): Promise<void> {
   assertBranchName(branch);
 
-  const proc = Bun.spawn(["git", "branch", "-D", "--", branch], { cwd, stderr: "pipe" });
+  const proc = spawn(["git", "branch", "-D", "--", branch], { cwd, stderr: "pipe" });
   await proc.exited;
   if (proc.exitCode !== 0) {
     const stderr = await new Response(proc.stderr).text();

--- a/apps/desktop/src/git/log.ts
+++ b/apps/desktop/src/git/log.ts
@@ -1,5 +1,6 @@
 import { tryCatch } from "@gozd/shared";
 import type { GitCommit } from "@gozd/rpc";
+import { spawn } from "../spawn";
 
 /**
  * git log のフィールド区切り文字。
@@ -27,9 +28,7 @@ const DEFAULT_MAX_COUNT = 200;
  */
 async function resolveDefaultBranch(cwd: string): Promise<string | undefined> {
   const result = await tryCatch(
-    new Response(
-      Bun.spawn(["git", "symbolic-ref", "refs/remotes/origin/HEAD"], { cwd }).stdout,
-    ).text(),
+    new Response(spawn(["git", "symbolic-ref", "refs/remotes/origin/HEAD"], { cwd }).stdout).text(),
   );
   if (!result.ok) return undefined;
   // "refs/remotes/origin/main" → "main"
@@ -42,7 +41,7 @@ async function resolveDefaultBranch(cwd: string): Promise<string | undefined> {
  */
 async function resolveCurrentBranch(cwd: string): Promise<string | undefined> {
   const result = await tryCatch(
-    new Response(Bun.spawn(["git", "rev-parse", "--abbrev-ref", "HEAD"], { cwd }).stdout).text(),
+    new Response(spawn(["git", "rev-parse", "--abbrev-ref", "HEAD"], { cwd }).stdout).text(),
   );
   if (!result.ok) return undefined;
   const branch = result.value.trim();
@@ -57,7 +56,7 @@ async function resolveCurrentBranch(cwd: string): Promise<string | undefined> {
 async function localRefExists({ cwd, branch }: { cwd: string; branch: string }): Promise<boolean> {
   const result = await tryCatch(
     new Response(
-      Bun.spawn(["git", "rev-parse", "--verify", `refs/heads/${branch}`], { cwd }).stdout,
+      spawn(["git", "rev-parse", "--verify", `refs/heads/${branch}`], { cwd }).stdout,
     ).text(),
   );
   return result.ok && result.value.trim() !== "";
@@ -76,7 +75,7 @@ async function resolveRemoteRef({
   const ref = `origin/${branch}`;
   const result = await tryCatch(
     new Response(
-      Bun.spawn(["git", "rev-parse", "--verify", `refs/remotes/${ref}`], {
+      spawn(["git", "rev-parse", "--verify", `refs/remotes/${ref}`], {
         cwd,
       }).stdout,
     ).text(),
@@ -138,11 +137,9 @@ export async function getGitLog({
 
   // HEAD 系統とデフォルトブランチ系統を並列で取得
   const [headResult, defaultResult] = await Promise.all([
-    tryCatch(new Response(Bun.spawn([...baseArgs, ...headRefs, "--"], { cwd }).stdout).text()),
+    tryCatch(new Response(spawn([...baseArgs, ...headRefs, "--"], { cwd }).stdout).text()),
     defaultRefs.length > 0
-      ? tryCatch(
-          new Response(Bun.spawn([...baseArgs, ...defaultRefs, "--"], { cwd }).stdout).text(),
-        )
+      ? tryCatch(new Response(spawn([...baseArgs, ...defaultRefs, "--"], { cwd }).stdout).text())
       : Promise.resolve(undefined),
   ]);
 

--- a/apps/desktop/src/git/pr.ts
+++ b/apps/desktop/src/git/pr.ts
@@ -1,5 +1,6 @@
 import type { GitPullRequest } from "@gozd/rpc";
 import { tryCatch } from "@gozd/shared";
+import { spawn } from "../spawn";
 
 /**
  * gh api graphql で open な PR 一覧を取得する。
@@ -63,7 +64,7 @@ export async function execGh({
   cwd: string;
 }): Promise<{ ok: true; stdout: string } | { ok: false; stderr: string }> {
   const spawnResult = tryCatch(() =>
-    Bun.spawn(["gh", ...args], { cwd, stdout: "pipe", stderr: "pipe" }),
+    spawn(["gh", ...args], { cwd, stdout: "pipe", stderr: "pipe" }),
   );
   if (!spawnResult.ok) {
     return { ok: false, stderr: String(spawnResult.error) };

--- a/apps/desktop/src/git/status.ts
+++ b/apps/desktop/src/git/status.ts
@@ -1,11 +1,12 @@
 import { tryCatch } from "@gozd/shared";
 import { UNCOMMITTED_HASH } from "@gozd/rpc";
 import type { GitFileChange } from "@gozd/rpc";
+import { spawn } from "../spawn";
 
 export async function filterIgnored(entries: string[], cwd: string): Promise<Set<string>> {
   if (entries.length === 0) return new Set();
   const result = await tryCatch(
-    new Response(Bun.spawn(["git", "check-ignore", ...entries], { cwd }).stdout).text(),
+    new Response(spawn(["git", "check-ignore", ...entries], { cwd }).stdout).text(),
   );
   if (!result.ok) return new Set();
   const text = result.value;
@@ -28,7 +29,7 @@ interface GitStatusResult {
 export async function getGitStatus(cwd: string): Promise<GitStatusResult> {
   const result = await tryCatch(
     new Response(
-      Bun.spawn(["git", "status", "--porcelain=v2", "--branch", "-z", "--untracked-files=all"], {
+      spawn(["git", "status", "--porcelain=v2", "--branch", "-z", "--untracked-files=all"], {
         cwd,
       }).stdout,
     ).text(),
@@ -149,7 +150,7 @@ export async function getGitCommitFiles(
   compareHash?: string,
 ): Promise<GitFileChange[]> {
   const args = await buildDiffArgs(cwd, hash, compareHash);
-  const result = await tryCatch(new Response(Bun.spawn(args, { cwd }).stdout).text());
+  const result = await tryCatch(new Response(spawn(args, { cwd }).stdout).text());
   if (!result.ok) return [];
   return parseDiffNameStatus(result.value);
 }
@@ -160,7 +161,7 @@ export async function getGitCommitFiles(
  * rev-parse に -- を渡すと rev 解決ではなくリテラル出力になるため使わない。
  */
 async function isRootCommit(cwd: string, hash: string): Promise<boolean> {
-  const proc = Bun.spawn(["git", "rev-parse", `${hash}^`], { cwd, stderr: "ignore" });
+  const proc = spawn(["git", "rev-parse", `${hash}^`], { cwd, stderr: "ignore" });
   const exitCode = await proc.exited;
   return exitCode !== 0;
 }
@@ -185,7 +186,7 @@ export async function resolveCommitDiffRefs(
     const hasUncommitted = hash === UNCOMMITTED_HASH || compareHash === UNCOMMITTED_HASH;
 
     const orderResult = await tryCatch(
-      Bun.spawn(["git", "merge-base", "--is-ancestor", commitA, commitB], { cwd }).exited,
+      spawn(["git", "merge-base", "--is-ancestor", commitA, commitB], { cwd }).exited,
     );
     const aIsOlder = orderResult.ok && orderResult.value === 0;
     const older = aIsOlder ? commitA : commitB;
@@ -217,7 +218,7 @@ async function buildDiffArgs(cwd: string, hash: string, compareHash?: string): P
 
     // 古い方の親を起点にする
     const orderResult = await tryCatch(
-      Bun.spawn(["git", "merge-base", "--is-ancestor", commitA, commitB], { cwd }).exited,
+      spawn(["git", "merge-base", "--is-ancestor", commitA, commitB], { cwd }).exited,
     );
     const aIsOlder = orderResult.ok && orderResult.value === 0;
     const older = aIsOlder ? commitA : commitB;

--- a/apps/desktop/src/git/utils.ts
+++ b/apps/desktop/src/git/utils.ts
@@ -2,6 +2,7 @@ import { existsSync, statSync } from "node:fs";
 import path from "node:path";
 import { tryCatch } from "@gozd/shared";
 import type { OpenTargetSelection } from "@gozd/rpc";
+import { spawnSync } from "../spawn";
 
 /** remote URL から owner/repo を抽出するパターン（HTTPS / SSH / ssh:// 対応、ローカルパスは除外） */
 const REMOTE_OWNER_REPO_RE =
@@ -21,7 +22,7 @@ export function parseOwnerRepo(url: string): string | undefined {
  */
 function resolveProjectDir(dir: string): string {
   const result = tryCatch(() =>
-    Bun.spawnSync(["git", "rev-parse", "--git-common-dir"], {
+    spawnSync(["git", "rev-parse", "--git-common-dir"], {
       cwd: dir,
       stdout: "pipe",
       stderr: "pipe",
@@ -43,7 +44,7 @@ function resolveProjectDir(dir: string): string {
  */
 function resolveWorktreeRoot(dir: string): string {
   const result = tryCatch(() =>
-    Bun.spawnSync(["git", "rev-parse", "--show-toplevel"], {
+    spawnSync(["git", "rev-parse", "--show-toplevel"], {
       cwd: dir,
       stdout: "pipe",
       stderr: "pipe",
@@ -68,7 +69,7 @@ interface ResolvedOpenTarget {
 /** dir が git リポジトリ内かどうかを同期的に判定する */
 export function checkIsGitRepo(dir: string): boolean {
   const result = tryCatch(() =>
-    Bun.spawnSync(["git", "rev-parse", "--is-inside-work-tree"], {
+    spawnSync(["git", "rev-parse", "--is-inside-work-tree"], {
       cwd: dir,
       stdout: "pipe",
       stderr: "pipe",

--- a/apps/desktop/src/git/worktree.ts
+++ b/apps/desktop/src/git/worktree.ts
@@ -5,6 +5,7 @@ import { tryCatch } from "@gozd/shared";
 import type { WorktreeEntry } from "@gozd/rpc";
 import { projectKey } from "../projectKey";
 import { resolveCreatableFsPath, resolveExistingFsPath, resolveGitPath } from "../security";
+import { spawn } from "../spawn";
 import { getGitStatus } from "./status";
 import { assertBranchName } from "./branch";
 
@@ -28,14 +29,14 @@ async function createWorktreeFromRemote({
   branch: string;
   wtPath: string;
 }): Promise<boolean> {
-  const fetchProc = Bun.spawn(["git", "fetch", "origin", branch], {
+  const fetchProc = spawn(["git", "fetch", "origin", branch], {
     cwd,
     stderr: "pipe",
   });
   await fetchProc.exited;
   if (fetchProc.exitCode !== 0) return false;
 
-  const wtProc = Bun.spawn(["git", "worktree", "add", "-b", branch, wtPath, `origin/${branch}`], {
+  const wtProc = spawn(["git", "worktree", "add", "-b", branch, wtPath, `origin/${branch}`], {
     cwd,
     stderr: "pipe",
   });
@@ -73,7 +74,7 @@ export async function addWorktree({
     const ORIGIN_PREFIX = "origin/";
     if (startPoint.startsWith(ORIGIN_PREFIX)) {
       const remoteBranch = startPoint.slice(ORIGIN_PREFIX.length);
-      const fetchProc = Bun.spawn(["git", "fetch", "origin", remoteBranch], {
+      const fetchProc = spawn(["git", "fetch", "origin", remoteBranch], {
         cwd,
         stderr: "pipe",
       });
@@ -85,7 +86,7 @@ export async function addWorktree({
     }
     // ローカルブランチが存在する場合、fast-forward 可能か検証してからリセットする
     const branchExists =
-      (await Bun.spawn(["git", "show-ref", "--verify", "--quiet", `refs/heads/${branch}`], { cwd })
+      (await spawn(["git", "show-ref", "--verify", "--quiet", `refs/heads/${branch}`], { cwd })
         .exited) === 0;
     if (branchExists) {
       // 別 worktree で使用中のブランチは -B でもリセットできない
@@ -96,10 +97,9 @@ export async function addWorktree({
       }
 
       const isAncestor =
-        (await Bun.spawn(
-          ["git", "merge-base", "--is-ancestor", `refs/heads/${branch}`, startPoint],
-          { cwd },
-        ).exited) === 0;
+        (await spawn(["git", "merge-base", "--is-ancestor", `refs/heads/${branch}`, startPoint], {
+          cwd,
+        }).exited) === 0;
       if (!isAncestor) {
         throw new Error(
           `Local branch "${branch}" has diverged from ${startPoint}. Remove the local branch or resolve manually.`,
@@ -108,7 +108,7 @@ export async function addWorktree({
     }
 
     // -B: ブランチが存在しなければ作成、存在すれば startPoint にリセット（fast-forward 検証済み）
-    const wtProc = Bun.spawn(["git", "worktree", "add", "-B", branch, wtPath, startPoint], {
+    const wtProc = spawn(["git", "worktree", "add", "-B", branch, wtPath, startPoint], {
       cwd,
       stderr: "pipe",
     });
@@ -122,7 +122,7 @@ export async function addWorktree({
   } else {
     // まず -b で新規ブランチ作成を試み、既存ブランチなら -b なしでリトライ。
     // タイムスタンプベースの名前では事実上リトライは発生しない
-    const newBranchProc = Bun.spawn(["git", "worktree", "add", "-b", branch, wtPath], {
+    const newBranchProc = spawn(["git", "worktree", "add", "-b", branch, wtPath], {
       cwd,
       stderr: "pipe",
     });
@@ -131,12 +131,12 @@ export async function addWorktree({
     if (newBranchProc.exitCode !== 0) {
       // ブランチが既に存在するかをロケール非依存で判定（stderr のメッセージは LANG で変わるため）
       const branchExists =
-        (await Bun.spawn(["git", "show-ref", "--verify", "--quiet", `refs/heads/${branch}`], {
+        (await spawn(["git", "show-ref", "--verify", "--quiet", `refs/heads/${branch}`], {
           cwd,
         }).exited) === 0;
 
       if (branchExists) {
-        const existingProc = Bun.spawn(["git", "worktree", "add", wtPath, branch], {
+        const existingProc = spawn(["git", "worktree", "add", wtPath, branch], {
           cwd,
           stderr: "pipe",
         });
@@ -174,7 +174,7 @@ export async function removeWorktree(cwd: string, wtPath: string, force?: boolea
   if (force) args.push("--force");
   args.push(wtPath);
 
-  const proc = Bun.spawn(args, { cwd, stderr: "pipe" });
+  const proc = spawn(args, { cwd, stderr: "pipe" });
   await proc.exited;
   if (proc.exitCode !== 0) {
     const stderr = await new Response(proc.stderr).text();
@@ -184,7 +184,7 @@ export async function removeWorktree(cwd: string, wtPath: string, force?: boolea
 
 export async function getWorktreeList(cwd: string): Promise<WorktreeEntry[]> {
   const result = await tryCatch(
-    new Response(Bun.spawn(["git", "worktree", "list", "--porcelain"], { cwd }).stdout).text(),
+    new Response(spawn(["git", "worktree", "list", "--porcelain"], { cwd }).stdout).text(),
   );
   if (!result.ok) return [];
 

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -34,6 +34,7 @@ import {
 } from "./security";
 import { generateClaudeSettings } from "./claudeHooks";
 import { getShellEnv } from "./shellEnv";
+import { spawn } from "./spawn";
 import { loadAppState, saveSnapshot, getDefaultFrame } from "./appState";
 import { loadConfig, saveConfig } from "./config";
 import { loadProjectConfig, saveProjectConfig } from "./projectConfig";
@@ -62,7 +63,9 @@ const channel = await Updater.localInfo.channel();
 
 /** git remote origin URL から owner/repo 形式の名前を取得。失敗時はディレクトリ名にフォールバック */
 async function getRepoName(dir: string): Promise<string> {
-  const result = await tryCatch(Promise.resolve(Bun.$`git -C ${dir} remote get-url origin`.text()));
+  const result = await tryCatch(
+    Promise.resolve(Bun.$`git -C ${dir} remote get-url origin`.env(process.env).text()),
+  );
   if (result.ok) {
     const ownerRepo = parseOwnerRepo(result.value.trim());
     if (ownerRepo) return ownerRepo;
@@ -229,7 +232,7 @@ const fileServer = Bun.serve({
     if (source === "git") {
       const insideResult = tryCatch(() => resolveGitPath(dir, relPath));
       if (!insideResult.ok) return new Response("Forbidden", { status: 403 });
-      const proc = Bun.spawn(["git", "show", `HEAD:${relPath}`], { cwd: dir });
+      const proc = spawn(["git", "show", `HEAD:${relPath}`], { cwd: dir });
       const bufResult = await tryCatch(new Response(proc.stdout).arrayBuffer());
       await proc.exited;
       if (!bufResult.ok || proc.exitCode !== 0) {
@@ -354,7 +357,7 @@ const windowWatchGen = new Map<GozdWindow, number>();
 /** linked worktree 対応: `.git` がファイル（gitdir: ...）の場合に実際の git ディレクトリを解決 */
 async function resolveGitDir(root: string): Promise<string> {
   const result = await tryCatch(
-    new Response(Bun.spawn(["git", "rev-parse", "--git-dir"], { cwd: root }).stdout).text(),
+    new Response(spawn(["git", "rev-parse", "--git-dir"], { cwd: root }).stdout).text(),
   );
   if (!result.ok) return path.join(root, ".git");
   const gitDir = result.value.trim();
@@ -398,7 +401,7 @@ function startWatching(win: GozdWindow, root: string, isGitRepo = true) {
     async function resolveRefPath(refName: string): Promise<string | undefined> {
       const result = await tryCatch(
         new Response(
-          Bun.spawn(["git", "rev-parse", "--git-path", refName], { cwd: root }).stdout,
+          spawn(["git", "rev-parse", "--git-path", refName], { cwd: root }).stdout,
         ).text(),
       );
       if (!result.ok) return undefined;
@@ -770,7 +773,7 @@ function createWindowWithRPC(dir: string, options?: CreateWindowOptions): GozdWi
         },
         gitShowFile: async ({ relPath }) => {
           resolveGitPath(currentDir, relPath);
-          const proc = Bun.spawn(["git", "show", `HEAD:${relPath}`], { cwd: currentDir });
+          const proc = spawn(["git", "show", `HEAD:${relPath}`], { cwd: currentDir });
           const result = await tryCatch(new Response(proc.stdout).arrayBuffer());
           await proc.exited;
           if (!result.ok || proc.exitCode !== 0) {
@@ -786,7 +789,7 @@ function createWindowWithRPC(dir: string, options?: CreateWindowOptions): GozdWi
           resolveGitPath(currentDir, relPath);
           const result = await tryCatch(
             new Response(
-              Bun.spawn(["git", "diff", "HEAD", "--", relPath], { cwd: currentDir }).stdout,
+              spawn(["git", "diff", "HEAD", "--", relPath], { cwd: currentDir }).stdout,
             ).text(),
           );
           if (!result.ok) return "";
@@ -803,7 +806,7 @@ function createWindowWithRPC(dir: string, options?: CreateWindowOptions): GozdWi
               // from=null: ルートコミット（親なし）→ ファイルは存在しない
               return { content: "", isBinary: false, notFound: true };
             }
-            const proc = Bun.spawn(["git", "show", `${ref}:${relPath}`], { cwd: currentDir });
+            const proc = spawn(["git", "show", `${ref}:${relPath}`], { cwd: currentDir });
             const result = await tryCatch(new Response(proc.stdout).arrayBuffer());
             await proc.exited;
             if (!result.ok || proc.exitCode !== 0) {
@@ -938,10 +941,10 @@ function createWindowWithRPC(dir: string, options?: CreateWindowOptions): GozdWi
         projectConfigSave: (config) => saveProjectConfig(projectDir, config),
         voicevoxLaunch: async () => {
           // mdfind で VOICEVOX.app を検索（/Applications, ~/Applications, カスタム場所に対応）
-          const mdfind = Bun.spawn(
-            ["mdfind", "kMDItemCFBundleIdentifier == 'jp.hiroshiba.voicevox'"],
-            { stdout: "pipe", stderr: "pipe" },
-          );
+          const mdfind = spawn(["mdfind", "kMDItemCFBundleIdentifier == 'jp.hiroshiba.voicevox'"], {
+            stdout: "pipe",
+            stderr: "pipe",
+          });
           const output = await new Response(mdfind.stdout).text();
           const mdfindStderr = await new Response(mdfind.stderr).text();
           const mdfindExitCode = await mdfind.exited;
@@ -961,7 +964,7 @@ function createWindowWithRPC(dir: string, options?: CreateWindowOptions): GozdWi
           }
           // Engine だけをバックグラウンドで起動（GUI なし）
           // stderr: "inherit" でパイプ詰まりを防ぎ、Electrobun コンソールに出力
-          const engine = Bun.spawn([enginePath], {
+          const engine = spawn([enginePath], {
             stdout: "ignore",
             stderr: "inherit",
           });
@@ -1331,9 +1334,8 @@ if (await isAlreadyRunning()) {
   process.exit(0);
 }
 
-// shellEnv を process.env にマージし、全ての Bun.spawn が正しい PATH・環境で動作するようにする。
-// Launch Services 経由の起動時は PATH が /usr/bin:/bin:/usr/sbin:/sbin のみで、
-// Homebrew の git/gh が解決できず Apple 版 git が使われてしまう問題を防ぐ。
+// shellEnv を process.env にマージする。Bun は env 省略時に起動時のネイティブ環境を継承するため、
+// process.env への変更だけでは子プロセスに反映されない。env: { ...process.env } の明示渡しが必要。
 Object.assign(process.env, await getShellEnv());
 
 // --- アプリメニュー ---

--- a/apps/desktop/src/spawn.ts
+++ b/apps/desktop/src/spawn.ts
@@ -17,14 +17,42 @@ export function spawn<
   const I extends In = "ignore",
   const O extends Out = "pipe",
   const E extends Out = "inherit",
->(cmd: string[], opts?: Bun.SpawnOptions.SpawnOptions<I, O, E>): Bun.Subprocess<I, O, E> {
-  return Bun.spawn(cmd, { ...opts, env: { ...process.env, ...opts?.env } });
+>(cmd: string[], opts?: Bun.SpawnOptions.SpawnOptions<I, O, E>): Bun.Subprocess<I, O, E>;
+export function spawn<
+  const I extends In = "ignore",
+  const O extends Out = "pipe",
+  const E extends Out = "inherit",
+>(opts: Bun.SpawnOptions.SpawnOptions<I, O, E> & { cmd: string[] }): Bun.Subprocess<I, O, E>;
+export function spawn(
+  cmdOrOpts: string[] | (Bun.SpawnOptions.SpawnOptions<In, Out, Out> & { cmd: string[] }),
+  maybeOpts?: Bun.SpawnOptions.SpawnOptions<In, Out, Out>,
+): Bun.Subprocess {
+  if (Array.isArray(cmdOrOpts)) {
+    return Bun.spawn(cmdOrOpts, { ...maybeOpts, env: { ...process.env, ...maybeOpts?.env } });
+  }
+  const { cmd, ...opts } = cmdOrOpts;
+  return Bun.spawn(cmd, { ...opts, env: { ...process.env, ...opts.env } });
 }
 
 export function spawnSync<
   const I extends In = "ignore",
   const O extends Out = "pipe",
   const E extends Out = "pipe",
->(cmd: string[], opts?: Bun.SpawnOptions.SpawnSyncOptions<I, O, E>): Bun.SyncSubprocess<O, E> {
-  return Bun.spawnSync(cmd, { ...opts, env: { ...process.env, ...opts?.env } });
+>(cmd: string[], opts?: Bun.SpawnOptions.SpawnSyncOptions<I, O, E>): Bun.SyncSubprocess<O, E>;
+export function spawnSync<
+  const I extends In = "ignore",
+  const O extends Out = "pipe",
+  const E extends Out = "pipe",
+>(
+  opts: Bun.SpawnOptions.SpawnSyncOptions<I, O, E> & { cmd: string[]; onExit?: never },
+): Bun.SyncSubprocess<O, E>;
+export function spawnSync(
+  cmdOrOpts: string[] | (Bun.SpawnOptions.SpawnSyncOptions<In, Out, Out> & { cmd: string[] }),
+  maybeOpts?: Bun.SpawnOptions.SpawnSyncOptions<In, Out, Out>,
+): Bun.SyncSubprocess {
+  if (Array.isArray(cmdOrOpts)) {
+    return Bun.spawnSync(cmdOrOpts, { ...maybeOpts, env: { ...process.env, ...maybeOpts?.env } });
+  }
+  const { cmd, ...opts } = cmdOrOpts;
+  return Bun.spawnSync(cmd, { ...opts, env: { ...process.env, ...opts.env } });
 }

--- a/apps/desktop/src/spawn.ts
+++ b/apps/desktop/src/spawn.ts
@@ -1,0 +1,30 @@
+/**
+ * Bun.spawn / Bun.spawnSync のラッパー。
+ *
+ * Bun は env 省略時に起動時のネイティブ環境（C の environ）を子プロセスに渡す。
+ * process.env への変更（Object.assign 含む）は JS Proxy 層にしか反映されず、
+ * Zig 内部の transpiler.env.map は更新されない。
+ * そのため Launch Services 経由の .app 起動では PATH が最小限のままになる。
+ *
+ * このモジュールは env: { ...process.env } を自動付与することで、
+ * process.env の現在値を確実に子プロセスに渡す。
+ */
+
+type In = Bun.SpawnOptions.Writable;
+type Out = Bun.SpawnOptions.Readable;
+
+export function spawn<
+  const I extends In = "ignore",
+  const O extends Out = "pipe",
+  const E extends Out = "inherit",
+>(cmd: string[], opts?: Bun.SpawnOptions.SpawnOptions<I, O, E>): Bun.Subprocess<I, O, E> {
+  return Bun.spawn(cmd, { ...opts, env: { ...process.env, ...opts?.env } });
+}
+
+export function spawnSync<
+  const I extends In = "ignore",
+  const O extends Out = "pipe",
+  const E extends Out = "pipe",
+>(cmd: string[], opts?: Bun.SpawnOptions.SpawnSyncOptions<I, O, E>): Bun.SyncSubprocess<O, E> {
+  return Bun.spawnSync(cmd, { ...opts, env: { ...process.env, ...opts?.env } });
+}


### PR DESCRIPTION
## 概要

`Bun.spawn` / `Bun.spawnSync` / `Bun.$` のラッパーを導入し、全ての子プロセスに `process.env` の現在値を明示的に渡すようにする。

## 背景

#378 で `shellEnv` を `process.env` にマージする方式に変更し、`execGh` 等から `env` パラメータを削除した。「`process.env` にマージすれば全 `Bun.spawn` が自動的に正しい環境を継承する」という前提だったが、build 版（Launch Services 経由）で PR/issue が取得できなくなった。

原因を調査したところ、Bun の内部実装に起因する問題であることが判明した。

- `process.env` への代入（`Object.assign` 含む）は JS の Proxy 層（`JSEnvironmentVariableMap.cpp` の `jsSetterEnvironmentVariable`）のみに書き込まれる
- `Bun.spawn` で `env` を省略した場合、Zig 側の `transpiler.env.map`（`js_bun_spawn_bindings.zig:435`）が使われる。これはプロセス起動時のネイティブ環境から構築され、JS 側の変更は反映されない
- `Bun.$` も同じソース（`shell/subproc.zig:766` → `EventLoopHandle.zig:119`）を参照しており、挙動は `Bun.spawn` と同一
- この問題は `oven-sh/bun` のソースコードで確認済み

dev 起動ではターミナルの環境変数がそのままネイティブ環境に入るため問題が顕在化せず、Launch Services 経由の build 版でのみ PATH が `/usr/bin:/bin:/usr/sbin:/sbin` に制限される。

## 変更内容

### `spawn` / `spawnSync` ラッパーの追加（`apps/desktop/src/spawn.ts`）

- `env: { ...process.env, ...opts?.env }` を自動付与するラッパー関数を作成
- ジェネリック型パラメータで `Bun.spawn` のオーバーロード解決（stdout/stderr のストリーム型）を保持

### 全 `Bun.spawn` / `Bun.spawnSync` 呼び出しの置換

- `apps/desktop/src/git/pr.ts` — `execGh`（gh コマンド）
- `apps/desktop/src/git/status.ts` — git status, check-ignore, rev-parse, merge-base, diff
- `apps/desktop/src/git/worktree.ts` — git fetch, worktree add/remove/list, show-ref, merge-base
- `apps/desktop/src/git/branch.ts` — git branch
- `apps/desktop/src/git/log.ts` — git symbolic-ref, rev-parse, log
- `apps/desktop/src/git/utils.ts` — `Bun.spawnSync` による git rev-parse（3箇所）
- `apps/desktop/src/index.ts` — git show, rev-parse, diff, mdfind, VOICEVOX engine

### `Bun.$` の対応

- `index.ts` の `getRepoName` で `.env(process.env)` を明示的に渡すよう変更

### 除外した箇所

- `spawnPty`（`index.ts:141`）— 既に `env: { ...process.env, ... }` を明示渡し済み
- `shellEnv.ts` の `Bun.spawn` — シェル環境の解決自体であり、独自に `env` を構築している

## 確認事項

- [ ] build 版（`pnpm build` → `.app` 起動）で PR 一覧・issue 一覧が表示されること
- [ ] build 版で worktree 作成（リモートブランチからの fetch を含む）が正常に動作すること
- [ ] dev 版で既存機能が壊れていないこと
