### PR TITLE
fix(desktop): PRからworktree作成時にdivergedブランチでもworktree作成を許可

### DIFF
--- a/apps/desktop/src/git/worktree.ts
+++ b/apps/desktop/src/git/worktree.ts
@@ -95,19 +95,9 @@ export async function addWorktree({
       if (usedBy) {
         throw new Error(`Branch "${branch}" is already checked out in worktree: ${usedBy.path}`);
       }
-
-      const isAncestor =
-        (await spawn(["git", "merge-base", "--is-ancestor", `refs/heads/${branch}`, startPoint], {
-          cwd,
-        }).exited) === 0;
-      if (!isAncestor) {
-        throw new Error(
-          `Local branch "${branch}" has diverged from ${startPoint}. Remove the local branch or resolve manually.`,
-        );
-      }
     }
 
-    // -B: ブランチが存在しなければ作成、存在すれば startPoint にリセット（fast-forward 検証済み）
+    // -B: ブランチが存在しなければ作成、存在すれば startPoint にリセット
     const wtProc = spawn(["git", "worktree", "add", "-B", branch, wtPath, startPoint], {
       cwd,
       stderr: "pipe",

--- a/apps/desktop/src/git/worktree.ts
+++ b/apps/desktop/src/git/worktree.ts
@@ -84,7 +84,7 @@ export async function addWorktree({
         throw new Error(`git fetch failed: ${stderr.trim() || `exit code ${fetchProc.exitCode}`}`);
       }
     }
-    // ローカルブランチが別 worktree で使用中でないことを検証する
+    // ローカルブランチが既存 worktree で checkout されていないことを検証する
     const branchExists =
       (await spawn(["git", "show-ref", "--verify", "--quiet", `refs/heads/${branch}`], { cwd })
         .exited) === 0;

--- a/apps/desktop/src/git/worktree.ts
+++ b/apps/desktop/src/git/worktree.ts
@@ -89,7 +89,7 @@ export async function addWorktree({
       (await spawn(["git", "show-ref", "--verify", "--quiet", `refs/heads/${branch}`], { cwd })
         .exited) === 0;
     if (branchExists) {
-      // 別 worktree で使用中のブランチは -B でもリセットできない
+      // checkout 済みのブランチは -B でもリセットできない
       const worktrees = await getWorktreeList(cwd);
       const usedBy = worktrees.find((wt) => wt.branch === branch);
       if (usedBy) {

--- a/apps/desktop/src/git/worktree.ts
+++ b/apps/desktop/src/git/worktree.ts
@@ -84,7 +84,7 @@ export async function addWorktree({
         throw new Error(`git fetch failed: ${stderr.trim() || `exit code ${fetchProc.exitCode}`}`);
       }
     }
-    // ローカルブランチが存在する場合、fast-forward 可能か検証してからリセットする
+    // ローカルブランチが別 worktree で使用中でないことを検証する
     const branchExists =
       (await spawn(["git", "show-ref", "--verify", "--quiet", `refs/heads/${branch}`], { cwd })
         .exited) === 0;


### PR DESCRIPTION
## 概要

PRからworktree作成時、ローカルブランチがリモートから diverged している場合でもworktreeを作成できるようにする。

## 背景

PRからworktreeを作成する際、同名のローカルブランチが既に存在し、かつリモートブランチから diverge している場合に `Failed to create worktree` エラーが発生していた。これは以前worktreeを作って解除した後、PRにforce pushされたケースなどで起きる。

PRからの作成は `origin/branch` を `startPoint` に指定しており、リモート最新にリセットすることが目的。`git worktree add -B` はブランチを `startPoint` にリセットする動作なので、fast-forward チェックは不要。

## 変更内容

### worktree 作成ロジック

- `addWorktree()` の `startPoint` ありパスから `merge-base --is-ancestor` による fast-forward チェックを削除
- `-B` オプションのリセット動作にそのまま委ねる
- 既存 worktree で checkout 済みブランチに対するチェックはそのまま維持

### コメント修正

- 実装と乖離していたコメントを現在の動作に合わせて更新

## 確認事項

- [ ] 既存ブランチが diverged した状態で PR から worktree 作成できること
- [ ] 既存ブランチが fast-forward 可能な状態でも引き続き作成できること
- [ ] 既存 worktree で checkout 済みのブランチではエラーになること
