### PR TITLE
fix(desktop): kill PTY process group to prevent orphan server processes

### DIFF
--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -136,24 +136,16 @@ let nextPtyId = 0;
 /**
  * PTY とその子プロセス（サーバー等）をプロセスグループごと終了する。
  * Bun.spawn({ terminal }) は forkpty(3) 相当で子プロセスを新セッションリーダーにするため
- * 通常 PID = PGID が成立する。成立しない環境では単体 kill にフォールバックする。
+ * PID = PGID が成立し、負の PID でプロセスグループ全体に SIGTERM が届く。
  */
 function killPtyProcess(entry: PtyEntry) {
   const pid = entry.proc.pid;
-  const groupResult = tryCatch(() => process.kill(-pid, "SIGTERM"));
-  if (!groupResult.ok) {
-    const code = (groupResult.error as NodeJS.ErrnoException).code;
-    if (code === "ESRCH") {
-      // プロセスグループが存在しない: PID != PGID か既に終了済み。単体 kill を試みる
-      const singleResult = tryCatch(() => process.kill(pid, "SIGTERM"));
-      if (!singleResult.ok) {
-        const singleCode = (singleResult.error as NodeJS.ErrnoException).code;
-        if (singleCode !== "ESRCH") {
-          console.error(`[killPtyProcess] failed to kill pid ${pid}:`, singleResult.error);
-        }
-      }
-    } else {
-      console.error(`[killPtyProcess] failed to kill process group ${pid}:`, groupResult.error);
+  const result = tryCatch(() => process.kill(-pid, "SIGTERM"));
+  if (!result.ok) {
+    const code = (result.error as NodeJS.ErrnoException).code;
+    // ESRCH: プロセスグループが既に終了済み
+    if (code !== "ESRCH") {
+      console.error(`[killPtyProcess] failed to kill process group ${pid}:`, result.error);
     }
   }
 }

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -133,14 +133,28 @@ interface PtyEntry {
 const ptys = new Map<number, PtyEntry>();
 let nextPtyId = 0;
 
-/** PTY とその子プロセス（サーバー等）をプロセスグループごと終了する */
+/**
+ * PTY とその子プロセス（サーバー等）をプロセスグループごと終了する。
+ * Bun.spawn({ terminal }) は forkpty(3) 相当で子プロセスを新セッションリーダーにするため
+ * 通常 PID = PGID が成立する。成立しない環境では単体 kill にフォールバックする。
+ */
 function killPtyProcess(entry: PtyEntry) {
   const pid = entry.proc.pid;
-  // 負の PID でプロセスグループ全体に SIGTERM を送る
-  const result = tryCatch(() => process.kill(-pid, "SIGTERM"));
-  if (!result.ok) {
-    // ESRCH: プロセスが既に終了済み
-    if ((result.error as NodeJS.ErrnoException).code !== "ESRCH") throw result.error;
+  const groupResult = tryCatch(() => process.kill(-pid, "SIGTERM"));
+  if (!groupResult.ok) {
+    const code = (groupResult.error as NodeJS.ErrnoException).code;
+    if (code === "ESRCH") {
+      // プロセスグループが存在しない: PID != PGID か既に終了済み。単体 kill を試みる
+      const singleResult = tryCatch(() => process.kill(pid, "SIGTERM"));
+      if (!singleResult.ok) {
+        const singleCode = (singleResult.error as NodeJS.ErrnoException).code;
+        if (singleCode !== "ESRCH") {
+          console.error(`[killPtyProcess] failed to kill pid ${pid}:`, singleResult.error);
+        }
+      }
+    } else {
+      console.error(`[killPtyProcess] failed to kill process group ${pid}:`, groupResult.error);
+    }
   }
 }
 

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -133,6 +133,17 @@ interface PtyEntry {
 const ptys = new Map<number, PtyEntry>();
 let nextPtyId = 0;
 
+/** PTY とその子プロセス（サーバー等）をプロセスグループごと終了する */
+function killPtyProcess(entry: PtyEntry) {
+  const pid = entry.proc.pid;
+  // 負の PID でプロセスグループ全体に SIGTERM を送る
+  const result = tryCatch(() => process.kill(-pid, "SIGTERM"));
+  if (!result.ok) {
+    // ESRCH: プロセスが既に終了済み
+    if ((result.error as NodeJS.ErrnoException).code !== "ESRCH") throw result.error;
+  }
+}
+
 function spawnPty(win: GozdWindow, cwd: string, cols: number, rows: number): number {
   const id = nextPtyId++;
   // stream: true で途中切れの UTF-8 バイト列を次のチャンクに繰り越す
@@ -692,7 +703,7 @@ function cleanupWindow(win: GozdWindow) {
   // このウィンドウが所有する PTY をすべて kill
   for (const [id, entry] of ptys) {
     if (entry.win === win) {
-      entry.proc.kill();
+      killPtyProcess(entry);
       ptys.delete(id);
     }
   }
@@ -891,7 +902,7 @@ function createWindowWithRPC(dir: string, options?: CreateWindowOptions): GozdWi
           // 削除成功後に worktree の PTY を kill する
           for (const [id, entry] of ptys) {
             if (entry.win === win && entry.worktreeDir === wtReal) {
-              entry.proc.kill();
+              killPtyProcess(entry);
               ptys.delete(id);
             }
           }
@@ -1056,7 +1067,7 @@ function createWindowWithRPC(dir: string, options?: CreateWindowOptions): GozdWi
         ptyKill: ({ id }) => {
           const entry = ptys.get(id);
           if (entry?.win === win) {
-            entry.proc.kill();
+            killPtyProcess(entry);
             ptys.delete(id);
           }
         },


### PR DESCRIPTION
## 概要

PTY 終了時にプロセスグループ全体に SIGTERM を送るよう変更し、PTY 配下の子プロセスが孤児プロセスとして残る問題を修正。

## 背景

各 worktree のターミナルでサーバー（`pnpm dev` 等）を起動したまま worktree を削除すると、サーバープロセスがポートを占有したまま残り続ける問題があった。

原因は `entry.proc.kill()` が PTY のシェルプロセスにのみ SIGTERM を送り、子プロセス（サーバー等）には届かないこと。シェルが終了しても子プロセスがシグナルを受け取らず孤児プロセスになっていた。

## 変更内容

### PTY kill 処理の改善

- `killPtyProcess()` ヘルパーを追加。`process.kill(-pid, "SIGTERM")` で負の PID を指定し、プロセスグループ全体にシグナルを送る
- `Bun.spawn({ terminal })` は `forkpty(3)` 相当で子プロセスを新セ���ションリーダーにするため、PID = PGID が成立する前提
- ESRCH（プロセスグループ既に終了済み）は正常ケースとして無視、その他のエラー（EPERM 等）は `console.error` で記録し throw しない（呼び出し元の `ptys.delete()` が確実に到達するため）
- 以下 3 箇所の `entry.proc.kill()` を `killPtyProcess(entry)` に置き換え:
  - worktree 削除時（`gitWorktreeRemove`）
  - 明示的 PTY kill 時（`ptyKill` メッセージハンドラ）
  - ウィンドウ close 時（`cleanupWindow`）

## 確認事項

- [ ] worktree でサーバーを起動 → worktree 削除 → ポートが解放されていること
- [ ] ターミナルの × ボタンでサーバー起動中のターミナルを閉じる → ポー��が解放されていること
- [ ] ウィンドウを閉じた際にも同様にポートが解放されること
