### PR TITLE
fix(desktop): close PTY master fd to terminate process tree reliably

### DIFF
--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -196,14 +196,17 @@ function spawnPty(win: GozdWindow, cwd: string, cols: number, rows: number): num
           win.webview.rpc?.send.ptyData({ id, data: text });
         }
       },
-      exit() {
+      async exit() {
         // 残りのバッファをフラッシュ
         const remaining = decoder.decode();
         if (remaining) {
           win.webview.rpc?.send.ptyData({ id, data: remaining });
         }
         ptys.delete(id);
-        win.webview.rpc?.send.ptyExit({ id, exitCode: proc.exitCode ?? 1 });
+        // exit callback は PTY ストリーム終了時に発火し、プロセス終了より先に来る場合がある。
+        // proc.exited を待って正確な exitCode を取得する。
+        const exitCode = await proc.exited;
+        win.webview.rpc?.send.ptyExit({ id, exitCode });
       },
     },
   });

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -91,6 +91,7 @@ const LAUNCH_DIR = path.join(tmpdir(), `gozd-${channel}-launch`);
 const LAUNCH_TTL_MS = 30_000;
 const GIT_STATUS_DEBOUNCE_MS = 300;
 const GIT_WATCH_POLL_MS = 500;
+const PTY_EXIT_TIMEOUT_MS = 5_000;
 
 // --- Claude Code hooks 設定 ---
 
@@ -196,17 +197,49 @@ function spawnPty(win: GozdWindow, cwd: string, cols: number, rows: number): num
           win.webview.rpc?.send.ptyData({ id, data: text });
         }
       },
-      async exit() {
+      exit() {
         // 残りのバッファをフラッシュ
         const remaining = decoder.decode();
         if (remaining) {
           win.webview.rpc?.send.ptyData({ id, data: remaining });
         }
         ptys.delete(id);
-        // exit callback は PTY ストリーム終了時に発火し、プロセス終了より先に来る場合がある。
-        // proc.exited を待って正確な exitCode を取得する。
-        const exitCode = await proc.exited;
-        win.webview.rpc?.send.ptyExit({ id, exitCode });
+
+        let sent = false;
+        let timeoutId: ReturnType<typeof setTimeout> | undefined = setTimeout(() => {
+          timeoutId = undefined;
+          if (proc.exitCode !== null) {
+            notifyExit(proc.exitCode);
+          }
+        }, PTY_EXIT_TIMEOUT_MS);
+
+        const notifyExit = (exitCode: number) => {
+          if (sent) return;
+          sent = true;
+          if (timeoutId !== undefined) {
+            clearTimeout(timeoutId);
+            timeoutId = undefined;
+          }
+          if (!windowIds.has(win)) return;
+          const sendResult = tryCatch(() => win.webview.rpc?.send.ptyExit({ id, exitCode }));
+          if (!sendResult.ok) {
+            console.error(`[pty exit] failed to notify renderer for PTY ${id}:`, sendResult.error);
+          }
+        };
+
+        void proc.exited
+          .then((exitCode) => {
+            notifyExit(exitCode);
+          })
+          .catch((error) => {
+            if (timeoutId !== undefined) {
+              clearTimeout(timeoutId);
+              timeoutId = undefined;
+            }
+            if (windowIds.has(win)) {
+              console.error(`[pty exit] failed to observe process exit for PTY ${id}:`, error);
+            }
+          });
       },
     },
   });

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -135,11 +135,16 @@ let nextPtyId = 0;
 
 /**
  * PTY とその子プロセス（サーバー等）を終了する。
- * セッションリーダー（シェル）に SIGHUP を送ると、シェルがセッション内の
- * 全フォアグラウンドプロセスグループに SIGHUP を伝搬する（POSIX 規定）。
- * 子プロセスが別のプロセスグループを作っていても到達する。
+ * terminal.close() で PTY master fd をクローズし、カーネルがセッション全体に
+ * SIGHUP を送る（shell の実装に依存しない確実な経路）。
+ * terminal が既に closed な場合は SIGHUP を直接送信するフォールバック。
  */
 function killPtyProcess(entry: PtyEntry) {
+  const terminal = entry.proc.terminal;
+  if (terminal && !terminal.closed) {
+    terminal.close();
+    return;
+  }
   const pid = entry.proc.pid;
   const result = tryCatch(() => process.kill(pid, "SIGHUP"));
   if (!result.ok) {

--- a/apps/desktop/src/index.ts
+++ b/apps/desktop/src/index.ts
@@ -134,18 +134,18 @@ const ptys = new Map<number, PtyEntry>();
 let nextPtyId = 0;
 
 /**
- * PTY とその子プロセス（サーバー等）をプロセスグループごと終了する。
- * Bun.spawn({ terminal }) は forkpty(3) 相当で子プロセスを新セッションリーダーにするため
- * PID = PGID が成立し、負の PID でプロセスグループ全体に SIGTERM が届く。
+ * PTY とその子プロセス（サーバー等）を終了する。
+ * セッションリーダー（シェル）に SIGHUP を送ると、シェルがセッション内の
+ * 全フォアグラウンドプロセスグループに SIGHUP を伝搬する（POSIX 規定）。
+ * 子プロセスが別のプロセスグループを作っていても到達する。
  */
 function killPtyProcess(entry: PtyEntry) {
   const pid = entry.proc.pid;
-  const result = tryCatch(() => process.kill(-pid, "SIGTERM"));
+  const result = tryCatch(() => process.kill(pid, "SIGHUP"));
   if (!result.ok) {
     const code = (result.error as NodeJS.ErrnoException).code;
-    // ESRCH: プロセスグループが既に終了済み
     if (code !== "ESRCH") {
-      console.error(`[killPtyProcess] failed to kill process group ${pid}:`, result.error);
+      console.error(`[killPtyProcess] failed to send SIGHUP to ${pid}:`, result.error);
     }
   }
 }


### PR DESCRIPTION
## 概要

PTY 終了時に `terminal.close()` で PTY master fd をクローズし、カーネルレベルでセッション全体に SIGHUP を発生させるよう変更。shell の実装に依存しない確実な経路で子プロセスツリーを終了する。また、exit callback の exitCode 通知をタイムアウト付き + 送信安全にする。

## 背景

#392 で `process.kill(-pid, "SIGTERM")` によるプロセスグループ kill を導入したが、`pnpm dev` 等で起動した node プロセスツリーが依然として残り続けた。

`ps -o pid,pgid` で確認したところ、zsh（PID 27215）は PGID 27215 だが、`nr` → `pnpm` → `vite` の node チェーンは PGID 28813（`nr` の PID）に属していた。`process.kill(-27215, "SIGTERM")` は zsh のプロセスグループにしか届かず、PGID 28813 のプロセス群は丸ごと残る。

### 調査経緯

- node-pty（`microsoft/node-pty#167`）と VS Code のターミナル実装を調査。node-pty の `destroy()` は PTY master fd をクローズしてから SIGHUP を送る 2 段構え
- SIGHUP を shell に直接送る方式は shell の終了処理に依存し、cross-shell で保証されない（zsh/bash/fish で job control の挙動が異なる）
- Bun のソースコード（`Terminal.zig` の `closeInternal()`）を調査し、`proc.terminal.close()` が master fd を直接 close することを確認。これが node-pty の `destroy()` 相当で、カーネル経由の SIGHUP を発生させる正式経路
- Bun docs で `exit` callback は「subprocess の exit ではなく PTY ストリーム終了」と明記されており、`proc.exitCode` が `null` のまま `exit` が発火する場合がある

## 変更内容

### PTY kill 処理の改善

- `process.kill(-pid, "SIGTERM")`（プロセスグループ SIGTERM）→ `terminal.close()`（master fd クローズ）に変更
- master fd クローズにより、カーネルがセッション全体に SIGHUP を送信。shell の実装に依存しない
- terminal が既に closed な場合のフォールバックとして `process.kill(pid, "SIGHUP")` を残す

### exit callback の exitCode 通知

- `notifyExit` 関数で `sent` フラグによる一回きりの通知保証
- `proc.exited` を fire-and-forget で待ち、正確な exitCode を後追いで通知
- 5 秒タイムアウトで `proc.exited` が解決しない場合に備え、`proc.exitCode` が取得できれば通知
- `windowIds.has(win)` でウィンドウ破棄後の送信をスキップ
- `tryCatch` で送信例外をキャッチし unhandled rejection を防止
- `clearTimeout` でタイマーリーク防止

## スコープ

- **スコープ外（別 PR で対応）**: `killPtyProcess()` 呼び出し後の `ptys.delete(id)` が即座にエントリを削除するため、プロセス終了を確認する監視手段がない。タイマーベースの SIGKILL エスカレーション等は設計変更を伴うため別 PR で検討
- **スコープ外（対応しない）**: `nohup` / `disown` / `setsid` で制御端末から切り離されたプロセスは PTY close でも終了しない。POSIX の仕様通りの挙動

## 確認事項

- [ ] worktree でサーバー（`pnpm dev` 等）を起動 → worktree 削除 → プロセスが残らないこと
- [ ] ターミナルの × ボタンでサーバー起動中のターミナルを閉じる → プロセスが残らないこと
- [ ] ウィンドウを閉じた際にも同様にプロセスが残らないこと
- [ ] ターミナルの正常終了時（`exit` 入力）に exitCode が正しいこと
- [ ] ウィンドウを閉じた直後にプロセスが終了しても unhandled rejection が出ないこと
