### PR TITLE
fix(git-ops): drain Process pipes during execution to avoid >64KB stdout deadlock

### DIFF
--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 // git CLI を Foundation `Process` 経由で呼び出すラッパー。
 //
@@ -11,9 +12,12 @@ import Foundation
 // 2. **`/usr/bin/env git`**: ハードコードした `/usr/bin/git` ではなく PATH 解決に
 //    任せることで Homebrew 版 git を含む各環境で自然に動かす。
 //
-// 3. **`Process.terminationHandler` 内で `readDataToEndOfFile()`**: pipe buffer
-//    (~64KB) を超えると deadlock するが、`git status` の出力はサイズ有界なので
-//    問題ない。大きい出力（git log）が必要になったら DispatchIO に切り替える。
+// 3. **stdout / stderr は子プロセス生存中に readabilityHandler で drain する**:
+//    `terminationHandler` 内で `readDataToEndOfFile()` する設計だと、出力が
+//    pipe buffer (macOS は最大 ~64KB) を超えた瞬間に子が write block →
+//    exit できず → terminationHandler が呼ばれない deadlock になる。
+//    readabilityHandler + DispatchGroup.notify で「stdout EOF / stderr EOF /
+//    process termination」が揃った時点で resume する。
 public struct WorktreeInfo: Equatable, Sendable {
   public let path: String
   public let head: String
@@ -275,85 +279,144 @@ private func parseNulSeparatedPaths(_ data: Data) -> Set<String> {
   return result
 }
 
-/// stdin にデータを渡して git を起動する。`runGit` と同じ戻り値契約。
-func runGitWithStdin(args: [String], cwd: String, stdin: Data) async throws -> Data {
-  try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Data, Error>) in
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-    process.arguments = ["git"] + args
-    process.currentDirectoryURL = URL(fileURLWithPath: cwd)
-    // 明示的に env snapshot を渡す。Foundation Process は environment が nil のとき
-    // 内部で `ProcessInfo.processInfo.environment` を遅延読みするが、その経路は
-    // `getenv`/`environ` の thread-unsafety が並列 spawn 時に EFAULT (Code=14) を
-    // 引く要因になり得る。spawn 前に snapshot を取って渡せば内部 lazy read を回避できる。
-    process.environment = ProcessInfo.processInfo.environment
+/// 共通 helper: 既に standardOutput/standardError が Pipe で構成されている `Process`
+/// を起動し、子プロセス生存中から stdout/stderr を別 thread で drain する。
+///
+/// terminationHandler 内で `readDataToEndOfFile()` する設計だと、出力が pipe buffer
+/// (macOS は最大 ~64KB) を超えた瞬間に子が write block → exit 不能 →
+/// terminationHandler 永遠に呼ばれない deadlock になる。回避のため、`process.run()`
+/// 直後に `DispatchQueue.global` 上で `readDataToEndOfFile()` を回し続ける。
+///
+/// `DispatchGroup` で「stdout EOF / stderr EOF / process termination」3 イベント
+/// 全てが揃った時点で `(stdoutData, stderrData)` を返す。launch 失敗時は throw する。
+///
+/// 注: `afterRun` の stdin write/close は同期実行のため、stdin を読まないコマンドに
+/// この helper を流用すると stdin write 自体が詰まる可能性がある。stdin 利用は
+/// `git check-ignore --stdin` のような stdin を実際に読むコマンド限定で使うこと。
+private func runProcessCollectingOutput(
+  process: Process,
+  stdoutPipe: Pipe,
+  stderrPipe: Pipe,
+  afterRun: () -> Void = {}
+) async throws -> (stdout: Data, stderr: Data) {
+  // launch 自体は continuation 突入前に試して、失敗時はクリーンに throw する。
+  // (continuation 内で run 失敗ハンドリングすると group 残しの retain leak が複雑になる)
+  try await withCheckedThrowingContinuation {
+    (cont: CheckedContinuation<(stdout: Data, stderr: Data), Error>) in
+    // 読み取り結果は background queue から書き込むため、@Sendable 制約を満たす形で
+    // OSAllocatedUnfairLock 越しに保持する。
+    let stdoutLock = OSAllocatedUnfairLock<Data>(initialState: Data())
+    let stderrLock = OSAllocatedUnfairLock<Data>(initialState: Data())
+    let group = DispatchGroup()
 
-    let stdinPipe = Pipe()
-    let stdoutPipe = Pipe()
-    let stderrPipe = Pipe()
-    process.standardInput = stdinPipe
-    process.standardOutput = stdoutPipe
-    process.standardError = stderrPipe
-
-    process.terminationHandler = { proc in
-      let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-      let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-      // git check-ignore は無視パスがあれば exit 0、無ければ exit 1。1 を「結果なし」
-      // として扱うため、stderr が空なら成功扱いで stdout を返す。
-      // exit code != 0 かつ stderr に出力があれば従来どおりエラー化する。
-      if proc.terminationStatus == 0 || stderrData.isEmpty {
-        cont.resume(returning: stdoutData)
-        return
-      }
-      let stderrText = String(decoding: stderrData, as: UTF8.self)
-      cont.resume(
-        throwing: GitError.commandFailed(
-          exitCode: proc.terminationStatus, stderr: stderrText))
+    // termination は run() より先に handler を仕掛けないと、超短命プロセスで
+    // 終了通知を取りこぼす。enter は handler 設定と対で行う。
+    group.enter()
+    process.terminationHandler = { _ in
+      group.leave()
     }
 
     do {
+      // stdout / stderr 用の enter も run() より前に行う必要がある。
+      // 超短命プロセスでは terminationHandler が即座に走って group count が 0 になり、
+      // reader 側 enter が後追いで来る前に notify が空データで早発火する race を防ぐ。
+      group.enter()
+      group.enter()
       try process.run()
-      // stdin を書き込んで EOF。書き込み中の例外は git 終了で拾うので try? で握る。
-      try? stdinPipe.fileHandleForWriting.write(contentsOf: stdin)
-      try? stdinPipe.fileHandleForWriting.close()
+      // process.run() 直後から別 thread で readDataToEndOfFile() を回す。
+      // readabilityHandler 1 回 1 chunk 方式だと未読 chunk を残して pipe が再満杯
+      // になり deadlock 再発するため、最初から EOF まで連続読みする方式にする。
+      DispatchQueue.global(qos: .userInitiated).async {
+        let data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        stdoutLock.withLock { $0 = data }
+        group.leave()
+      }
+      DispatchQueue.global(qos: .userInitiated).async {
+        let data = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        stderrLock.withLock { $0 = data }
+        group.leave()
+      }
+      afterRun()
+      // notify は reader 起動 + afterRun の後に登録。これより前に登録すると
+      // reader enter のタイミング次第で空データ resume になる。
+      group.notify(queue: DispatchQueue.global()) {
+        let stdout = stdoutLock.withLock { $0 }
+        let stderr = stderrLock.withLock { $0 }
+        cont.resume(returning: (stdout, stderr))
+      }
     } catch {
+      // run 失敗時: termination + reader 用に 3 回 enter したが、いずれも leave
+      // されない。group.notify は登録していないので発火しない。cont は直接 throw。
       cont.resume(throwing: GitError.launchFailed(error.localizedDescription))
     }
   }
 }
 
-func runGit(args: [String], cwd: String) async throws -> Data {
-  try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Data, Error>) in
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-    process.arguments = ["git"] + args
-    process.currentDirectoryURL = URL(fileURLWithPath: cwd)
-    process.environment = ProcessInfo.processInfo.environment
+/// stdin にデータを渡して git を起動する。`runGit` と同じ戻り値契約。
+func runGitWithStdin(args: [String], cwd: String, stdin: Data) async throws -> Data {
+  let process = Process()
+  process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+  process.arguments = ["git"] + args
+  process.currentDirectoryURL = URL(fileURLWithPath: cwd)
+  // 明示的に env snapshot を渡す。Foundation Process は environment が nil のとき
+  // 内部で `ProcessInfo.processInfo.environment` を遅延読みするが、その経路は
+  // `getenv`/`environ` の thread-unsafety が並列 spawn 時に EFAULT (Code=14) を
+  // 引く要因になり得る。spawn 前に snapshot を取って渡せば内部 lazy read を回避できる。
+  process.environment = ProcessInfo.processInfo.environment
 
-    let stdoutPipe = Pipe()
-    let stderrPipe = Pipe()
-    process.standardOutput = stdoutPipe
-    process.standardError = stderrPipe
+  let stdinPipe = Pipe()
+  let stdoutPipe = Pipe()
+  let stderrPipe = Pipe()
+  process.standardInput = stdinPipe
+  process.standardOutput = stdoutPipe
+  process.standardError = stderrPipe
 
-    process.terminationHandler = { proc in
-      let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-      let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-      if proc.terminationStatus == 0 {
-        cont.resume(returning: stdoutData)
-        return
-      }
-      let stderrText = String(decoding: stderrData, as: UTF8.self)
-      cont.resume(
-        throwing: GitError.commandFailed(
-          exitCode: proc.terminationStatus, stderr: stderrText))
+  let (stdoutData, stderrData) = try await runProcessCollectingOutput(
+    process: process,
+    stdoutPipe: stdoutPipe,
+    stderrPipe: stderrPipe,
+    afterRun: {
+      // stdin を書き込んで EOF を送る。書き込み中の例外は git 終了で拾うので try? で握る。
+      try? stdinPipe.fileHandleForWriting.write(contentsOf: stdin)
+      try? stdinPipe.fileHandleForWriting.close()
     }
+  )
 
-    do {
-      try process.run()
-    } catch {
-      cont.resume(throwing: GitError.launchFailed(error.localizedDescription))
-    }
+  // git check-ignore は無視パスがあれば exit 0、無ければ exit 1。1 を「結果なし」
+  // として扱うため、stderr が空なら成功扱いで stdout を返す。
+  // exit code != 0 かつ stderr に出力があれば従来どおりエラー化する。
+  if process.terminationStatus == 0 || stderrData.isEmpty {
+    return stdoutData
   }
+  throw GitError.commandFailed(
+    exitCode: process.terminationStatus,
+    stderr: String(decoding: stderrData, as: UTF8.self))
+}
+
+func runGit(args: [String], cwd: String) async throws -> Data {
+  let process = Process()
+  process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+  process.arguments = ["git"] + args
+  process.currentDirectoryURL = URL(fileURLWithPath: cwd)
+  process.environment = ProcessInfo.processInfo.environment
+
+  let stdoutPipe = Pipe()
+  let stderrPipe = Pipe()
+  process.standardOutput = stdoutPipe
+  process.standardError = stderrPipe
+
+  let (stdoutData, stderrData) = try await runProcessCollectingOutput(
+    process: process,
+    stdoutPipe: stdoutPipe,
+    stderrPipe: stderrPipe
+  )
+
+  if process.terminationStatus == 0 {
+    return stdoutData
+  }
+  throw GitError.commandFailed(
+    exitCode: process.terminationStatus,
+    stderr: String(decoding: stderrData, as: UTF8.self))
 }
 
 /// `git worktree list --porcelain` の出力をパースする。

--- a/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
+++ b/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
@@ -101,7 +101,7 @@ struct GitOpsRunGitLargeOutputTests {
   /// 旧実装は `Process.terminationHandler` 内で `readDataToEndOfFile()` していたため、
   /// 出力 > buffer の瞬間に子が write block → exit 不能 → terminationHandler が呼ばれない
   /// deadlock になっていた（gozd リポジトリ実体で再現していた症状）。
-  @Test("64KB を超える stdout を deadlock せず読み切れる")
+  @Test("64KB を超える stdout を deadlock せず読み切れる", .timeLimit(.minutes(1)))
   func largeStdoutDoesNotDeadlock() async throws {
     let dir = try await makeGitRepo()
     defer { try? FileManager.default.removeItem(at: dir) }
@@ -125,7 +125,7 @@ struct GitOpsRunGitLargeOutputTests {
 
   /// 同様の deadlock テストを `runGitWithStdin` 側にも適用する。
   /// `git check-ignore --stdin -z` は 64KB 超の path 一覧を flush できる必要がある。
-  @Test("runGitWithStdin も 64KB 超の stdin / stdout で deadlock しない")
+  @Test("runGitWithStdin も 64KB 超の stdin / stdout で deadlock しない", .timeLimit(.minutes(1)))
   func runGitWithStdinLargeIO() async throws {
     let dir = try await makeGitRepo()
     defer { try? FileManager.default.removeItem(at: dir) }

--- a/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
+++ b/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
@@ -94,6 +94,65 @@ struct GitOpsGitStatusTests {
   }
 }
 
+@Suite("GitOps.runGit large output")
+struct GitOpsRunGitLargeOutputTests {
+  /// pipe buffer (macOS は最大 ~64KB) を超える stdout で `runGit` が deadlock しないことを保証する。
+  ///
+  /// 旧実装は `Process.terminationHandler` 内で `readDataToEndOfFile()` していたため、
+  /// 出力 > buffer の瞬間に子が write block → exit 不能 → terminationHandler が呼ばれない
+  /// deadlock になっていた（gozd リポジトリ実体で再現していた症状）。
+  @Test("64KB を超える stdout を deadlock せず読み切れる")
+  func largeStdoutDoesNotDeadlock() async throws {
+    let dir = try await makeGitRepo()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    // 100KB の本文を持つ commit を作る。`git log --format=%B` で本文を吐かせて
+    // 100KB 超の stdout を確実に発生させる。
+    let bigBody = String(repeating: "a", count: 100_000)
+    let msgFile = dir.appendingPathComponent("msg.txt")
+    try bigBody.write(to: msgFile, atomically: true, encoding: .utf8)
+    try await runTestGit(args: ["commit", "--allow-empty", "-F", "msg.txt"], cwd: dir.path)
+    try? FileManager.default.removeItem(at: msgFile)
+
+    // production 側の drain が正しく動けば自然に返る。修正前は無限 hang していた。
+    let result = try await runGit(args: ["log", "--format=%B"], cwd: dir.path)
+
+    #expect(result.count >= 100_000)
+    // 大きい出力を別物にすり替えていないことを確認するため、本文の中身まで検証する
+    let text = String(decoding: result, as: UTF8.self)
+    #expect(text.contains(bigBody))
+  }
+
+  /// 同様の deadlock テストを `runGitWithStdin` 側にも適用する。
+  /// `git check-ignore --stdin -z` は 64KB 超の path 一覧を flush できる必要がある。
+  @Test("runGitWithStdin も 64KB 超の stdin / stdout で deadlock しない")
+  func runGitWithStdinLargeIO() async throws {
+    let dir = try await makeGitRepo()
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    // .gitignore に 1 行のグロブを書き、check-ignore に多数のパスを流して
+    // 大量の ignored path を吐かせる。
+    try "*.tmp\n".write(
+      to: dir.appendingPathComponent(".gitignore"), atomically: true, encoding: .utf8)
+
+    // 10000 個の `tmp/N.tmp` を NUL 区切りで作る（≈ 100KB 超）。
+    let stdinBytes: Data = {
+      var buf = Data()
+      for i in 0..<10_000 {
+        buf.append(Data("tmp/\(i).tmp\u{0}".utf8))
+      }
+      return buf
+    }()
+
+    let result = try await runGitWithStdin(
+      args: ["check-ignore", "--stdin", "-z"], cwd: dir.path, stdin: stdinBytes)
+
+    // ignored entry が NUL 区切りで返る。10000 件すべて返ることまで検証する。
+    let nulCount = result.reduce(0) { $0 + ($1 == 0x00 ? 1 : 0) }
+    #expect(nulCount == 10_000)
+  }
+}
+
 // MARK: - Helpers
 
 private func makeTempDir() throws -> URL {
@@ -115,6 +174,11 @@ private func makeGitRepo() async throws -> URL {
 /// テスト helper: GitOps と同じ `/usr/bin/env git` 経由で任意の git コマンドを実行する。
 /// production 側と同じく `process.environment` を明示 snapshot で渡すことで、
 /// 並列 test 実行時の Foundation `Process` 内部の lazy env read による EFAULT を避ける。
+///
+/// 出力は `/dev/null` に直接捨てる。`Pipe` + `terminationHandler` 内の
+/// `readDataToEndOfFile()` パターンは pipe buffer (~64KB) を超える出力で deadlock
+/// するため、大きい出力を出すコマンドでも helper 自体が詰まらないように、
+/// stdout/stderr を捕捉する必要がない場合は最初から nullDevice に流す。
 private func runTestGit(args: [String], cwd: String) async throws {
   try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
     let process = Process()
@@ -122,11 +186,10 @@ private func runTestGit(args: [String], cwd: String) async throws {
     process.arguments = ["git"] + args
     process.currentDirectoryURL = URL(fileURLWithPath: cwd)
     process.environment = ProcessInfo.processInfo.environment
-    let nullPipe = Pipe()
-    process.standardOutput = nullPipe
-    process.standardError = nullPipe
+    let null = FileHandle.nullDevice
+    process.standardOutput = null
+    process.standardError = null
     process.terminationHandler = { proc in
-      _ = nullPipe.fileHandleForReading.readDataToEndOfFile()
       if proc.terminationStatus == 0 {
         cont.resume()
       } else {


### PR DESCRIPTION
## 概要

Foundation `Process` の stdout / stderr 出力を子プロセス生存中に drain する形に書き換え、出力が macOS pipe buffer (~64KB) を超えると deadlock する不具合を解消した。`apps/native/Sources/GozdCore/GitOps.swift` の `runGit` / `runGitWithStdin` が対象。

## 背景

window 内マルチ repo モード（ #310 / PR #420 ）で「repo を切り替えても git graph が前の repo のまま更新されない」という症状が報告された。renderer 側の `[gitGraph] loadLog rpc threw – TypeError: Load failed` と `[rpc] fetch start seq=15 path=/git/log` に対応する `fetch ok` が永遠に来ないログから、`/git/log` RPC が native 側で hang していることが分かった。

両 repo に対して `git log --max-count=200 --format='%H%x1f%h%x1f%P%x1f%an%x1f%at%x1f%s%x1f%b%x1f%D%x1e' HEAD` を実行したところ、出力サイズはそれぞれ:

- gozd: 94175 bytes
- liver-streams: 50028 bytes

macOS の pipe buffer は最大 ~64KB なので、gozd は溢れて `git` 側が write block → process が exit できず → `terminationHandler` が永遠に呼ばれない deadlock になっていた。WKURLSchemeHandler 側は `dispatcher.dispatch(...)` await 中に response を 1 byte も yield しない実装のため、native の hang は WebKit からは HTTP 5xx ではなく「ネットワーク失敗」として観測され `TypeError: Load failed` になっていた。

PR #420 で Bun → Swift native に移植した際、Bun.spawn の ReadableStream auto-drain だった部分が `Process.terminationHandler` 内 `readDataToEndOfFile()` という Foundation の古典的アンチパターンに置き換わったのが直接原因。

実装中に Codex に複数回レビューを依頼し、最初に試した `readabilityHandler` 1-event 1-chunk 方式が「`availableData` は EOF まで全 drain しないため、未読 chunk を残して pipe 再満杯 → deadlock 再発」と却下された経緯がある。最終的に `DispatchQueue.global(qos: .userInitiated)` 上で `readDataToEndOfFile()` を回し、`DispatchGroup.notify` で「stdout EOF / stderr EOF / process termination」3 イベントを待ち合わせる形に落ち着いた。

関連: #310 (マルチ repo) / PR #420 (Swift 移植)

## 変更内容

### `apps/native/Sources/GozdCore/GitOps.swift`

- `runProcessCollectingOutput` private helper を新設。`process.run()` 直後に stdout / stderr の readers を `DispatchQueue.global` 上で起動し、`DispatchGroup.notify` で 3 イベントが揃った時点で `(stdoutData, stderrData)` を返す
- `OSAllocatedUnfairLock<Data>` で background queue からの append を `@Sendable` 制約満たしつつ同期
- 短命プロセスでの早発火 race を避けるため、stdout / stderr 用 `group.enter()` を `process.run()` 前に行う
- `runGit` / `runGitWithStdin` をこの helper 経由に統合。`runGitWithStdin` は `afterRun` callback で stdin write/close を行う形

### `apps/native/Tests/GozdCoreTests/GitOpsTests.swift`

- `GitOpsRunGitLargeOutputTests` Suite を追加
  - `largeStdoutDoesNotDeadlock`: 100KB 本文の commit を作り `git log --format=%B` で 100KB 超 stdout を発生させ、`runGit` が deadlock しないこと + `bigBody` が結果に含まれることを検証
  - `runGitWithStdinLargeIO`: 10000 件 NUL 区切りパスを `git check-ignore --stdin` に流し、`runGitWithStdin` が deadlock しないこと + 10000 件すべて返ることを検証
  - 両テストに Swift Testing の `.timeLimit(.minutes(1))` を付与し、将来の回帰で test runner が無限 hang するのを防ぐ
- test helper `runTestGit` も同じ Pipe + terminationHandler readDataToEndOfFile パターンだったため `FileHandle.nullDevice` に流す形に修正（`git commit -F` で 100KB 本文を渡すと test 準備で hang していた）

## 確認事項

- [ ] `swift test` 全 66 tests が短時間で完了する（local 0.842 秒）
- [ ] gozd リポジトリ自身を含む 64KB 超出力の repo を開いた際に git graph が正しく表示される
- [ ] 複数 repo 間切替で graph が前の repo のまま固まらない
- [ ] `runGit` を使う他 RPC (`/git/diff` `/git/show` 等) も同様に大きい出力で問題なく返る
