### PR TITLE
refactor(renderer): split App.vue responsibilities into feature composables

### DIFF
--- a/apps/renderer/src/App.vue
+++ b/apps/renderer/src/App.vue
@@ -1,160 +1,23 @@
 <doc lang="md">
-アプリケーションのルートコンポーネント。
+アプリケーションのルート。MainLayout を render し、各 feature の app-scope な購読・watcher を起動する。
 
-## 責務
-
-- Swift → renderer の `gozdOpen` push を受信し、ワークスペース（ディレクトリ・ファイル）を設定する
-- `notify` push を受信してトースト表示する
+具体的なロジックは各 feature の composable に閉じ、ここでは bootstrap の呼び出しだけを行う。
 </doc>
 
 <script setup lang="ts">
-import { tryCatch } from "@gozd/shared";
-import { onMounted, onUnmounted, watch } from "vue";
-import { rpcFsUnwatch, rpcFsWatch } from "./features/filer";
-import { MainLayout } from "./features/layout";
-import { rpcGitBranchList, rpcGitWorktreeList } from "./features/sidebar";
-import { useTerminalStore } from "./features/terminal";
-import { useGitStatusStore, useWorktreeStore } from "./features/worktree";
-import { useAppStore } from "./shared/app";
-import { useCommandRegistry, useContextKeys, useKeyBindings } from "./shared/command";
-import { useNotificationStore } from "./shared/notification";
-import { useRepoStore } from "./shared/repo";
-import { onMessage } from "./shared/rpc";
-
-interface GozdOpenPayload {
-  dir: string;
-  selection?: { kind: string; relPath: string; lineNumber: number };
-  channel: string;
-  repoName: string;
-  isGitRepo: boolean;
-  switchToDir: string;
-}
-
-interface NotifyPayload {
-  type: "error" | "info";
-  source: string;
-  message: string;
-  detail: string;
-}
+import { useFsWatchSync } from "./features/filer";
+import { MainLayout, useCommandErrorBridge, useNotifySubscription } from "./features/layout";
+import { useGozdOpenHandler, useRepoContextKey } from "./features/sidebar";
+import { useGitStatusSync } from "./features/worktree";
+import { useKeyBindings } from "./shared/command";
 
 useKeyBindings();
-
-const worktreeStore = useWorktreeStore();
-const appStore = useAppStore();
-const repoStore = useRepoStore();
-const terminalStore = useTerminalStore();
-const gitStatusStore = useGitStatusStore();
-const contextKeys = useContextKeys();
-const notify = useNotificationStore();
-const { setErrorHandler } = useCommandRegistry();
-setErrorHandler(notify.error);
-
-const disposeNotify = onMessage<NotifyPayload>("notify", ({ type, source, message, detail }) => {
-  const notifyFn = type === "error" ? notify.error : notify.info;
-  notifyFn(`[${source}] ${message}`, detail);
-});
-
-let cleanup: (() => void) | undefined;
-
-/**
- * gozdOpen 受信時の repo 解決フロー:
- *  1. targetDir が既存のいずれかの repo の worktrees に含まれる → 切替のみ（既存 repo フォーカス）
- *  2. 含まれない → 新規 repo として worktrees / branches を fetch して repoStore に登録 → 切替
- */
-async function handleGozdOpen(payload: GozdOpenPayload) {
-  const { dir, selection, channel, repoName, isGitRepo, switchToDir } = payload;
-  if (channel) {
-    appStore.setChannel(channel);
-  }
-  const targetDir = switchToDir !== "" ? switchToDir : dir;
-  // proto3 scalar では undefined が表現できないため、空 selection は未指定として扱う
-  const sel = selection !== undefined && selection.relPath !== "" ? selection : undefined;
-
-  if (repoStore.findRepoOwning(targetDir) === undefined) {
-    // 新規 repo: worktrees / freeBranches を取得してから登録
-    let worktrees: import("@gozd/proto").WorktreeEntry[] = [];
-    let freeBranches: string[] = [];
-    if (isGitRepo) {
-      const result = await tryCatch(
-        Promise.all([rpcGitWorktreeList({ dir }), rpcGitBranchList({ dir })]),
-      );
-      if (result.ok) {
-        const [wtRes, branchRes] = result.value;
-        worktrees = wtRes.worktrees;
-        const wtBranches = new Set(worktrees.map((wt) => wt.branch).filter(Boolean));
-        freeBranches = branchRes.branches.filter((b) => !wtBranches.has(b));
-      } else {
-        notify.error("Failed to fetch repo data", result.error);
-      }
-    }
-    repoStore.addRepo({ rootDir: dir, repoName, isGitRepo, worktrees, freeBranches });
-  }
-
-  worktreeStore.setOpen(targetDir, { selection: sel });
-}
-
-onMounted(() => {
-  cleanup = onMessage<GozdOpenPayload>("gozdOpen", (payload) => {
-    void handleGozdOpen(payload);
-  });
-});
-
-// 選択中 repo の isGitRepo を context key に反映（when 条件で git 関連コマンドを制御）
-const stopWatchIsGitRepo = watch(
-  () => repoStore.selectedIsGitRepo,
-  (isGitRepo) => contextKeys.set("isGitRepo", isGitRepo),
-  { immediate: true },
-);
-
-// worktreeStore.dir の変更に追従して FSWatchRegistry の対象 dir を切り替える。
-// 旧 dir は unwatch、新 dir は watch することで、サーバー側の FSWatcher を
-// 現在表示中の worktree に同期させる（fsChange / gitStatusChange 等の push が届く）。
-const stopWatchDir = watch(
-  () => worktreeStore.dir,
-  async (newDir, oldDir) => {
-    if (oldDir !== undefined && oldDir !== newDir) {
-      await tryCatch(rpcFsUnwatch({ dir: oldDir }));
-    }
-    if (newDir !== undefined && newDir !== oldDir) {
-      const result = await tryCatch(rpcFsWatch({ dir: newDir }));
-      if (!result.ok) {
-        notify.error("Failed to start FS watch", result.error);
-      }
-    }
-  },
-  { immediate: true },
-);
-
-// 選択中 repo に紐づく PTY の Claude state 集合を文字列化して watch する。
-// state 遷移（idle/working/asking/done）が起きたら、選択中 dir の git status を再取得する。
-// fsChange と並ぶ「git status 更新トリガー」のもう一方。Claude が動く dir では FS watch を
-// 入れていなくても、エージェント完了時に状態を最新化できるための経路。
-const stopWatchClaudeForGitStatus = watch(
-  () => {
-    const dir = repoStore.selectedDir;
-    if (dir === undefined) return "";
-    const statuses = terminalStore.getClaudeStatusesByDir(dir);
-    return statuses
-      .map((s) => s.state)
-      .sort()
-      .join(",");
-  },
-  (newKey, oldKey) => {
-    if (newKey === oldKey) return;
-    void gitStatusStore.loadGitStatus();
-  },
-);
-
-onUnmounted(() => {
-  cleanup?.();
-  disposeNotify();
-  stopWatchDir();
-  stopWatchIsGitRepo();
-  stopWatchClaudeForGitStatus();
-  if (worktreeStore.dir !== undefined) {
-    void tryCatch(rpcFsUnwatch({ dir: worktreeStore.dir }));
-  }
-});
+useNotifySubscription();
+useCommandErrorBridge();
+useGozdOpenHandler();
+useRepoContextKey();
+useFsWatchSync();
+useGitStatusSync();
 </script>
 
 <template>

--- a/apps/renderer/src/features/filer/index.ts
+++ b/apps/renderer/src/features/filer/index.ts
@@ -1,4 +1,5 @@
 export { default as FilerPane } from "./FilerPane.vue";
-export { rpcFsReadFile, rpcFsReadFileAbsolute, rpcFsUnwatch, rpcFsWatch } from "./rpc";
+export { rpcFsReadFile, rpcFsReadFileAbsolute,   } from "./rpc";
 export type { FsChangePayload } from "./rpc";
 export { getFileIconName, getIconUrl } from "./useFileIcon";
+export { useFsWatchSync } from "./useFsWatchSync";

--- a/apps/renderer/src/features/filer/useFsWatchSync.ts
+++ b/apps/renderer/src/features/filer/useFsWatchSync.ts
@@ -1,0 +1,38 @@
+/**
+ * 選択中 dir に応じて native 側の FSWatchRegistry の対象 dir を切り替える app-scope な watcher。
+ *
+ * 旧 dir は unwatch、新 dir は watch することで、サーバー側の FSWatcher を選択中 worktree に
+ * 同期させる。fsChange / gitStatusChange 等の push event がここを起点に届くようになる。
+ */
+import { tryCatch } from "@gozd/shared";
+import { onUnmounted, watch } from "vue";
+import { useNotificationStore } from "../../shared/notification";
+import { useWorktreeStore } from "../worktree";
+import { rpcFsUnwatch, rpcFsWatch } from "./rpc";
+
+export function useFsWatchSync() {
+  const worktreeStore = useWorktreeStore();
+  const notify = useNotificationStore();
+
+  watch(
+    () => worktreeStore.dir,
+    async (newDir, oldDir) => {
+      if (oldDir !== undefined && oldDir !== newDir) {
+        await tryCatch(rpcFsUnwatch({ dir: oldDir }));
+      }
+      if (newDir !== undefined && newDir !== oldDir) {
+        const result = await tryCatch(rpcFsWatch({ dir: newDir }));
+        if (!result.ok) {
+          notify.error("Failed to start FS watch", result.error);
+        }
+      }
+    },
+    { immediate: true },
+  );
+
+  onUnmounted(() => {
+    if (worktreeStore.dir !== undefined) {
+      void tryCatch(rpcFsUnwatch({ dir: worktreeStore.dir }));
+    }
+  });
+}

--- a/apps/renderer/src/features/layout/index.ts
+++ b/apps/renderer/src/features/layout/index.ts
@@ -1,3 +1,5 @@
 export { default as MainLayout } from "./MainLayout.vue";
 export { default as ResizeHandle } from "./ResizeHandle.vue";
 export { rpcPickAndOpen } from "./rpc";
+export { useCommandErrorBridge } from "./useCommandErrorBridge";
+export { useNotifySubscription } from "./useNotifySubscription";

--- a/apps/renderer/src/features/layout/useCommandErrorBridge.ts
+++ b/apps/renderer/src/features/layout/useCommandErrorBridge.ts
@@ -1,0 +1,14 @@
+/**
+ * command 実行エラーをトースト通知に流す。
+ *
+ * shared/command と shared/notification の橋渡し。shared 間の依存は禁じられているため、
+ * 上位層（layout feature）でこの bridge を組む。
+ */
+import { useCommandRegistry } from "../../shared/command";
+import { useNotificationStore } from "../../shared/notification";
+
+export function useCommandErrorBridge() {
+  const notify = useNotificationStore();
+  const { setErrorHandler } = useCommandRegistry();
+  setErrorHandler(notify.error);
+}

--- a/apps/renderer/src/features/layout/useNotifySubscription.ts
+++ b/apps/renderer/src/features/layout/useNotifySubscription.ts
@@ -1,0 +1,31 @@
+/**
+ * native の `notify` push を購読し、トーストとして表示する。
+ *
+ * shared/rpc と shared/notification の橋渡し。shared 間の依存は禁じられているため、
+ * 上位層（layout feature）でこの bridge を組む。
+ */
+import { onMounted, onUnmounted } from "vue";
+import { useNotificationStore } from "../../shared/notification";
+import { onMessage } from "../../shared/rpc";
+
+interface NotifyPayload {
+  type: "error" | "info";
+  source: string;
+  message: string;
+  detail: string;
+}
+
+export function useNotifySubscription() {
+  const notify = useNotificationStore();
+
+  let dispose: (() => void) | undefined;
+  onMounted(() => {
+    dispose = onMessage<NotifyPayload>("notify", ({ type, source, message, detail }) => {
+      const fn = type === "error" ? notify.error : notify.info;
+      fn(`[${source}] ${message}`, detail);
+    });
+  });
+  onUnmounted(() => {
+    dispose?.();
+  });
+}

--- a/apps/renderer/src/features/sidebar/index.ts
+++ b/apps/renderer/src/features/sidebar/index.ts
@@ -1,3 +1,5 @@
 export { default as SidebarPane } from "./SidebarPane.vue";
-export { rpcCreateWorktree, rpcGitBranchList, rpcGitWorktreeList, rpcTaskAdd } from "./rpc";
+export { rpcCreateWorktree,  rpcGitWorktreeList, rpcTaskAdd } from "./rpc";
 export type { BranchChangePayload } from "./rpc";
+export { useGozdOpenHandler } from "./useGozdOpenHandler";
+export { useRepoContextKey } from "./useRepoContextKey";

--- a/apps/renderer/src/features/sidebar/useGozdOpenHandler.ts
+++ b/apps/renderer/src/features/sidebar/useGozdOpenHandler.ts
@@ -1,0 +1,73 @@
+/**
+ * native の `gozdOpen` push を購読し、ワークスペースに repo を登録する。
+ *
+ * 解決フロー（docs/workspace.md「プロジェクト管理」参照）:
+ * - targetDir が既存 repo の worktrees に含まれる → 切替のみ
+ * - 含まれない → 新規 repo として worktrees / freeBranches を fetch して `addRepo` → 切替
+ */
+import type { WorktreeEntry } from "@gozd/proto";
+import { tryCatch } from "@gozd/shared";
+import { onMounted, onUnmounted } from "vue";
+import { useAppStore } from "../../shared/app";
+import { useNotificationStore } from "../../shared/notification";
+import { useRepoStore } from "../../shared/repo";
+import { onMessage } from "../../shared/rpc";
+import { useWorktreeStore } from "../worktree";
+import { rpcGitBranchList, rpcGitWorktreeList } from "./rpc";
+
+interface GozdOpenPayload {
+  dir: string;
+  selection?: { kind: string; relPath: string; lineNumber: number };
+  channel: string;
+  repoName: string;
+  isGitRepo: boolean;
+  switchToDir: string;
+}
+
+export function useGozdOpenHandler() {
+  const repoStore = useRepoStore();
+  const worktreeStore = useWorktreeStore();
+  const appStore = useAppStore();
+  const notify = useNotificationStore();
+
+  async function handle(payload: GozdOpenPayload) {
+    const { dir, selection, channel, repoName, isGitRepo, switchToDir } = payload;
+    if (channel) {
+      appStore.setChannel(channel);
+    }
+    const targetDir = switchToDir !== "" ? switchToDir : dir;
+    // proto3 scalar では undefined が表現できないため、空 selection は未指定として扱う
+    const sel = selection !== undefined && selection.relPath !== "" ? selection : undefined;
+
+    if (repoStore.findRepoOwning(targetDir) === undefined) {
+      let worktrees: WorktreeEntry[] = [];
+      let freeBranches: string[] = [];
+      if (isGitRepo) {
+        const result = await tryCatch(
+          Promise.all([rpcGitWorktreeList({ dir }), rpcGitBranchList({ dir })]),
+        );
+        if (result.ok) {
+          const [wtRes, branchRes] = result.value;
+          worktrees = wtRes.worktrees;
+          const wtBranches = new Set(worktrees.map((wt) => wt.branch).filter(Boolean));
+          freeBranches = branchRes.branches.filter((b) => !wtBranches.has(b));
+        } else {
+          notify.error("Failed to fetch repo data", result.error);
+        }
+      }
+      repoStore.addRepo({ rootDir: dir, repoName, isGitRepo, worktrees, freeBranches });
+    }
+
+    worktreeStore.setOpen(targetDir, { selection: sel });
+  }
+
+  let dispose: (() => void) | undefined;
+  onMounted(() => {
+    dispose = onMessage<GozdOpenPayload>("gozdOpen", (payload) => {
+      void handle(payload);
+    });
+  });
+  onUnmounted(() => {
+    dispose?.();
+  });
+}

--- a/apps/renderer/src/features/sidebar/useRepoContextKey.ts
+++ b/apps/renderer/src/features/sidebar/useRepoContextKey.ts
@@ -1,0 +1,18 @@
+/**
+ * 選択中 repo の isGitRepo を context key に反映する。
+ * keybinding / command の `when` 条件で git 関連コマンドを gating するために使う。
+ */
+import { watch } from "vue";
+import { useContextKeys } from "../../shared/command";
+import { useRepoStore } from "../../shared/repo";
+
+export function useRepoContextKey() {
+  const repoStore = useRepoStore();
+  const contextKeys = useContextKeys();
+
+  watch(
+    () => repoStore.selectedIsGitRepo,
+    (isGitRepo) => contextKeys.set("isGitRepo", isGitRepo),
+    { immediate: true },
+  );
+}

--- a/apps/renderer/src/features/worktree/index.ts
+++ b/apps/renderer/src/features/worktree/index.ts
@@ -4,6 +4,7 @@ export type { GitStatusChangePayload } from "./rpc";
 export { default as StatusIcons } from "./StatusIcons.vue";
 export { useWorktreeStore } from "./useWorktreeStore";
 export { useGitStatusStore } from "./useGitStatusStore";
+export { useGitStatusSync } from "./useGitStatusSync";
 export {
   computeStatusIcons,
   resolveDirectoryGitChange,

--- a/apps/renderer/src/features/worktree/useGitStatusStore.ts
+++ b/apps/renderer/src/features/worktree/useGitStatusStore.ts
@@ -12,7 +12,11 @@ export const useGitStatusStore = defineStore("gitStatus", () => {
   const repoStore = useRepoStore();
   const worktreeStore = useWorktreeStore();
 
+  /** 並行 loadGitStatus で古いレスポンスが新しい結果を上書きするのを防ぐ世代カウンタ */
+  let loadGen = 0;
+
   async function loadGitStatus() {
+    const gen = ++loadGen;
     if (!repoStore.selectedIsGitRepo) {
       gitStatuses.value = {};
       return;
@@ -23,6 +27,7 @@ export const useGitStatusStore = defineStore("gitStatus", () => {
       return;
     }
     const result = await tryCatch(rpcGitStatus({ dir }));
+    if (gen !== loadGen) return;
     if (result.ok) {
       gitStatuses.value = result.value.entries;
     } else {

--- a/apps/renderer/src/features/worktree/useGitStatusSync.ts
+++ b/apps/renderer/src/features/worktree/useGitStatusSync.ts
@@ -1,0 +1,43 @@
+/**
+ * 選択中 dir の git status を最新に保つ app-scope な watcher。
+ *
+ * docs/workspace.md の「git status は選択中 dir のみ」方針に従い、以下のトリガで loadGitStatus する:
+ * - dir 切替時（fsChange / gitStatusChange は watch 開始時には push されないため、切替自体をトリガに含める）
+ * - 同 dir に紐づく PTY の Claude state 遷移時（fs 変更がない静的な repo でも反映させるため）
+ */
+import { watch } from "vue";
+import { useRepoStore } from "../../shared/repo";
+import { useTerminalStore } from "../terminal";
+import { useGitStatusStore } from "./useGitStatusStore";
+import { useWorktreeStore } from "./useWorktreeStore";
+
+export function useGitStatusSync() {
+  const repoStore = useRepoStore();
+  const worktreeStore = useWorktreeStore();
+  const terminalStore = useTerminalStore();
+  const gitStatusStore = useGitStatusStore();
+
+  watch(
+    () => worktreeStore.dir,
+    () => {
+      void gitStatusStore.loadGitStatus();
+    },
+    { immediate: true },
+  );
+
+  watch(
+    () => {
+      const dir = repoStore.selectedDir;
+      if (dir === undefined) return "";
+      return terminalStore
+        .getClaudeStatusesByDir(dir)
+        .map((s) => s.state)
+        .sort()
+        .join(",");
+    },
+    (newKey, oldKey) => {
+      if (newKey === oldKey) return;
+      void gitStatusStore.loadGitStatus();
+    },
+  );
+}


### PR DESCRIPTION
## 概要

App.vue から各 feature 固有の購読・watcher を抜き、bootstrap composable の呼び出しだけにする。約 100 行 → 16 行に圧縮。

## 背景

PR #420 の Phase 6（マルチ repo 対応）で App.vue に以下の app-scope な処理が集中していた:

- `gozdOpen` push 受信 + 新規 repo 登録 + `setOpen`
- `notify` push 受信 + トースト
- `setErrorHandler(notify.error)` でコマンドエラーをトーストに流す
- `selectedIsGitRepo` → `isGitRepo` context key 同期
- `worktreeStore.dir` 切替時の `rpcFsWatch` / `rpcFsUnwatch` 付替
- 選択中 dir に紐づく PTY の Claude state 変化時の `loadGitStatus` 再取得

これらは「app の root で起動する必要がある」という共通点があるだけで、責務はそれぞれ異なる feature に属する。App.vue が複数 feature 内部の RPC・store・型を直接 import しており、新 feature を追加するたびに App.vue を編集する形になっていた。

責務をそれぞれの feature 配下の composable に閉じ、App.vue は「各 composable を呼ぶだけ」の薄い root にする。

## 変更内容

### App.vue を bootstrap composable の集約点に薄化

```vue
<script setup lang="ts">
useKeyBindings();
useNotifySubscription();
useCommandErrorBridge();
useGozdOpenHandler();
useRepoContextKey();
useFsWatchSync();
useGitStatusSync();
</script>
<template><MainLayout /></template>
```

### 各 feature に bootstrap composable を新設

| 配置 | 役割 |
| --- | --- |
| `features/worktree/useGitStatusSync.ts` | `dir` 切替と Claude state 遷移で `loadGitStatus` |
| `features/filer/useFsWatchSync.ts` | `rpcFsWatch` / `rpcFsUnwatch` 付替 |
| `features/sidebar/useGozdOpenHandler.ts` | `gozdOpen` 購読 + `addRepo` |
| `features/sidebar/useRepoContextKey.ts` | `selectedIsGitRepo` → `isGitRepo` context key |
| `features/layout/useNotifySubscription.ts` | `notify` push をトーストに流す |
| `features/layout/useCommandErrorBridge.ts` | command error をトーストに流す |

### shared 間の依存禁止ルールへの対応

`shared/rpc` ↔ `shared/notification`、`shared/command` ↔ `shared/notification` のような橋渡しは shared 間依存禁止ルール（`isolateModules`）に抵触するため、`features/layout` 配下に置いた。

### `useGitStatusStore.loadGitStatus` に世代カウンタを追加

並行 `loadGitStatus` 呼び出しで古いレスポンスが新しい結果を上書きする race を抑止。

## 確認事項

- [ ] `pnpm typecheck:all` / `pnpm lint:all` / `pnpm test:all` 通過
- [ ] アプリ起動時に gozdOpen が処理され、初期 repo が表示される
- [ ] notify push 受信でトーストが出る
- [ ] worktree 切替で fsWatch が新 dir に切り替わる（fsChange / gitStatusChange push が新 dir で届く）
- [ ] worktree 切替で git status が新 dir のものに更新される
- [ ] 選択 repo の isGitRepo に応じて git 関連コマンドの when 条件が動く
