### PR TITLE
fix(worktree): リポジトリ外に worktree を配置する

### DIFF
--- a/apps/native/Sources/GozdCore/ProjectConfigStore.swift
+++ b/apps/native/Sources/GozdCore/ProjectConfigStore.swift
@@ -36,7 +36,10 @@ public final class ProjectConfigStore {
   }
 
   private func filePath(for dir: String) -> String {
-    let projectKey = ProjectKey.compute(forMainRepoRoot: dir)
+    // 呼び出し元（renderer）は active worktree の path を渡してくる場合があるため、
+    // main repo root に解決してから projectKey を算出する。これで main / worktree / subdir のどこから
+    // 開いても同じ config.json を参照する。
+    let projectKey = ProjectKey.resolveAndCompute(for: dir)
     return (configDir as NSString)
       .appendingPathComponent("projects")
       .appending("/\(projectKey)/config.json")

--- a/apps/native/Sources/GozdCore/ProjectConfigStore.swift
+++ b/apps/native/Sources/GozdCore/ProjectConfigStore.swift
@@ -1,10 +1,9 @@
-import CryptoKit
 import Foundation
 import GozdProto
 import SwiftProtobuf
 
 // プロジェクト固有の設定永続化（`~/.config/gozd/projects/<projectKey>/config.json`）。
-// projectKey は dir realpath の SHA-256 先頭 12 文字 + repoName。
+// projectKey の算出は `ProjectKey` を参照。
 //
 // 将来バージョンが増やしたフィールドが入った JSON を旧 binary で読んでも
 // parse error にならないよう `ignoreUnknownFields = true` を渡す。
@@ -37,11 +36,7 @@ public final class ProjectConfigStore {
   }
 
   private func filePath(for dir: String) -> String {
-    let realpath = (dir as NSString).resolvingSymlinksInPath
-    let repoName = (realpath as NSString).lastPathComponent
-    let digest = SHA256.hash(data: Data(realpath.utf8))
-    let hash = digest.compactMap { String(format: "%02x", $0) }.joined()
-    let projectKey = "\(repoName)-\(String(hash.prefix(12)))"
+    let projectKey = ProjectKey.compute(forMainRepoRoot: dir)
     return (configDir as NSString)
       .appendingPathComponent("projects")
       .appending("/\(projectKey)/config.json")

--- a/apps/native/Sources/GozdCore/ProjectKey.swift
+++ b/apps/native/Sources/GozdCore/ProjectKey.swift
@@ -1,0 +1,66 @@
+import CryptoKit
+import Foundation
+
+// プロジェクト固有の永続化先を決める projectKey の生成。
+//
+// projectKey は `<repoName>-<sha256(realpath)[0..12]>`。
+// 同じ main repo の worktree 配下からどの dir で呼んでも、main repo root に解決した上で
+// 同一 projectKey が出るようにする。
+//
+// 利用箇所:
+// - `~/.config/gozd/projects/<projectKey>/config.json`（ProjectConfigStore）
+// - `~/.config/gozd/projects/<projectKey>/tasks.json`（TaskStore）
+// - `~/.local/share/gozd/worktrees/<projectKey>/<leaf>`（WorktreeOps）
+//
+// 形式変更は全 store の保存先を変えるため、変更時は移行コードを別途用意する必要がある。
+public enum ProjectKey {
+  /// すでに main repo root と分かっている dir から projectKey を生成する。
+  /// 内部で realpath（symlink 解決）してからハッシュする。
+  public static func compute(forMainRepoRoot dir: String) -> String {
+    let resolved = (dir as NSString).resolvingSymlinksInPath
+    let repoName = (resolved as NSString).lastPathComponent
+    let digest = SHA256.hash(data: Data(resolved.utf8))
+    let hash = digest.compactMap { String(format: "%02x", $0) }.joined()
+    return "\(repoName)-\(String(hash.prefix(12)))"
+  }
+
+  /// 任意の dir（worktree 配下を含む）から main repo root を引いて projectKey を生成する。
+  /// `git rev-parse --git-common-dir` の親が main worktree のパス。git 外 / 失敗時は dir 自体を使う。
+  public static func resolveAndCompute(for dir: String) -> String {
+    return compute(forMainRepoRoot: resolveMainRepoRoot(for: dir))
+  }
+
+  /// `git rev-parse --git-common-dir` の出力（典型的には `<main-worktree>/.git`）の親を realpath。
+  /// 失敗時は dir 自体を realpath して返す（git 外でも壊れないため）。
+  public static func resolveMainRepoRoot(for dir: String) -> String {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["git", "rev-parse", "--git-common-dir"]
+    process.currentDirectoryURL = URL(fileURLWithPath: dir)
+    process.environment = ProcessInfo.processInfo.environment
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+    process.standardOutput = stdoutPipe
+    process.standardError = stderrPipe
+    do {
+      try process.run()
+      process.waitUntilExit()
+      let data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+      _ = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+      if process.terminationStatus != 0 {
+        return (dir as NSString).resolvingSymlinksInPath
+      }
+      let text = String(decoding: data, as: UTF8.self)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+      // common-dir が相対パスなら dir 起点で resolve する
+      let commonDir =
+        text.hasPrefix("/")
+        ? text
+        : (URL(fileURLWithPath: dir).appendingPathComponent(text)).path
+      let parent = (commonDir as NSString).deletingLastPathComponent
+      return (parent as NSString).resolvingSymlinksInPath
+    } catch {
+      return (dir as NSString).resolvingSymlinksInPath
+    }
+  }
+}

--- a/apps/native/Sources/GozdCore/TaskStore.swift
+++ b/apps/native/Sources/GozdCore/TaskStore.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import Foundation
 import GozdProto
 
@@ -6,8 +5,8 @@ import GozdProto
 //
 // 設計判断:
 //
-// 1. **projectKey は dir realpath の SHA-256 先頭 12 文字 + repoName**。
-//    旧 desktop 実装と互換。`~/.config/gozd/projects/<repoName>-<hash>/`。
+// 1. **projectKey の算出は `ProjectKey` を参照**。worktree 配下のどの dir から呼ばれても
+//    main repo root に解決した上で同一 projectKey に揃える（`resolveAndCompute`）。
 //
 // 2. **永続化形式は proto JSON**。AppStateStore / AppConfigStore と同流儀。
 //    `TaskList` ラッパーを介して `tasks` を array として保存する。
@@ -70,51 +69,10 @@ public actor TaskStore {
   // MARK: - paths
 
   private func projectDir(for dir: String) -> String {
-    // worktree 配下のどの dir から呼ばれても同一 projectKey になるよう、
-    // git common-dir の親（= main worktree path）を realpath 解決して使う。
-    let projectRoot = resolveProjectRoot(for: dir)
-    let repoName = (projectRoot as NSString).lastPathComponent
-    let digest = SHA256.hash(data: Data(projectRoot.utf8))
-    let hash = digest.compactMap { String(format: "%02x", $0) }.joined()
-    let shortHash = String(hash.prefix(12))
-    let projectKey = "\(repoName)-\(shortHash)"
+    let projectKey = ProjectKey.resolveAndCompute(for: dir)
     return (configDir as NSString)
       .appendingPathComponent("projects")
       .appending("/\(projectKey)")
-  }
-
-  /// `git rev-parse --git-common-dir` の出力（典型的には `<main-worktree>/.git`）の親を realpath。
-  /// 失敗時は dir 自体を realpath して返す（git 外でも壊れないため）。
-  private func resolveProjectRoot(for dir: String) -> String {
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-    process.arguments = ["git", "rev-parse", "--git-common-dir"]
-    process.currentDirectoryURL = URL(fileURLWithPath: dir)
-    process.environment = ProcessInfo.processInfo.environment
-    let stdoutPipe = Pipe()
-    let stderrPipe = Pipe()
-    process.standardOutput = stdoutPipe
-    process.standardError = stderrPipe
-    do {
-      try process.run()
-      process.waitUntilExit()
-      let data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-      _ = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-      if process.terminationStatus != 0 {
-        return (dir as NSString).resolvingSymlinksInPath
-      }
-      let text = String(decoding: data, as: UTF8.self)
-        .trimmingCharacters(in: .whitespacesAndNewlines)
-      // common-dir が相対パスなら dir 起点で resolve する
-      let commonDir =
-        text.hasPrefix("/")
-        ? text
-        : (URL(fileURLWithPath: dir).appendingPathComponent(text)).path
-      let parent = (commonDir as NSString).deletingLastPathComponent
-      return (parent as NSString).resolvingSymlinksInPath
-    } catch {
-      return (dir as NSString).resolvingSymlinksInPath
-    }
   }
 
   private func tasksFilePath(for dir: String) -> String {

--- a/apps/native/Sources/GozdCore/WorktreeOps.swift
+++ b/apps/native/Sources/GozdCore/WorktreeOps.swift
@@ -4,8 +4,9 @@ import Foundation
 // 読み取り系（list / log）は GitOps、副作用持ち（create / remove / delete）はここ。
 public enum WorktreeOps {
   /// `git worktree add [<startPoint>] <absPath> [-b <branch>]` 相当。
-  /// `worktreeDir` はリーフ名（典型的にはタイムスタンプ）。リポジトリ汚染を避けるため
-  /// `~/.local/share/gozd/worktrees/<projectKey>/<worktreeDir>` に絶対パスとして配置する。
+  /// `worktreeDir` はリーフ名（typically タイムスタンプ）。1 path component のみ許可（`/`, `..`, `.` は拒否）。
+  /// リポジトリ汚染を避けるため `~/.local/share/gozd/worktrees/<projectKey>/<worktreeDir>` に絶対パスとして配置する。
+  /// `dir` は main repo / worktree subdir のどれでも可。内部で main repo root に解決して projectKey を統一する。
   /// startPoint があれば -b で新規ブランチを作る。なければ既存ブランチを使う。
   public static func createWorktree(
     dir: String, worktreeDir: String, branch: String, startPoint: String?
@@ -36,8 +37,21 @@ public enum WorktreeOps {
   }
 
   /// `~/.local/share/gozd/worktrees/<projectKey>/<leaf>` の絶対パスを返し、親ディレクトリを作成する。
+  /// `projectDir` は main / worktree / その配下 subdir のいずれでも可（内部で main repo root に解決）。
+  /// `leaf` は 1 path component のみ許可。`/`, `.`, `..`, NUL バイト、制御文字を含むものは拒否する
+  /// （base 配下からの逸脱や、ファイル API への橋渡しでの予期しない扱いを防ぐ）。
   private static func ensureWorktreePath(projectDir: String, leaf: String) throws -> String {
-    let projectKey = ProjectKey.compute(forMainRepoRoot: projectDir)
+    let invalid =
+      leaf.isEmpty
+      || leaf.contains("/")
+      || leaf == "."
+      || leaf == ".."
+      || leaf.unicodeScalars.contains(where: { $0.value < 0x20 || $0.value == 0x7F })
+    if invalid {
+      throw GitError.commandFailed(
+        exitCode: -1, stderr: "invalid worktree leaf name: \(leaf)")
+    }
+    let projectKey = ProjectKey.resolveAndCompute(for: projectDir)
     let home = NSHomeDirectory()
     let base = (home as NSString)
       .appendingPathComponent(".local/share/gozd/worktrees")

--- a/apps/native/Sources/GozdCore/WorktreeOps.swift
+++ b/apps/native/Sources/GozdCore/WorktreeOps.swift
@@ -1,30 +1,56 @@
+import CryptoKit
 import Foundation
 
 // worktree / branch を変更する書き込み系操作。
 // 読み取り系（list / log）は GitOps、副作用持ち（create / remove / delete）はここ。
 public enum WorktreeOps {
-  /// `git worktree add [<startPoint>] <worktreeDir> [-b <branch>]` 相当。
+  /// `git worktree add [<startPoint>] <absPath> [-b <branch>]` 相当。
+  /// `worktreeDir` はリーフ名（典型的にはタイムスタンプ）。リポジトリ汚染を避けるため
+  /// `~/.local/share/gozd/worktrees/<projectKey>/<worktreeDir>` に絶対パスとして配置する。
   /// startPoint があれば -b で新規ブランチを作る。なければ既存ブランチを使う。
   public static func createWorktree(
     dir: String, worktreeDir: String, branch: String, startPoint: String?
   ) async throws -> WorktreeInfo {
+    let absPath = try ensureWorktreePath(projectDir: dir, leaf: worktreeDir)
     var args = ["worktree", "add"]
     if let startPoint, !startPoint.isEmpty {
       args.append("-b")
       args.append(branch)
-      args.append(worktreeDir)
+      args.append(absPath)
       args.append(startPoint)
     } else {
-      args.append(worktreeDir)
+      args.append(absPath)
       args.append(branch)
     }
     _ = try await runGit(args: args, cwd: dir)
     let list = try await GitOps.worktreeList(dir: dir)
-    guard let entry = list.first(where: { $0.path == worktreeDir }) else {
+    let resolved = (absPath as NSString).resolvingSymlinksInPath
+    guard
+      let entry = list.first(where: {
+        $0.path == absPath || ($0.path as NSString).resolvingSymlinksInPath == resolved
+      })
+    else {
       throw GitError.commandFailed(
-        exitCode: -1, stderr: "worktree created but not found in list: \(worktreeDir)")
+        exitCode: -1, stderr: "worktree created but not found in list: \(absPath)")
     }
     return entry
+  }
+
+  /// `~/.local/share/gozd/worktrees/<projectKey>/<leaf>` の絶対パスを返し、親ディレクトリを作成する。
+  /// projectKey は `<repoName>-<sha256(realpath(projectDir))[0..12]>`。
+  private static func ensureWorktreePath(projectDir: String, leaf: String) throws -> String {
+    let resolved = (projectDir as NSString).resolvingSymlinksInPath
+    let repoName = (resolved as NSString).lastPathComponent
+    let digest = SHA256.hash(data: Data(resolved.utf8))
+    let hash = digest.compactMap { String(format: "%02x", $0) }.joined()
+    let projectKey = "\(repoName)-\(String(hash.prefix(12)))"
+    let home = NSHomeDirectory()
+    let base = (home as NSString)
+      .appendingPathComponent(".local/share/gozd/worktrees")
+      .appending("/\(projectKey)")
+    try FileManager.default.createDirectory(
+      atPath: base, withIntermediateDirectories: true)
+    return (base as NSString).appendingPathComponent(leaf)
   }
 
   /// `git worktree remove [-f] <path>` 相当。

--- a/apps/native/Sources/GozdCore/WorktreeOps.swift
+++ b/apps/native/Sources/GozdCore/WorktreeOps.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import Foundation
 
 // worktree / branch を変更する書き込み系操作。
@@ -37,13 +36,8 @@ public enum WorktreeOps {
   }
 
   /// `~/.local/share/gozd/worktrees/<projectKey>/<leaf>` の絶対パスを返し、親ディレクトリを作成する。
-  /// projectKey は `<repoName>-<sha256(realpath(projectDir))[0..12]>`。
   private static func ensureWorktreePath(projectDir: String, leaf: String) throws -> String {
-    let resolved = (projectDir as NSString).resolvingSymlinksInPath
-    let repoName = (resolved as NSString).lastPathComponent
-    let digest = SHA256.hash(data: Data(resolved.utf8))
-    let hash = digest.compactMap { String(format: "%02x", $0) }.joined()
-    let projectKey = "\(repoName)-\(String(hash.prefix(12)))"
+    let projectKey = ProjectKey.compute(forMainRepoRoot: projectDir)
     let home = NSHomeDirectory()
     let base = (home as NSString)
       .appendingPathComponent(".local/share/gozd/worktrees")


### PR DESCRIPTION
## 概要

新規 worktree を `~/.local/share/gozd/worktrees/<repoName>-<hash>/<timestamp>/` に配置するよう修正する。あわせて、3 箇所に散在していた `projectKey` 算出ロジックを共通 helper `ProjectKey` に集約し、active worktree 経由の呼び出しでも main repo 単位の projectKey に解決するよう統一する。

## 背景

`docs/workspace.md` には worktree を `~/.local/share/gozd/worktrees/<repoName>-<hash>/<timestamp>/` に配置すると明記されている（リポ外なので `.gitignore` の追加が不要、という前提で設計）。

実際の現象として「worktree が `<repo>/<timestamp>/` に作られている」という報告から実装を追ったところ、原因は `apps/native/Sources/GozdCore/WorktreeOps.swift` の `createWorktree` が、renderer から渡される **タイムスタンプ（相対パス）** をそのまま `git worktree add` に渡していたこと。`git worktree add <相対>` は cwd 基準で resolve されるため、`cwd: dir`（リポジトリのメインディレクトリ）と組み合わさってリポ内に worktree が作成されていた。

旧実装には `worktreeBasePath(projectDir:)` で `~/.local/share/gozd/worktrees/<projectKey>` を解決して prepend する実装があったが、Swift モジュール再編の過程で当該ロジックが脱落していた。

renderer 側は 3 箇所すべて `worktreeDir: generateTimestamp()` を渡している（`useWorktreeActions.ts` / `registerPrCommand.ts` / `useTaskActions.ts`）。SSOT として renderer 側に prefix を撒くより、Swift 側で leaf 名 → 絶対パスを解決する責務を集約するのが妥当と判断。

加えて、修正過程で `projectKey`（`<repoName>-<sha256(realpath)[0..12]>`）の算出が `ProjectConfigStore` / `TaskStore` / `WorktreeOps`（本 PR で追加）の 3 箇所に重複していることが判明したため、本 PR の中で同時に SSOT 化する。

さらに Codex レビュー（PR #431 のループ）で、PR/Issue picker や Project Config パネル等の renderer 側呼び出しは `worktreeStore.dir`（active worktree path）を `dir` として渡してくる経路があり、`ProjectKey.compute(forMainRepoRoot:)` 前提のままだと worktree 固有の projectKey が生まれる問題が指摘されたため、`ProjectConfigStore` と `WorktreeOps` の両方を `resolveAndCompute(for:)` 経由に統一した。

## 変更内容

### worktree 配置パスの解決を Swift 側で完結させる

- `apps/native/Sources/GozdCore/WorktreeOps.swift`
  - `ensureWorktreePath(projectDir:leaf:)` を新設
  - `createWorktree` 内で `worktreeDir`（リーフ名）を絶対パスへ変換してから `git worktree add` に渡すよう修正
  - `worktreeList` の戻り値が macOS の `/var` ↔ `/private/var` のように symlink resolved になるケースを `resolvingSymlinksInPath` で吸収
  - `leaf` パラメータのガードを追加（`/`, `.`, `..`, 空文字, U+0000 を含む C0 制御文字と DEL を reject）

### projectKey 算出ロジックの SSOT 化

- `apps/native/Sources/GozdCore/ProjectKey.swift`（新設）
  - `compute(forMainRepoRoot:)`: 呼び出し側が main repo root を保証するケース向けの純粋関数
  - `resolveAndCompute(for:)`: worktree 配下のどの dir から呼ばれても同一 projectKey に揃える（`git rev-parse --git-common-dir` で main repo root に解決してから compute）
  - `resolveMainRepoRoot(for:)`: 上記 resolve 部分を単独でも使える形で公開
- `ProjectConfigStore.swift`: `ProjectKey.resolveAndCompute(for:)` に置換
- `TaskStore.swift`: `projectDir` / `resolveProjectRoot` の自前実装を `ProjectKey.resolveAndCompute(for:)` に置換
- `WorktreeOps.swift`: `ensureWorktreePath` 内で `ProjectKey.resolveAndCompute(for:)` を使用

### コントラクト変更の明文化

- `createWorktree` の docstring に「`worktreeDir` はリーフ名」「リポジトリ汚染を避けるため `~/.local/share/gozd/worktrees/<projectKey>/` に絶対パス配置」「`dir` は main / worktree / subdir のどれでも可」「leaf 検証ルール」を記載
- `ProjectKey` のコメントで「形式変更は全 store の保存先を変えるため移行コード必須」と明記

## 今回含めない点

- **既に誤った場所に作成済みの worktree のクリーンアップ**: 各環境の作業状態に依存し、破壊的操作を伴うため自動化は避ける。本 PR が反映された後、`git worktree list` で各自確認の上で `git worktree move` または `git worktree remove` を行うのが安全
- **legacy projectKey の後方互換読み込み**: `ProjectConfigStore` の修正前は active worktree dir 由来の projectKey に config が保存されていたケースがあるが、CLAUDE.md の「後方互換性を作らない」方針および「旧挙動はバグ的挙動」と判断し、移行コードは追加しない。修正後に `worktreeSymlinks` 等が消えて見える場合は再設定が必要

## 確認事項

- [ ] 新規 worktree 作成（サイドバー `+` ボタン / branch link / PR-picker / Issue-picker / タスク経由）が `~/.local/share/gozd/worktrees/<repoName>-<hash>/<timestamp>/` に配置されることを確認
- [ ] active worktree から PR/Issue picker で worktree 作成しても、main repo と同じ `<projectKey>` 配下に作られることを確認
- [ ] 作成直後の worktree 削除（`git worktree remove`）が正常に動作することを確認
- [ ] tasks.json / project config.json の保存先 projectKey が、worktree の親ディレクトリ projectKey と一致することを確認（同一 main repo について）
