### PR TITLE
fix(palette): unblock Open PR/Issue commands after RPC migration

### DIFF
--- a/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
+++ b/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
@@ -40,6 +40,10 @@ export function registerIssueCommand(): () => void {
           return;
         }
         const [issuesRes, worktreesRes, viewerRes] = fetchResult.value;
+        if (!issuesRes.ok) {
+          notify.error("Failed to load issues from GitHub");
+          return;
+        }
         if (issuesRes.issues.length === 0) return;
 
         const wtByIssue = new Map(
@@ -48,7 +52,7 @@ export function registerIssueCommand(): () => void {
             .map((wt) => [wt.task?.issueNumber, wt.path]),
         );
 
-        show(issuesRes.issues, viewerRes.login, (issue) => {
+        show(issuesRes.issues, viewerRes.ok ? viewerRes.login : "", (issue) => {
           const existingDir = wtByIssue.get(issue.number);
           if (existingDir !== undefined) {
             terminalStore.viewMode = "wt";

--- a/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
+++ b/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
@@ -28,12 +28,19 @@ export function registerIssueCommand(): () => void {
       void (async () => {
         const dir = worktreeStore.dir;
         if (dir === undefined) return;
-        const [issuesRes, worktreesRes, viewerRes] = await Promise.all([
-          rpcGitIssueList({ dir }),
-          rpcGitWorktreeList({ dir }),
-          rpcGitViewer({ dir }),
-        ]);
-        if (!issuesRes.ok || issuesRes.issues.length === 0) return;
+        const fetchResult = await tryCatch(
+          Promise.all([
+            rpcGitIssueList({ dir }),
+            rpcGitWorktreeList({ dir }),
+            rpcGitViewer({ dir }),
+          ]),
+        );
+        if (!fetchResult.ok) {
+          notify.error("Failed to load issues", fetchResult.error);
+          return;
+        }
+        const [issuesRes, worktreesRes, viewerRes] = fetchResult.value;
+        if (issuesRes.issues.length === 0) return;
 
         const wtByIssue = new Map(
           worktreesRes.worktrees
@@ -41,7 +48,7 @@ export function registerIssueCommand(): () => void {
             .map((wt) => [wt.task?.issueNumber, wt.path]),
         );
 
-        show(issuesRes.issues, viewerRes.ok ? viewerRes.login : "", (issue) => {
+        show(issuesRes.issues, viewerRes.login, (issue) => {
           const existingDir = wtByIssue.get(issue.number);
           if (existingDir !== undefined) {
             terminalStore.viewMode = "wt";

--- a/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
+++ b/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
@@ -27,18 +27,21 @@ export function registerPrCommand(): () => void {
       void (async () => {
         const dir = worktreeStore.dir;
         if (dir === undefined) return;
-        const [prsRes, worktreesRes, viewerRes] = await Promise.all([
-          rpcGitPrList({ dir }),
-          rpcGitWorktreeList({ dir }),
-          rpcGitViewer({ dir }),
-        ]);
-        if (!prsRes.ok || prsRes.prs.length === 0) return;
+        const fetchResult = await tryCatch(
+          Promise.all([rpcGitPrList({ dir }), rpcGitWorktreeList({ dir }), rpcGitViewer({ dir })]),
+        );
+        if (!fetchResult.ok) {
+          notify.error("Failed to load pull requests", fetchResult.error);
+          return;
+        }
+        const [prsRes, worktreesRes, viewerRes] = fetchResult.value;
+        if (prsRes.prs.length === 0) return;
 
         const wtByBranch = new Map(
           worktreesRes.worktrees.filter((wt) => wt.branch !== "").map((wt) => [wt.branch, wt.path]),
         );
 
-        show(prsRes.prs, viewerRes.ok ? viewerRes.login : "", (pr) => {
+        show(prsRes.prs, viewerRes.login, (pr) => {
           const existingDir = wtByBranch.get(pr.headRef);
           if (existingDir !== undefined) {
             // 既存 worktree に切り替え（ステートレス化により switchDir RPC は廃止）

--- a/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
+++ b/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
@@ -35,13 +35,17 @@ export function registerPrCommand(): () => void {
           return;
         }
         const [prsRes, worktreesRes, viewerRes] = fetchResult.value;
+        if (!prsRes.ok) {
+          notify.error("Failed to load pull requests from GitHub");
+          return;
+        }
         if (prsRes.prs.length === 0) return;
 
         const wtByBranch = new Map(
           worktreesRes.worktrees.filter((wt) => wt.branch !== "").map((wt) => [wt.branch, wt.path]),
         );
 
-        show(prsRes.prs, viewerRes.login, (pr) => {
+        show(prsRes.prs, viewerRes.ok ? viewerRes.login : "", (pr) => {
           const existingDir = wtByBranch.get(pr.headRef);
           if (existingDir !== undefined) {
             // 既存 worktree に切り替え（ステートレス化により switchDir RPC は廃止）


### PR DESCRIPTION
## 概要

コマンドパレットの "Workspace: Open Pull Request" / "Workspace: Open Issue" が無反応になっていた問題を修正する。

## 背景

コマンド実行時に picker が開かない症状が出ていた。原因は 2 段の `ok` を混同していたこと:

- transport 層: コミット bdac6bd で RPC クライアントは proto3 JSON のレスポンス本体を直接返し、失敗時は throw する設計に変わった。Result-like (`{ ok, ... }`) は返さなくなった
- payload 層: 一方で `GitPrListResponse` / `GitIssueListResponse` / `GitViewerResponse` は **今も payload に `bool ok = 1` を持つ**。`gh` の失敗（未インストール / 未認証 / 非 0 終了）を backend が `resp.ok = false` で表現するための schema

旧 handler は `if (!prsRes.ok || prsRes.prs.length === 0) return;` と単一判定で書かれており、`gh` 失敗時に silent early-return するため「無反応」に見えていた。

## 変更内容

### palette/pr-picker, palette/issue-picker

- `Promise.all([...])` を `tryCatch` でラップし、transport 失敗（fetch reject 等）を `Result.ok` で受ける。失敗時は `useNotificationStore.error(message, cause)` でトースト通知
- payload 側の `prsRes.ok` / `issuesRes.ok` を別レイヤとして判定。`false` の場合は `"Failed to load pull requests from GitHub"` / `"Failed to load issues from GitHub"` でトースト通知
- viewer は picker 動作に必須でないため `viewerRes.ok ? viewerRes.login : ""` で劣化動作させる

## 確認事項

- [ ] コマンドパレットから "Workspace: Open Pull Request" を実行して PR picker が開くこと
- [ ] コマンドパレットから "Workspace: Open Issue" を実行して issue picker が開くこと
- [ ] `gh auth logout` 等で `gh` を失敗状態にしたとき、トースト通知が表示されること
- [ ] viewer 取得だけ失敗しても picker が開けること
