### PR TITLE
fix(github-ops): resolve gh CLI via user login shell for build .app

### DIFF
--- a/apps/native/Sources/GozdCore/GitHubOps.swift
+++ b/apps/native/Sources/GozdCore/GitHubOps.swift
@@ -109,31 +109,51 @@ public struct IssueInfo: Sendable, Equatable {
   public let authorAvatarUrl: String
 }
 
+// `gh` の絶対パスは `CommandResolver` で解決する。`.app` を Finder/Dock から起動すると
+// launchd 由来の最小 PATH しか継承されないため `/usr/bin/env gh` では `gh` を解決
+// できない。`CommandResolver` がユーザーログインシェル経由で `command -v gh` を実行
+// して絶対パスを取得し、結果はキャッシュされる。見つからない場合は launchFailed を
+// throw して上位（`prList` / `issueList` / `viewer`）が `try?` で nil 化する。
+//
+// `launchFailed` を検知した場合、キャッシュが stale な可能性があるため 1 回だけ
+// invalidate + 再 resolve して retry する。
+//
+// 出力収集は `runProcessCollectingOutput` (ProcessExec.swift) に寄せる。
+// `terminationHandler` 内で一括 drain する旧実装は `gh pr list --json --limit 100` の
+// 出力が pipe buffer (~64KB) を超えると deadlock する。
 private func runGh(args: [String], cwd: String) async throws -> Data {
-  try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Data, Error>) in
-    let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-    process.arguments = ["gh"] + args
-    process.currentDirectoryURL = URL(fileURLWithPath: cwd)
-    process.environment = ProcessInfo.processInfo.environment
-    let stdoutPipe = Pipe()
-    let stderrPipe = Pipe()
-    process.standardOutput = stdoutPipe
-    process.standardError = stderrPipe
-    process.terminationHandler = { proc in
-      let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-      _ = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-      if proc.terminationStatus == 0 {
-        cont.resume(returning: stdoutData)
-      } else {
-        cont.resume(
-          throwing: GitError.commandFailed(exitCode: proc.terminationStatus, stderr: ""))
-      }
-    }
-    do {
-      try process.run()
-    } catch {
-      cont.resume(throwing: GitError.launchFailed(error.localizedDescription))
-    }
+  do {
+    return try await runGhOnce(args: args, cwd: cwd)
+  } catch GitError.launchFailed {
+    await CommandResolver.shared.invalidate("gh")
+    return try await runGhOnce(args: args, cwd: cwd)
   }
+}
+
+private func runGhOnce(args: [String], cwd: String) async throws -> Data {
+  guard let ghPath = await CommandResolver.shared.resolve("gh") else {
+    throw GitError.launchFailed("gh CLI not found in PATH or user login shell")
+  }
+  let process = Process()
+  process.executableURL = URL(fileURLWithPath: ghPath)
+  process.arguments = args
+  process.currentDirectoryURL = URL(fileURLWithPath: cwd)
+  process.environment = ProcessInfo.processInfo.environment
+  let stdoutPipe = Pipe()
+  let stderrPipe = Pipe()
+  process.standardOutput = stdoutPipe
+  process.standardError = stderrPipe
+
+  let (stdoutData, stderrData) = try await runProcessCollectingOutput(
+    process: process,
+    stdoutPipe: stdoutPipe,
+    stderrPipe: stderrPipe
+  )
+
+  if process.terminationStatus == 0 {
+    return stdoutData
+  }
+  throw GitError.commandFailed(
+    exitCode: process.terminationStatus,
+    stderr: String(decoding: stderrData, as: UTF8.self))
 }

--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -9,8 +9,10 @@ import os
 //    （`Gozd_V1_GitStatusResponse`）への変換は RPC 境界（URLSchemeHandler）で行う。
 //    ロジック層を proto に縛らないことでテスト容易性と将来の proto 変更耐性を確保する。
 //
-// 2. **`/usr/bin/env git`**: ハードコードした `/usr/bin/git` ではなく PATH 解決に
-//    任せることで Homebrew 版 git を含む各環境で自然に動かす。
+// 2. **`CommandResolver` 経由で `git` の絶対パスを解決**: `.app` を Finder/Dock 起動
+//    すると launchd 由来の最小 PATH しか継承されないため `/usr/bin/env` の PATH 解決
+//    では Homebrew 版 git を選べない。`CommandResolver` がユーザーログインシェル経由で
+//    解決した絶対パスを使い、見つからない場合のみ Apple stub `/usr/bin/git` に倒す。
 //
 // 3. **stdout / stderr は子プロセス生存中に readabilityHandler で drain する**:
 //    `terminationHandler` 内で `readDataToEndOfFile()` する設計だと、出力が
@@ -279,84 +281,36 @@ private func parseNulSeparatedPaths(_ data: Data) -> Set<String> {
   return result
 }
 
-/// 共通 helper: 既に standardOutput/standardError が Pipe で構成されている `Process`
-/// を起動し、子プロセス生存中から stdout/stderr を別 thread で drain する。
-///
-/// terminationHandler 内で `readDataToEndOfFile()` する設計だと、出力が pipe buffer
-/// (macOS は最大 ~64KB) を超えた瞬間に子が write block → exit 不能 →
-/// terminationHandler 永遠に呼ばれない deadlock になる。回避のため、`process.run()`
-/// 直後に `DispatchQueue.global` 上で `readDataToEndOfFile()` を回し続ける。
-///
-/// `DispatchGroup` で「stdout EOF / stderr EOF / process termination」3 イベント
-/// 全てが揃った時点で `(stdoutData, stderrData)` を返す。launch 失敗時は throw する。
-///
-/// 注: `afterRun` の stdin write/close は同期実行のため、stdin を読まないコマンドに
-/// この helper を流用すると stdin write 自体が詰まる可能性がある。stdin 利用は
-/// `git check-ignore --stdin` のような stdin を実際に読むコマンド限定で使うこと。
-private func runProcessCollectingOutput(
-  process: Process,
-  stdoutPipe: Pipe,
-  stderrPipe: Pipe,
-  afterRun: () -> Void = {}
-) async throws -> (stdout: Data, stderr: Data) {
-  // launch 自体は continuation 突入前に試して、失敗時はクリーンに throw する。
-  // (continuation 内で run 失敗ハンドリングすると group 残しの retain leak が複雑になる)
-  try await withCheckedThrowingContinuation {
-    (cont: CheckedContinuation<(stdout: Data, stderr: Data), Error>) in
-    // 読み取り結果は background queue から書き込むため、@Sendable 制約を満たす形で
-    // OSAllocatedUnfairLock 越しに保持する。
-    let stdoutLock = OSAllocatedUnfairLock<Data>(initialState: Data())
-    let stderrLock = OSAllocatedUnfairLock<Data>(initialState: Data())
-    let group = DispatchGroup()
+// `runProcessCollectingOutput` は `ProcessExec.swift` に共通化した。
 
-    // termination は run() より先に handler を仕掛けないと、超短命プロセスで
-    // 終了通知を取りこぼす。enter は handler 設定と対で行う。
-    group.enter()
-    process.terminationHandler = { _ in
-      group.leave()
-    }
-
-    do {
-      // stdout / stderr 用の enter も run() より前に行う必要がある。
-      // 超短命プロセスでは terminationHandler が即座に走って group count が 0 になり、
-      // reader 側 enter が後追いで来る前に notify が空データで早発火する race を防ぐ。
-      group.enter()
-      group.enter()
-      try process.run()
-      // process.run() 直後から別 thread で readDataToEndOfFile() を回す。
-      // readabilityHandler 1 回 1 chunk 方式だと未読 chunk を残して pipe が再満杯
-      // になり deadlock 再発するため、最初から EOF まで連続読みする方式にする。
-      DispatchQueue.global(qos: .userInitiated).async {
-        let data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-        stdoutLock.withLock { $0 = data }
-        group.leave()
-      }
-      DispatchQueue.global(qos: .userInitiated).async {
-        let data = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-        stderrLock.withLock { $0 = data }
-        group.leave()
-      }
-      afterRun()
-      // notify は reader 起動 + afterRun の後に登録。これより前に登録すると
-      // reader enter のタイミング次第で空データ resume になる。
-      group.notify(queue: DispatchQueue.global()) {
-        let stdout = stdoutLock.withLock { $0 }
-        let stderr = stderrLock.withLock { $0 }
-        cont.resume(returning: (stdout, stderr))
-      }
-    } catch {
-      // run 失敗時: termination + reader 用に 3 回 enter したが、いずれも leave
-      // されない。group.notify は登録していないので発火しない。cont は直接 throw。
-      cont.resume(throwing: GitError.launchFailed(error.localizedDescription))
-    }
+/// `git` の絶対パスを resolve する。1 次解決失敗時のみ Apple stub `/usr/bin/git` に倒す。
+private func resolveGitPath() async -> String {
+  if let path = await CommandResolver.shared.resolve("git") {
+    return path
   }
+  return "/usr/bin/git"
 }
 
 /// stdin にデータを渡して git を起動する。`runGit` と同じ戻り値契約。
+/// `launchFailed` を検知した場合、CommandResolver のキャッシュが stale な可能性が
+/// あるため 1 回だけ invalidate + 再 resolve して retry する。
 func runGitWithStdin(args: [String], cwd: String, stdin: Data) async throws -> Data {
+  do {
+    return try await runGitWithStdinOnce(
+      gitPath: await resolveGitPath(), args: args, cwd: cwd, stdin: stdin)
+  } catch GitError.launchFailed {
+    await CommandResolver.shared.invalidate("git")
+    return try await runGitWithStdinOnce(
+      gitPath: await resolveGitPath(), args: args, cwd: cwd, stdin: stdin)
+  }
+}
+
+private func runGitWithStdinOnce(gitPath: String, args: [String], cwd: String, stdin: Data)
+  async throws -> Data
+{
   let process = Process()
-  process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-  process.arguments = ["git"] + args
+  process.executableURL = URL(fileURLWithPath: gitPath)
+  process.arguments = args
   process.currentDirectoryURL = URL(fileURLWithPath: cwd)
   // 明示的に env snapshot を渡す。Foundation Process は environment が nil のとき
   // 内部で `ProcessInfo.processInfo.environment` を遅延読みするが、その経路は
@@ -394,9 +348,18 @@ func runGitWithStdin(args: [String], cwd: String, stdin: Data) async throws -> D
 }
 
 func runGit(args: [String], cwd: String) async throws -> Data {
+  do {
+    return try await runGitOnce(gitPath: await resolveGitPath(), args: args, cwd: cwd)
+  } catch GitError.launchFailed {
+    await CommandResolver.shared.invalidate("git")
+    return try await runGitOnce(gitPath: await resolveGitPath(), args: args, cwd: cwd)
+  }
+}
+
+private func runGitOnce(gitPath: String, args: [String], cwd: String) async throws -> Data {
   let process = Process()
-  process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-  process.arguments = ["git"] + args
+  process.executableURL = URL(fileURLWithPath: gitPath)
+  process.arguments = args
   process.currentDirectoryURL = URL(fileURLWithPath: cwd)
   process.environment = ProcessInfo.processInfo.environment
 

--- a/apps/native/Sources/GozdCore/ProcessExec.swift
+++ b/apps/native/Sources/GozdCore/ProcessExec.swift
@@ -1,0 +1,262 @@
+import Darwin
+import Foundation
+import os
+
+// `Process` を `git` / `gh` 等の外部 CLI 起動に使うときの共通基盤。
+//
+// 解決すべき 2 つの問題:
+//
+// 1. **PATH 不足**: `.app` を Finder/Dock から起動すると launchd 経由で渡される PATH は
+//    `/usr/bin:/bin:/usr/sbin:/sbin` のみ。Homebrew (`/opt/homebrew/bin`) や mise / asdf
+//    配下の CLI は解決できない。`git` は `/usr/bin/git` の Apple stub に救われるが
+//    `gh` は救われない。dev (`pnpm dev`) ではターミナル PATH を継承するので顕在化しない。
+//
+// 2. **pipe drain の deadlock**: `terminationHandler` 内で `readDataToEndOfFile()` する
+//    naive 実装は出力が macOS の pipe buffer (~64KB) を超えると子プロセスが
+//    write block → exit 不能 → terminationHandler 永遠に呼ばれない deadlock を起こす。
+//
+// `CommandResolver` で 1 を、`runProcessCollectingOutput` で 2 を解決する。
+
+// MARK: - CommandResolver
+
+/// 外部 CLI の絶対パスを解決してキャッシュする actor。
+///
+/// 解決手順:
+///
+/// 1. **現在の PATH で 1 次解決**: `ProcessInfo.processInfo.environment["PATH"]` を
+///    分割して各 dir に candidate が存在するか走査。dev 経路（ターミナル PATH 継承）や
+///    `git` のように Apple stub 経路で見つかる場合はここで終わる。
+///
+/// 2. **ユーザーログインシェル経由で 2 次解決**: 1 次で見つからない場合、
+///    `getpwuid_r(getuid())->pw_shell` でユーザーのログインシェルを取得し、
+///    `<shell> -i -l -c '<script>'` で起動して `command -v <name>` の絶対パスを得る。
+///
+///    `-i -l` 両方付ける理由: `mise activate` / `asdf` 等は `.zshrc` 経由で activate
+///    されるケースが多く、`-l` (login) 単独では `.zshrc` を読まない。VSCode の
+///    shell environment resolver も同じ理由で `-i -l -c` を採用している。
+///
+///    結果は alias / function ではなく絶対パスかつ executable であることを検証する。
+///
+/// 解決結果は actor 内のキャッシュに保存する。`invalidate(_:)` で無効化することで
+/// stale cache（mise/asdf upgrade で versioned path が消えた等）に再解決の余地を残す。
+public actor CommandResolver {
+  public static let shared = CommandResolver()
+
+  private var cache: [String: String] = [:]
+  private var inflight: [String: Task<String?, Never>] = [:]
+
+  /// 指定 name の絶対パスを返す。見つからなければ nil。結果はキャッシュされる。
+  public func resolve(_ name: String) async -> String? {
+    if let cached = cache[name] { return cached }
+    if let inflight = inflight[name] { return await inflight.value }
+
+    let task = Task { await Self.lookup(name) }
+    inflight[name] = task
+    let result = await task.value
+    inflight[name] = nil
+    if let result {
+      cache[name] = result
+    }
+    return result
+  }
+
+  /// キャッシュを無効化する。`runGit` / `runGh` が `launchFailed` を受けたときに
+  /// 呼んで再解決のチャンスを与える。
+  public func invalidate(_ name: String) {
+    cache[name] = nil
+  }
+
+  private static func lookup(_ name: String) async -> String? {
+    if let direct = lookupInCurrentPath(name) {
+      return direct
+    }
+    return await lookupViaLoginShell(name)
+  }
+
+  /// 現在プロセスの PATH を分割して走査。`/usr/bin/env` と同じ挙動。
+  /// 空 PATH 要素は cwd 解釈になるが、セキュリティ理由から走査しない。
+  private static func lookupInCurrentPath(_ name: String) -> String? {
+    let pathEnv = ProcessInfo.processInfo.environment["PATH"] ?? ""
+    if pathEnv.isEmpty { return nil }
+    for dir in pathEnv.split(separator: ":", omittingEmptySubsequences: true) {
+      let candidate = (String(dir) as NSString).appendingPathComponent(name)
+      if let validated = validateExecutablePath(candidate) {
+        return validated
+      }
+    }
+    return nil
+  }
+
+  /// `getpwuid_r(getuid())->pw_shell` でユーザーのログインシェルを取得。
+  /// `getpwuid` は thread-unsafe（共有 buffer を返す）なので reentrant 版を使う。
+  /// 取れない場合は `$SHELL` → `/bin/zsh` の順で fallback。
+  private static func userLoginShell() -> String {
+    let suggested = sysconf(_SC_GETPW_R_SIZE_MAX)
+    let bufSize: Int = suggested > 0 ? Int(suggested) : 4096
+    var buffer = [CChar](repeating: 0, count: bufSize)
+    var pwd = passwd()
+    var result: UnsafeMutablePointer<passwd>? = nil
+    let rc = getpwuid_r(getuid(), &pwd, &buffer, bufSize, &result)
+    if rc == 0, result != nil {
+      let shellPtr: UnsafeMutablePointer<CChar>? = pwd.pw_shell
+      if let shellPtr {
+        let shell = String(cString: shellPtr)
+        if !shell.isEmpty {
+          return shell
+        }
+      }
+    }
+    if let envShell = ProcessInfo.processInfo.environment["SHELL"], !envShell.isEmpty {
+      return envShell
+    }
+    return "/bin/zsh"
+  }
+
+  /// `<shell> -i -l -c '<script>'` で絶対パスを取得。
+  /// rc ファイルが余計な文字列を stdout に流すケースに備えて UUID marker で囲んで抽出する。
+  /// `-i` で interactive shell を起動するため、親の stdin 継承を防ぐべく `/dev/null` を渡し、
+  /// rc の hang に備えて 10 秒で SIGKILL する。
+  ///
+  /// 対応シェル: `-i -l -c` フラグおよび POSIX `command -v` を解釈する shell（bash / zsh /
+  /// dash / fish 等）を想定。これらに該当しないログインシェル（tcsh / nushell / xonsh の
+  /// 一部呼び出し方法等）の場合は本関数が nil を返す。呼び出し側はそれを受けて
+  /// `runGh` / `runGit` で `launchFailed` を throw し、`prList` / `issueList` 等は `try?`
+  /// で nil 化する。
+  private static func lookupViaLoginShell(_ name: String) async -> String? {
+    let shell = userLoginShell()
+    let token = UUID().uuidString
+    let beginMarker = "GOZD_BEGIN_\(token)"
+    let endMarker = "GOZD_END_\(token)"
+    let script =
+      "printf '%s\\n' \(beginMarker); command -v \(name); printf '%s\\n' \(endMarker)"
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: shell)
+    process.arguments = ["-i", "-l", "-c", script]
+    // 余計な ZDOTDIR 等が継承されないよう、PATH 解決には素の env を渡す。
+    // gozd の PTY overlay (GozdEnvOverlay) はここに混ざらない（PTYRegistry でのみ merge）。
+    process.environment = ProcessInfo.processInfo.environment
+    if let devNull = FileHandle(forReadingAtPath: "/dev/null") {
+      process.standardInput = devNull
+    }
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+    process.standardOutput = stdoutPipe
+    process.standardError = stderrPipe
+
+    let timeoutTask = Task { [process] in
+      try? await Task.sleep(nanoseconds: 10 * 1_000_000_000)
+      if process.isRunning {
+        let pid = process.processIdentifier
+        if pid > 0 { _ = kill(pid, SIGKILL) }
+      }
+    }
+    defer { timeoutTask.cancel() }
+
+    let (stdoutData, _): (Data, Data)
+    do {
+      (stdoutData, _) = try await runProcessCollectingOutput(
+        process: process,
+        stdoutPipe: stdoutPipe,
+        stderrPipe: stderrPipe
+      )
+    } catch {
+      return nil
+    }
+
+    guard process.terminationStatus == 0 else { return nil }
+    let text = String(decoding: stdoutData, as: UTF8.self)
+    return extractAndValidatePath(text, begin: beginMarker, end: endMarker)
+  }
+
+  /// marker 間から「絶対パスかつ実行可能なファイル」となる行を抽出する。
+  /// `command -v` は通常 1 行を返すが、shell によっては alias / function 名を返すことが
+  /// あるため、`/` 始まり + `isExecutableFile` の二重検証で弾く。
+  private static func extractAndValidatePath(_ text: String, begin: String, end: String)
+    -> String?
+  {
+    guard let beginRange = text.range(of: begin),
+      let endRange = text.range(of: end, range: beginRange.upperBound..<text.endIndex)
+    else { return nil }
+    let body = text[beginRange.upperBound..<endRange.lowerBound]
+    for line in body.split(separator: "\n") {
+      let trimmed = line.trimmingCharacters(in: .whitespaces)
+      if let validated = validateExecutablePath(trimmed) {
+        return validated
+      }
+    }
+    return nil
+  }
+
+  /// 絶対パスでかつ実行可能ファイルである場合のみ正規化したパスを返す。
+  /// `isExecutableFile` は execute bit が立った directory も true を返すため、
+  /// 通常ファイルであることも併せて検証する。
+  private static func validateExecutablePath(_ path: String) -> String? {
+    guard path.hasPrefix("/") else { return nil }
+    let fm = FileManager.default
+    var isDir: ObjCBool = false
+    guard fm.fileExists(atPath: path, isDirectory: &isDir), !isDir.boolValue else {
+      return nil
+    }
+    return fm.isExecutableFile(atPath: path) ? path : nil
+  }
+}
+
+// MARK: - runProcessCollectingOutput
+
+/// 共通 helper: 既に standardOutput/standardError が Pipe で構成されている `Process`
+/// を起動し、子プロセス生存中から stdout/stderr を別 thread で drain する。
+///
+/// terminationHandler 内で `readDataToEndOfFile()` する設計だと、出力が pipe buffer
+/// (macOS は最大 ~64KB) を超えた瞬間に子が write block → exit 不能 →
+/// terminationHandler 永遠に呼ばれない deadlock になる。回避のため、`process.run()`
+/// 直後に `DispatchQueue.global` 上で `readDataToEndOfFile()` を回し続ける。
+///
+/// `DispatchGroup` で「stdout EOF / stderr EOF / process termination」3 イベント
+/// 全てが揃った時点で `(stdoutData, stderrData)` を返す。launch 失敗時は throw する。
+///
+/// 注: `afterRun` の stdin write/close は同期実行のため、stdin を読まないコマンドに
+/// この helper を流用すると stdin write 自体が詰まる可能性がある。stdin 利用は
+/// `git check-ignore --stdin` のような stdin を実際に読むコマンド限定で使うこと。
+func runProcessCollectingOutput(
+  process: Process,
+  stdoutPipe: Pipe,
+  stderrPipe: Pipe,
+  afterRun: () -> Void = {}
+) async throws -> (stdout: Data, stderr: Data) {
+  try await withCheckedThrowingContinuation {
+    (cont: CheckedContinuation<(stdout: Data, stderr: Data), Error>) in
+    let stdoutLock = OSAllocatedUnfairLock<Data>(initialState: Data())
+    let stderrLock = OSAllocatedUnfairLock<Data>(initialState: Data())
+    let group = DispatchGroup()
+
+    group.enter()
+    process.terminationHandler = { _ in
+      group.leave()
+    }
+
+    do {
+      group.enter()
+      group.enter()
+      try process.run()
+      DispatchQueue.global(qos: .userInitiated).async {
+        let data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        stdoutLock.withLock { $0 = data }
+        group.leave()
+      }
+      DispatchQueue.global(qos: .userInitiated).async {
+        let data = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        stderrLock.withLock { $0 = data }
+        group.leave()
+      }
+      afterRun()
+      group.notify(queue: DispatchQueue.global()) {
+        let stdout = stdoutLock.withLock { $0 }
+        let stderr = stderrLock.withLock { $0 }
+        cont.resume(returning: (stdout, stderr))
+      }
+    } catch {
+      cont.resume(throwing: GitError.launchFailed(error.localizedDescription))
+    }
+  }
+}

--- a/apps/native/Tests/GozdCoreTests/CommandResolverTests.swift
+++ b/apps/native/Tests/GozdCoreTests/CommandResolverTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+
+@testable import GozdCore
+
+@Suite("CommandResolver")
+struct CommandResolverTests {
+  @Test("git は絶対パスで解決できる（PATH 走査または login shell 経由）")
+  func resolvesGit() async {
+    let resolver = CommandResolver()
+    let path = await resolver.resolve("git")
+    #expect(path != nil)
+    if let path {
+      #expect(path.hasPrefix("/"))
+      #expect(FileManager.default.isExecutableFile(atPath: path))
+    }
+  }
+
+  @Test("存在しないコマンドは nil を返す")
+  func returnsNilForUnknownCommand() async {
+    let resolver = CommandResolver()
+    // 衝突しないよう UUID を含める
+    let bogus = "gozd_nonexistent_\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
+    let path = await resolver.resolve(bogus)
+    #expect(path == nil)
+  }
+
+  @Test("同名の連続 resolve は同じパスを返す（キャッシュ）")
+  func cachesResult() async {
+    let resolver = CommandResolver()
+    let p1 = await resolver.resolve("git")
+    let p2 = await resolver.resolve("git")
+    #expect(p1 == p2)
+    #expect(p1 != nil)
+  }
+
+  @Test("invalidate 後の resolve も同じパスを返す（再解決）")
+  func reResolvesAfterInvalidate() async {
+    let resolver = CommandResolver()
+    let p1 = await resolver.resolve("git")
+    await resolver.invalidate("git")
+    let p2 = await resolver.resolve("git")
+    #expect(p1 == p2)
+  }
+
+  @Test("並列 resolve は重複起動しない（inflight 共有）")
+  func deduplicatesInflightResolves() async {
+    let resolver = CommandResolver()
+    async let a = resolver.resolve("git")
+    async let b = resolver.resolve("git")
+    async let c = resolver.resolve("git")
+    let results = await [a, b, c]
+    #expect(results[0] != nil)
+    #expect(results[0] == results[1])
+    #expect(results[1] == results[2])
+  }
+
+  /// hang 系 shell の検証用に SHELL を `sleep infinity` を実行する自前バイナリに
+  /// 差し替えるのは困難（シェル interpreter として呼ばれる必要がある）なので、
+  /// 公開 API では「resolver が永久 hang しないこと」を timeout 観測で確認する。
+  ///
+  /// 不明コマンドを解決するパスは `lookupViaLoginShell` を必ず通る。rc が極端に重く
+  /// ても 10 秒で SIGKILL されるため、テスト全体は数秒で終わる必要がある。
+  @Test("不明コマンドの解決は 30 秒以内に完了する（timeout 経路を含めても無限 hang しない）")
+  func resolveDoesNotHangIndefinitely() async throws {
+    let resolver = CommandResolver()
+    let bogus = "gozd_hang_probe_\(UUID().uuidString.replacingOccurrences(of: "-", with: ""))"
+    let start = Date()
+    _ = await resolver.resolve(bogus)
+    let elapsed = Date().timeIntervalSince(start)
+    #expect(elapsed < 30.0)
+  }
+}


### PR DESCRIPTION
## 概要

build した `.app` を Finder/Dock から起動した状態でコマンドパレットの "Workspace: Open Pull Request" / "Workspace: Open Issue" を実行すると `Failed to load pull requests from GitHub` / `Failed to load issues from GitHub` のトーストが出て無反応になる問題を修正する。

dev 起動 (`pnpm dev`) では同じ操作が成功し、build 起動でのみ再現していた。

## 背景

### root cause

`.app` を Finder/Dock 経由で起動すると launchd が渡す PATH は `/usr/bin:/bin:/usr/sbin:/sbin` の最小構成で、Homebrew (`/opt/homebrew/bin`) や mise / asdf 配下の `gh` は解決できない。`git` は `/usr/bin/git` の Apple stub があるため最小 PATH でも通るが、`gh` には stub がないため `runGh` の `/usr/bin/env gh` 起動が exit code != 0 で落ち、`GitHubOps.prList` / `issueList` / `viewer` が nil を返し、`RpcDispatcher.handleGitPrList` 等で `resp.ok = false` がセットされていた。

dev 起動時はターミナル（mise / Homebrew PATH 入り）から `pnpm dev` 経由で立ち上がるため `Process` が継承する `ProcessInfo.processInfo.environment` に PATH が乗っており顕在化していなかった。

直近 PR ( #432 ) はこの native 側の `resp.ok = false` を picker 側でトースト通知に可視化したものであり、トーストが出る根本原因（PATH 解決の失敗）はそこでは未対処だった。

### 設計判断の経緯

修正方針は Codex とのレビューループおよび Web 調査（VSCode の `shellEnv.ts` での shell environment resolver、`getpwuid_r` の thread-safety、`mise` / `asdf` の `.zshrc`-based activate 仕様）を踏まえて確定した。

`/bin/zsh -lc 'exec gh "$@"'` のような login shell 経由で実行する案は、`-l` 単独では `.zshrc` を読まないため `mise activate` 経由の PATH が効かないこと、非 zsh ユーザーで失敗すること、毎回 shell 起動コストと rc 副作用が乗ることから却下した。

代わりに「shell を実行器ではなく resolver として使う」設計を採用し、ユーザーログインシェル (`getpwuid_r` 取得) 経由で `command -v <name>` を一度だけ実行して絶対パスを取得しキャッシュ、以後は `Process` で直接叩く形に統一した。

## 変更内容

### apps/native/Sources/GozdCore/ProcessExec.swift（新規）

- `CommandResolver` actor: 外部 CLI の絶対パスを解決してキャッシュ
  - 1 次解決: 現在 PATH (`ProcessInfo.processInfo.environment["PATH"]`) を走査
  - 2 次解決: 失敗時のみ `getpwuid_r(getuid())->pw_shell` で取得したログインシェル (`$SHELL` → `/bin/zsh` で fallback) を `<shell> -i -l -c 'command -v <name>'` で起動
  - VSCode の `shellEnv.ts` と同じ `-i -l -c` パターン (`mise activate` 等が `.zshrc` 経由で行われるため `-l` 単独では不十分)
  - alias / function 戻り値や directory を弾くため、絶対パス始まり + `isExecutableFile` + 非 directory の三重検証
  - rc が stdout に流すゴミに備えて UUID ベースの begin/end marker で結果を囲む
  - 親 stdin の継承を防ぐべく `/dev/null` を渡し、rc の hang に備えて 10 秒で `kill(pid, SIGKILL)`（`Process.terminate()` の SIGTERM は interactive zsh が無視するため）
  - actor 内で結果キャッシュ + inflight Task で重複起動を防止 + `invalidate(_:)` API で再解決可能
- `runProcessCollectingOutput` を `GitOps.swift` から移動して同一モジュールで共通化（pipe buffer ~64KB 超で `terminationHandler` 内一括 drain が deadlock する件への対処を共有）

### apps/native/Sources/GozdCore/GitOps.swift

- `runGit` / `runGitWithStdin` を `CommandResolver.shared.resolve("git")` 経由の絶対パス起動に変更（resolver が nil を返した場合のみ Apple stub `/usr/bin/git` に倒す）
- `launchFailed` を catch して 1 回だけ `invalidate("git")` + 再 resolve + 再実行する retry を追加（mise/asdf upgrade で versioned path が消えた場合の自己回復）
- 設計判断コメントの 2 番を `/usr/bin/env git` 前提から `CommandResolver` 経由 + Apple stub fallback に更新
- `runProcessCollectingOutput` は ProcessExec.swift 側へ移動

### apps/native/Sources/GozdCore/GitHubOps.swift

- `runGh` を `CommandResolver.shared.resolve("gh")` 経由の絶対パス起動に変更（nil なら `GitError.launchFailed` を throw）
- 出力収集を `runProcessCollectingOutput` 経由に変更（旧実装は `gh pr list --json --limit 100` で 64KB を超えると deadlock するリスクを抱えていた）
- stderr を捕捉して `GitError.commandFailed` に渡すよう変更（旧実装は読み捨てていた）
- `runGit` と同じ `launchFailed` retry を追加

### apps/native/Tests/GozdCoreTests/CommandResolverTests.swift（新規）

- `git` 解決 / 不明コマンド nil / キャッシュ / `invalidate` / inflight 重複防止 / timeout 観測（無限 hang しないこと）の 6 件

## 今回含めない点

- **proto に `errorMessage` を載せる拡張**: 現状の `prList` / `issueList` / `viewer` は `ok=false` のみを返し、picker 側のトースト文言は固定文字列。`gh` 未インストールと認証エラーが同じトーストになる。Codex レビューでも「次段として `errorMessage` を proto に載せる余地はある」と指摘されたが、これは別の決定点（RPC 設計層）であり、本 PR の責務（PATH 解決基盤）からは離れるため別 PR に分ける

## 確認事項

- [ ] build した `.app` を Finder/Dock から起動し、コマンドパレットの "Workspace: Open Pull Request" で PR picker が開くこと
- [ ] 同 "Workspace: Open Issue" で issue picker が開くこと
- [ ] dev 起動 (`pnpm dev`) でも従来通り両 picker が開くこと
- [ ] `gh auth logout` 等で `gh` を失敗状態にしたとき、トーストが表示されること（PR #432 の挙動の維持）
- [ ] `gh` 自体を mise でアンインストールした状態で picker を開くと nil 化されてトーストが出ること（永久 hang しないこと）
- [ ] `swift test` で 72 件全通過すること（既存 66 + 新規 CommandResolverTests 6 件）
