### PR TITLE
feat(notification): expand cause details in toast

### DIFF
--- a/apps/renderer/CLAUDE.md
+++ b/apps/renderer/CLAUDE.md
@@ -2,7 +2,7 @@
 
 - 例外処理では必ず `useNotificationStore` の `error(message, cause?)` / `info(message, cause?)` でトースト通知する。`console.error` で握りつぶさない
 - store 内部で `console.error` / `console.info` を出力するため、呼び出し側で console を呼ぶ必要はない
-- cause にエラーオブジェクトを渡すとコンソールにスタックトレースが出る。トーストには message のみ表示
+- cause にエラーオブジェクトを渡すとコンソールにスタックトレースが出る。トースト本文をクリックすると `cause` の詳細（`Error` なら stack、それ以外は文字列化）を展開表示し、Copy ボタンで内容をクリップボードにコピーできる
 
 ## イベントリスナー
 

--- a/apps/renderer/src/features/layout/NotificationToast.vue
+++ b/apps/renderer/src/features/layout/NotificationToast.vue
@@ -12,6 +12,7 @@ Popover API (`popover="manual"`) によるトースト通知。
 import { useEventListener } from "@vueuse/core";
 import { useTemplateRef, watch } from "vue";
 import { useNotificationStore } from "../../shared/notification";
+import NotificationToastItem from "./NotificationToastItem.vue";
 
 const { notifications, dismiss } = useNotificationStore();
 
@@ -39,21 +40,6 @@ useEventListener(popoverRef, "toggle", (e: ToggleEvent) => {
     }
   }
 });
-
-const iconMap = {
-  error: "icon-[lucide--circle-x]",
-  info: "icon-[lucide--info]",
-} as const;
-
-const colorMap = {
-  error: "border-red-800 bg-red-950",
-  info: "border-zinc-700 bg-zinc-900",
-} as const;
-
-const iconColorMap = {
-  error: "text-red-400",
-  info: "text-blue-400",
-} as const;
 </script>
 
 <template>
@@ -62,25 +48,14 @@ const iconColorMap = {
     popover="manual"
     class="_notification-toast pointer-events-none m-0 flex flex-col items-end gap-2 border-0 bg-transparent p-4 [&:popover-open]:flex"
   >
-    <div
+    <NotificationToastItem
       v-for="n in notifications"
       :key="n.id"
-      :class="[
-        'pointer-events-auto flex max-w-md items-start gap-2 rounded-lg border p-3 text-sm text-white shadow-lg',
-        colorMap[n.type],
-      ]"
-    >
-      <span :class="['mt-0.5 size-4 shrink-0', iconMap[n.type], iconColorMap[n.type]]" />
-      <p class="min-w-0 flex-1 break-all">{{ n.message }}</p>
-      <button
-        type="button"
-        class="shrink-0 text-zinc-400 hover:text-zinc-200"
-        aria-label="Dismiss"
-        @click="dismiss(n.id)"
-      >
-        <span class="icon-[lucide--x] size-4" />
-      </button>
-    </div>
+      :type="n.type"
+      :message="n.message"
+      :cause="n.cause"
+      @dismiss="dismiss(n.id)"
+    />
   </div>
 </template>
 

--- a/apps/renderer/src/features/layout/NotificationToastItem.vue
+++ b/apps/renderer/src/features/layout/NotificationToastItem.vue
@@ -10,6 +10,7 @@
 </doc>
 
 <script setup lang="ts">
+import { tryCatch } from "@gozd/shared";
 import { computed, ref } from "vue";
 
 const props = defineProps<{
@@ -20,8 +21,24 @@ const props = defineProps<{
 
 defineEmits<{ dismiss: [] }>();
 
+type CopyState = "idle" | "copied" | "failed";
+
 const expanded = ref(false);
-const copied = ref(false);
+const copyState = ref<CopyState>("idle");
+
+const COPY_FEEDBACK_MS = 1500;
+
+const copyLabelMap: Record<CopyState, string> = {
+  idle: "Copy",
+  copied: "Copied",
+  failed: "Failed",
+};
+
+const copyIconMap: Record<CopyState, string> = {
+  idle: "icon-[lucide--copy]",
+  copied: "icon-[lucide--check]",
+  failed: "icon-[lucide--triangle-alert]",
+};
 
 const iconMap = {
   error: "icon-[lucide--circle-x]",
@@ -40,6 +57,35 @@ const iconColorMap = {
 
 const hasCause = computed(() => props.cause !== undefined);
 
+// 循環参照や toString が壊れたオブジェクトでもトースト描画を壊さないように整形する
+function safeStringify(value: unknown): string {
+  // String() は Symbol.toPrimitive / toString / valueOf が壊れている時に throw する
+  const stringResult = tryCatch(() => String(value));
+  if (stringResult.ok && stringResult.value !== "[object Object]") {
+    return stringResult.value;
+  }
+  // Object 系で String() が "[object Object]" になるケースは JSON 整形を試す
+  const seen = new WeakSet<object>();
+  const jsonResult = tryCatch(() =>
+    JSON.stringify(
+      value,
+      (_key, v) => {
+        if (typeof v === "object" && v !== null) {
+          if (seen.has(v)) return "[Circular]";
+          seen.add(v);
+        }
+        return v;
+      },
+      2,
+    ),
+  );
+  if (jsonResult.ok && jsonResult.value !== undefined) return jsonResult.value;
+  // どちらも失敗 / undefined を返す場合は prototype-free な型表記にフォールバック。
+  // Symbol.toStringTag の getter が throw するケースに備えてこれも tryCatch で包む
+  const tagResult = tryCatch(() => Object.prototype.toString.call(value));
+  return tagResult.ok ? tagResult.value : "[unrepresentable cause]";
+}
+
 const detail = computed(() => {
   const { cause } = props;
   if (cause instanceof Error) {
@@ -47,13 +93,7 @@ const detail = computed(() => {
     return cause.stack !== undefined && cause.stack !== "" ? cause.stack : head;
   }
   if (typeof cause === "string") return cause;
-  const stringified = String(cause);
-  if (stringified !== "[object Object]") return stringified;
-  try {
-    return JSON.stringify(cause, null, 2);
-  } catch {
-    return stringified;
-  }
+  return safeStringify(cause);
 });
 
 function toggle() {
@@ -63,11 +103,15 @@ function toggle() {
 
 async function copyDetail() {
   const text = `${props.message}\n\n${detail.value}`;
-  await navigator.clipboard.writeText(text);
-  copied.value = true;
+  // navigator.clipboard 自体が undefined の環境（古い WebView / 非 secure context）で
+  // .writeText 参照時点の同期 throw も拾うため、async IIFE で Promise 化してから tryCatch に渡す。
+  // tryCatch の関数版は Result<Promise<T>> を返すだけで Promise の reject を拾わないため、
+  // ここでは Promise 版に流し込む必要がある。
+  const result = await tryCatch((async () => navigator.clipboard.writeText(text))());
+  copyState.value = result.ok ? "copied" : "failed";
   setTimeout(() => {
-    copied.value = false;
-  }, 1500);
+    copyState.value = "idle";
+  }, COPY_FEEDBACK_MS);
 }
 </script>
 
@@ -118,8 +162,8 @@ async function copyDetail() {
           class="flex cursor-pointer items-center gap-1 rounded-sm border border-white/15 px-2 py-0.5 text-xs text-zinc-200 hover:bg-white/10"
           @click="copyDetail"
         >
-          <span :class="[copied ? 'icon-[lucide--check]' : 'icon-[lucide--copy]', 'size-3']" />
-          {{ copied ? "Copied" : "Copy" }}
+          <span :class="[copyIconMap[copyState], 'size-3']" />
+          {{ copyLabelMap[copyState] }}
         </button>
       </div>
       <pre

--- a/apps/renderer/src/features/layout/NotificationToastItem.vue
+++ b/apps/renderer/src/features/layout/NotificationToastItem.vue
@@ -1,0 +1,131 @@
+<doc lang="md">
+通知トーストの 1 アイテム。
+
+## 動作
+
+- `cause` がある場合のみメッセージ全体をクリック可能にし、詳細パネルを展開する
+- `Error` インスタンスは `name + message + stack`、それ以外は `String(cause)` または `JSON.stringify` フォールバックで表示
+- 詳細パネルには「Copy」ボタンを併設し、issue 報告にコピペしやすくする
+- dismiss ボタンは独立しており、本文クリックで dismiss されない
+</doc>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+
+const props = defineProps<{
+  type: "error" | "info";
+  message: string;
+  cause?: unknown;
+}>();
+
+defineEmits<{ dismiss: [] }>();
+
+const expanded = ref(false);
+const copied = ref(false);
+
+const iconMap = {
+  error: "icon-[lucide--circle-x]",
+  info: "icon-[lucide--info]",
+} as const;
+
+const colorMap = {
+  error: "border-red-800 bg-red-950",
+  info: "border-zinc-700 bg-zinc-900",
+} as const;
+
+const iconColorMap = {
+  error: "text-red-400",
+  info: "text-blue-400",
+} as const;
+
+const hasCause = computed(() => props.cause !== undefined);
+
+const detail = computed(() => {
+  const { cause } = props;
+  if (cause instanceof Error) {
+    const head = `${cause.name}: ${cause.message}`;
+    return cause.stack !== undefined && cause.stack !== "" ? cause.stack : head;
+  }
+  if (typeof cause === "string") return cause;
+  const stringified = String(cause);
+  if (stringified !== "[object Object]") return stringified;
+  try {
+    return JSON.stringify(cause, null, 2);
+  } catch {
+    return stringified;
+  }
+});
+
+function toggle() {
+  if (!hasCause.value) return;
+  expanded.value = !expanded.value;
+}
+
+async function copyDetail() {
+  const text = `${props.message}\n\n${detail.value}`;
+  await navigator.clipboard.writeText(text);
+  copied.value = true;
+  setTimeout(() => {
+    copied.value = false;
+  }, 1500);
+}
+</script>
+
+<template>
+  <div
+    :class="[
+      'pointer-events-auto flex w-md max-w-md flex-col rounded-lg border text-sm text-white shadow-lg',
+      colorMap[type],
+    ]"
+  >
+    <div class="flex items-start gap-2 p-3">
+      <span :class="['mt-0.5 size-4 shrink-0', iconMap[type], iconColorMap[type]]" />
+      <button
+        type="button"
+        :class="[
+          'min-w-0 flex-1 text-left break-all',
+          hasCause ? 'cursor-pointer hover:underline' : 'cursor-default',
+        ]"
+        :aria-expanded="hasCause ? expanded : undefined"
+        :disabled="!hasCause"
+        :title="hasCause ? (expanded ? 'Hide details' : 'Show details') : undefined"
+        @click="toggle"
+      >
+        <span class="flex items-center gap-1">
+          <span>{{ message }}</span>
+          <span
+            v-if="hasCause"
+            :class="[
+              'icon-[lucide--chevron-down] size-3 shrink-0 text-zinc-400 transition-transform',
+              expanded ? 'rotate-180' : '',
+            ]"
+          />
+        </span>
+      </button>
+      <button
+        type="button"
+        class="shrink-0 cursor-pointer text-zinc-400 hover:text-zinc-200"
+        aria-label="Dismiss"
+        @click="$emit('dismiss')"
+      >
+        <span class="icon-[lucide--x] size-4" />
+      </button>
+    </div>
+    <div v-if="hasCause && expanded" class="border-t border-white/10 p-3">
+      <div class="mb-2 flex justify-end">
+        <button
+          type="button"
+          class="flex cursor-pointer items-center gap-1 rounded-sm border border-white/15 px-2 py-0.5 text-xs text-zinc-200 hover:bg-white/10"
+          @click="copyDetail"
+        >
+          <span :class="[copied ? 'icon-[lucide--check]' : 'icon-[lucide--copy]', 'size-3']" />
+          {{ copied ? "Copied" : "Copy" }}
+        </button>
+      </div>
+      <pre
+        class="max-h-64 overflow-auto font-mono text-xs break-all whitespace-pre-wrap text-zinc-200"
+        >{{ detail }}</pre
+      >
+    </div>
+  </div>
+</template>

--- a/apps/renderer/src/shared/notification/useNotificationStore.ts
+++ b/apps/renderer/src/shared/notification/useNotificationStore.ts
@@ -23,12 +23,18 @@ const CONSOLE_BY_TYPE = {
   info: console.info,
 } as const;
 
-/** 同一メッセージの重複を抑制する。既に表示中なら console 出力のみ行い、トーストは追加しない */
+/**
+ * 同一メッセージの重複を抑制する。既に表示中ならトーストは追加せず、cause だけ最新で上書きする。
+ * cause を上書きするのは、ユーザーが Copy する詳細を最新の発生時点に揃えるため。
+ */
 function add(type: Notification["type"], message: string, cause?: unknown) {
   CONSOLE_BY_TYPE[type](message, ...(cause !== undefined ? [cause] : []));
 
   const duplicate = notifications.value.find((n) => n.type === type && n.message === message);
-  if (duplicate) return;
+  if (duplicate) {
+    duplicate.cause = cause;
+    return;
+  }
 
   const id = nextId++;
   notifications.value.push({ id, type, message, cause });

--- a/apps/renderer/src/shared/notification/useNotificationStore.ts
+++ b/apps/renderer/src/shared/notification/useNotificationStore.ts
@@ -8,6 +8,7 @@ interface Notification {
   id: number;
   type: "error" | "info";
   message: string;
+  cause?: unknown;
 }
 
 /** info 通知の自動消去時間（ms） */
@@ -30,7 +31,7 @@ function add(type: Notification["type"], message: string, cause?: unknown) {
   if (duplicate) return;
 
   const id = nextId++;
-  notifications.value.push({ id, type, message });
+  notifications.value.push({ id, type, message, cause });
 
   if (type === "info") {
     const timer = setTimeout(() => dismiss(id), INFO_AUTO_DISMISS_MS);


### PR DESCRIPTION
## 概要

通知トーストの `cause` を保持して詳細展開できるようにします。エラートースト本文をクリックすると `cause` の中身（`Error` の stack、文字列、その他オブジェクトの整形 JSON）を展開表示し、Copy ボタンでまるごとクリップボードに送れます。

## 背景

現状 `useNotificationStore.error(message, cause?)` は `cause` を `console.error` に渡したきり保持しておらず、トーストには `message` 1 行しか出ません。「Failed to add worktree」とだけ出てもユーザーは原因を把握できず、issue 報告に十分な情報を貼れない、という問題が ( #430 ) で挙がっていました。

呼び出し側はすでに 18 箇所程度で `cause` を渡しており、データは届いているのに UI 側で捨てているだけ、という状態でした。

## 変更内容

### `useNotificationStore`

- `Notification` 型に `cause?: unknown` を追加
- 重複抑制（`type + message` 一致時に 2 件目以降を弾く）は維持しつつ、検出時に `duplicate.cause` を最新値で上書きする方針に変更（Copy する詳細が stale にならないよう、最後に発生した時点の cause を見せる）

### `NotificationToastItem.vue`（新規）

- per-item の状態（展開、Copy 状態）と `cause` 整形ロジックをローカルに閉じ込める子コンポーネント
- `cause` がある時のみ本文をクリック可能にし、詳細パネルをトグル展開
- `cause` 整形（`safeStringify`）: render を絶対に壊さないよう `@gozd/shared` の `tryCatch` で多段防御
  - `Error` インスタンス → `error.stack`（空なら `name: message`）
  - 文字列 → そのまま
  - それ以外 → `String(value)` を tryCatch で実行 → `[object Object]` のときは循環参照対応 replacer 付き `JSON.stringify` を tryCatch で実行 → どちらも失敗時は `Object.prototype.toString.call(value)` も tryCatch で実行 → 最終的に `"[unrepresentable cause]"` 固定文字列にフォールバック
  - 循環参照は WeakSet ベース replacer で `"[Circular]"` に置換
- 詳細パネルは `max-h-64 overflow-auto whitespace-pre-wrap break-all` で高さ上限とスクロール
- Copy ボタン
  - `${message}\n\n${detail}` をクリップボードに送る
  - 状態は `"idle" | "copied" | "failed"` の 3 値。`navigator.clipboard` 未実装環境（古い WebView / 非 secure context）での同期 throw、`writeText()` の reject の両方を 1 経路で拾うため、async IIFE で Promise 化してから Promise 版 `tryCatch` に渡す
  - 失敗時は `Failed` + triangle-alert アイコンを 1500ms 表示し、silent failure を防ぐ
- dismiss `×` ボタンは独立しており、本文クリックで dismiss されない

### `NotificationToast.vue`

- per-item テンプレートを `NotificationToastItem` 呼び出しに置き換え。親は通知ストアと popover の開閉だけを担う

### ドキュメント

- `apps/renderer/CLAUDE.md` のエラーハンドリング節を、トースト本文クリックで詳細展開・Copy できる現状に合わせて更新

## 確認事項

- [ ] `cause` がない info / error トーストは従来どおりクリックで何も起きず、× で dismiss できる
- [ ] `cause` が `Error` のときに本文クリックで stack が展開され、Copy で `message + stack` がコピーされる
- [ ] `cause` がプレーンオブジェクトのときに JSON 整形で表示される
- [ ] 循環参照を持つオブジェクトを cause に渡しても render が落ちず、`"[Circular]"` で展開される
- [ ] error トーストは本文クリックで dismiss されない（dismiss は × ボタンのみ）
- [ ] 詳細パネルが長文（長い stack）でも `max-h-64` 内でスクロールし、トースト全体が画面外に伸びない
- [ ] 同一メッセージのエラーが連発した時、トーストは 1 件のままで Copy 内容が最新の cause になっている
