### PR TITLE
fix(github-ops): restore PR/Issue picker author avatars via gh GraphQL

### DIFF
--- a/apps/native/Sources/GozdCore/GitHubOps.swift
+++ b/apps/native/Sources/GozdCore/GitHubOps.swift
@@ -7,25 +7,81 @@ import Foundation
 // 1. **gh CLI 必須**。未インストール / 未認証時は launch 失敗または exit code != 0 を
 //    nil 相当として扱い、呼び出し側が UI 非表示にできるようにする。
 //
-// 2. **JSON 出力 (`--json`)**。gh が安定 schema で吐くフィールドのみ取り出す。
+// 2. **GraphQL 経由**。`gh pr list --json author` / `gh issue list --json author` は
+//    `{login, id, is_bot, name}` のみで `avatarUrl` を返さない。アバター画像 URL を
+//    取得するには `gh api graphql` で `author { avatarUrl }` を直接問い合わせる
+//    必要がある。bot アカウント（renovate 等）も正しく解決するため
+//    `https://github.com/{login}.png` 構築は採らない。
 //
 // 3. **戻り値は素の Swift struct**。proto への詰め替えは RPC 境界で行う。
 public enum GitHubOps {
-  public static func prList(dir: String) async -> [PullRequestInfo]? {
-    let fields = "number,title,url,state,author,headRefName,baseRefName,isDraft,assignees,reviewRequests,updatedAt"
-    guard let data = try? await runGh(args: ["pr", "list", "--json", fields, "--limit", "100"], cwd: dir)
-    else { return nil }
-    guard let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
-      return nil
+  // GitHub の avatar 画像サイズ（px）。PR/Issue picker 行の表示サイズに合わせる。
+  private static let avatarSize = 64
+
+  private static let prQuery = """
+    query($owner: String!, $repo: String!, $limit: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequests(first: $limit, states: OPEN, orderBy: {field: UPDATED_AT, direction: DESC}) {
+          nodes {
+            number
+            title
+            url
+            state
+            isDraft
+            headRefName
+            baseRefName
+            author { login avatarUrl(size: \(avatarSize)) }
+            updatedAt
+            assignees(first: 20) { nodes { login } }
+            reviewRequests(first: 20) { nodes { requestedReviewer { ... on User { login } } } }
+          }
+        }
+      }
     }
-    return arr.map { item in
+    """
+
+  private static let issueQuery = """
+    query($owner: String!, $repo: String!, $limit: Int!) {
+      repository(owner: $owner, name: $repo) {
+        issues(first: $limit, states: OPEN, orderBy: {field: UPDATED_AT, direction: DESC}) {
+          nodes {
+            number
+            title
+            url
+            state
+            author { login avatarUrl(size: \(avatarSize)) }
+            updatedAt
+            labels(first: 20) { nodes { name } }
+            assignees(first: 20) { nodes { login } }
+          }
+        }
+      }
+    }
+    """
+
+  public static func prList(dir: String) async -> [PullRequestInfo]? {
+    guard let (owner, repo) = await repoOwnerName(dir: dir) else { return nil }
+    guard
+      let data = try? await runGh(
+        args: graphqlArgs(owner: owner, repo: repo, query: prQuery), cwd: dir)
+    else { return nil }
+    guard
+      let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+      let nodes = (((root["data"] as? [String: Any])?["repository"] as? [String: Any])?[
+        "pullRequests"] as? [String: Any])?["nodes"] as? [[String: Any]]
+    else { return nil }
+
+    return nodes.map { item in
       let authorDict = item["author"] as? [String: Any]
       let author = authorDict?["login"] as? String ?? ""
       let avatar = authorDict?["avatarUrl"] as? String ?? ""
       let assignees =
-        (item["assignees"] as? [[String: Any]])?.compactMap { $0["login"] as? String } ?? []
+        ((item["assignees"] as? [String: Any])?["nodes"] as? [[String: Any]])?
+        .compactMap { $0["login"] as? String } ?? []
       let reviewers =
-        (item["reviewRequests"] as? [[String: Any]])?.compactMap { $0["login"] as? String } ?? []
+        ((item["reviewRequests"] as? [String: Any])?["nodes"] as? [[String: Any]])?
+        .compactMap { ($0["requestedReviewer"] as? [String: Any])?["login"] as? String } ?? []
+      // ISO8601 (Z) → "yyyy-MM-ddTHH:mm:ssZ" のまま渡す。proto は string 型。
       return PullRequestInfo(
         number: UInt32(item["number"] as? Int ?? 0),
         title: item["title"] as? String ?? "",
@@ -44,19 +100,27 @@ public enum GitHubOps {
   }
 
   public static func issueList(dir: String) async -> [IssueInfo]? {
-    let fields = "number,title,url,state,author,labels,assignees,updatedAt"
-    guard let data = try? await runGh(args: ["issue", "list", "--json", fields, "--limit", "100"], cwd: dir)
+    guard let (owner, repo) = await repoOwnerName(dir: dir) else { return nil }
+    guard
+      let data = try? await runGh(
+        args: graphqlArgs(owner: owner, repo: repo, query: issueQuery), cwd: dir)
     else { return nil }
-    guard let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
-      return nil
-    }
-    return arr.map { item in
+    guard
+      let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+      let nodes = (((root["data"] as? [String: Any])?["repository"] as? [String: Any])?[
+        "issues"] as? [String: Any])?["nodes"] as? [[String: Any]]
+    else { return nil }
+
+    return nodes.map { item in
       let authorDict = item["author"] as? [String: Any]
       let author = authorDict?["login"] as? String ?? ""
       let avatar = authorDict?["avatarUrl"] as? String ?? ""
-      let labels = (item["labels"] as? [[String: Any]])?.compactMap { $0["name"] as? String } ?? []
+      let labels =
+        ((item["labels"] as? [String: Any])?["nodes"] as? [[String: Any]])?
+        .compactMap { $0["name"] as? String } ?? []
       let assignees =
-        (item["assignees"] as? [[String: Any]])?.compactMap { $0["login"] as? String } ?? []
+        ((item["assignees"] as? [String: Any])?["nodes"] as? [[String: Any]])?
+        .compactMap { $0["login"] as? String } ?? []
       return IssueInfo(
         number: UInt32(item["number"] as? Int ?? 0),
         title: item["title"] as? String ?? "",
@@ -69,6 +133,32 @@ public enum GitHubOps {
         authorAvatarUrl: avatar
       )
     }
+  }
+
+  private static func graphqlArgs(owner: String, repo: String, query: String) -> [String] {
+    return [
+      "api", "graphql",
+      "-F", "owner=\(owner)",
+      "-F", "repo=\(repo)",
+      "-F", "limit=100",
+      "-f", "query=\(query)",
+    ]
+  }
+
+  private static func repoOwnerName(dir: String) async -> (owner: String, repo: String)? {
+    guard
+      let data = try? await runGh(
+        args: ["repo", "view", "--json", "owner,name", "--jq", ".owner.login + \"/\" + .name"],
+        cwd: dir)
+    else { return nil }
+    let text = String(decoding: data, as: UTF8.self)
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    let parts = text.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
+    guard parts.count == 2 else { return nil }
+    let owner = String(parts[0])
+    let repo = String(parts[1])
+    if owner.isEmpty || repo.isEmpty { return nil }
+    return (owner, repo)
   }
 
   /// `gh api user --jq .login` で認証中ユーザーの login を返す。未認証なら nil。

--- a/apps/native/Sources/GozdCore/GitHubOps.swift
+++ b/apps/native/Sources/GozdCore/GitHubOps.swift
@@ -21,6 +21,7 @@ public enum GitHubOps {
   private static let prQuery = """
     query($owner: String!, $repo: String!, $limit: Int!) {
       repository(owner: $owner, name: $repo) {
+        owner { login }
         pullRequests(first: $limit, states: OPEN, orderBy: {field: UPDATED_AT, direction: DESC}) {
           nodes {
             number
@@ -32,8 +33,9 @@ public enum GitHubOps {
             baseRefName
             author { login avatarUrl(size: \(avatarSize)) }
             updatedAt
-            assignees(first: 20) { nodes { login } }
-            reviewRequests(first: 20) { nodes { requestedReviewer { ... on User { login } } } }
+            headRepository { owner { login } }
+            assignees(first: 100) { nodes { login } }
+            reviewRequests(first: 100) { nodes { requestedReviewer { ... on User { login } } } }
           }
         }
       }
@@ -51,8 +53,8 @@ public enum GitHubOps {
             state
             author { login avatarUrl(size: \(avatarSize)) }
             updatedAt
-            labels(first: 20) { nodes { name } }
-            assignees(first: 20) { nodes { login } }
+            labels(first: 100) { nodes { name } }
+            assignees(first: 100) { nodes { login } }
           }
         }
       }
@@ -67,11 +69,22 @@ public enum GitHubOps {
     else { return nil }
     guard
       let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-      let nodes = (((root["data"] as? [String: Any])?["repository"] as? [String: Any])?[
-        "pullRequests"] as? [String: Any])?["nodes"] as? [[String: Any]]
+      let repository = (root["data"] as? [String: Any])?["repository"] as? [String: Any],
+      let nodes = (repository["pullRequests"] as? [String: Any])?["nodes"] as? [[String: Any]]
     else { return nil }
 
-    return nodes.map { item in
+    // fork PR を除外（自リポジトリの owner と一致するもののみ）。
+    // worktree 作成側 (registerPrCommand.ts) が `origin/<headRef>` を startPoint に
+    // 使うため、fork からの PR は ref 解決に失敗する。
+    let repoOwner = (repository["owner"] as? [String: Any])?["login"] as? String
+
+    return nodes.compactMap { item -> PullRequestInfo? in
+      if let repoOwner = repoOwner {
+        let headOwner =
+          ((item["headRepository"] as? [String: Any])?["owner"] as? [String: Any])?["login"]
+          as? String
+        if headOwner != repoOwner { return nil }
+      }
       let authorDict = item["author"] as? [String: Any]
       let author = authorDict?["login"] as? String ?? ""
       let avatar = authorDict?["avatarUrl"] as? String ?? ""
@@ -135,11 +148,13 @@ public enum GitHubOps {
     }
   }
 
+  // `-F` は型推論で number/bool を渡しうるため、string にしたい owner/repo/query は
+  // `-f` を使う。limit のみ Int として渡したいので `-F` で渡す。
   private static func graphqlArgs(owner: String, repo: String, query: String) -> [String] {
     return [
       "api", "graphql",
-      "-F", "owner=\(owner)",
-      "-F", "repo=\(repo)",
+      "-f", "owner=\(owner)",
+      "-f", "repo=\(repo)",
       "-F", "limit=100",
       "-f", "query=\(query)",
     ]


### PR DESCRIPTION
## 概要

PR / Issue picker でアカウント名横のアバター画像が表示されなくなっていた問題を修正する。`apps/native/Sources/GozdCore/GitHubOps.swift` の `prList` / `issueList` を `gh pr list --json` / `gh issue list --json` から `gh api graphql` 経由に切替え、`author { avatarUrl(size: 64) }` を取得するようにする。あわせて fork PR の除外と `gh api graphql` 引数型の明示も行う。

## 背景

旧 Electrobun 版では `apps/desktop/src/git/pr.ts` が `gh api graphql` 経由でアバター URL を取得していた ( e2a291b )。Swift / RPC に移植した際 ( bdac6bd ) に `gh pr list --json author,...` ベースの実装へ縮退してしまい、`author` フィールドが返す `{login, id, is_bot, name}` には `avatarUrl` が含まれないため `authorAvatarUrl` が常に空文字となっていた。結果として `PrPickerRow.vue` / `IssuePickerRow.vue` の `<img v-if="pr.authorAvatarUrl !== ''">` が常に false となり、フォールバックの `lucide--user` アイコンしか出ない状態になっていた。

旧実装のコミットメッセージにある通り、`https://github.com/{login}.png` 形式の URL 構築は bot アカウント (renovate 等) で破綻するため、GraphQL の `avatarUrl` を直接使う方式に戻す。

加えて Codex レビューで以下が指摘されたため同 PR で対応:

- 旧 GraphQL 実装にあった fork PR の除外が抜けており、fork PR を選択すると `registerPrCommand.ts` の `startPoint = origin/${pr.headRef}` が解決できず worktree 作成に失敗する
- `gh api graphql` の `-F` は型推論を行うため、repo 名が `123` 等の数字文字列の場合に number として送られる余地がある

## 変更内容

### apps/native/Sources/GozdCore/GitHubOps.swift

- `prList` / `issueList` を `gh api graphql` 呼び出しに置き換え、`author { login avatarUrl(size: 64) }` を取得
- owner/repo 解決を `repoOwnerName` ヘルパに切り出し、PR / Issue 双方で共有
- GraphQL 引数の組立を `graphqlArgs` ヘルパに集約。string として渡したい `owner` / `repo` / `query` は `-f` (string 強制)、Int として渡したい `limit` は `-F` に分離
- PR クエリに `repository.owner` と `headRepository.owner` を追加し、`prList` 内で `repoOwner == headOwner` の PR のみ返すように `compactMap` で絞り込み
- assignees / reviewRequests / labels は GraphQL の `nodes` 形式に合わせてパース。`first` は 100 を採用

## 今回含めない点

- **assignees / reviewRequests / labels の `first: 100` 上限**: 101 件以上の場合は欠落するが、ページング導入は今回の修正スコープ外とする。旧 TS 実装も無制限ではなく、現状の発火頻度を踏まえて割り切り

## 確認事項

- [ ] PR picker (`Workspace: Open Pull Request`) で各 PR 行にアバター画像が表示される
- [ ] Issue picker (`Workspace: Open Issue`) で各 Issue 行にアバター画像が表示される
- [ ] bot アカウント (renovate 等) が起票した PR / Issue でも正しいアバターが出る
- [ ] author が deleted user (null) の項目で fallback アイコンが表示される
- [ ] fork からの PR が picker に表示されない（自リポジトリ owner と一致するもののみ表示）
