### PR TITLE
fix(sidebar): hide #0 prefix on worktree items without PR/issue number

### DIFF
--- a/apps/renderer/src/features/sidebar/features/worktree/WorktreeItem.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/WorktreeItem.vue
@@ -151,9 +151,9 @@ const statusIcons = computed(() => {
         @click="emit('select', wt)"
       >
         <span class="line-clamp-2"
-          ><span v-if="wt.task?.prNumber !== undefined" class="mr-1 text-xs text-zinc-400"
+          ><span v-if="wt.task && wt.task.prNumber > 0" class="mr-1 text-xs text-zinc-400"
             >#{{ wt.task.prNumber }}</span
-          ><span v-else-if="wt.task?.issueNumber !== undefined" class="mr-1 text-xs text-zinc-400"
+          ><span v-else-if="wt.task && wt.task.issueNumber > 0" class="mr-1 text-xs text-zinc-400"
             >#{{ wt.task.issueNumber }}</span
           >{{ worktreeDisplayName(wt) }}</span
         >

--- a/docs/task.md
+++ b/docs/task.md
@@ -8,7 +8,7 @@ worktree の前段として作業計画を管理する。Task と worktree を 1
 interface Task {
   id: string; // UUID (crypto.randomUUID)
   body: string; // git commit 形式: 一行目=タイトル、残り=本文
-  worktreeDir?: string; // 紐づいた worktree のパス（未着手なら undefined）
+  worktreeDir: string; // 紐づいた worktree のパス。空文字は未紐付けを表す（proto3 string のため optional ではない）
   prNumber: number; // 紐づく PR 番号。0 は未設定を表す（proto3 uint32 のため optional ではない）
   issueNumber: number; // 紐づく issue 番号。0 は未設定を表す（proto3 uint32 のため optional ではない）
   createdAt: string; // ISO 8601

--- a/docs/task.md
+++ b/docs/task.md
@@ -9,8 +9,8 @@ interface Task {
   id: string; // UUID (crypto.randomUUID)
   body: string; // git commit 形式: 一行目=タイトル、残り=本文
   worktreeDir?: string; // 紐づいた worktree のパス（未着手なら undefined）
-  prNumber?: number; // 紐づく PR 番号（PR から worktree を作成した場合に設定）
-  issueNumber?: number; // 紐づく issue 番号（issue から worktree を作成した場合に設定）
+  prNumber: number; // 紐づく PR 番号。0 は未設定を表す（proto3 uint32 のため optional ではない）
+  issueNumber: number; // 紐づく issue 番号。0 は未設定を表す（proto3 uint32 のため optional ではない）
   createdAt: string; // ISO 8601
 }
 ```
@@ -45,7 +45,7 @@ interface Task {
 "Workspace: Open Pull Request" → PR 選択 → worktree 作成 + Task 作成（body=PR タイトル、prNumber=PR 番号）
 ```
 
-- `prNumber` が設定された Task は、サイドバーで `#番号` をタイトルの前にプレフィックス表示する
+- `prNumber > 0` の Task は、サイドバーで `#番号` をタイトルの前にプレフィックス表示する
 
 ### Issue から worktree 作成
 
@@ -54,7 +54,7 @@ interface Task {
 ```
 
 - PR と異なり既存ブランチがないため、タイムスタンプ名で新規ブランチを作成する
-- `issueNumber` が設定された Task は、`prNumber` と同様にサイドバーで `#番号` をプレフィックス表示する
+- `issueNumber > 0` の Task は、`prNumber` と同様にサイドバーで `#番号` をプレフィックス表示する
 
 ### 削除・クリーンアップ
 
@@ -120,7 +120,7 @@ WORKTREES
 
 ```text
 taskList:               undefined → Task[]
-taskAdd:                { body, worktreeDir?, prNumber?, issueNumber? } → Task
+taskAdd:                { body, worktreeDir, prNumber, issueNumber } → Task
 taskUpdate:             { id, body } → Task
 taskRemove:             { id } → void
 createWorktreeWithTask: { id, worktreeDir, branch } → { task, worktree, dir, fileServerBaseUrl }


### PR DESCRIPTION
## 概要

サイドバーの worktree アイテムで、紐づく Task に PR / Issue 番号がないとき `#0` という接頭辞が表示される問題を修正します。あわせて、原因が同じ proto3 default-value センチネルの取り扱いだったことを踏まえ、`docs/task.md` の `Task` 型表記が optional 風になっていた箇所も実装に揃えます。

## 背景

ユーザー報告:

- Open Pull Request 経由で worktree を作ると番号は正しく入る
- Open Issue 経由で worktree を作ると `#0` になる
- 通常の Task 作成（PR / Issue 紐づけなし）でも `#0` になる

調査の結果、ストア側は問題なく、`apps/renderer/src/features/sidebar/features/worktree/WorktreeItem.vue` の表示分岐の判定式が原因と判明しました。

```vue
<span v-if="wt.task?.prNumber !== undefined">#{{ wt.task.prNumber }}</span>
<span v-else-if="wt.task?.issueNumber !== undefined">#{{ wt.task.issueNumber }}</span>
```

proto3 の `uint32` は `@gozd/proto` の生成コード上、デコード時に必ずゼロ初期化されます（`fromPartial` 内で `?? 0`）。そのため `prNumber !== undefined` は常に `true` になり、

- Issue 経由（`prNumber: 0`, `issueNumber: 42`）でも 1 つ目の分岐に入って `#0` を出力し、`issueNumber` の分岐には到達しない
- PR 経由（`prNumber: 123`, `issueNumber: 0`）の場合のみ、たまたま 1 つ目の分岐の値が実数なので `#123` が正しく出る
- 番号なし Task（`prNumber: 0`, `issueNumber: 0`）も `#0` を出してしまう

`registerIssueCommand.ts` 側ではすでに `task.issueNumber > 0` でフィルタしており、ドメイン的にも 0 を「番号なし」のセンチネルとして扱う方針が採られています。表示側の判定をその規約に揃える形で修正します。

加えてレビュー過程で、同じ proto3 default-value 起因の表記乖離が `docs/task.md` の `Task` interface 表記（`prNumber?` / `issueNumber?` / `worktreeDir?` を optional として記述）にも残っていることが判明したため、ドキュメントを実装の仕様に揃えました。

## 変更内容

### `apps/renderer/src/features/sidebar/features/worktree/WorktreeItem.vue`

- `wt.task?.prNumber !== undefined` を `wt.task && wt.task.prNumber > 0` に変更
- `wt.task?.issueNumber !== undefined` を `wt.task && wt.task.issueNumber > 0` に変更
- 結果として、PR 番号があるときは `#<PR>`、Issue 番号のみあるときは `#<Issue>`、どちらも 0 のときは番号接頭辞を出さない挙動になる

### `docs/task.md`

- `Task` interface の表記を proto3 の実態に合わせて修正
  - `prNumber?: number` → `prNumber: number;  // 0 は未設定を表す（proto3 uint32 のため optional ではない）`
  - `issueNumber?: number` → `issueNumber: number;  // 同上`
  - `worktreeDir?: string` → `worktreeDir: string;  // 空文字は未紐付けを表す（proto3 string のため optional ではない）`
- 「`prNumber` が設定された Task」「`issueNumber` が設定された Task」を「`prNumber > 0` の Task」「`issueNumber > 0` の Task」に変更
- RPC スキーマ説明欄の `taskAdd: { body, worktreeDir?, prNumber?, issueNumber? }` を `{ body, worktreeDir, prNumber, issueNumber }` に変更

## 今回含めない点

- **別 PR で対応**: proto schema を `optional uint32` / `optional string` に変更して field presence を持たせる選択肢は見送りました。永続化済み `tasks.json`、Swift `TaskStore`、proto-ts 生成コード、他の参照箇所すべてに影響が及び、表示専用バグの修正としてはスコープ過大なため。必要であれば別途検討する。

## 確認事項

- [ ] PR 経由で作成した worktree が `#<PR番号>` 表示になる
- [ ] Issue 経由で作成した worktree が `#<Issue番号>` 表示になる（`#0` にならない）
- [ ] 番号なしで作成した Task の worktree がタイトルのみ表示になる（`#` 接頭辞が出ない）
- [ ] `docs/task.md` の `Task` 型表記が proto3 の実態（0 / 空文字センチネル）と整合している
