### PR TITLE
fix(sidebar): use showPopover source over anchor-name strings

### DIFF
--- a/apps/renderer/src/features/sidebar/SidebarMenu.vue
+++ b/apps/renderer/src/features/sidebar/SidebarMenu.vue
@@ -3,7 +3,7 @@
 
 worktree / branch の各セクションから呼ばれ、
 コンテキストに応じたアクション（編集・削除・作成）を表示する。
-CSS Anchor Positioning で ⋮ ボタンの直下に配置。
+`showPopover({ source })` の implicit anchor で ⋮ ボタンの直下に配置する。
 
 親から `openMenu()` を expose 経由で呼び出してメニューを開く。
 アクション選択時は emit で親に通知し、メニューを閉じる。
@@ -27,16 +27,21 @@ type MenuContext =
   | { type: "worktree"; worktree: WorktreeEntry; rootDir: string }
   | { type: "branch"; branch: string; rootDir: string };
 
-const menuRef = ref<HTMLElement>();
-const menuContext = ref<MenuContext>();
-/** 現在 anchor になっている ⋮ ボタンの anchor-name */
-const activeAnchorName = ref("");
+/**
+ * showPopover に渡す `source` 引数の型。
+ * Popover API の最新仕様（HTMLElement.showPopover(options)）。
+ * lib.dom.d.ts への取り込みが追いついていないため最小宣言を持つ。
+ */
+type ShowPopoverOptions = { source?: HTMLElement };
+type PopoverElement = HTMLElement & { showPopover(options?: ShowPopoverOptions): void };
 
-function openMenu(anchorName: string, context: MenuContext) {
-  activeAnchorName.value = anchorName;
+const menuRef = ref<PopoverElement>();
+const menuContext = ref<MenuContext>();
+
+function openMenu(anchorEl: HTMLElement, context: MenuContext) {
   menuContext.value = context;
   nextTick(() => {
-    menuRef.value?.showPopover();
+    menuRef.value?.showPopover({ source: anchorEl });
   });
 }
 
@@ -68,7 +73,6 @@ defineExpose({ openMenu });
     popover="auto"
     class="m-0 min-w-36 rounded-lg border border-zinc-700 bg-zinc-900 py-1 text-sm text-zinc-200 shadow-lg"
     :style="{
-      positionAnchor: activeAnchorName,
       top: 'anchor(bottom)',
       left: 'anchor(left)',
     }"

--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -218,12 +218,12 @@ const activeRootWorktree = computed(() => {
           @add-worktree="addWorktree"
           @set-view-mode="terminalStore.viewMode = $event"
           @open-worktree-menu="
-            (anchorName, wt, rd) =>
-              sidebarMenuRef?.openMenu(anchorName, { type: 'worktree', worktree: wt, rootDir: rd })
+            (anchorEl, wt, rd) =>
+              sidebarMenuRef?.openMenu(anchorEl, { type: 'worktree', worktree: wt, rootDir: rd })
           "
           @open-branch-menu="
-            (anchorName, branch, rd) =>
-              sidebarMenuRef?.openMenu(anchorName, { type: 'branch', branch, rootDir: rd })
+            (anchorEl, branch, rd) =>
+              sidebarMenuRef?.openMenu(anchorEl, { type: 'branch', branch, rootDir: rd })
           "
         >
           <template #after-worktree-item="{ wt }">

--- a/apps/renderer/src/features/sidebar/features/repo/RepoSection.vue
+++ b/apps/renderer/src/features/sidebar/features/repo/RepoSection.vue
@@ -171,6 +171,7 @@ function onHeaderClick() {
         :now="now"
         :view-mode="viewMode"
         :get-claude-statuses="getClaudeStatuses"
+        :repo-index="index"
         @select="emit('selectWorktree', $event)"
         @open-menu="(anchorName, wt) => emit('openWorktreeMenu', anchorName, wt, rootDir)"
         @add="emit('addWorktree', rootDir)"
@@ -183,6 +184,7 @@ function onHeaderClick() {
 
       <BranchList
         :branches="sortedBranches"
+        :repo-index="index"
         @open-menu="(anchorName, branch) => emit('openBranchMenu', anchorName, branch, rootDir)"
       />
     </div>

--- a/apps/renderer/src/features/sidebar/features/repo/RepoSection.vue
+++ b/apps/renderer/src/features/sidebar/features/repo/RepoSection.vue
@@ -50,8 +50,8 @@ const emit = defineEmits<{
   selectRoot: [wt: WorktreeEntry];
   selectWorktree: [wt: WorktreeEntry];
   addWorktree: [rootDir: string];
-  openWorktreeMenu: [anchorName: string, wt: WorktreeEntry, rootDir: string];
-  openBranchMenu: [anchorName: string, branch: string, rootDir: string];
+  openWorktreeMenu: [anchorEl: HTMLElement, wt: WorktreeEntry, rootDir: string];
+  openBranchMenu: [anchorEl: HTMLElement, branch: string, rootDir: string];
   setViewMode: [mode: ViewMode];
 }>();
 
@@ -171,9 +171,8 @@ function onHeaderClick() {
         :now="now"
         :view-mode="viewMode"
         :get-claude-statuses="getClaudeStatuses"
-        :repo-index="index"
         @select="emit('selectWorktree', $event)"
-        @open-menu="(anchorName, wt) => emit('openWorktreeMenu', anchorName, wt, rootDir)"
+        @open-menu="(anchorEl, wt) => emit('openWorktreeMenu', anchorEl, wt, rootDir)"
         @add="emit('addWorktree', rootDir)"
         @set-view-mode="emit('setViewMode', $event)"
       >
@@ -184,8 +183,7 @@ function onHeaderClick() {
 
       <BranchList
         :branches="sortedBranches"
-        :repo-index="index"
-        @open-menu="(anchorName, branch) => emit('openBranchMenu', anchorName, branch, rootDir)"
+        @open-menu="(anchorEl, branch) => emit('openBranchMenu', anchorEl, branch, rootDir)"
       />
     </div>
   </section>

--- a/apps/renderer/src/features/sidebar/features/worktree/BranchList.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/BranchList.vue
@@ -5,13 +5,18 @@
 <script setup lang="ts">
 defineProps<{
   branches: string[];
-  /** repo ごとの anchor-name 衝突回避用スコープ */
-  repoIndex: number;
 }>();
 
-defineEmits<{
-  openMenu: [anchorName: string, branch: string];
+const emit = defineEmits<{
+  openMenu: [anchorEl: HTMLElement, branch: string];
 }>();
+
+function onMenuClick(event: MouseEvent, branch: string) {
+  const target = event.currentTarget;
+  if (target instanceof HTMLElement) {
+    emit("openMenu", target, branch);
+  }
+}
 </script>
 
 <template>
@@ -19,7 +24,7 @@ defineEmits<{
     <h2 class="mb-1 text-xs font-medium text-zinc-500">BRANCHES</h2>
 
     <div
-      v-for="(branch, i) in branches"
+      v-for="branch in branches"
       :key="branch"
       class="group/br grid grid-cols-[auto_1fr_auto] gap-x-2 rounded-sm py-1.5 pl-2 text-sm text-zinc-500 hover:bg-zinc-800"
     >
@@ -28,8 +33,7 @@ defineEmits<{
       <button
         aria-label="Menu"
         class="grid size-6 place-items-center self-center rounded-sm text-zinc-600 opacity-0 transition-opacity group-focus-within/br:opacity-100 group-hover/br:opacity-100 hover:text-zinc-300"
-        :style="{ anchorName: `--br-menu-${repoIndex}-${i}` }"
-        @click.stop="$emit('openMenu', `--br-menu-${repoIndex}-${i}`, branch)"
+        @click.stop="onMenuClick($event, branch)"
       >
         <span class="icon-[lucide--ellipsis-vertical] text-sm" />
       </button>

--- a/apps/renderer/src/features/sidebar/features/worktree/BranchList.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/BranchList.vue
@@ -5,6 +5,8 @@
 <script setup lang="ts">
 defineProps<{
   branches: string[];
+  /** repo ごとの anchor-name 衝突回避用スコープ */
+  repoIndex: number;
 }>();
 
 defineEmits<{
@@ -26,8 +28,8 @@ defineEmits<{
       <button
         aria-label="Menu"
         class="grid size-6 place-items-center self-center rounded-sm text-zinc-600 opacity-0 transition-opacity group-focus-within/br:opacity-100 group-hover/br:opacity-100 hover:text-zinc-300"
-        :style="{ anchorName: `--br-menu-${i}` }"
-        @click.stop="$emit('openMenu', `--br-menu-${i}`, branch)"
+        :style="{ anchorName: `--br-menu-${repoIndex}-${i}` }"
+        @click.stop="$emit('openMenu', `--br-menu-${repoIndex}-${i}`, branch)"
       >
         <span class="icon-[lucide--ellipsis-vertical] text-sm" />
       </button>

--- a/apps/renderer/src/features/sidebar/features/worktree/WorktreeItem.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/WorktreeItem.vue
@@ -51,7 +51,6 @@ const props = defineProps<{
   active: boolean;
   claudeStatuses: ClaudeStatus[];
   now: number;
-  anchorName: string;
   /** Ctrl キー押下中か（番号バッジの表示制御用） */
   ctrlPressed: boolean;
   /** worktree リスト内のインデックス（Ctrl 番号バッジの表示用） */
@@ -60,8 +59,15 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   select: [wt: WorktreeEntry];
-  openMenu: [anchorName: string, wt: WorktreeEntry];
+  openMenu: [anchorEl: HTMLElement, wt: WorktreeEntry];
 }>();
+
+function onMenuClick(event: MouseEvent) {
+  const target = event.currentTarget;
+  if (target instanceof HTMLElement) {
+    emit("openMenu", target, props.wt);
+  }
+}
 
 /** 経過ミリ秒を "m:ss" 形式に変換 */
 function formatElapsed(startedAt: number, now: number): string {
@@ -162,8 +168,7 @@ const statusIcons = computed(() => {
       <button
         aria-label="Menu"
         class="absolute top-1 right-0 z-10 grid size-6 place-items-center rounded-sm bg-zinc-800 text-zinc-400 opacity-0 shadow-sm transition-opacity group-focus-within/wt:opacity-100 group-hover/wt:opacity-100 hover:text-zinc-200"
-        :style="{ anchorName }"
-        @click="emit('openMenu', anchorName, wt)"
+        @click="onMenuClick"
       >
         <span class="icon-[lucide--ellipsis-vertical] text-sm" />
       </button>

--- a/apps/renderer/src/features/sidebar/features/worktree/WorktreeList.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/WorktreeList.vue
@@ -35,6 +35,8 @@ defineProps<{
   now: number;
   viewMode: ViewMode;
   getClaudeStatuses: (dir: string) => ClaudeStatus[];
+  /** repo ごとの anchor-name 衝突回避用スコープ */
+  repoIndex: number;
 }>();
 
 defineEmits<{
@@ -90,7 +92,7 @@ defineSlots<{
         :active="activeDir === wt.path"
         :claude-statuses="getClaudeStatuses(wt.path)"
         :now="now"
-        :anchor-name="`--wt-menu-${i}`"
+        :anchor-name="`--wt-menu-${repoIndex}-${i}`"
         :ctrl-pressed="ctrlPressed"
         :index="i"
         @select="$emit('select', $event)"

--- a/apps/renderer/src/features/sidebar/features/worktree/WorktreeList.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/WorktreeList.vue
@@ -35,13 +35,11 @@ defineProps<{
   now: number;
   viewMode: ViewMode;
   getClaudeStatuses: (dir: string) => ClaudeStatus[];
-  /** repo ごとの anchor-name 衝突回避用スコープ */
-  repoIndex: number;
 }>();
 
 defineEmits<{
   select: [wt: WorktreeEntry];
-  openMenu: [anchorName: string, wt: WorktreeEntry];
+  openMenu: [anchorEl: HTMLElement, wt: WorktreeEntry];
   add: [];
   setViewMode: [mode: ViewMode];
 }>();
@@ -92,11 +90,10 @@ defineSlots<{
         :active="activeDir === wt.path"
         :claude-statuses="getClaudeStatuses(wt.path)"
         :now="now"
-        :anchor-name="`--wt-menu-${repoIndex}-${i}`"
         :ctrl-pressed="ctrlPressed"
         :index="i"
         @select="$emit('select', $event)"
-        @open-menu="(anchorName, w) => $emit('openMenu', anchorName, w)"
+        @open-menu="(anchorEl, w) => $emit('openMenu', anchorEl, w)"
       />
       <slot name="after-item" :wt="wt" />
     </div>


### PR DESCRIPTION
## 概要

サイドバーの worktree / branch 行の ⋮ メニューをクリックしたときに、popover が想定と違う位置（別 repo の同じ index の⋮ボタン下など）に出ていたのを直します。修正方針は、「`anchor-name` 文字列を id として割り当てて popover の `position-anchor` で参照する」構成を廃止し、Popover API の `showPopover({ source })` の implicit anchor 解決に寄せる方向にしました。

## 背景

サイドバーの ⋮ ポップオーバー位置は CSS Anchor Positioning で決定しています。⋮ ボタン側に `anchor-name`、共有 `SidebarMenu` 側に `position-anchor` を指定して紐付ける構成でした。

しかし `WorktreeList` / `BranchList` では `anchor-name` をリストインスタンス内のインデックスだけで命名しており、`--wt-menu-${i}` / `--br-menu-${i}` の形でした。`RepoSection` はウィンドウ内に開いている repo 数だけ生成されるため、複数 repo を開いていると **同名の `anchor-name` を持つ⋮ボタンが document 内に複数存在** します。CSS Anchor Positioning は同名 anchor が複数ある場合 source order 上の最後の anchor に結び付くため、クリックされた⋮ボタンとは別の repo の同 index ボタン基準で popover が配置され、ユーザーから見ると「位置がズレている」現象になっていました。

最初は `anchor-name` を `--wt-menu-${repoIndex}-${i}` のように repo index でスコープ化する変更で衝突を解消しましたが、Codex レビューで「`anchor-name` 文字列を持ち回す代わりに、クリックされた button 要素自体を popover の `source` に渡す方が自己完結性が高く、命名衝突の構造的可能性自体を消せる」という指摘を受けたため、最終的にはそちらの設計に寄せています。

## 変更内容

### sidebar

- 共有 `SidebarMenu` の `openMenu()` に `anchor-name` 文字列ではなくクリックされた button 要素 (`HTMLElement`) を渡し、`menuRef.showPopover({ source: anchorEl })` で popover の implicit anchor を確立する形に変更
- `SidebarMenu` の popover style から `position-anchor` 指定を撤去（implicit anchor が `anchor()` を解決）
- `WorktreeItem` から `anchorName` prop を削除し、⋮ ボタンの click ハンドラで `event.currentTarget` を emit する形に変更
- `WorktreeList` / `BranchList` から `anchor-name` 関連コードと anchor-name 衝突回避用の `repoIndex` prop を削除
- `RepoSection` / `SidebarPane` の emit / handler 型と引数名を `anchorEl: HTMLElement` に統一

### 設計上のメリット

- 命名衝突の懸念が構造的に消える（anchor 名を作って配る設計自体がなくなる）
- repo の並び替え順に依存した `repoIndex` を伝播する必要がない
- 将来 `RootWorktree` などに同種の⋮メニューを追加する際も、同じパターンで自然に組める

## 確認事項

- [ ] ウィンドウに複数 repo を追加した状態で、各 repo の worktree 行・branch 行の ⋮ をクリックして popover がそれぞれ正しい⋮ボタン直下に表示されること
- [ ] 単一 repo のみの場合でも従来通り正しい位置に表示されること
- [ ] 編集モードでの repo 並び替え後も popover 位置が破綻しないこと
- [ ] WKWebView (Electrobun) 環境で `showPopover({ source })` が期待通り動作すること（implicit anchor 解決の実機検証）
