### PR TITLE
fix(git-graph): parse HEAD/tag decorations and pin --decorate=short in git log

### DIFF
--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -211,18 +211,36 @@ public enum GitOps {
         parts[2].isEmpty
         ? [] : parts[2].split(separator: " ", omittingEmptySubsequences: true).map(String.init)
       let date = Int64(parts[4]) ?? 0
-      let refs =
-        parts[7].isEmpty
-        ? []
-        : parts[7].split(separator: ",").map {
-          $0.trimmingCharacters(in: .whitespaces)
-        }
+      let refs = parseRefs(parts[7])
       commits.append(
         CommitInfo(
           hash: parts[0], shortHash: parts[1], parents: parents, author: parts[3], date: date,
           message: parts[5], body: parts[6], refs: refs))
     }
     return commits
+  }
+
+  /// `git log --format=%D` の出力をパースする。
+  /// "HEAD -> main, origin/main, tag: v1.0" → ["HEAD", "main", "origin/main", "tag:v1.0"]
+  /// "HEAD -> branch" は ["HEAD", "branch"] に分解する。renderer 側が
+  /// refs.includes("HEAD") で HEAD 行を識別するため、HEAD は独立要素である必要がある。
+  static func parseRefs(_ refStr: String) -> [String] {
+    let trimmed = refStr.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmed.isEmpty { return [] }
+    var result: [String] = []
+    for raw in trimmed.split(separator: ",", omittingEmptySubsequences: false) {
+      let part = raw.trimmingCharacters(in: .whitespaces)
+      if part.isEmpty { continue }
+      if part.hasPrefix("HEAD -> ") {
+        result.append("HEAD")
+        result.append(String(part.dropFirst("HEAD -> ".count)))
+      } else if part.hasPrefix("tag: ") {
+        result.append("tag:" + String(part.dropFirst("tag: ".count)))
+      } else {
+        result.append(part)
+      }
+    }
+    return result
   }
 
   /// `git diff -- <path>` 相当（作業ツリー差分）。

--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -193,7 +193,10 @@ public enum GitOps {
   ) async throws -> [CommitInfo] {
     // %x1f = unit separator (US), %x1e = record separator (RS)
     let format = "%H%x1f%h%x1f%P%x1f%an%x1f%at%x1f%s%x1f%b%x1f%D%x1e"
-    var args = ["log", "--format=\(format)"]
+    // `--decorate=short` でユーザーの `log.decorate=full` 設定を上書きする。
+    // full にすると %D が `refs/heads/main` / `refs/remotes/origin/main` 形式になり、
+    // renderer の `r.startsWith("origin/")` / current branch 抽出が崩れる。
+    var args = ["log", "--format=\(format)", "--decorate=short"]
     if maxCount > 0 { args.append("--max-count=\(maxCount)") }
     if firstParentOnly { args.append("--first-parent") }
     args.append(ref)
@@ -224,11 +227,16 @@ public enum GitOps {
   /// "HEAD -> main, origin/main, tag: v1.0" → ["HEAD", "main", "origin/main", "tag:v1.0"]
   /// "HEAD -> branch" は ["HEAD", "branch"] に分解する。renderer 側が
   /// refs.includes("HEAD") で HEAD 行を識別するため、HEAD は独立要素である必要がある。
+  ///
+  /// 区切り子は `, `（カンマ+スペース）固定（git の log-tree.c::format_decoration_default）。
+  /// ref 名にはカンマを含めることが許されている（`git check-ref-format --branch 'foo,bar'` が
+  /// 通る）ため、単純な `,` 分割は ref 名を破壊する。スペースは ref 名に含められないので
+  /// `", "` 区切りなら一意にトークン化できる。
   static func parseRefs(_ refStr: String) -> [String] {
     let trimmed = refStr.trimmingCharacters(in: .whitespacesAndNewlines)
     if trimmed.isEmpty { return [] }
     var result: [String] = []
-    for raw in trimmed.split(separator: ",", omittingEmptySubsequences: false) {
+    for raw in trimmed.components(separatedBy: ", ") {
       let part = raw.trimmingCharacters(in: .whitespaces)
       if part.isEmpty { continue }
       if part.hasPrefix("HEAD -> ") {

--- a/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
+++ b/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
@@ -94,6 +94,34 @@ struct GitOpsGitStatusTests {
   }
 }
 
+@Suite("GitOps.parseRefs")
+struct GitOpsParseRefsTests {
+  @Test("空文字は空配列")
+  func empty() {
+    #expect(GitOps.parseRefs("") == [])
+    #expect(GitOps.parseRefs("   ") == [])
+  }
+
+  @Test("HEAD -> branch を 2 要素に分解する")
+  func splitsHeadArrow() {
+    #expect(GitOps.parseRefs("HEAD -> main") == ["HEAD", "main"])
+  }
+
+  @Test("tag: prefix は tag: ラベルに正規化する")
+  func normalizesTag() {
+    #expect(GitOps.parseRefs("tag: v1.0") == ["tag:v1.0"])
+  }
+
+  @Test("HEAD / origin / tag が混在するケース")
+  func mixed() {
+    let input = "HEAD -> 20260510, origin/20260510, tag: v1.0, origin/HEAD"
+    #expect(
+      GitOps.parseRefs(input) == [
+        "HEAD", "20260510", "origin/20260510", "tag:v1.0", "origin/HEAD",
+      ])
+  }
+}
+
 @Suite("GitOps.runGit large output")
 struct GitOpsRunGitLargeOutputTests {
   /// pipe buffer (macOS は最大 ~64KB) を超える stdout で `runGit` が deadlock しないことを保証する。

--- a/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
+++ b/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
@@ -120,6 +120,27 @@ struct GitOpsParseRefsTests {
         "HEAD", "20260510", "origin/20260510", "tag:v1.0", "origin/HEAD",
       ])
   }
+
+  @Test("detached HEAD は HEAD 単独要素になる")
+  func detachedHead() {
+    #expect(GitOps.parseRefs("HEAD") == ["HEAD"])
+  }
+
+  @Test("detached HEAD on tag")
+  func detachedHeadOnTag() {
+    #expect(GitOps.parseRefs("HEAD, tag: v1.0") == ["HEAD", "tag:v1.0"])
+  }
+
+  /// ref 名にカンマを含めることは git で合法（`git check-ref-format --branch 'foo,bar'` が exit 0）。
+  /// `%D` の区切り子は `", "` 固定なので、単純な `","` split で誤分解させてはならない。
+  @Test("ref 名に含まれるカンマで誤分解しない")
+  func preservesCommaInRefName() {
+    #expect(GitOps.parseRefs("HEAD -> foo,bar") == ["HEAD", "foo,bar"])
+    #expect(
+      GitOps.parseRefs("HEAD -> foo,bar, origin/foo,bar") == [
+        "HEAD", "foo,bar", "origin/foo,bar",
+      ])
+  }
 }
 
 @Suite("GitOps.runGit large output")


### PR DESCRIPTION
## 概要

`git log --format=%D` の出力をパースする `GitOps.log` の処理が壊れていたため、Git Graph の HEAD バッジ表示と Working Tree → HEAD コミットへの接続線が描画されなくなる回帰を修正する。あわせて Codex レビューで判明した 2 件の追加リスク（カンマを含む合法な ref 名の誤分解 / `log.decorate=full` 環境での short 形式破綻）も同時に塞ぐ。

## 背景

PR ( #420 ) で `apps/desktop/`（Bun）から `apps/native/`（Swift）へ全面書き直した際、旧 `apps/desktop/src/git/log.ts` の `parseRefs` 相当の整形処理が Swift 側に移植されず、refs を単純に `,` で split + trim するだけになっていた。

`%D` の出力形式: `HEAD -> 20260510_052052, origin/20260510_052052, tag: v1.0`

旧 TS 実装は `HEAD -> branch` を `["HEAD", "branch"]` の 2 要素に分解し、`tag: v1.0` を `tag:v1.0` に正規化していた。renderer 側 (`GitGraphPane.vue`) は `refs.includes("HEAD")` で HEAD 行を識別し、HEAD バッジ位置（行右端の `→` マーカー）・Working Tree → HEAD レーンへの接続ダッシュ線・カレントブランチ抽出に使う。HEAD が独立要素として存在することが前提だった。

Swift 実装ではこれが `"HEAD -> 20260510_052052"` という 1 要素として返るため、すべての判定が外れて接続線が消え、RefBadge には合体ラベル `HEAD -> 20260510_052052` がそのまま表示されていた。

レビュー過程で判明した追加リスク:

- ref 名にカンマは合法（`git check-ref-format --branch 'foo,bar'` exit 0）。単純な `,` 分割は ref 名を破壊する
- `git log --format=%D` の decoration スタイルは `log.decorate` 設定の影響を受け、`full` 設定下では `refs/heads/main` / `refs/remotes/origin/main` 形式になる。renderer の `startsWith("origin/")` 判定や current branch 抽出が崩れる

## 変更内容

### `GitOps.log` の refs パース

- `parseRefs(_ refStr: String) -> [String]` を `GitOps` に追加
- `HEAD -> X` を `["HEAD", "X"]` に分解
- `tag: v1.0` を `tag:v1.0` に正規化
- それ以外（`origin/HEAD` 含む）はそのまま通す
- 区切り子は `","` ではなく `", "`（カンマ+スペース）で分割。git の `log-tree.c::format_decoration_default` が `, ` 固定の sep を使うため曖昧性なくトークン化できる
- `log()` 内の旧 split + trim を `parseRefs` 呼び出しに置換

### `--decorate=short` の明示

- `git log` の args に `--decorate=short` を追加し、ユーザーの `log.decorate=full` 設定を per-invocation で打ち消す
- 根拠（renderer の `r.startsWith("origin/")` / current branch 抽出が崩れる）をコメントで明記

### テスト

- `GitOpsParseRefsTests` を追加（合計 7 ケース）
  - 空文字
  - `HEAD -> branch` の分解
  - `tag:` 正規化
  - HEAD / origin / tag 混在
  - detached HEAD（`"HEAD"` 単独）
  - detached HEAD on tag（`"HEAD, tag: v1.0"`）
  - ref 名に含まれるカンマで誤分解しない（`"HEAD -> foo,bar"`、`"HEAD -> foo,bar, origin/foo,bar"`）
- `git` 起動を介さずフォーマット規約を回帰検出できる粒度

## 確認事項

- [ ] Git Graph の Working Tree 行から HEAD コミットへ緑のダッシュ線が描画される
- [ ] HEAD コミット行の右端に `→` マーカーが出る
- [ ] HEAD が指すローカルブランチが `current` 表示（緑強調）になる
- [ ] `tag: vX` が付いたコミットでタグバッジが表示される
- [ ] `~/.gitconfig` で `log.decorate = full` を設定しても Git Graph が正常に表示される
- [ ] `swift test` が全 79 ケース pass する
