### PR TITLE
fix(changes): restore file-level entries and merge commit diff after Swift rewrite

### DIFF
--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -282,7 +282,8 @@ public enum GitOps {
   /// - 単一ルートコミット: `git diff-tree --root --no-commit-id -r` を使う（親が無いので
   ///   `^` で解決できない）。
   /// - 範囲指定: 旧 / 新を `merge-base --is-ancestor` で決定し、旧^（旧が root の場合は
-  ///   旧自身）から新へ `git diff` する。
+  ///   well-known empty tree hash）から新へ `git diff` する。empty tree を起点にすることで
+  ///   root 自身の変更が range に含まれる（`from = older` だと root の追加分が落ちる）。
   /// - UNCOMMITTED_HASH（all-zero）が範囲の片方に含まれる場合は working tree と比較する
   ///   ため `git diff <from>` で第 2 引数省略（working tree と比較される）。
   ///
@@ -298,10 +299,11 @@ public enum GitOps {
     if let compareHash, !compareHash.isEmpty {
       let commitA = hash == uncommitted ? "HEAD" : hash
       let commitB = compareHash == uncommitted ? "HEAD" : compareHash
-      let aIsOlder = await isAncestor(dir: dir, ancestor: commitA, descendant: commitB)
+      let aIsOlder = try await isAncestor(dir: dir, ancestor: commitA, descendant: commitB)
       let older = aIsOlder ? commitA : commitB
       let newer = aIsOlder ? commitB : commitA
-      let from = (await isRootCommit(dir: dir, hash: older)) ? older : "\(older)^"
+      let from =
+        (try await isRootCommit(dir: dir, hash: older)) ? emptyTreeHash : "\(older)^"
       if hasUncommitted {
         let stdout = try await runGit(
           args: ["diff"] + diffOptions + [from], cwd: dir)
@@ -312,7 +314,7 @@ public enum GitOps {
       return parseDiffNameStatus(stdout)
     }
 
-    if await isRootCommit(dir: dir, hash: hash) {
+    if try await isRootCommit(dir: dir, hash: hash) {
       let stdout = try await runGit(
         args: ["diff-tree", "--root", "--no-commit-id", "-r"] + diffOptions + [hash], cwd: dir)
       return parseDiffNameStatus(stdout)
@@ -322,6 +324,11 @@ public enum GitOps {
     return parseDiffNameStatus(stdout)
   }
 }
+
+/// git の well-known empty tree object hash。`git hash-object -t tree </dev/null` で
+/// 得られる固定値。root commit を range の起点にする際、`<root>` 自身ではなく empty tree
+/// を `from` に置くことで root commit が追加したファイルも diff に含まれる。
+private let emptyTreeHash = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
 public enum GitError: Error, Equatable {
   case commandFailed(exitCode: Int32, stderr: String)
@@ -489,18 +496,30 @@ private func parseWorktreePorcelain(_ data: Data) -> [WorktreeInfo] {
 }
 
 /// 与えられた hash がルートコミット（親なし）かどうかを判定する。
-/// `git rev-parse <hash>^` がルートコミットでは exit 128 で失敗するのを利用する。
-private func isRootCommit(dir: String, hash: String) async -> Bool {
-  let result = try? await runGit(args: ["rev-parse", "\(hash)^"], cwd: dir)
-  return result == nil
+/// `git rev-list --parents -n 1 <hash>` の出力は valid な hash であれば必ず exit 0 で
+/// `<hash> <parent1> <parent2>...` の 1 行を返す。トークン数 1（hash のみ） = root、
+/// 2 以上 = 非 root と判定できる。
+/// invalid hash の場合は `commandFailed` が上がるためそのまま throw して上位に返す
+/// （`git rev-parse <hash>^` を使うと root と invalid hash がどちらも exit 128 で
+/// 区別できないため避ける）。
+private func isRootCommit(dir: String, hash: String) async throws -> Bool {
+  let stdout = try await runGit(args: ["rev-list", "--parents", "-n", "1", hash], cwd: dir)
+  let line = String(decoding: stdout, as: UTF8.self)
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+  return line.split(separator: " ").count == 1
 }
 
 /// `git merge-base --is-ancestor <ancestor> <descendant>` で先祖関係を判定する。
-/// exit 0 で ancestor、exit 1 で非 ancestor。
-private func isAncestor(dir: String, ancestor: String, descendant: String) async -> Bool {
-  let result = try? await runGit(
-    args: ["merge-base", "--is-ancestor", ancestor, descendant], cwd: dir)
-  return result != nil
+/// exit 0 で ancestor、exit 1 で非 ancestor。それ以外（128 / launch failure 等）は本物の
+/// エラーなので throw して上位へ返す（誤って Bool に潰すと範囲指定の older/newer が壊れる）。
+private func isAncestor(dir: String, ancestor: String, descendant: String) async throws -> Bool {
+  do {
+    _ = try await runGit(
+      args: ["merge-base", "--is-ancestor", ancestor, descendant], cwd: dir)
+    return true
+  } catch GitError.commandFailed(let exitCode, _) where exitCode == 1 {
+    return false
+  }
 }
 
 /// `git diff` / `git diff-tree` の `--name-status -z` 出力をパースする。

--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -69,9 +69,12 @@ public struct FileChangeInfo: Equatable, Sendable {
 }
 
 public enum GitOps {
-  /// `git status --porcelain=v1 -z` 相当。
+  /// `git status --porcelain=v1 -z --untracked-files=all` 相当。
+  /// `--untracked-files=all` は untracked ディレクトリ配下のファイルも個別に列挙させる
+  /// ため必須（外すと git が `dir/` のように親ディレクトリ 1 エントリに畳む）。
   public static func gitStatus(dir: String) async throws -> [String: String] {
-    let stdout = try await runGit(args: ["status", "--porcelain=v1", "-z"], cwd: dir)
+    let stdout = try await runGit(
+      args: ["status", "--porcelain=v1", "-z", "--untracked-files=all"], cwd: dir)
     return parsePorcelainV1(stdout)
   }
 
@@ -124,12 +127,14 @@ public enum GitOps {
   /// status + HEAD + upstream + ahead/behind を 1 セットで取得する。
   /// `gitStatusChange` push event の payload を構築するために使う。
   ///
-  /// `git status --porcelain=v2 --branch -z` の `# branch.oid` / `# branch.upstream`
-  /// / `# branch.ab` 行を読む。porcelain v2 の整形が一発で済むので外部呼び出しを
-  /// 1 回で済ませられる。
+  /// `git status --porcelain=v2 --branch -z --untracked-files=all` の `# branch.oid` /
+  /// `# branch.upstream` / `# branch.ab` 行を読む。porcelain v2 の整形が一発で済むので
+  /// 外部呼び出しを 1 回で済ませられる。
+  /// `--untracked-files=all` は untracked ディレクトリ配下のファイルも個別に列挙させる
+  /// ため必須（外すと git が `dir/` のように親ディレクトリ 1 エントリに畳む）。
   public static func gitStatusFull(dir: String) async throws -> StatusFull {
     let stdout = try await runGit(
-      args: ["status", "--porcelain=v2", "--branch", "-z"], cwd: dir)
+      args: ["status", "--porcelain=v2", "--branch", "-z", "--untracked-files=all"], cwd: dir)
     return parsePorcelainV2WithBranch(stdout)
   }
 
@@ -269,19 +274,52 @@ public enum GitOps {
     return try await runGit(args: ["show", "\(hash):\(relPath)"], cwd: dir)
   }
 
-  /// `git diff-tree -r --name-status -z <hash>` または 2 コミット間。
+  /// 指定コミット（または 2 コミット間）の name-status 差分を返す。
+  ///
+  /// - 単一コミット非ルート: `git diff <hash>^ <hash>` で first parent との比較。
+  ///   merge commit でも `hash^` が first parent に解決されるため GitHub の表示と一致する
+  ///   差分になる。`diff-tree -m --first-parent` は先祖の変更が混入するので使わない。
+  /// - 単一ルートコミット: `git diff-tree --root --no-commit-id -r` を使う（親が無いので
+  ///   `^` で解決できない）。
+  /// - 範囲指定: 旧 / 新を `merge-base --is-ancestor` で決定し、旧^（旧が root の場合は
+  ///   旧自身）から新へ `git diff` する。
+  /// - UNCOMMITTED_HASH（all-zero）が範囲の片方に含まれる場合は working tree と比較する
+  ///   ため `git diff <from>` で第 2 引数省略（working tree と比較される）。
+  ///
+  /// 共通 diff オプション: `--name-status -z --find-renames --diff-filter=AMDR`。
   public static func commitFiles(dir: String, hash: String, compareHash: String?) async throws
     -> [FileChangeInfo]
   {
-    var args = ["diff-tree", "-r", "--name-status", "-z"]
+    let diffOptions = ["--name-status", "-z", "--find-renames", "--diff-filter=AMDR"]
+    let uncommitted = "0000000000000000000000000000000000000000"
+    let hasUncommitted =
+      hash == uncommitted || (compareHash.map { $0 == uncommitted } ?? false)
+
     if let compareHash, !compareHash.isEmpty {
-      args.append(compareHash)
-      args.append(hash)
-    } else {
-      args.append(hash)
+      let commitA = hash == uncommitted ? "HEAD" : hash
+      let commitB = compareHash == uncommitted ? "HEAD" : compareHash
+      let aIsOlder = await isAncestor(dir: dir, ancestor: commitA, descendant: commitB)
+      let older = aIsOlder ? commitA : commitB
+      let newer = aIsOlder ? commitB : commitA
+      let from = (await isRootCommit(dir: dir, hash: older)) ? older : "\(older)^"
+      if hasUncommitted {
+        let stdout = try await runGit(
+          args: ["diff"] + diffOptions + [from], cwd: dir)
+        return parseDiffNameStatus(stdout)
+      }
+      let stdout = try await runGit(
+        args: ["diff"] + diffOptions + [from, newer], cwd: dir)
+      return parseDiffNameStatus(stdout)
     }
-    let stdout = try await runGit(args: args, cwd: dir)
-    return parseDiffTreeNameStatus(stdout)
+
+    if await isRootCommit(dir: dir, hash: hash) {
+      let stdout = try await runGit(
+        args: ["diff-tree", "--root", "--no-commit-id", "-r"] + diffOptions + [hash], cwd: dir)
+      return parseDiffNameStatus(stdout)
+    }
+    let stdout = try await runGit(
+      args: ["diff"] + diffOptions + ["\(hash)^", hash], cwd: dir)
+    return parseDiffNameStatus(stdout)
   }
 }
 
@@ -450,9 +488,25 @@ private func parseWorktreePorcelain(_ data: Data) -> [WorktreeInfo] {
   return result
 }
 
-/// `git diff-tree --name-status -z` の出力をパースする。
-/// 通常エントリ: `<status>\0<path>\0`、rename: `R<score>\0<old>\0<new>\0`
-private func parseDiffTreeNameStatus(_ data: Data) -> [FileChangeInfo] {
+/// 与えられた hash がルートコミット（親なし）かどうかを判定する。
+/// `git rev-parse <hash>^` がルートコミットでは exit 128 で失敗するのを利用する。
+private func isRootCommit(dir: String, hash: String) async -> Bool {
+  let result = try? await runGit(args: ["rev-parse", "\(hash)^"], cwd: dir)
+  return result == nil
+}
+
+/// `git merge-base --is-ancestor <ancestor> <descendant>` で先祖関係を判定する。
+/// exit 0 で ancestor、exit 1 で非 ancestor。
+private func isAncestor(dir: String, ancestor: String, descendant: String) async -> Bool {
+  let result = try? await runGit(
+    args: ["merge-base", "--is-ancestor", ancestor, descendant], cwd: dir)
+  return result != nil
+}
+
+/// `git diff` / `git diff-tree` の `--name-status -z` 出力をパースする。
+/// フォーマットは両者同一: 通常エントリ `<status>\0<path>\0`、rename/copy
+/// `R<score>\0<old>\0<new>\0`（C も同様）。
+private func parseDiffNameStatus(_ data: Data) -> [FileChangeInfo] {
   let text = String(decoding: data, as: UTF8.self)
   let parts = text.split(separator: "\0", omittingEmptySubsequences: false).map(String.init)
   var result: [FileChangeInfo] = []


### PR DESCRIPTION
## 概要

Changes ペインが PR #420（Swift / SwiftUI への全面書き直し）以降に発生していた 3 つのデグレを修正する。あわせて Codex レビューで露見した周辺の堅牢性改善も同居させる。UI 側の契約は変えず、Swift backend の git 呼び出しを旧 desktop 実装の挙動 + α に揃える。

## 背景

PR #420 で `apps/desktop`（Bun + TypeScript）を撤廃し `apps/native`（Swift）に置き換えた際、`GitOps.swift` の git status / commit files 取得が旧 `apps/desktop/src/git/status.ts` と挙動互換になっておらず、Changes ペインで以下の症状が発生していた:

- untracked ディレクトリが `dir/` 1 エントリに畳まれ、フロントの `fileName(path)` が末尾スラッシュ後ろを空文字として返すため、種別 `U` ラベルだけ見えてファイル名が空欄になる
- 単一コミット選択時、`git diff-tree -r --name-status -z <hash>` を `--no-commit-id` 抜きで叩いていたため、出力先頭の `<hash>\n` 行が NUL split に紛れ、1 件目のエントリの type が hex 文字に化ける
- マージコミット選択時に差分が空になる（`git diff-tree` は merge をデフォルトで出力しない）

旧 TS 実装 ( commit ff4ce5a ) では「`git diff-tree -m --first-parent` は先祖の変更が混入する」という learning を経て `git diff <hash>^ <hash>` に切り替えた経緯が残っているのに、Swift 移植時にそれを踏まえずに `diff-tree` 単発呼び出しに戻していたのが二段目のデグレ。

さらに Codex レビューで以下が判明し、同時に修正した:

- root commit が range の older 側に来る場合 `from = older` だと root の追加分が diff から落ちる（empty tree からの diff にする必要がある）
- `isRootCommit` / `isAncestor` が `try?` で全エラーを Bool に潰しており、exit 1 と invalid revision (128) と launch failure を区別していない
- `git rev-parse <hash>^` は root commit と invalid hash の両方が exit 128 を返し区別不能。`isRootCommit` が invalid hash を root と誤認するリスクがある

## 変更内容

### git status

- `GitOps.gitStatus` (porcelain v1, `/git/status` RPC 経路) と `GitOps.gitStatusFull` (porcelain v2, `gitStatusChange` push event 経路) の両方に `--untracked-files=all` を追加
- これにより untracked ディレクトリ配下のファイルが個別に列挙され、Changes ペインがファイル単位で並ぶ

### commit files の差分取得戦略

- `GitOps.commitFiles` を以下の分岐に整理:
  - 単一非ルートコミット: `git diff <hash>^ <hash>` — merge commit でも `hash^` が first parent に解決されるため GitHub 表示と一致
  - 単一ルートコミット: `git diff-tree --root --no-commit-id -r ...`（`^` で親解決できないため）
  - 範囲指定: `merge-base --is-ancestor` で旧 / 新を確定し、`git diff <from> <newer>`。旧が root commit のときは `<from>` を well-known empty tree hash (`4b825dc642cb6eb9a060e54bf8d69288fbee4904`) に置く
  - 範囲に UNCOMMITTED_HASH (`0000...`) を含む場合: `git diff <from>` で working tree と比較
- 共通 diff オプションとして `--name-status -z --find-renames --diff-filter=AMDR` を付与
- parser を `parseDiffNameStatus` に rename（diff / diff-tree 両方で同一フォーマット）

### root 判定 / ancestor 判定の堅牢化

- `isRootCommit` を `git rev-list --parents -n 1 <hash>` ベースに変更:
  - valid root: 出力 `<hash>` 単独 → root
  - valid non-root: 出力 `<hash> <parent1> ...` → 非 root
  - invalid hash: exit 128 で `commandFailed` を throw → 上位へ伝搬
- `isRootCommit` / `isAncestor` を `throws` に変更し、`runGit` の例外を以下のとおり切り分け:
  - `isRootCommit`: `commandFailed` を root にしない（invalid hash と区別するため `rev-list --parents` の出力で判定）
  - `isAncestor`: `commandFailed(exitCode: 1)` だけを `false`（= 非 ancestor）として catch、それ以外は throw
- 呼び出し側 `commitFiles` は `try await isRootCommit(...)` / `try await isAncestor(...)` に追従

## 今回含めない点

- **非 ancestor 同士の range 選択（別枝の 2 commit を shift+click で範囲選択）の挙動**: `merge-base --is-ancestor` の片方向しか見ていないため `aIsOlder` が常に false に倒れて誤った diff を返す。これは旧 TS 実装 ( `apps/desktop/src/git/status.ts` の `buildDiffArgs`) でも同じ片方向判定で同じ挙動だった既存問題で、今 PR の「PR #420 起因のデグレ修正」スコープ外。`merge-base` ベースで range の意味を再定義するか UI で禁止するかは別 PR で扱う

## 確認事項

- [ ] 作業ツリーで untracked ディレクトリ（中身複数ファイル）を作ると Changes に個別ファイルとして列挙される
- [ ] 通常コミットを選択するとファイル名と種別が正しく表示される（M/A/D/R/U が UI に正しく出る）
- [ ] マージコミットを選択すると first parent との差分（PR で取り込んだ変更）が表示される
- [ ] ルートコミット（最初のコミット）を選択すると全ファイルが列挙される
- [ ] 範囲選択（shift+click）で 2 コミット間の変更ファイルが表示される
- [ ] 範囲選択の older 側がルートコミットでも root commit が追加したファイルが diff に含まれる
- [ ] 範囲選択で Uncommitted Changes 行を含めると working tree との差分になる
- [ ] rename されたファイルが `R` として表示される
