### PR TITLE
fix(config): dev/stable で永続データ保存先を統一する

### DIFF
--- a/apps/native/Sources/Gozd/GozdApp.swift
+++ b/apps/native/Sources/Gozd/GozdApp.swift
@@ -349,15 +349,12 @@ final class AppRuntime {
     // SocketServer は deinit で listener.cancel() + unlink するので明示は不要。
   }
 
-  /// `~/.config/gozd`（stable）/ `~/.config/gozd-dev`（dev）。
-  /// 判定軸は socket / window タイトルと同じ `GOZD_DEV_PROJECT_ROOT` 有無に揃える。
-  /// dev で sidebar 並び順 / app config を変更しても stable の永続ファイルを汚染しない。
+  /// `~/.config/gozd`。dev/stable で同じパスを使う。worktree 本体
+  /// （`~/.local/share/gozd/worktrees/`）が channel 共有なのと同じく、
+  /// app state / config / Task / ProjectConfig も同じものを共有する。
   private static func defaultConfigDir() -> String {
     let home = FileManager.default.homeDirectoryForCurrentUser
-    let env = ProcessInfo.processInfo.environment
-    let isDev = (env["GOZD_DEV_PROJECT_ROOT"] ?? "").isEmpty == false
-    let suffix = isDev ? "-dev" : ""
-    return home.appendingPathComponent(".config/\(bundlePrefix)\(suffix)").path
+    return home.appendingPathComponent(".config/\(bundlePrefix)").path
   }
 
   /// socket / settings / launch dir / Bundle ID で共有する prefix。

--- a/apps/renderer/src/features/sidebar/useSidebarData.ts
+++ b/apps/renderer/src/features/sidebar/useSidebarData.ts
@@ -205,14 +205,13 @@ export function useSidebarData() {
     hydrated = true;
   }
 
+  // snapshot 自体を watch source にすることで、buildAppStateSnapshot が読む
+  // フィールド（dirOrder / collapsedRoots / selectedDir / 各 repo の repoName・
+  // isGitRepo）だけが依存追跡される。worktrees / gitStatuses / task などサイドバー
+  // 表示用の reactive データは snapshot に含まれないので、git status push や
+  // Task title sync では save が走らない。
   watch(
-    [
-      () => [...repoStore.dirOrder],
-      () => Array.from(repoStore.collapsedRoots),
-      () => repoStore.selectedDir,
-      // repoName / isGitRepo の変化を拾うため repos を deep watch
-      () => repoStore.repos,
-    ],
+    () => repoStore.buildAppStateSnapshot(),
     () => {
       if (!hydrated) return;
       if (saveTimer !== undefined) clearTimeout(saveTimer);

--- a/apps/renderer/src/features/sidebar/useSidebarData.ts
+++ b/apps/renderer/src/features/sidebar/useSidebarData.ts
@@ -205,13 +205,15 @@ export function useSidebarData() {
     hydrated = true;
   }
 
-  // snapshot 自体を watch source にすることで、buildAppStateSnapshot が読む
-  // フィールド（dirOrder / collapsedRoots / selectedDir / 各 repo の repoName・
-  // isGitRepo）だけが依存追跡される。worktrees / gitStatuses / task などサイドバー
-  // 表示用の reactive データは snapshot に含まれないので、git status push や
-  // Task title sync では save が走らない。
+  // snapshot を JSON シリアライズした文字列を watch source にする。
+  // updateRepoData は `repos.value[rootDir] = { ...current, worktrees, ... }` で
+  // スロット自体を差し替えるため、`repos.value[rootDir]` を読む getter は必ず
+  // invalidate される。source は再実行されるが、シリアライズ結果が前と同じなら
+  // Vue の値比較で callback は呼ばれず save も走らない。これにより worktrees /
+  // freeBranches / gitStatuses / task の変化（git status push, fetchRepo, Task
+  // title sync）では `app-state.json` が save されなくなる。
   watch(
-    () => repoStore.buildAppStateSnapshot(),
+    () => JSON.stringify(repoStore.buildAppStateSnapshot()),
     () => {
       if (!hydrated) return;
       if (saveTimer !== undefined) clearTimeout(saveTimer);
@@ -220,7 +222,6 @@ export function useSidebarData() {
         await tryCatch(rpcAppStateSave({ state: repoStore.buildAppStateSnapshot() }));
       }, SAVE_DEBOUNCE_MS);
     },
-    { deep: true },
   );
 
   return {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,9 +146,7 @@ zsh 起動
 
 ## データ永続化
 
-アプリの状態と設定は `~/.config/gozd/`（stable）/ `~/.config/gozd-dev/`（dev）に JSON ファイルで保存する。dev / stable は `GOZD_DEV_PROJECT_ROOT` env の有無で切り替わるため、dev は stable と独立した永続ストアを持つ。ファイル I/O は常に desktop（Bun）側で行い、renderer からは RPC request 経由でアクセスする。
-
-以下は stable の例。dev では同じレイアウトが `~/.config/gozd-dev/` 配下に作られる。
+アプリの状態と設定は `~/.config/gozd/` に JSON ファイルで保存する。dev / stable で永続ディレクトリは共有する（worktree 本体 `~/.local/share/gozd/worktrees/` と同じ扱い）。channel で分離するのは衝突回避が必要な実行時リソース（socket / TMPDIR / Vite URL / CLI ソース参照先）のみ。ファイル I/O は常に desktop（Bun）側で行い、renderer からは RPC request 経由でアクセスする。
 
 ```text
 ~/.config/gozd/

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,13 +148,17 @@ zsh 起動
 
 アプリの状態と設定は `~/.config/gozd/` に JSON ファイルで保存する。dev / stable で永続ディレクトリは共有する（worktree 本体 `~/.local/share/gozd/worktrees/` と同じ扱い）。channel で分離するのは衝突回避が必要な実行時リソース（socket / TMPDIR / Vite URL / CLI ソース参照先）のみ。ファイル I/O は常に desktop（Bun）側で行い、renderer からは RPC request 経由でアクセスする。
 
+> [!WARNING]
+> 永続ファイルへの cross-process ロックは未実装。dev / stable を同時起動した場合、各ストア（`AppStateStore` / `AppConfigStore` / `TaskStore` / `ProjectConfigStore`）の `load → mutate → save` が並走すると、最後に save したプロセスが他方の変更を上書きする可能性がある。`AppStateStore` 経由の `app-state.json` save は snapshot 内容が変化した時のみ発火するため頻度は低いが、論理的なレース自体は残る。
+
 ```text
 ~/.config/gozd/
 ├── app-state.json                        # グローバル: ウィンドウ状態（位置・サイズ・プロジェクト）
 ├── config.json                           # グローバル: ユーザー設定（VOICEVOX 等）
 └── projects/
     └── <projectKey>/                     # <repoName>-<hash>（realpath の SHA-256 先頭12文字）
-        └── tasks.json                    # プロジェクト固有: Task 一覧
+        ├── tasks.json                    # プロジェクト固有: Task 一覧
+        └── config.json                   # プロジェクト固有: worktreeSymlinks 等
 ```
 
 ### スコープの使い分け

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,7 +146,7 @@ zsh 起動
 
 ## データ永続化
 
-アプリの状態と設定は `~/.config/gozd/` に JSON ファイルで保存する。dev / stable で永続ディレクトリは共有する（worktree 本体 `~/.local/share/gozd/worktrees/` と同じ扱い）。channel で分離するのは衝突回避が必要な実行時リソース（socket / TMPDIR / Vite URL / CLI ソース参照先）のみ。ファイル I/O は常に desktop（Bun）側で行い、renderer からは RPC request 経由でアクセスする。
+アプリの状態と設定は `~/.config/gozd/` に JSON ファイルで保存する。dev / stable で永続ディレクトリは共有する（worktree 本体 `~/.local/share/gozd/worktrees/` と同じ扱い）。channel で分離するのは衝突回避が必要な実行時リソース（socket / TMPDIR / Vite URL / CLI ソース参照先）のみ。ファイル I/O は常に native（Swift）側で行い、renderer からは RPC request 経由でアクセスする。
 
 > [!WARNING]
 > 永続ファイルへの cross-process ロックは未実装。dev / stable を同時起動した場合、各ストア（`AppStateStore` / `AppConfigStore` / `TaskStore` / `ProjectConfigStore`）の `load → mutate → save` が並走すると、最後に save したプロセスが他方の変更を上書きする可能性がある。`AppStateStore` 経由の `app-state.json` save は snapshot 内容が変化した時のみ発火するため頻度は低いが、論理的なレース自体は残る。

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -30,7 +30,7 @@
 
 ## アプリ状態の復元
 
-`~/.config/gozd/app-state.json`（stable）/ `~/.config/gozd-dev/app-state.json`（dev）に最後のウィンドウ状態を保存し、次回起動時に sidebar として hydrate する。dev / stable は `GOZD_DEV_PROJECT_ROOT` env の有無で切り替わるため、dev での操作は stable 側の永続ファイルを汚染しない。
+`~/.config/gozd/app-state.json` に最後のウィンドウ状態を保存し、次回起動時に sidebar として hydrate する。dev / stable で同じファイルを共有する。同時起動時は最後に save したプロセスが他方の sidebar 状態を上書きする可能性があるが、`buildAppStateSnapshot()` が serialize するフィールド（`dirOrder` / `collapsedRoots` / `selectedDir` / `repoName` / `isGitRepo`）の変化でしか save が走らないため、ユーザーが両ウィンドウで sidebar を能動的に操作しなければ衝突しない。
 
 保存する情報:
 

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -30,7 +30,12 @@
 
 ## アプリ状態の復元
 
-`~/.config/gozd/app-state.json` に最後のウィンドウ状態を保存し、次回起動時に sidebar として hydrate する。dev / stable で同じファイルを共有する。同時起動時は最後に save したプロセスが他方の sidebar 状態を上書きする可能性があるが、`buildAppStateSnapshot()` が serialize するフィールド（`dirOrder` / `collapsedRoots` / `selectedDir` / `repoName` / `isGitRepo`）の変化でしか save が走らないため、ユーザーが両ウィンドウで sidebar を能動的に操作しなければ衝突しない。
+`~/.config/gozd/app-state.json` に最後のウィンドウ状態を保存し、次回起動時に sidebar として hydrate する。dev / stable で同じファイルを共有する。
+
+save の発火条件は `buildAppStateSnapshot()` のシリアライズ結果が前回と変化した時のみ。`worktrees` / `freeBranches` / `gitStatuses` / `task` などサイドバー描画用のデータは snapshot に含まれないため、git status push / `fetchRepo` / Task title 同期では save が走らない。発火するのは `dirOrder` / `collapsedRoots` / `selectedDir` / 各 repo の `repoName` / `isGitRepo` が実際に変化した時のみ。
+
+> [!WARNING]
+> dev / stable を同時起動して両方の sidebar を編集した場合、最後に save したプロセスが他方の sidebar 状態を上書きする。プロセス間ロックは未実装。詳細は [architecture.md](./architecture.md#データ永続化) を参照。
 
 保存する情報:
 


### PR DESCRIPTION
## 概要

dev/stable で別々に分けていた永続データの保存先 `~/.config/gozd-dev/` を廃止し、`~/.config/gozd/` に統一する。あわせて、`app-state.json` への過剰な save を抑止して dev/stable 同時起動時のレース範囲を縮小する。

## 背景

dev で起動した worktree のサイドバー表示が、Task のタイトルではなくブランチ名にフォールバックしていた。

調査の結果、`apps/native/Sources/Gozd/GozdApp.swift` の `defaultConfigDir()` が `GOZD_DEV_PROJECT_ROOT` の有無で `-dev` suffix を付けて 2 系統のディレクトリを返していた。これにより:

- stable 起動時の Task は `~/.config/gozd/projects/<projectKey>/tasks.json` に保存される
- dev 起動時の `TaskStore.list()` は `~/.config/gozd-dev/projects/<projectKey>/tasks.json` を読みに行くが、ファイルが存在しないので空配列が返る
- `handleGitWorktreeList` で `wt.task` が常に nil となり、`worktreeDisplayName` がブランチ名にフォールバックする

`~/.local/share/gozd/worktrees/` (worktree 本体) は dev/stable 共通の場所に置かれているのに、永続データだけ分離する整合性のない構造になっていた。dev/stable で分けるべきなのは「同時起動時に衝突する実行時リソース」(socket / TMPDIR / Vite URL / CLI ソース参照先) のみで、永続データの分離は不要だった。

統一後の懸念として Codex レビューから「dev/stable 同時起動時に `app-state.json` への cross-process race が起きる」と指摘があった。確認したところ、`useSidebarData.ts` の watcher が `() => repoStore.repos` を `{ deep: true }` で監視していたため、git status push / fetchRepo / Task title sync など `app-state.json` には書き出さないフィールドの変化でも 300ms debounce で save が走っていた。

watch source の修正は 2 段階で行った:

- 第 1 案: watch source を `() => repoStore.buildAppStateSnapshot()` に変更
- 問題: `updateRepoData` が `repos.value[rootDir] = { ...current, worktrees, ... }` でスロット自体を差し替えるため、`repos.value[rootDir]` を読む getter は invalidate され source が再実行される
- 第 2 案: watch source を `() => JSON.stringify(repoStore.buildAppStateSnapshot())` に変更
- source の再実行は走るが、シリアライズ結果が前と同じなら Vue の値比較で callback はトリガーされない。これにより worktrees / freeBranches / gitStatuses / task の変化で `app-state.json` が save されなくなる

## 変更内容

### `apps/native/Sources/Gozd/GozdApp.swift`

- `defaultConfigDir()` から `GOZD_DEV_PROJECT_ROOT` 分岐と `-dev` suffix を削除し、常に `~/.config/gozd/` を返すようにした
- これにより `AppStateStore` / `AppConfigStore` / `TaskStore` / `ProjectConfigStore` が dev/stable で同じファイルを共有する

### `apps/renderer/src/features/sidebar/useSidebarData.ts`

- `app-state.json` save の watch source を `[dirOrder, collapsedRoots, selectedDir, repos (deep)]` から `() => JSON.stringify(repoStore.buildAppStateSnapshot())` に変更
- snapshot に含まれるフィールド（`dirOrder` / `collapsedRoots` / `selectedDir` / `repos[*].repoName` / `isGitRepo`）が実際に変化した時のみ callback がトリガーされ save が走る

### ドキュメント

- `docs/architecture.md` の「データ永続化」セクションを dev/stable 共有の前提に更新。WARNING 注記で cross-process ロック未実装を明示。保存レイアウト図に `projects/<projectKey>/config.json` を追記。`desktop（Bun）側` を `native（Swift）側` に修正
- `docs/workspace.md` の「アプリ状態の復元」セクションを dev/stable 共有 + 同時起動時の挙動に更新。save 発火条件を明記

### 残骸処理

`~/.config/gozd-dev/` に過去 dev 起動時のファイルが残っている場合があるが、次回 dev 起動時は読まれなくなる。`~/.local/share/gozd/worktrees/` の worktree 本体はもともと共有なので影響なし。マイグレーションコードは入れない（CLAUDE.md の「後方互換性を作らない」原則）。

## 今回は対応しない

- **プロセス間ファイルロック (flock)**: dev/stable 同時起動時に `AppConfigStore` / `TaskStore` / `ProjectConfigStore` への書き込みが厳密にレース可能だが、実装コスト大かつ実用上の発生頻度が低いため別 PR でも入れない方針。docs に既知のリスクとして明示済み

## 確認事項

- [ ] dev (`pnpm dev`) で起動し、stable で作成した Task のタイトルがサイドバーに表示されること
- [ ] dev で新しく Task を作成した際に `~/.config/gozd/projects/<projectKey>/tasks.json` に書き込まれること
- [ ] dev / stable 同時起動時に sidebar 状態が頻繁に上書きされないこと（git status push 等で `app-state.json` の mtime が更新されないこと）
- [ ] dev / stable を同時起動した場合に socket 衝突などが起きないこと (channel 分離は維持されている)
