### PR TITLE
ci: gate swift-test on swift package diffs

### DIFF
--- a/.github/workflows/code_validation.yml
+++ b/.github/workflows/code_validation.yml
@@ -74,13 +74,45 @@ jobs:
           fi
 
   # ==============================================================
+  # Swift 差分検出
+  #
+  # Swift パッケージ（apps/native, packages/proto-swift）または
+  # swift-test job 自体の定義に変更があるときだけ macOS runner を起動する。
+  # apps/native は packages/proto-swift を local path 依存しているため両方を監視する。
+  # Linux runner で軽量に判定する。
+  # ==============================================================
+  detect-swift-changes:
+    name: detect-swift-changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      changed: ${{ steps.changed.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          filter: blob:none
+          fetch-depth: 0
+          show-progress: false
+
+      - uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+        id: changed
+        with:
+          files: |
+            apps/native/**
+            packages/proto-swift/**
+            .github/workflows/code_validation.yml
+
+  # ==============================================================
   # Swift テスト（macOS 専用）
   #
   # @gozd/native は SwiftUI / WebKit / FSEvents 等 macOS 専用 API に依存するため
   # Linux runner では build できない。macos-26 runner で `swift test` を実行する。
+  # apps/native/ に差分があるときのみ実行する。
   # ==============================================================
   swift-test:
     name: swift-test
+    needs: detect-swift-changes
+    if: needs.detect-swift-changes.outputs.changed == 'true'
     runs-on: macos-26
     timeout-minutes: 15
     steps:
@@ -103,10 +135,11 @@ jobs:
     if: always()
     needs:
       - validation
+      - detect-swift-changes
       - swift-test
     steps:
       - name: Check all CI jobs status
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: validation
+          allowed-skips: validation,swift-test

--- a/.github/workflows/code_validation.yml
+++ b/.github/workflows/code_validation.yml
@@ -107,7 +107,8 @@ jobs:
   #
   # @gozd/native は SwiftUI / WebKit / FSEvents 等 macOS 専用 API に依存するため
   # Linux runner では build できない。macos-26 runner で `swift test` を実行する。
-  # apps/native/ に差分があるときのみ実行する。
+  # detect-swift-changes が監視する path（apps/native, packages/proto-swift,
+  # workflow 自身）に差分があるときのみ実行する。
   # ==============================================================
   swift-test:
     name: swift-test


### PR DESCRIPTION
## 概要

`swift-test` job を Swift パッケージに差分があるときのみ実行するようにゲートする。差分なしの PR では macOS runner を起動しない。

## 背景

`code_validation.yml` の `validation` job は `pnpm --filter '...[origin/<base>]'` で差分のあるワークスペースだけ typecheck / lint / test を回している。一方 `swift-test` job は path 条件を持たず、すべての PR で macOS runner を起動して `swift test` を走らせていた。

macOS runner は Linux runner より時間課金が高く、Swift にも `apps/native` にも触れない PR でも毎回起動する状態は無駄が大きい。`validation` 側と粒度を揃えて、Swift パッケージに差分があるときだけ `swift-test` を実行したい。

## 変更内容

### `detect-swift-changes` job 追加

- Linux runner 上で `tj-actions/changed-files` を使い、Swift 関連 path の差分有無を判定して `changed` output に出す
- 監視対象:
  - `apps/native/**`
  - `packages/proto-swift/**`（`apps/native` が `.package(path: "../../packages/proto-swift")` で local 依存しているため）
  - `.github/workflows/code_validation.yml`（swift-test job 自体の編集を検証するため）

### `swift-test` job をゲート

- `needs: detect-swift-changes` と `if: needs.detect-swift-changes.outputs.changed == 'true'` を追加
- step ではなく job 単位で if ガードすることで、差分なし時に macOS runner 自体を起動しない

### `all-green` の互換性維持

- `needs` に `detect-swift-changes` を追加
- `alls-green` の `allowed-skips` に `swift-test` を追加し、Branch Protection で必須にしている `all-green` チェックが skip 時にも緑になるようにする

## 確認事項

- [ ] Swift 関連 path に変更のない PR で `swift-test` が skipped となり、`all-green` が緑になる
- [ ] `apps/native/**` または `packages/proto-swift/**` を変更した PR で `swift-test` が実行される
- [ ] `.github/workflows/code_validation.yml` のみ変更した PR でも `swift-test` が実行される（この PR 自体）
