### PR TITLE
fix(git-graph): walk first-parents in renderer for range selection diff

### DIFF
--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -281,36 +281,32 @@ public enum GitOps {
   ///   差分になる。`diff-tree -m --first-parent` は先祖の変更が混入するので使わない。
   /// - 単一ルートコミット: `git diff-tree --root --no-commit-id -r` を使う（親が無いので
   ///   `^` で解決できない）。
-  /// - 範囲指定（rangeHashes 非空）: renderer が git-graph の表示順で組み立てた commit hash 列を
-  ///   受け取り、各 commit の first-parent diff を union する。git の祖先関係に依存せず
-  ///   「画面上で見える範囲 = 対象」を保証する。同一ファイルが複数 commit で変更される場合、
-  ///   newer 側（配列の先頭）の type を採用する（最終的に何になっているかを優先）。
-  ///   root commit が含まれる場合は empty tree を起点にする。
+  /// - 範囲指定（rangeHashes 非空）: renderer が git-graph の表示順で組み立てた commit hash 列の
+  ///   先頭（newer）と末尾（older）を 2 endpoint として `git diff <older>^ <newer>` を 1 回実行する。
+  ///   commit ごとの first-parent diff を union するアプローチは rename chain（foo→bar→baz）や
+  ///   rename 後 delete を解決できず、logical file identity が壊れるため避ける。
+  ///   2 点 diff にすれば git の rename detection が一発で chain を畳む。中間 commit で revert
+  ///   された変更が消える点はトレードオフだが、UI 直感（最終状態の差分）と一致する。
+  ///   older が root commit なら empty tree を起点にする。
+  ///   includeWorkingTree が true の場合（範囲の片端が Working Tree）は第 2 引数を省略して
+  ///   working tree との比較に切り替える。
   ///
   /// 共通 diff オプション: `--name-status -z --find-renames --diff-filter=AMDR`。
   public static func commitFiles(
-    dir: String, hash: String, compareHash: String?, rangeHashes: [String] = []
+    dir: String, hash: String, compareHash: String?, rangeHashes: [String] = [],
+    includeWorkingTree: Bool = false
   ) async throws -> [FileChangeInfo] {
     let diffOptions = ["--name-status", "-z", "--find-renames", "--diff-filter=AMDR"]
 
-    if !rangeHashes.isEmpty {
-      // 配列の先頭が newer。先頭から順に処理して、newPath をキーに最初に出会った change を採用する
-      // （= newer 側の type を優先）。
-      var changeMap: [String: FileChangeInfo] = [:]
-      var order: [String] = []
-      for hash in rangeHashes {
-        let isRoot = try await isRootCommit(dir: dir, hash: hash)
-        let from = isRoot ? emptyTreeHash : "\(hash)^"
-        let stdout = try await runGit(
-          args: ["diff"] + diffOptions + [from, hash], cwd: dir)
-        for change in parseDiffNameStatus(stdout) {
-          if changeMap[change.newPath] == nil {
-            changeMap[change.newPath] = change
-            order.append(change.newPath)
-          }
-        }
-      }
-      return order.compactMap { changeMap[$0] }
+    if let newer = rangeHashes.first, let older = rangeHashes.last {
+      let isOlderRoot = try await isRootCommit(dir: dir, hash: older)
+      let from = isOlderRoot ? emptyTreeHash : "\(older)^"
+      let diffArgs: [String] =
+        includeWorkingTree
+        ? ["diff"] + diffOptions + [from]
+        : ["diff"] + diffOptions + [from, newer]
+      let stdout = try await runGit(args: diffArgs, cwd: dir)
+      return parseDiffNameStatus(stdout)
     }
 
     if try await isRootCommit(dir: dir, hash: hash) {

--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -274,44 +274,43 @@ public enum GitOps {
     return try await runGit(args: ["show", "\(hash):\(relPath)"], cwd: dir)
   }
 
-  /// 指定コミット（または 2 コミット間）の name-status 差分を返す。
+  /// 指定コミット（または範囲指定）の name-status 差分を返す。
   ///
   /// - 単一コミット非ルート: `git diff <hash>^ <hash>` で first parent との比較。
   ///   merge commit でも `hash^` が first parent に解決されるため GitHub の表示と一致する
   ///   差分になる。`diff-tree -m --first-parent` は先祖の変更が混入するので使わない。
   /// - 単一ルートコミット: `git diff-tree --root --no-commit-id -r` を使う（親が無いので
   ///   `^` で解決できない）。
-  /// - 範囲指定: 旧 / 新を `merge-base --is-ancestor` で決定し、旧^（旧が root の場合は
-  ///   well-known empty tree hash）から新へ `git diff` する。empty tree を起点にすることで
-  ///   root 自身の変更が range に含まれる（`from = older` だと root の追加分が落ちる）。
-  /// - UNCOMMITTED_HASH（all-zero）が範囲の片方に含まれる場合は working tree と比較する
-  ///   ため `git diff <from>` で第 2 引数省略（working tree と比較される）。
+  /// - 範囲指定（rangeHashes 非空）: renderer が git-graph の表示順で組み立てた commit hash 列を
+  ///   受け取り、各 commit の first-parent diff を union する。git の祖先関係に依存せず
+  ///   「画面上で見える範囲 = 対象」を保証する。同一ファイルが複数 commit で変更される場合、
+  ///   newer 側（配列の先頭）の type を採用する（最終的に何になっているかを優先）。
+  ///   root commit が含まれる場合は empty tree を起点にする。
   ///
   /// 共通 diff オプション: `--name-status -z --find-renames --diff-filter=AMDR`。
-  public static func commitFiles(dir: String, hash: String, compareHash: String?) async throws
-    -> [FileChangeInfo]
-  {
+  public static func commitFiles(
+    dir: String, hash: String, compareHash: String?, rangeHashes: [String] = []
+  ) async throws -> [FileChangeInfo] {
     let diffOptions = ["--name-status", "-z", "--find-renames", "--diff-filter=AMDR"]
-    let uncommitted = "0000000000000000000000000000000000000000"
-    let hasUncommitted =
-      hash == uncommitted || (compareHash.map { $0 == uncommitted } ?? false)
 
-    if let compareHash, !compareHash.isEmpty {
-      let commitA = hash == uncommitted ? "HEAD" : hash
-      let commitB = compareHash == uncommitted ? "HEAD" : compareHash
-      let aIsOlder = try await isAncestor(dir: dir, ancestor: commitA, descendant: commitB)
-      let older = aIsOlder ? commitA : commitB
-      let newer = aIsOlder ? commitB : commitA
-      let from =
-        (try await isRootCommit(dir: dir, hash: older)) ? emptyTreeHash : "\(older)^"
-      if hasUncommitted {
+    if !rangeHashes.isEmpty {
+      // 配列の先頭が newer。先頭から順に処理して、newPath をキーに最初に出会った change を採用する
+      // （= newer 側の type を優先）。
+      var changeMap: [String: FileChangeInfo] = [:]
+      var order: [String] = []
+      for hash in rangeHashes {
+        let isRoot = try await isRootCommit(dir: dir, hash: hash)
+        let from = isRoot ? emptyTreeHash : "\(hash)^"
         let stdout = try await runGit(
-          args: ["diff"] + diffOptions + [from], cwd: dir)
-        return parseDiffNameStatus(stdout)
+          args: ["diff"] + diffOptions + [from, hash], cwd: dir)
+        for change in parseDiffNameStatus(stdout) {
+          if changeMap[change.newPath] == nil {
+            changeMap[change.newPath] = change
+            order.append(change.newPath)
+          }
+        }
       }
-      let stdout = try await runGit(
-        args: ["diff"] + diffOptions + [from, newer], cwd: dir)
-      return parseDiffNameStatus(stdout)
+      return order.compactMap { changeMap[$0] }
     }
 
     if try await isRootCommit(dir: dir, hash: hash) {
@@ -507,19 +506,6 @@ private func isRootCommit(dir: String, hash: String) async throws -> Bool {
   let line = String(decoding: stdout, as: UTF8.self)
     .trimmingCharacters(in: .whitespacesAndNewlines)
   return line.split(separator: " ").count == 1
-}
-
-/// `git merge-base --is-ancestor <ancestor> <descendant>` で先祖関係を判定する。
-/// exit 0 で ancestor、exit 1 で非 ancestor。それ以外（128 / launch failure 等）は本物の
-/// エラーなので throw して上位へ返す（誤って Bool に潰すと範囲指定の older/newer が壊れる）。
-private func isAncestor(dir: String, ancestor: String, descendant: String) async throws -> Bool {
-  do {
-    _ = try await runGit(
-      args: ["merge-base", "--is-ancestor", ancestor, descendant], cwd: dir)
-    return true
-  } catch GitError.commandFailed(let exitCode, _) where exitCode == 1 {
-    return false
-  }
 }
 
 /// `git diff` / `git diff-tree` の `--name-status -z` 出力をパースする。

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -448,7 +448,8 @@ public actor RpcDispatcher {
     let req = try Gozd_V1_GitCommitFilesRequest(jsonUTF8Data: body)
     let compare = req.compareHash.isEmpty ? nil : req.compareHash
     let changes = try await GitOps.commitFiles(
-      dir: req.dir, hash: req.hash, compareHash: compare, rangeHashes: req.rangeHashes)
+      dir: req.dir, hash: req.hash, compareHash: compare, rangeHashes: req.rangeHashes,
+      includeWorkingTree: req.includeWorkingTree)
     var resp = Gozd_V1_GitCommitFilesResponse()
     resp.changes = changes.map { c in
       var pb = Gozd_V1_GitFileChange()

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -448,7 +448,7 @@ public actor RpcDispatcher {
     let req = try Gozd_V1_GitCommitFilesRequest(jsonUTF8Data: body)
     let compare = req.compareHash.isEmpty ? nil : req.compareHash
     let changes = try await GitOps.commitFiles(
-      dir: req.dir, hash: req.hash, compareHash: compare)
+      dir: req.dir, hash: req.hash, compareHash: compare, rangeHashes: req.rangeHashes)
     var resp = Gozd_V1_GitCommitFilesResponse()
     resp.changes = changes.map { c in
       var pb = Gozd_V1_GitFileChange()

--- a/apps/renderer/src/features/changes/ChangesPane.vue
+++ b/apps/renderer/src/features/changes/ChangesPane.vue
@@ -5,12 +5,19 @@ Changed files list. Shows HEAD vs working directory by default, or a selected co
 
 - Default (Uncommitted Changes selected): shows git status converted to GitFileChange[]
 - Normal commit selected: fetches changed files via `gitCommitFiles` RPC
-- Shift+click range: walks first-parents from the upper endpoint (newer) until reaching the
-  lower endpoint's display position. Both endpoints are inclusive when they sit on the
-  walked line. Independent commits from another branch that the date-sorted display
-  interleaves are skipped because they are not on `parents[0]`. The resulting hash list is
-  sent to the backend as `range_hashes`, and stored in the git-graph store so the graph can
-  highlight the same set of commits.
+- Shift+click range:
+  - Walks first-parents from the upper endpoint (newer, falling back to HEAD when newer is
+    Working Tree) until reaching the lower endpoint's display position. Both endpoints are
+    inclusive when they sit on the walked line.
+  - Independent commits from another branch that the date-sorted display interleaves are
+    skipped because they are not on `parents[0]`.
+  - The resulting hash list is sent to the backend as `range_hashes` and stored in the
+    git-graph store as `activeCommitHashes` for dot highlighting.
+  - When the range includes Working Tree, `include_working_tree=true` is sent so the backend
+    diffs against the working tree (`git diff <older>^`).
+  - When the non-Working-Tree endpoint is the HEAD commit itself, the range collapses to
+    "Working Tree only" — RPC is skipped and gitStatuses is shown as if a single Uncommitted
+    Changes row were selected. Visual range highlighting is preserved.
 - Clicking a file emits `select` with the relative path
 </doc>
 
@@ -48,6 +55,38 @@ const isUncommittedMode = computed(() => gitGraphStore.selectedHash === UNCOMMIT
 /** 範囲選択モードか */
 const isRangeMode = computed(() => gitGraphStore.compareHash !== null);
 
+/** HEAD ref を持つ commit の hash */
+const headHash = computed(() => gitGraphStore.commits.find((c) => c.refs.includes("HEAD"))?.hash);
+
+/** 範囲選択の片端が Working Tree か */
+const includesWorkingTree = computed(
+  () =>
+    gitGraphStore.selectedHash === UNCOMMITTED_HASH ||
+    gitGraphStore.compareHash === UNCOMMITTED_HASH,
+);
+
+/** 非 Working Tree 側 endpoint の hash */
+const otherEndpointHash = computed(() =>
+  gitGraphStore.selectedHash === UNCOMMITTED_HASH
+    ? gitGraphStore.compareHash
+    : gitGraphStore.selectedHash,
+);
+
+/**
+ * Working Tree のみとして処理すべきか。
+ * 範囲選択の片端が Working Tree かつ、もう片端が HEAD ref を持つ commit のとき、
+ * 「Working Tree から HEAD まで」 = uncommitted changes のみ、という UI 直感に倒す。
+ * 表示位置ではなく endpoint 自体が HEAD かどうかで判定するため、origin/main が中間に
+ * 挟まっても影響を受けない。
+ */
+const workingTreeOnly = computed(
+  () =>
+    isRangeMode.value &&
+    includesWorkingTree.value &&
+    otherEndpointHash.value !== null &&
+    otherEndpointHash.value === headHash.value,
+);
+
 /** git status の Record<string, string> を GitFileChange[] に変換 */
 function gitStatusToFileChanges(statuses: Record<string, string>): GitFileChange[] {
   return Object.entries(statuses).map(([filePath, statusCode]) => {
@@ -67,9 +106,15 @@ function gitStatusToFileChanges(statuses: Record<string, string>): GitFileChange
   });
 }
 
-/** 表示するファイル一覧 */
+/**
+ * 表示するファイル一覧。
+ *
+ * - 単一 Working Tree 選択: gitStatuses ベース (uncommitted changes)
+ * - workingTreeOnly (Working Tree + HEAD の範囲): gitStatuses ベース (single Working Tree と一致)
+ * - それ以外: commitFiles ref (RPC で取得した diff)
+ */
 const fileChanges = computed<GitFileChange[]>(() => {
-  if (isUncommittedMode.value && !isRangeMode.value) {
+  if ((isUncommittedMode.value && !isRangeMode.value) || workingTreeOnly.value) {
     return gitStatusToFileChanges(gitStatusStore.gitStatuses);
   }
   return commitFiles.value;
@@ -156,17 +201,20 @@ function buildRangeHashes(
   return result;
 }
 
-// コミット選択が変わったら変更ファイルを取得
+// コミット選択 / commits 配列が変わったら変更ファイルを取得
+// commits 依存を持つことで、fetch / branch update / HEAD 変化で commits が再構築された後も
+// rangeHashes / activeCommitHashes / Changes diff / workingTreeOnly が再評価される
 watch(
-  () => [gitGraphStore.selectedHash, gitGraphStore.compareHash] as const,
+  () => [gitGraphStore.selectedHash, gitGraphStore.compareHash, gitGraphStore.commits] as const,
   async ([hash, compareHash]) => {
     const seq = ++requestSeq;
+
+    // 単一 Working Tree 選択: 既存通り gitStatuses 経由
     if (hash === UNCOMMITTED_HASH && compareHash === null) {
       commitFiles.value = [];
       loading.value = false;
       return;
     }
-    loading.value = true;
     const dir = worktreeStore.dir;
     if (dir === undefined) {
       commitFiles.value = [];
@@ -174,20 +222,64 @@ watch(
       return;
     }
 
-    const rangeHashes =
-      compareHash !== null
-        ? buildRangeHashes(hash, compareHash, gitGraphStore.hashToIndex, gitGraphStore.commits)
-        : [];
+    // 範囲選択 mode
     if (compareHash !== null) {
+      // workingTreeOnly: activeCommitHashes を空集合にして dot 強調と Detail pane も
+      // 「Uncommitted Changes のみ」に倒す。visual range (isSelectedRow) は維持される
+      if (workingTreeOnly.value) {
+        gitGraphStore.setActiveCommitHashes([]);
+        commitFiles.value = [];
+        loading.value = false;
+        return;
+      }
+
+      const rangeHashes = buildRangeHashes(
+        hash,
+        compareHash,
+        gitGraphStore.hashToIndex,
+        gitGraphStore.commits,
+      );
       gitGraphStore.setActiveCommitHashes(rangeHashes);
+
+      // Working Tree 端を含むのに HEAD が見つからない: walk 起点が決まらないので空に倒す
+      if (includesWorkingTree.value && headHash.value === undefined) {
+        commitFiles.value = [];
+        loading.value = false;
+        return;
+      }
+
+      // rangeHashes 空: range 解決失敗。単一 commit 経路に落とさず空で確定
+      if (rangeHashes.length === 0) {
+        commitFiles.value = [];
+        loading.value = false;
+        return;
+      }
+
+      loading.value = true;
+      const result = await tryCatch(
+        rpcGitCommitFiles({
+          dir,
+          hash,
+          compareHash,
+          rangeHashes,
+          includeWorkingTree: includesWorkingTree.value,
+        }),
+      );
+      if (seq !== requestSeq) return;
+      commitFiles.value = result.ok ? result.value.changes : [];
+      loading.value = false;
+      return;
     }
 
+    // 単一 commit mode
+    loading.value = true;
     const result = await tryCatch(
       rpcGitCommitFiles({
         dir,
         hash,
-        compareHash: compareHash ?? "",
-        rangeHashes,
+        compareHash: "",
+        rangeHashes: [],
+        includeWorkingTree: false,
       }),
     );
     if (seq !== requestSeq) return;

--- a/apps/renderer/src/features/changes/ChangesPane.vue
+++ b/apps/renderer/src/features/changes/ChangesPane.vue
@@ -5,12 +5,17 @@ Changed files list. Shows HEAD vs working directory by default, or a selected co
 
 - Default (Uncommitted Changes selected): shows git status converted to GitFileChange[]
 - Normal commit selected: fetches changed files via `gitCommitFiles` RPC
-- Shift+click range: fetches diff between the two commits
+- Shift+click range: walks first-parents from the upper endpoint (newer) until reaching the
+  lower endpoint's display position. Both endpoints are inclusive when they sit on the
+  walked line. Independent commits from another branch that the date-sorted display
+  interleaves are skipped because they are not on `parents[0]`. The resulting hash list is
+  sent to the backend as `range_hashes`, and stored in the git-graph store so the graph can
+  highlight the same set of commits.
 - Clicking a file emits `select` with the relative path
 </doc>
 
 <script setup lang="ts">
-import type { GitFileChange } from "@gozd/proto";
+import type { GitCommit, GitFileChange } from "@gozd/proto";
 import { tryCatch } from "@gozd/shared";
 import { computed, ref, watch } from "vue";
 import { getFileIconName, getIconUrl } from "../filer";
@@ -97,6 +102,60 @@ function dirPath(filePath: string): string {
   return lastSlash === -1 ? "" : filePath.slice(0, lastSlash);
 }
 
+/**
+ * 範囲選択時の対象 commit hash 列を組み立てる。
+ *
+ * 仕様: newer (上端) から `commit.parents[0]` を辿り、older の表示位置に到達したら停止する。
+ * 「先端ブランチの first-parent walk」を表現し、別枝の独立コミット（mergeCommitStreams が
+ * date 順で挿入する origin/HEAD 系の commit など）は対象に含まれない。
+ *
+ * 終了条件:
+ *   - 次の commit が older の表示位置を **超えた**（older 自身は first-parent 線上にあれば含む）
+ *   - 次の commit が commits 配列に存在しない（= log フェッチ範囲外）
+ *   - parents[0] が無い（= root commit）
+ *
+ * UNCOMMITTED_HASH 端の扱い:
+ *   - newer = UNCOMMITTED_HASH: HEAD ref を持つ commit を walk 開始点にフォールバック
+ *   - older = UNCOMMITTED_HASH: stopIdx = -1 → 即停止すべきところを Infinity に倒し、
+ *     walk が最後まで進むようにする（Working Tree 端は「最も新しい」扱い）
+ */
+function buildRangeHashes(
+  selected: string,
+  compare: string,
+  hashToIndex: Map<string, number>,
+  commits: readonly GitCommit[],
+): string[] {
+  const sIdx = selected === UNCOMMITTED_HASH ? -1 : (hashToIndex.get(selected) ?? Infinity);
+  const cIdx = compare === UNCOMMITTED_HASH ? -1 : (hashToIndex.get(compare) ?? Infinity);
+
+  const newerIsSelected = sIdx <= cIdx;
+  const newerRaw = newerIsSelected ? selected : compare;
+  const olderIdxRaw = newerIsSelected ? cIdx : sIdx;
+
+  const startHash =
+    newerRaw === UNCOMMITTED_HASH
+      ? (commits.find((c) => c.refs.includes("HEAD"))?.hash ?? "")
+      : newerRaw;
+  if (startHash === "") return [];
+
+  // older が UNCOMMITTED_HASH (-1) の場合は stopIdx を Infinity にして最後まで walk する
+  const stopIdx = olderIdxRaw < 0 ? Number.POSITIVE_INFINITY : olderIdxRaw;
+
+  const result: string[] = [];
+  let currentHash = startHash;
+  while (true) {
+    const idx = hashToIndex.get(currentHash);
+    if (idx === undefined || idx > stopIdx) break;
+    const commit = commits[idx];
+    result.push(commit.hash);
+    if (idx === stopIdx) break; // older 自身に到達。追加してから停止
+    const firstParent = commit.parents[0];
+    if (firstParent === undefined) break;
+    currentHash = firstParent;
+  }
+  return result;
+}
+
 // コミット選択が変わったら変更ファイルを取得
 watch(
   () => [gitGraphStore.selectedHash, gitGraphStore.compareHash] as const,
@@ -114,11 +173,21 @@ watch(
       loading.value = false;
       return;
     }
+
+    const rangeHashes =
+      compareHash !== null
+        ? buildRangeHashes(hash, compareHash, gitGraphStore.hashToIndex, gitGraphStore.commits)
+        : [];
+    if (compareHash !== null) {
+      gitGraphStore.setActiveCommitHashes(rangeHashes);
+    }
+
     const result = await tryCatch(
       rpcGitCommitFiles({
         dir,
         hash,
         compareHash: compareHash ?? "",
+        rangeHashes,
       }),
     );
     if (seq !== requestSeq) return;

--- a/apps/renderer/src/features/changes/ChangesPane.vue
+++ b/apps/renderer/src/features/changes/ChangesPane.vue
@@ -15,9 +15,12 @@ Changed files list. Shows HEAD vs working directory by default, or a selected co
     git-graph store as `activeCommitHashes` for dot highlighting.
   - When the range includes Working Tree, `include_working_tree=true` is sent so the backend
     diffs against the working tree (`git diff <older>^`).
-  - When the non-Working-Tree endpoint is the HEAD commit itself, the range collapses to
+  - When the non-Working-Tree endpoint is the HEAD commit AND HEAD is not at the top of the
+    commits array (origin/main commits are interleaved above HEAD), the range collapses to
     "Working Tree only" — RPC is skipped and gitStatuses is shown as if a single Uncommitted
-    Changes row were selected. Visual range highlighting is preserved.
+    Changes row were selected. Visual range highlighting is preserved. When HEAD is the top
+    commit (no other branch above it), the range is treated normally so HEAD's commit diff
+    plus uncommitted changes are both shown.
 - Clicking a file emits `select` with the relative path
 </doc>
 
@@ -74,18 +77,23 @@ const otherEndpointHash = computed(() =>
 
 /**
  * Working Tree のみとして処理すべきか。
- * 範囲選択の片端が Working Tree かつ、もう片端が HEAD ref を持つ commit のとき、
- * 「Working Tree から HEAD まで」 = uncommitted changes のみ、という UI 直感に倒す。
- * 表示位置ではなく endpoint 自体が HEAD かどうかで判定するため、origin/main が中間に
- * 挟まっても影響を受けない。
+ *
+ * 「Working Tree と HEAD を選んだが、HEAD が表示順で最上位ではない」ケースに限定する。
+ * これは origin/main 等が HEAD より進行していて、Working Tree と HEAD の間に他枝の
+ * commit が挟まっている状態。範囲を素直に解釈すると挟まる commit まで含めてしまうので、
+ * uncommitted changes のみに倒す。
+ *
+ * HEAD が表示順で最上位 (commits[0]) の通常ケース (Working Tree → HEAD で間に他 commit
+ * なし) では false を返し、`include_working_tree=true` の通常 range として処理する
+ * (`git diff <HEAD>^` で HEAD コミット差分 + uncommitted changes が出る)。
  */
-const workingTreeOnly = computed(
-  () =>
-    isRangeMode.value &&
-    includesWorkingTree.value &&
-    otherEndpointHash.value !== null &&
-    otherEndpointHash.value === headHash.value,
-);
+const workingTreeOnly = computed(() => {
+  if (!isRangeMode.value || !includesWorkingTree.value) return false;
+  const otherHash = otherEndpointHash.value;
+  if (otherHash === null || otherHash !== headHash.value) return false;
+  const headIdx = gitGraphStore.hashToIndex.get(otherHash);
+  return headIdx !== undefined && headIdx > 0;
+});
 
 /** git status の Record<string, string> を GitFileChange[] に変換 */
 function gitStatusToFileChanges(statuses: Record<string, string>): GitFileChange[] {

--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -608,19 +608,17 @@ function rowHighlightClass(hash: string): string {
 }
 
 /**
- * 単一選択 / 範囲選択を統一して「選択された行」を判定する。
+ * 単一選択 / 範囲選択の visual range（青背景の対象行）を判定する。
  *
- * 範囲選択時は `<older>..<newer>` semantics に従い older 端を含まない。
- * dot ハイライトと完全一致させることで「青い行 = diff 対象」を保証する。
- * activeCommitHashes が未取得（fetch 中）の間のみ、両端 + 範囲内をフォールバック表示する。
+ * activeCommitHashes（実 diff 対象 = first-parent walk 結果）には依存させない。
+ * activeCommitHashes は dot 強調用 (isActiveDot) に限定し、行 background は
+ * 「ユーザーが shift+click で選んだ範囲そのもの」を素直に表現する。
+ * Working Tree 端は activeCommitHashes に含まれないため、ここで明示的にハイライト対象に含める。
  */
 function isSelectedRow(hash: string): boolean {
-  const { selectedHash, compareHash, activeCommitHashes } = gitGraphStore;
+  const { selectedHash, compareHash } = gitGraphStore;
   if (compareHash === null) {
     return hash === selectedHash;
-  }
-  if (activeCommitHashes !== null) {
-    return activeCommitHashes.has(hash);
   }
   return hash === selectedHash || hash === compareHash || isInRange(hash);
 }

--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -594,15 +594,35 @@ function onRowClick(hash: string, e: MouseEvent) {
   }
 }
 
-/** 行のハイライトクラスを返す */
+/**
+ * 行のハイライトクラスを返す。
+ *
+ * 単一選択 / 範囲選択どちらも同一の単色背景でハイライトする。
+ * 「実 diff 対象 commit」の強調は SVG の dot 側で行うため、ここでは選択範囲そのものの提示に専念する。
+ */
 function rowHighlightClass(hash: string): string {
-  if (hash === gitGraphStore.selectedHash || hash === gitGraphStore.compareHash) {
-    return "bg-blue-900/40 hover:bg-blue-900/50";
-  }
-  if (isInRange(hash)) {
-    return "bg-blue-900/20 hover:bg-blue-900/30";
+  if (isSelectedRow(hash)) {
+    return "bg-blue-900/30 hover:bg-blue-900/40";
   }
   return "hover:bg-zinc-800/60";
+}
+
+/**
+ * 単一選択 / 範囲選択を統一して「選択された行」を判定する。
+ *
+ * 範囲選択時は `<older>..<newer>` semantics に従い older 端を含まない。
+ * dot ハイライトと完全一致させることで「青い行 = diff 対象」を保証する。
+ * activeCommitHashes が未取得（fetch 中）の間のみ、両端 + 範囲内をフォールバック表示する。
+ */
+function isSelectedRow(hash: string): boolean {
+  const { selectedHash, compareHash, activeCommitHashes } = gitGraphStore;
+  if (compareHash === null) {
+    return hash === selectedHash;
+  }
+  if (activeCommitHashes !== null) {
+    return activeCommitHashes.has(hash);
+  }
+  return hash === selectedHash || hash === compareHash || isInRange(hash);
 }
 
 /**
@@ -626,6 +646,20 @@ function isInRange(hash: string): boolean {
   const idx = gitGraphStore.hashToIndex.get(hash);
   if (idx === undefined) return false;
   return idx > range.min && idx < range.max;
+}
+
+/**
+ * SVG の dot を branch color で塗りつぶして強調する対象かどうか。
+ *
+ * - 単一選択時: 選択中の commit
+ * - 範囲選択時: first-parent walk で得た実 diff 対象 commit（activeCommitHashes）
+ */
+function isActiveDot(hash: string): boolean {
+  const { selectedHash, compareHash, activeCommitHashes } = gitGraphStore;
+  if (compareHash === null) {
+    return hash === selectedHash;
+  }
+  return activeCommitHashes?.has(hash) ?? false;
 }
 </script>
 
@@ -760,10 +794,10 @@ function isInRange(hash: string): boolean {
                 :key="`dot-${node.commit.hash}`"
                 :cx="laneX(node.lane)"
                 :cy="rowY(row)"
-                :r="DOT_RADIUS"
-                fill="currentColor"
+                :r="isActiveDot(node.commit.hash) ? DOT_RADIUS + 1 : DOT_RADIUS"
+                :fill="isActiveDot(node.commit.hash) ? colorFor(node.color) : 'currentColor'"
                 :stroke="colorFor(node.color)"
-                stroke-width="1.5"
+                :stroke-width="isActiveDot(node.commit.hash) ? 2 : 1.5"
                 class="text-zinc-900"
               />
             </svg>

--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -659,6 +659,16 @@ function isActiveDot(hash: string): boolean {
   }
   return activeCommitHashes?.has(hash) ?? false;
 }
+
+/**
+ * Working Tree 行の dot をハイライトするかどうか。
+ * 単一 Working Tree 選択 / 範囲選択の片端が Working Tree のとき teal で塗りつぶす。
+ */
+const isWorkingTreeActive = computed(
+  () =>
+    gitGraphStore.selectedHash === UNCOMMITTED_HASH ||
+    gitGraphStore.compareHash === UNCOMMITTED_HASH,
+);
 </script>
 
 <template>
@@ -728,8 +738,8 @@ function isActiveDot(hash: string): boolean {
             <circle
               :cx="laneX(0)"
               :cy="ROW_HEIGHT / 2"
-              :r="DOT_RADIUS"
-              fill="#1c1c1c"
+              :r="isWorkingTreeActive ? DOT_RADIUS + 1 : DOT_RADIUS"
+              :fill="isWorkingTreeActive ? '#4ec9b0' : '#1c1c1c'"
               stroke="#4ec9b0"
               stroke-width="2"
             />

--- a/apps/renderer/src/features/git-graph/useGitGraphStore.ts
+++ b/apps/renderer/src/features/git-graph/useGitGraphStore.ts
@@ -23,6 +23,13 @@ export const useGitGraphStore = defineStore("gitGraph", () => {
   /** ユーザー操作による選択のバージョン。select / selectCompare でのみインクリメント */
   const selectionVersion = ref(0);
 
+  /**
+   * 範囲選択時に first-parent walk で得られた実 diff 対象 commit hash の Set。
+   * ChangesPane が rpcGitCommitFiles の戻り値から書き込み、GitGraphPane がハイライト判定に使う。
+   * null は単一選択 / 未取得状態。
+   */
+  const activeCommitHashes = ref<Set<string> | null>(null);
+
   /** git log で取得したコミット一覧。GitGraphPane が loadLog() で更新し、ChangesPane が選択状態経由で参照する */
   const commits = ref<GitCommit[]>([]);
 
@@ -35,7 +42,14 @@ export const useGitGraphStore = defineStore("gitGraph", () => {
     return map;
   });
 
-  /** 選択中のコミット配列。範囲選択時は selected〜compare 間の全コミットを返す */
+  /**
+   * 選択中のコミット配列。
+   *
+   * - 単一選択: そのコミット 1 つ
+   * - 範囲選択 + activeCommitHashes 取得済み: first-parent walk で得た実 diff 対象のみ。
+   *   walk 対象外の別枝コミットは除外する。range 内に UNCOMMITTED_HASH の端点があれば先頭に含める
+   * - 範囲選択 + activeCommitHashes 未取得（fetch 中）: range 内の全コミットをフォールバック表示
+   */
   const selectedCommits = computed<GitCommit[]>(() => {
     const map = hashToIndex.value;
 
@@ -45,33 +59,51 @@ export const useGitGraphStore = defineStore("gitGraph", () => {
       return idx !== undefined ? [commits.value[idx]] : [];
     }
 
-    // UNCOMMITTED_HASH を -1 として扱い、範囲の始点に含める
     const selectedIdx = selectedHash.value === UNCOMMITTED_HASH ? -1 : map.get(selectedHash.value);
     const compareIdx = compareHash.value === UNCOMMITTED_HASH ? -1 : map.get(compareHash.value);
     if (selectedIdx === undefined || compareIdx === undefined) return [];
 
     const minIdx = Math.min(selectedIdx, compareIdx);
     const maxIdx = Math.max(selectedIdx, compareIdx);
-    const result = commits.value.slice(Math.max(0, minIdx), maxIdx + 1);
-    if (minIdx === -1) result.unshift(uncommittedCommit);
+    const includesUncommitted = minIdx === -1;
+    const sliceStart = Math.max(0, minIdx);
+
+    const active = activeCommitHashes.value;
+    if (active !== null) {
+      const filtered = commits.value
+        .slice(sliceStart, maxIdx + 1)
+        .filter((c) => active.has(c.hash));
+      if (includesUncommitted) filtered.unshift(uncommittedCommit);
+      return filtered;
+    }
+
+    const result = commits.value.slice(sliceStart, maxIdx + 1);
+    if (includesUncommitted) result.unshift(uncommittedCommit);
     return result;
   });
 
   function select(hash: string) {
     selectedHash.value = hash;
     compareHash.value = null;
+    activeCommitHashes.value = null;
     selectionVersion.value++;
   }
 
   /** shift+クリックで範囲選択の終点を指定する */
   function selectCompare(hash: string) {
     compareHash.value = hash;
+    activeCommitHashes.value = null;
     selectionVersion.value++;
   }
 
   function resetSelection() {
     selectedHash.value = UNCOMMITTED_HASH;
     compareHash.value = null;
+    activeCommitHashes.value = null;
+  }
+
+  function setActiveCommitHashes(hashes: string[]) {
+    activeCommitHashes.value = new Set(hashes);
   }
 
   return {
@@ -81,9 +113,11 @@ export const useGitGraphStore = defineStore("gitGraph", () => {
     commits,
     selectedCommits,
     hashToIndex,
+    activeCommitHashes,
     select,
     selectCompare,
     resetSelection,
+    setActiveCommitHashes,
   };
 });
 

--- a/apps/renderer/src/features/git-graph/useGitGraphStore.ts
+++ b/apps/renderer/src/features/git-graph/useGitGraphStore.ts
@@ -43,11 +43,12 @@ export const useGitGraphStore = defineStore("gitGraph", () => {
   });
 
   /**
-   * 選択中のコミット配列。
+   * 選択中のコミット配列（CommitDetailPane が参照する diff 対象 commit 列）。
    *
    * - 単一選択: そのコミット 1 つ
    * - 範囲選択 + activeCommitHashes 取得済み: first-parent walk で得た実 diff 対象のみ。
    *   walk 対象外の別枝コミットは除外する。range 内に UNCOMMITTED_HASH の端点があれば先頭に含める
+   *   （Working Tree 端を含む range で uncommitted changes も diff 対象になるため）
    * - 範囲選択 + activeCommitHashes 未取得（fetch 中）: range 内の全コミットをフォールバック表示
    */
   const selectedCommits = computed<GitCommit[]>(() => {

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
@@ -219,6 +219,10 @@ public struct Gozd_V1_GitShowCommitFileResponse: Sendable {
 }
 
 /// gitCommitFiles: コミット（または 2 コミット間）の変更ファイル一覧
+///
+/// 単一 commit 選択時は hash のみを使う。range_hashes が非空なら range mode で、
+/// renderer が git-graph の表示順で slice した commit hash 列を渡す。Swift 側は
+/// 各 commit の first-parent diff を union して返す（git 祖先関係に依存しない）。
 public struct Gozd_V1_GitCommitFilesRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -229,6 +233,10 @@ public struct Gozd_V1_GitCommitFilesRequest: Sendable {
   public var hash: String = String()
 
   public var compareHash: String = String()
+
+  /// 範囲選択時の対象 commit 列。renderer が表示順で組み立てる（newer 端を含み older 端を含まない）。
+  /// 非空なら hash / compare_hash は無視され、各 commit の first-parent diff の union が返る。
+  public var rangeHashes: [String] = []
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -847,7 +855,7 @@ extension Gozd_V1_GitShowCommitFileResponse: SwiftProtobuf.Message, SwiftProtobu
 
 extension Gozd_V1_GitCommitFilesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GitCommitFilesRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}dir\0\u{1}hash\0\u{3}compare_hash\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}dir\0\u{1}hash\0\u{3}compare_hash\0\u{3}range_hashes\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -858,6 +866,7 @@ extension Gozd_V1_GitCommitFilesRequest: SwiftProtobuf.Message, SwiftProtobuf._M
       case 1: try { try decoder.decodeSingularStringField(value: &self.dir) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self.hash) }()
       case 3: try { try decoder.decodeSingularStringField(value: &self.compareHash) }()
+      case 4: try { try decoder.decodeRepeatedStringField(value: &self.rangeHashes) }()
       default: break
       }
     }
@@ -873,6 +882,9 @@ extension Gozd_V1_GitCommitFilesRequest: SwiftProtobuf.Message, SwiftProtobuf._M
     if !self.compareHash.isEmpty {
       try visitor.visitSingularStringField(value: self.compareHash, fieldNumber: 3)
     }
+    if !self.rangeHashes.isEmpty {
+      try visitor.visitRepeatedStringField(value: self.rangeHashes, fieldNumber: 4)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -880,6 +892,7 @@ extension Gozd_V1_GitCommitFilesRequest: SwiftProtobuf.Message, SwiftProtobuf._M
     if lhs.dir != rhs.dir {return false}
     if lhs.hash != rhs.hash {return false}
     if lhs.compareHash != rhs.compareHash {return false}
+    if lhs.rangeHashes != rhs.rangeHashes {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
@@ -218,11 +218,11 @@ public struct Gozd_V1_GitShowCommitFileResponse: Sendable {
   fileprivate var _to: Gozd_V1_FileReadResult? = nil
 }
 
-/// gitCommitFiles: コミット（または 2 コミット間）の変更ファイル一覧
+/// gitCommitFiles: コミット（または範囲指定）の変更ファイル一覧
 ///
 /// 単一 commit 選択時は hash のみを使う。range_hashes が非空なら range mode で、
-/// renderer が git-graph の表示順で slice した commit hash 列を渡す。Swift 側は
-/// 各 commit の first-parent diff を union して返す（git 祖先関係に依存しない）。
+/// renderer が git-graph の first-parent walk で組み立てた commit hash 列を渡す。Swift 側は
+/// 配列の先頭（newer）と末尾（older）の 2 endpoint で `git diff <older>^ <newer>` を実行する。
 public struct Gozd_V1_GitCommitFilesRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -234,9 +234,14 @@ public struct Gozd_V1_GitCommitFilesRequest: Sendable {
 
   public var compareHash: String = String()
 
-  /// 範囲選択時の対象 commit 列。renderer が表示順で組み立てる（newer 端を含み older 端を含まない）。
-  /// 非空なら hash / compare_hash は無視され、各 commit の first-parent diff の union が返る。
+  /// 範囲選択時の対象 commit 列。renderer が newer から first-parent walk で組み立てる。
+  /// 配列は newer (上端) から older (下端) の順で、両端を含む閉区間。
+  /// 非空なら hash / compare_hash は無視され、先頭と末尾の 2 endpoint diff が返る。
   public var rangeHashes: [String] = []
+
+  /// 範囲選択の片端が Working Tree（UNCOMMITTED_HASH）の場合 true。
+  /// Swift 側で `git diff <older>^` (第二引数省略 = working tree 比較) に切り替える。
+  public var includeWorkingTree: Bool = false
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -855,7 +860,7 @@ extension Gozd_V1_GitShowCommitFileResponse: SwiftProtobuf.Message, SwiftProtobu
 
 extension Gozd_V1_GitCommitFilesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GitCommitFilesRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}dir\0\u{1}hash\0\u{3}compare_hash\0\u{3}range_hashes\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}dir\0\u{1}hash\0\u{3}compare_hash\0\u{3}range_hashes\0\u{3}include_working_tree\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -867,6 +872,7 @@ extension Gozd_V1_GitCommitFilesRequest: SwiftProtobuf.Message, SwiftProtobuf._M
       case 2: try { try decoder.decodeSingularStringField(value: &self.hash) }()
       case 3: try { try decoder.decodeSingularStringField(value: &self.compareHash) }()
       case 4: try { try decoder.decodeRepeatedStringField(value: &self.rangeHashes) }()
+      case 5: try { try decoder.decodeSingularBoolField(value: &self.includeWorkingTree) }()
       default: break
       }
     }
@@ -885,6 +891,9 @@ extension Gozd_V1_GitCommitFilesRequest: SwiftProtobuf.Message, SwiftProtobuf._M
     if !self.rangeHashes.isEmpty {
       try visitor.visitRepeatedStringField(value: self.rangeHashes, fieldNumber: 4)
     }
+    if self.includeWorkingTree != false {
+      try visitor.visitSingularBoolField(value: self.includeWorkingTree, fieldNumber: 5)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -893,6 +902,7 @@ extension Gozd_V1_GitCommitFilesRequest: SwiftProtobuf.Message, SwiftProtobuf._M
     if lhs.hash != rhs.hash {return false}
     if lhs.compareHash != rhs.compareHash {return false}
     if lhs.rangeHashes != rhs.rangeHashes {return false}
+    if lhs.includeWorkingTree != rhs.includeWorkingTree {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
@@ -79,21 +79,27 @@ export interface GitShowCommitFileResponse {
 }
 
 /**
- * gitCommitFiles: コミット（または 2 コミット間）の変更ファイル一覧
+ * gitCommitFiles: コミット（または範囲指定）の変更ファイル一覧
  *
  * 単一 commit 選択時は hash のみを使う。range_hashes が非空なら range mode で、
- * renderer が git-graph の表示順で slice した commit hash 列を渡す。Swift 側は
- * 各 commit の first-parent diff を union して返す（git 祖先関係に依存しない）。
+ * renderer が git-graph の first-parent walk で組み立てた commit hash 列を渡す。Swift 側は
+ * 配列の先頭（newer）と末尾（older）の 2 endpoint で `git diff <older>^ <newer>` を実行する。
  */
 export interface GitCommitFilesRequest {
   dir: string;
   hash: string;
   compareHash: string;
   /**
-   * 範囲選択時の対象 commit 列。renderer が表示順で組み立てる（newer 端を含み older 端を含まない）。
-   * 非空なら hash / compare_hash は無視され、各 commit の first-parent diff の union が返る。
+   * 範囲選択時の対象 commit 列。renderer が newer から first-parent walk で組み立てる。
+   * 配列は newer (上端) から older (下端) の順で、両端を含む閉区間。
+   * 非空なら hash / compare_hash は無視され、先頭と末尾の 2 endpoint diff が返る。
    */
   rangeHashes: string[];
+  /**
+   * 範囲選択の片端が Working Tree（UNCOMMITTED_HASH）の場合 true。
+   * Swift 側で `git diff <older>^` (第二引数省略 = working tree 比較) に切り替える。
+   */
+  includeWorkingTree: boolean;
 }
 
 export interface GitCommitFilesResponse {
@@ -1078,7 +1084,7 @@ export const GitShowCommitFileResponse: MessageFns<GitShowCommitFileResponse> = 
 };
 
 function createBaseGitCommitFilesRequest(): GitCommitFilesRequest {
-  return { dir: "", hash: "", compareHash: "", rangeHashes: [] };
+  return { dir: "", hash: "", compareHash: "", rangeHashes: [], includeWorkingTree: false };
 }
 
 export const GitCommitFilesRequest: MessageFns<GitCommitFilesRequest> = {
@@ -1094,6 +1100,9 @@ export const GitCommitFilesRequest: MessageFns<GitCommitFilesRequest> = {
     }
     for (const v of message.rangeHashes) {
       writer.uint32(34).string(v!);
+    }
+    if (message.includeWorkingTree !== false) {
+      writer.uint32(40).bool(message.includeWorkingTree);
     }
     return writer;
   },
@@ -1137,6 +1146,14 @@ export const GitCommitFilesRequest: MessageFns<GitCommitFilesRequest> = {
           message.rangeHashes.push(reader.string());
           continue;
         }
+        case 5: {
+          if (tag !== 40) {
+            break;
+          }
+
+          message.includeWorkingTree = reader.bool();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1160,6 +1177,11 @@ export const GitCommitFilesRequest: MessageFns<GitCommitFilesRequest> = {
         : globalThis.Array.isArray(object?.range_hashes)
         ? object.range_hashes.map((e: any) => globalThis.String(e))
         : [],
+      includeWorkingTree: isSet(object.includeWorkingTree)
+        ? globalThis.Boolean(object.includeWorkingTree)
+        : isSet(object.include_working_tree)
+        ? globalThis.Boolean(object.include_working_tree)
+        : false,
     };
   },
 
@@ -1177,6 +1199,9 @@ export const GitCommitFilesRequest: MessageFns<GitCommitFilesRequest> = {
     if (message.rangeHashes?.length) {
       obj.rangeHashes = message.rangeHashes;
     }
+    if (message.includeWorkingTree !== false) {
+      obj.includeWorkingTree = message.includeWorkingTree;
+    }
     return obj;
   },
 
@@ -1189,6 +1214,7 @@ export const GitCommitFilesRequest: MessageFns<GitCommitFilesRequest> = {
     message.hash = object.hash ?? "";
     message.compareHash = object.compareHash ?? "";
     message.rangeHashes = object.rangeHashes?.map((e) => e) || [];
+    message.includeWorkingTree = object.includeWorkingTree ?? false;
     return message;
   },
 };

--- a/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
@@ -78,11 +78,22 @@ export interface GitShowCommitFileResponse {
   to: FileReadResult | undefined;
 }
 
-/** gitCommitFiles: コミット（または 2 コミット間）の変更ファイル一覧 */
+/**
+ * gitCommitFiles: コミット（または 2 コミット間）の変更ファイル一覧
+ *
+ * 単一 commit 選択時は hash のみを使う。range_hashes が非空なら range mode で、
+ * renderer が git-graph の表示順で slice した commit hash 列を渡す。Swift 側は
+ * 各 commit の first-parent diff を union して返す（git 祖先関係に依存しない）。
+ */
 export interface GitCommitFilesRequest {
   dir: string;
   hash: string;
   compareHash: string;
+  /**
+   * 範囲選択時の対象 commit 列。renderer が表示順で組み立てる（newer 端を含み older 端を含まない）。
+   * 非空なら hash / compare_hash は無視され、各 commit の first-parent diff の union が返る。
+   */
+  rangeHashes: string[];
 }
 
 export interface GitCommitFilesResponse {
@@ -1067,7 +1078,7 @@ export const GitShowCommitFileResponse: MessageFns<GitShowCommitFileResponse> = 
 };
 
 function createBaseGitCommitFilesRequest(): GitCommitFilesRequest {
-  return { dir: "", hash: "", compareHash: "" };
+  return { dir: "", hash: "", compareHash: "", rangeHashes: [] };
 }
 
 export const GitCommitFilesRequest: MessageFns<GitCommitFilesRequest> = {
@@ -1080,6 +1091,9 @@ export const GitCommitFilesRequest: MessageFns<GitCommitFilesRequest> = {
     }
     if (message.compareHash !== "") {
       writer.uint32(26).string(message.compareHash);
+    }
+    for (const v of message.rangeHashes) {
+      writer.uint32(34).string(v!);
     }
     return writer;
   },
@@ -1115,6 +1129,14 @@ export const GitCommitFilesRequest: MessageFns<GitCommitFilesRequest> = {
           message.compareHash = reader.string();
           continue;
         }
+        case 4: {
+          if (tag !== 34) {
+            break;
+          }
+
+          message.rangeHashes.push(reader.string());
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1133,6 +1155,11 @@ export const GitCommitFilesRequest: MessageFns<GitCommitFilesRequest> = {
         : isSet(object.compare_hash)
         ? globalThis.String(object.compare_hash)
         : "",
+      rangeHashes: globalThis.Array.isArray(object?.rangeHashes)
+        ? object.rangeHashes.map((e: any) => globalThis.String(e))
+        : globalThis.Array.isArray(object?.range_hashes)
+        ? object.range_hashes.map((e: any) => globalThis.String(e))
+        : [],
     };
   },
 
@@ -1147,6 +1174,9 @@ export const GitCommitFilesRequest: MessageFns<GitCommitFilesRequest> = {
     if (message.compareHash !== "") {
       obj.compareHash = message.compareHash;
     }
+    if (message.rangeHashes?.length) {
+      obj.rangeHashes = message.rangeHashes;
+    }
     return obj;
   },
 
@@ -1158,6 +1188,7 @@ export const GitCommitFilesRequest: MessageFns<GitCommitFilesRequest> = {
     message.dir = object.dir ?? "";
     message.hash = object.hash ?? "";
     message.compareHash = object.compareHash ?? "";
+    message.rangeHashes = object.rangeHashes?.map((e) => e) || [];
     return message;
   },
 };

--- a/packages/proto/gozd/v1/git_ops.proto
+++ b/packages/proto/gozd/v1/git_ops.proto
@@ -64,18 +64,22 @@ message GitShowCommitFileResponse {
   FileReadResult to = 2;
 }
 
-// gitCommitFiles: コミット（または 2 コミット間）の変更ファイル一覧
+// gitCommitFiles: コミット（または範囲指定）の変更ファイル一覧
 //
 // 単一 commit 選択時は hash のみを使う。range_hashes が非空なら range mode で、
-// renderer が git-graph の表示順で slice した commit hash 列を渡す。Swift 側は
-// 各 commit の first-parent diff を union して返す（git 祖先関係に依存しない）。
+// renderer が git-graph の first-parent walk で組み立てた commit hash 列を渡す。Swift 側は
+// 配列の先頭（newer）と末尾（older）の 2 endpoint で `git diff <older>^ <newer>` を実行する。
 message GitCommitFilesRequest {
   string dir = 1;
   string hash = 2;
   string compare_hash = 3;
-  // 範囲選択時の対象 commit 列。renderer が表示順で組み立てる（newer 端を含み older 端を含まない）。
-  // 非空なら hash / compare_hash は無視され、各 commit の first-parent diff の union が返る。
+  // 範囲選択時の対象 commit 列。renderer が newer から first-parent walk で組み立てる。
+  // 配列は newer (上端) から older (下端) の順で、両端を含む閉区間。
+  // 非空なら hash / compare_hash は無視され、先頭と末尾の 2 endpoint diff が返る。
   repeated string range_hashes = 4;
+  // 範囲選択の片端が Working Tree（UNCOMMITTED_HASH）の場合 true。
+  // Swift 側で `git diff <older>^` (第二引数省略 = working tree 比較) に切り替える。
+  bool include_working_tree = 5;
 }
 message GitCommitFilesResponse {
   repeated GitFileChange changes = 1;

--- a/packages/proto/gozd/v1/git_ops.proto
+++ b/packages/proto/gozd/v1/git_ops.proto
@@ -65,10 +65,17 @@ message GitShowCommitFileResponse {
 }
 
 // gitCommitFiles: コミット（または 2 コミット間）の変更ファイル一覧
+//
+// 単一 commit 選択時は hash のみを使う。range_hashes が非空なら range mode で、
+// renderer が git-graph の表示順で slice した commit hash 列を渡す。Swift 側は
+// 各 commit の first-parent diff を union して返す（git 祖先関係に依存しない）。
 message GitCommitFilesRequest {
   string dir = 1;
   string hash = 2;
   string compare_hash = 3;
+  // 範囲選択時の対象 commit 列。renderer が表示順で組み立てる（newer 端を含み older 端を含まない）。
+  // 非空なら hash / compare_hash は無視され、各 commit の first-parent diff の union が返る。
+  repeated string range_hashes = 4;
 }
 message GitCommitFilesResponse {
   repeated GitFileChange changes = 1;


### PR DESCRIPTION
## 概要

git-graph で別枝のコミットを範囲選択（shift+click）した際に Changes ペインへ無関係な diff が出ていた問題を修正する ( #443 )。範囲選択の対象 commit 集合を git の祖先関係ではなく **renderer 側の first-parent walk + 表示位置 stop** で算出するよう設計を変更し、UI の責務を「visual selection state」「actual diff target」「changes computation mode」の 3 概念に分離する。

## 背景

PR ( #441 ) の Codex レビューで判明した既存問題。`commitFiles` の range 経路が `git merge-base --is-ancestor` を片方向しか見ておらず、互いに非 ancestor な 2 コミットを選ぶと older/newer 判定が固定値に倒れて誤った diff が出ていた。

修正方針の検討で複数回の方向転換と Codex レビュー、ユーザーからの仕様明確化を経た:

- 当初: `git rev-list --first-parent <older>..<newer>` を Swift 側で実行
  - `^older` の除外集合は full ancestry なのに `--first-parent` は walk 側 (Y) にしか効かない非対称 semantics。older が newer の first-parent 線上にいないと除外が空振りし、共通祖先まで遡る walk になる
- 次案: renderer で `commits.slice(min, max)` を取って Swift に渡す
  - `mergeCommitStreams` は HEAD 系統と origin/HEAD 系統を date 順マージするため、別枝の独立コミットが date 的に間に挟まる
- 採用案: renderer 側で `commit.parents[0]` を辿る first-parent walk + 表示位置 stop。`mergeCommitStreams` の commits 配列に parents 情報があるので git fork 不要

加えて Codex レビューで以下のエッジケースが判明し、対応した:

- `loadLog()` で `commits` 配列が再構築されたとき rangeHashes / activeCommitHashes / Changes diff が再計算されない問題
- 各 commit の first-parent diff の union だと rename chain (foo→bar→baz) や rename 後 delete で logical file identity が壊れる問題 → `git diff <older>^ <newer>` の 2 endpoint diff に変更し git の rename detection に任せる
- rangeHashes が空のとき silently 単一 commit 経路にフォールバックする問題
- Working Tree を片端に含む範囲選択で、HEAD コミット差分が混入する問題 (origin/main 等が進行している場合のみ uncommitted-only に倒すべき)

## 変更内容

### 範囲選択の対象 commit 集合の算出

- `apps/renderer/src/features/changes/ChangesPane.vue` に `buildRangeHashes` を追加
  - newer (上端) から `commit.parents[0]` を辿って older の表示 index に到達 (含む) か超えたら停止
  - UNCOMMITTED_HASH 端は newer 側なら HEAD ref を持つ commit を walk 開始点にフォールバック、older 側なら stopIdx = Infinity でフォールバック
- watcher 依存に `gitGraphStore.commits` を追加し、commits 再構築で再評価する

### 3 概念の分離 (Codex レビュー指摘への対応)

| 概念 | 担当 | 振る舞い |
|---|---|---|
| visual selection state | `isSelectedRow` (GitGraphPane) | shift+click で選んだ範囲の青背景。`selectedHash / compareHash / isInRange` のみで判定 |
| actual diff target | `activeCommitHashes` + `isActiveDot` (GitGraphPane) | first-parent walk で得た commit のみ dot 強調 (branch color 塗りつぶし) |
| changes computation mode | `fileChanges` computed (ChangesPane) | gitStatuses or RPC 結果のいずれかを返す |

### Working Tree 端の扱い

- `headHash` / `includesWorkingTree` / `otherEndpointHash` / `workingTreeOnly` の computed を追加
- `workingTreeOnly` 判定: 「片端が Working Tree かつもう片端が HEAD ref を持つ commit、かつ HEAD が表示順で最上位ではない」
  - HEAD が `commits[0]` (= 通常ケース、Working Tree → HEAD 直接隣接): `workingTreeOnly = false` → 通常 range として `git diff <HEAD>^` で HEAD コミット差分 + uncommitted changes
  - HEAD が `commits[0]` でない (= origin/main 等が進行中で間に他枝 commit が挟まる): `workingTreeOnly = true` → uncommitted only (RPC 呼ばず gitStatuses)
- `workingTreeOnly === true` のとき:
  - `setActiveCommitHashes([])` で空集合をセット → Detail pane / dot 強調が単一 Working Tree 選択と一致
  - RPC を呼ばず `gitStatuses` を直接表示 (`fileChanges` computed が処理)
  - `isSelectedRow` は visual range のままなので青背景は維持される
- 通常 range (Working Tree 片端含む): `include_working_tree=true` を送って Swift 側で `git diff <older>^` (working tree との比較)
- HEAD ref が見つからない場合: RPC 呼ばず空に倒す

### Working Tree 行の dot ハイライト

- `isWorkingTreeActive` computed を追加。`selectedHash === UNCOMMITTED_HASH || compareHash === UNCOMMITTED_HASH` のとき true
- Working Tree 行の SVG circle の `fill` / `r` を bind して、選択時に teal で塗りつぶし (size +1)。単一選択も範囲片端も同じ見た目

### Backend API

- `GitCommitFilesRequest` に `range_hashes` (field 4) と `include_working_tree` (field 5) を追加
- `commit_hashes` レスポンスフィールドは廃止（renderer が source of truth）
- Swift 側 `GitOps.commitFiles`: range_hashes が非空ならその経路で配列の先頭 (newer) と末尾 (older) を 2 endpoint として `git diff <older>^ <newer>` を 1 回実行（rename chain は git の rename detection に任せる）。`includeWorkingTree=true` なら `git diff <older>^` (working tree 比較) に切り替え。older が root commit なら empty tree 起点
- 不要になった `isAncestor` ヘルパーを削除

### git-graph の UI 統一

- 範囲選択の濃淡 2 段階ハイライトを廃止し、行 background は visual range の単一色に統一
- 単一選択時もコミットの dot を branch color で塗りつぶす形に統一
- `useGitGraphStore` に `activeCommitHashes: Set<string> | null` と `setActiveCommitHashes` を追加。`select` / `selectCompare` / `resetSelection` で null クリア
- `selectedCommits` computed (CommitDetailPane が参照) も `activeCommitHashes` でフィルタ

## 確認事項

- [ ] 別枝の cross-branch range で「先端ブランチ → main first-parent」と表示順通りに対象 commit が並ぶこと
- [ ] HEAD 上の上下 2 コミットを範囲選択し、両端含む閉区間で対象 commit が出ること
- [ ] 単一コミット選択時に dot が branch color で塗られ、行 background が単一色で表示されること
- [ ] 範囲選択の older 端が別枝にいる場合、walk が通り過ぎて older 自身が対象に含まれないこと
- [ ] rename chain (`foo → bar → baz` のような連鎖) が含まれる範囲で 1 ファイル分のエントリにまとまること
- [ ] **Working Tree + HEAD (HEAD が最上位、通常ケース)** の範囲選択で HEAD コミット差分 + uncommitted changes が出ること
- [ ] **Working Tree + HEAD (origin/main 進行中、HEAD が最上位ではない)** の範囲選択で uncommitted changes のみが出ること (Detail pane に HEAD commit が出ない、HEAD dot 強調なし、青背景は visual range 維持)
- [ ] Working Tree + HEAD の親コミットの範囲選択で `git diff <older>^` (uncommitted changes + コミット差分) が表示されること
- [ ] 単一 Working Tree 選択時 / 範囲選択の片端が Working Tree のとき、Working Tree 行の dot が teal で塗りつぶしハイライトされること
- [ ] `git fetch` / branch update 等で commits 配列が再構築されたあと、選択範囲のハイライト・Detail・Changes が新しい first-parent 線で再計算されること
