### PR TITLE
fix(navigator): prevent Changes pane from collapsing on initial mount

### DIFF
--- a/apps/renderer/src/features/navigator/NavigatorPane.vue
+++ b/apps/renderer/src/features/navigator/NavigatorPane.vue
@@ -37,10 +37,12 @@ const filerWrapperRef = useTemplateRef<HTMLElement>("filerWrapper");
 const containerRef = useTemplateRef<HTMLElement>("container");
 const { height: containerHeight } = useElementSize(containerRef);
 
-const changesHeight = ref(200);
+const changesHeight = ref(360);
 
 // コンテナ縮小時に changesHeight をクランプ（Filer が潰れるのを防ぐ）
+// useElementSize は mount 直後 0 を返すため、計測前は clamp をスキップする
 watchEffect(() => {
+  if (containerHeight.value <= 0) return;
   const maxChanges = containerHeight.value - FILER_MIN_HEIGHT - HANDLE_HEIGHT;
   if (changesHeight.value > maxChanges) {
     changesHeight.value = Math.max(CHANGES_MIN_HEIGHT, maxChanges);


### PR DESCRIPTION
## 概要

NavigatorPane 下部の Changes ペインが起動直後に最小高さ (60px) まで潰れる問題を修正する。

## 背景

サイドバー右下の Changes 欄が初期表示で極端に狭く、ヘッダーと 1 行ぶんしか見えない状態だった。
原因は `NavigatorPane.vue` の clamp ロジックにある。

- `useElementSize(containerRef)` は mount 直後の最初の ResizeObserver tick まで `0` を返す
- その瞬間 `watchEffect` が走ると `maxChanges = 0 - FILER_MIN_HEIGHT - HANDLE_HEIGHT = -108` となる
- `changesHeight (200) > -108` が成立し、`Math.max(CHANGES_MIN_HEIGHT, -108) = 60` に書き換わる
- その後コンテナの実寸が届いても、もう `changesHeight > maxChanges` の条件には引っかからないので戻らない

つまり「コンテナ縮小時のクランプ」が、実体は計測前の偽の縮小に反応して初期高さを破壊していた。

## 変更内容

### apps/renderer/src/features/navigator/NavigatorPane.vue

- `containerHeight <= 0` のときは clamp をスキップする (計測前の `0` を縮小と誤認しない)
- `changesHeight` の初期値を 200 → 360 に引き上げ、初回描画で十分な行数が見えるようにする

## 確認事項

- [ ] git リポジトリを開いた直後、右下の Changes ペインが 360px 程度の高さで表示される
- [ ] ResizeHandle で Changes を縮小／拡大できる
- [ ] ウィンドウを縦に縮めたとき、Filer が `FILER_MIN_HEIGHT` を割らない範囲で Changes が縮む
- [ ] git リポジトリでない worktree を開いたとき Filer のみが表示される (Changes と ResizeHandle が出ない)
