### PR TITLE
fix(git-status): subscribe gitStatusChange push to refresh active dir without switch

### DIFF
--- a/apps/native/Sources/GozdCore/FSWatchRegistry.swift
+++ b/apps/native/Sources/GozdCore/FSWatchRegistry.swift
@@ -32,6 +32,11 @@ public actor FSWatchRegistry {
     let watcher: FSWatcher
     let task: Task<Void, Never>
     let continuation: AsyncStream<[FSWatcher.Event]>.Continuation
+    /// `/fs/watch` で renderer から渡された原文の dir。
+    /// push event の payload はこの値を返し、renderer 側の `worktreeStore.dir` /
+    /// `wt.path` 等の生文字列キーと直接比較できるようにする。
+    /// （entries のキーは `realpath` 解決済み path で、FSEvents の path 比較に使う）
+    let originalDir: String
   }
 
   private struct Classification {
@@ -90,7 +95,8 @@ public actor FSWatchRegistry {
     }
 
     entries[dir] = Entry(
-      generation: generation, watcher: watcher, task: task, continuation: continuation)
+      generation: generation, watcher: watcher, task: task, continuation: continuation,
+      originalDir: userDir)
   }
 
   /// dir の監視を停止する。watch されていなければ no-op。
@@ -110,8 +116,14 @@ public actor FSWatchRegistry {
 
   /// 1 バッチの events を分類して push event として配送する。
   /// 各 await 後にも `isActive` を再 check し、unwatch 済みの世代からの dispatch を抑止する。
+  ///
+  /// push payload には `originalDir`（renderer が `/fs/watch` で渡した原文 dir）を使う。
+  /// FSEvents の path 比較に使う `dir`（realpath 解決済み）とは別に保持しているのは、
+  /// renderer 側の `worktreeStore.dir` / `wt.path` が生文字列で扱われるため、
+  /// realpath を返すと symlink 経路（`/var` vs `/private/var` 等）で比較が外れるから。
   private func handleEvents(dir: String, generation: UInt64, events: [FSWatcher.Event]) async {
     guard isActive(dir: dir, generation: generation) else { return }
+    guard let originalDir = entries[dir]?.originalDir else { return }
 
     let result = FSWatchRegistry.classify(dir: dir, events: events)
 
@@ -120,21 +132,21 @@ public actor FSWatchRegistry {
 
     if result.hasFsChange {
       for relDir in result.fsRelDirs {
-        onFsChange(dir, relDir)
+        onFsChange(originalDir, relDir)
       }
     }
     if result.hasBranchChange {
-      onBranchChange(dir)
+      onBranchChange(originalDir)
     }
     if result.hasWorktreeChange {
-      onWorktreeChange(dir)
+      onWorktreeChange(originalDir)
     }
 
     if result.hasGitStatusChange {
       let status = try? await GitOps.gitStatusFull(dir: dir)
       // gitStatusFull の await 中に unwatch されている可能性があるため再 check
       guard isActive(dir: dir, generation: generation), let status else { return }
-      onGitStatusChange(dir, status)
+      onGitStatusChange(originalDir, status)
     }
   }
 

--- a/apps/renderer/src/features/worktree/useGitStatusStore.ts
+++ b/apps/renderer/src/features/worktree/useGitStatusStore.ts
@@ -37,7 +37,13 @@ export const useGitStatusStore = defineStore("gitStatus", () => {
     }
   }
 
+  /**
+   * push event 経由で受け取った最新 statuses を即時反映する。
+   * loadGen を進めることで、先行する loadGitStatus の RPC が後から返ってきても
+   * その結果で上書きされないようにする（push が truth source）。
+   */
   function setGitStatuses(statuses: Record<string, string>) {
+    loadGen++;
     gitStatuses.value = statuses;
   }
 

--- a/apps/renderer/src/features/worktree/useGitStatusSync.ts
+++ b/apps/renderer/src/features/worktree/useGitStatusSync.ts
@@ -1,13 +1,16 @@
 /**
  * 選択中 dir の git status を最新に保つ app-scope な watcher。
  *
- * docs/workspace.md の「git status は選択中 dir のみ」方針に従い、以下のトリガで loadGitStatus する:
- * - dir 切替時（fsChange / gitStatusChange は watch 開始時には push されないため、切替自体をトリガに含める）
+ * docs/workspace.md の「git status は選択中 dir のみ」方針に従い、以下のトリガで store を更新する:
+ * - dir 切替時（gitStatusChange は watch 開始時には push されないため、切替自体をトリガに含める）
  * - 同 dir に紐づく PTY の Claude state 遷移時（fs 変更がない静的な repo でも反映させるため）
+ * - native 側 FSWatchRegistry からの gitStatusChange push（外部エディタ等での編集を反映）
  */
-import { watch } from "vue";
+import { onMounted, onUnmounted, watch } from "vue";
 import { useRepoStore } from "../../shared/repo";
+import { onMessage } from "../../shared/rpc";
 import { useTerminalStore } from "../terminal";
+import type { GitStatusChangePayload } from "./rpc";
 import { useGitStatusStore } from "./useGitStatusStore";
 import { useWorktreeStore } from "./useWorktreeStore";
 
@@ -40,4 +43,15 @@ export function useGitStatusSync() {
       void gitStatusStore.loadGitStatus();
     },
   );
+
+  let cleanup: (() => void) | undefined;
+  onMounted(() => {
+    cleanup = onMessage<GitStatusChangePayload>("gitStatusChange", (payload) => {
+      if (payload.dir !== worktreeStore.dir) return;
+      gitStatusStore.setGitStatuses(payload.statuses);
+    });
+  });
+  onUnmounted(() => {
+    cleanup?.();
+  });
 }


### PR DESCRIPTION
## 概要

選択中 worktree の git status が worktree 切替時にしか更新されず、外部エディタや CLI から作業ツリーを変更しても Changes ペインや status badge に反映されない問題を修正する。`useGitStatusSync` で native 側からの `gitStatusChange` push を購読し、active dir 一致時に payload を `gitStatusStore` に直接流す。あわせて push と先行 RPC のレース、および native 側の realpath 化された payload.dir と renderer 側の生 dir 比較がずれる問題も解消する。

## 背景

`docs/workspace.md` の方針では「git status は FS watch event **または** その dir に紐づく PTY の Claude state 変化」で更新されると明記されている（`docs/workspace.md:147`）。native 側 `FSWatchRegistry` は `<dir>/.git/index` / `HEAD` 変更や作業ツリー変更を検知して payload 付きで `gitStatusChange` を push しており、push 経路は完全に動作している（`apps/native/Sources/GozdCore/FSWatchRegistry.swift`）。

ところが renderer 側で push を受けて `gitStatusStore` を更新する経路が落ちていた。

PR ( #420 ) の Electrobun → Swift 移行時に、旧版で `FilerPane.vue` が担っていた `gitStatusChange` push 購読 → `setGitStatuses(statuses)` の処理が `useSidebarData.ts` の `fetchOwnerOfActive()` に集約された。しかし `fetchOwnerOfActive()` は worktree / branch 一覧の再取得しか行わず、選択中 dir の `gitStatusStore.gitStatuses` は更新しない。結果として `useGitStatusSync` の「dir 切替」と「Claude state 遷移」だけが store 更新トリガとして残り、Claude を介さない外部からの変更が即時反映されなくなっていた。

Codex レビューで以下の追加問題が指摘され、本 PR で同時に対応した:

- 高: `gitStatusStore.setGitStatuses` で世代カウンタを進めていないため、push が反映された直後に先行する `loadGitStatus()` の RPC レスポンスが返ると、その古い値で push 由来の最新 statuses を上書きするレースがある
- 中: native 側 `FSWatchRegistry` は push payload の `dir` を `realpath()` 解決済みの値で送るが、renderer 側は `worktreeStore.dir` を生文字列のまま比較しており、symlink 経路（`/var` vs `/private/var` 等）で `payload.dir === worktreeStore.dir` が外れて active worktree 向けの push を捨てる可能性がある

## 変更内容

### `apps/renderer/src/features/worktree/useGitStatusSync.ts`

- `gitStatusChange` push event を `onMessage` で購読
- `payload.dir` が `worktreeStore.dir` と一致するときのみ `gitStatusStore.setGitStatuses(payload.statuses)` を呼ぶ
- `rpcGitStatus` の再実行はしない（payload にすでに statuses が含まれているため）
- `onUnmounted` で listener を解除
- ファイル冒頭の docコメントを実態に合わせて更新（push 購読も明記）

### `apps/renderer/src/features/worktree/useGitStatusStore.ts`

- `setGitStatuses` 内で `loadGen++` を行い、push 到着時点で先行する `loadGitStatus()` の RPC レスポンスを stale 扱いにして上書きされないようにする

### `apps/native/Sources/GozdCore/FSWatchRegistry.swift`

- `Entry` に `originalDir: String` を追加し、`/fs/watch` で renderer から渡された原文 dir を保持
- `handleEvents` で各 callback (`onFsChange` / `onGitStatusChange` / `onBranchChange` / `onWorktreeChange`) に渡す dir を `entries[dir]?.originalDir` に変更
- `entries` のキー（FSEvents path 比較用）と `GitOps.gitStatusFull(dir:)` に渡す dir は引き続き realpath 解決済みの値を使う。watch の実体管理と renderer 向け識別子を分離する形にした

### 影響範囲

- `FsChangePayload` の dir フィールド: `FilerPane.vue` / `PreviewPane.vue` は `relDir` のみ参照するため、payload の dir が realpath から userDir に変わっても影響なし
- `BranchChangePayload` / `WorktreeChangePayload`: `useSidebarData` の listener は payload を見ず `worktreeStore.dir` を起点に `fetchOwnerOfActive` を呼ぶため影響なし
- `GitStatusChangePayload`: 今回追加した `useGitStatusSync` の listener が payload.dir を比較に使うため、native 側で生 dir に揃える必要がある

## 確認事項

- [ ] 選択中 worktree で外部エディタからファイルを編集すると、ターミナル / Claude を介さずとも Changes ペインの一覧が即時更新される
- [ ] 選択中 worktree で `git add` / `git restore` などの CLI 操作を行うと status が即時反映される
- [ ] dir 切替や Claude state 変化で `loadGitStatus()` を投げた直後に push が届いた場合、先行 RPC のレスポンスが push 由来の最新 statuses を上書きしない
- [ ] symlink 経路の worktree path（`/var` vs `/private/var` 等）でも push が active dir 向けに正しく適用される
- [ ] 非選択 worktree の状態は変わらない（FS watch は active dir のみ、という方針は維持）
- [ ] worktree 切替時に旧 dir の listener が新 dir にも誤反応しない（`worktreeStore.dir` 一致チェックで弾かれる）
- [ ] swift test FSWatchRegistryTests 全 3 テスト pass（ローカル確認済み）
