### PR TITLE
fix(sidebar): restore per-worktree git diff badges after Swift rewrite

### DIFF
--- a/apps/native/Sources/GozdCore/ProcessExec.swift
+++ b/apps/native/Sources/GozdCore/ProcessExec.swift
@@ -261,6 +261,13 @@ func runProcessCollectingOutput(
           processLock.withLock { $0 = nil }
           throw error
         }
+        // run() 直後にキャンセル済みなら自分で terminate する。
+        // 「Task.isCancelled の事前チェック → run() 起動完了 → isRunning=true 遷移」の
+        // 一連の中で onCancel が走った場合、isRunning がまだ false の window を見て
+        // terminate がスキップされる可能性がある。run() 後の自前チェックで救う。
+        if Task.isCancelled {
+          process.terminate()
+        }
         DispatchQueue.global(qos: .userInitiated).async {
           let data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
           stdoutLock.withLock { $0 = data }

--- a/apps/native/Sources/GozdCore/ProcessExec.swift
+++ b/apps/native/Sources/GozdCore/ProcessExec.swift
@@ -224,39 +224,63 @@ func runProcessCollectingOutput(
   stderrPipe: Pipe,
   afterRun: () -> Void = {}
 ) async throws -> (stdout: Data, stderr: Data) {
-  try await withCheckedThrowingContinuation {
-    (cont: CheckedContinuation<(stdout: Data, stderr: Data), Error>) in
-    let stdoutLock = OSAllocatedUnfairLock<Data>(initialState: Data())
-    let stderrLock = OSAllocatedUnfairLock<Data>(initialState: Data())
-    let group = DispatchGroup()
+  // Task cancellation 対応:
+  // 親 Task（例: withThrowingTaskGroup の sibling 失敗）が cancel されたとき、
+  // 子 Process を SIGTERM して fail-fast にする。`withTaskCancellationHandler` で
+  // continuation を包むことで cancel ハンドラから process.terminate() を呼べる。
+  // process は actor 越しの参照を避けるため `nonisolated(unsafe)` ラッパーは使わず、
+  // OSAllocatedUnfairLock で Process? を保護する。
+  let processLock = OSAllocatedUnfairLock<Process?>(initialState: nil)
+  return try await withTaskCancellationHandler {
+    try await withCheckedThrowingContinuation {
+      (cont: CheckedContinuation<(stdout: Data, stderr: Data), Error>) in
+      let stdoutLock = OSAllocatedUnfairLock<Data>(initialState: Data())
+      let stderrLock = OSAllocatedUnfairLock<Data>(initialState: Data())
+      let group = DispatchGroup()
 
-    group.enter()
-    process.terminationHandler = { _ in
-      group.leave()
+      group.enter()
+      process.terminationHandler = { _ in
+        group.leave()
+      }
+
+      do {
+        // run() 前に既に cancel 済みなら起動せずに即返す
+        if Task.isCancelled {
+          cont.resume(throwing: CancellationError())
+          return
+        }
+        group.enter()
+        group.enter()
+        try process.run()
+        processLock.withLock { $0 = process }
+        DispatchQueue.global(qos: .userInitiated).async {
+          let data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+          stdoutLock.withLock { $0 = data }
+          group.leave()
+        }
+        DispatchQueue.global(qos: .userInitiated).async {
+          let data = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+          stderrLock.withLock { $0 = data }
+          group.leave()
+        }
+        afterRun()
+        group.notify(queue: DispatchQueue.global()) {
+          processLock.withLock { $0 = nil }
+          let stdout = stdoutLock.withLock { $0 }
+          let stderr = stderrLock.withLock { $0 }
+          cont.resume(returning: (stdout, stderr))
+        }
+      } catch {
+        cont.resume(throwing: GitError.launchFailed(error.localizedDescription))
+      }
     }
-
-    do {
-      group.enter()
-      group.enter()
-      try process.run()
-      DispatchQueue.global(qos: .userInitiated).async {
-        let data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-        stdoutLock.withLock { $0 = data }
-        group.leave()
+  } onCancel: {
+    // 起動済みの Process を SIGTERM で止める。terminationHandler が group.leave() を
+    // 呼び、stdout/stderr drain が EOF で抜けて group.notify が cont を resume する。
+    processLock.withLock { proc in
+      if let proc, proc.isRunning {
+        proc.terminate()
       }
-      DispatchQueue.global(qos: .userInitiated).async {
-        let data = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-        stderrLock.withLock { $0 = data }
-        group.leave()
-      }
-      afterRun()
-      group.notify(queue: DispatchQueue.global()) {
-        let stdout = stdoutLock.withLock { $0 }
-        let stderr = stderrLock.withLock { $0 }
-        cont.resume(returning: (stdout, stderr))
-      }
-    } catch {
-      cont.resume(throwing: GitError.launchFailed(error.localizedDescription))
     }
   }
 }

--- a/apps/native/Sources/GozdCore/ProcessExec.swift
+++ b/apps/native/Sources/GozdCore/ProcessExec.swift
@@ -251,8 +251,16 @@ func runProcessCollectingOutput(
         }
         group.enter()
         group.enter()
-        try process.run()
+        // run() の前に processLock に格納する。run() と格納の間に onCancel が
+        // 走っても、onCancel 側は `proc.isRunning` を見るので未起動なら何もしない。
+        // run() が throw した場合は catch で nil に戻す。
         processLock.withLock { $0 = process }
+        do {
+          try process.run()
+        } catch {
+          processLock.withLock { $0 = nil }
+          throw error
+        }
         DispatchQueue.global(qos: .userInitiated).async {
           let data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
           stdoutLock.withLock { $0 = data }

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -342,19 +342,19 @@ public actor RpcDispatcher {
     let worktrees = try await GitOps.worktreeList(dir: req.dir)
     let allTasks = try await tasks.list(dir: req.dir)
     // サイドバーで各 worktree に変更ファイル数を出すため、worktree ごとに git status を並列取得する。
-    // 取得失敗（worktree ディレクトリ消失等）は空 dict で握り潰す（旧 Bun 実装と同じ tolerance）。
-    let statusesByPath: [String: [String: String]] = await withTaskGroup(
+    // 1 worktree でも失敗したら集約段階で throw して上位（renderer 側 tryCatch → notify.error）に伝える。
+    let statusesByPath: [String: [String: String]] = try await withThrowingTaskGroup(
       of: (String, [String: String]).self
     ) { group in
       for wt in worktrees {
         let path = wt.path
         group.addTask {
-          let statuses = (try? await GitOps.gitStatus(dir: path)) ?? [:]
+          let statuses = try await GitOps.gitStatus(dir: path)
           return (path, statuses)
         }
       }
       var result: [String: [String: String]] = [:]
-      for await (path, statuses) in group { result[path] = statuses }
+      for try await (path, statuses) in group { result[path] = statuses }
       return result
     }
     var resp = Gozd_V1_GitWorktreeListResponse()

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -340,8 +340,23 @@ public actor RpcDispatcher {
   private func handleGitWorktreeList(_ body: Data) async throws -> Data {
     let req = try Gozd_V1_GitWorktreeListRequest(jsonUTF8Data: body)
     let worktrees = try await GitOps.worktreeList(dir: req.dir)
-    let statuses = try await GitOps.gitStatus(dir: req.dir)
     let allTasks = try await tasks.list(dir: req.dir)
+    // サイドバーで各 worktree に変更ファイル数を出すため、worktree ごとに git status を並列取得する。
+    // 取得失敗（worktree ディレクトリ消失等）は空 dict で握り潰す（旧 Bun 実装と同じ tolerance）。
+    let statusesByPath: [String: [String: String]] = await withTaskGroup(
+      of: (String, [String: String]).self
+    ) { group in
+      for wt in worktrees {
+        let path = wt.path
+        group.addTask {
+          let statuses = (try? await GitOps.gitStatus(dir: path)) ?? [:]
+          return (path, statuses)
+        }
+      }
+      var result: [String: [String: String]] = [:]
+      for await (path, statuses) in group { result[path] = statuses }
+      return result
+    }
     var resp = Gozd_V1_GitWorktreeListResponse()
     resp.worktrees = worktrees.map { wt in
       var entry = Gozd_V1_WorktreeEntry()
@@ -349,10 +364,7 @@ public actor RpcDispatcher {
       entry.head = wt.head
       entry.branch = wt.branch ?? ""
       entry.isMain = wt.isMain
-      // active worktree の status のみ返す（旧実装互換）
-      if wt.path == req.dir {
-        entry.gitStatuses = statuses
-      }
+      entry.gitStatuses = statusesByPath[wt.path] ?? [:]
       // この worktree に紐づく Task を埋める
       if let task = allTasks.first(where: { $0.worktreeDir == wt.path }) {
         entry.task = task

--- a/apps/renderer/src/features/filer/FilerPane.vue
+++ b/apps/renderer/src/features/filer/FilerPane.vue
@@ -144,8 +144,9 @@ function handleFsChange(relDir: string) {
   }
 }
 
-async function handleGitStatusChange(statuses: Record<string, string>) {
-  gitStatusStore.setGitStatuses(statuses);
+async function handleGitStatusChange() {
+  // gitStatuses 自体は useGitStatusSync が repoStore に書き込み済み。
+  // ここではファイルツリーの再構築（新規 / 削除ファイル反映）だけを行う。
   const dirPath = dir.value;
   if (dirPath === undefined) return;
   try {
@@ -173,8 +174,8 @@ watch(
 const unsubscribeFsChange = onMessage<FsChangePayload>("fsChange", ({ relDir }) =>
   handleFsChange(relDir),
 );
-const unsubscribeGitStatus = onMessage<GitStatusChangePayload>("gitStatusChange", ({ statuses }) =>
-  handleGitStatusChange(statuses),
+const unsubscribeGitStatus = onMessage<GitStatusChangePayload>("gitStatusChange", () =>
+  handleGitStatusChange(),
 );
 onUnmounted(() => {
   unsubscribeFsChange();

--- a/apps/renderer/src/features/sidebar/useSidebarData.ts
+++ b/apps/renderer/src/features/sidebar/useSidebarData.ts
@@ -172,9 +172,10 @@ export function useSidebarData() {
 
   const cleanups: Array<() => void> = [];
   onMounted(() => {
-    // gitStatusChange / branchChange / worktreeChange は active dir watch から発火するので
-    // active を所有する repo だけを refetch する。他 repo は別経路で更新する
-    cleanups.push(onMessage("gitStatusChange", () => fetchOwnerOfActive()));
+    // branchChange / worktreeChange は worktree 構成自体が変わるので worktree list の
+    // 全件再取得が必要。gitStatusChange は payload に dir + statuses を持ち、
+    // useGitStatusSync が repoStore.setWorktreeGitStatuses で該当 wt のみ更新するため
+    // ここで全件 refetch を走らせない（N 倍の git status 実行を避ける）。
     cleanups.push(onMessage<BranchChangePayload>("branchChange", () => fetchOwnerOfActive()));
     cleanups.push(onMessage<WorktreeChangePayload>("worktreeChange", () => fetchOwnerOfActive()));
     void hydrateAppState();

--- a/apps/renderer/src/features/sidebar/useSidebarData.ts
+++ b/apps/renderer/src/features/sidebar/useSidebarData.ts
@@ -38,6 +38,15 @@ export function useSidebarData() {
     const gen = (fetchGenByRoot.get(rootDir) ?? 0) + 1;
     fetchGenByRoot.set(rootDir, gen);
 
+    // fetch 開始時点の per-wt gitStatuses 世代スナップショット。
+    // RPC 往復中に gitStatusChange push / loadGitStatus が走って個別 wt の status を
+    // 更新した場合、ここで取った世代より進んでいるので、レスポンスの古い gitStatuses を
+    // 捨てて現値を保持する判断に使う。
+    const gitStatusGenSnapshot = new Map<string, number>();
+    for (const wt of repo.worktrees) {
+      gitStatusGenSnapshot.set(wt.path, repoStore.getGitStatusGen(wt.path));
+    }
+
     const result = await tryCatch(
       Promise.all([rpcGitWorktreeList({ dir: rootDir }), rpcGitBranchList({ dir: rootDir })]),
     );
@@ -55,7 +64,7 @@ export function useSidebarData() {
     const newPaths = new Set(wtList.map((wt) => wt.path));
     const stalePaths = repo.worktrees.map((w) => w.path).filter((p) => !newPaths.has(p));
 
-    repoStore.updateRepoData(rootDir, wtList, newFreeBranches);
+    repoStore.updateRepoData(rootDir, wtList, newFreeBranches, gitStatusGenSnapshot);
 
     for (const dir of stalePaths) terminalStore.remove(dir);
   }

--- a/apps/renderer/src/features/worktree/useGitStatusStore.ts
+++ b/apps/renderer/src/features/worktree/useGitStatusStore.ts
@@ -1,53 +1,60 @@
 import { tryCatch } from "@gozd/shared";
 import { acceptHMRUpdate, defineStore } from "pinia";
-import { ref } from "vue";
+import { computed } from "vue";
 import { useNotificationStore } from "../../shared/notification";
 import { useRepoStore } from "../../shared/repo";
 import { rpcGitStatus } from "./rpc";
-import { useWorktreeStore } from "./useWorktreeStore";
 
+/**
+ * active worktree の git status を提供する読み取り専用 store。
+ *
+ * 真の source は `repoStore.repos[rootDir].worktrees[i].gitStatuses`。
+ * この store は active dir に対応する worktree.gitStatuses を派生 computed として
+ * 公開し、書き込みは `repoStore.setWorktreeGitStatuses(dir, statuses)` に集約する。
+ *
+ * 設計理由:
+ *
+ * - サイドバーは `wt.gitStatuses` を直接読むため、別 store に最新値を持つと
+ *   gitStatusChange push 受信時に「サイドバーは更新されないが Filer は更新される」
+ *   という SSOT 違反が起きる
+ * - ファイル変更 push に対し、Swift 側に worktree list を全件再 RPC させる経路を
+ *   挟まずに、push payload を直接 repoStore に書いて全リーダーへ伝搬させる
+ */
 export const useGitStatusStore = defineStore("gitStatus", () => {
-  const gitStatuses = ref<Record<string, string>>({});
-
   const repoStore = useRepoStore();
-  const worktreeStore = useWorktreeStore();
+
+  /** active dir の gitStatuses を repoStore から派生させる */
+  const gitStatuses = computed<Record<string, string>>(() => {
+    const dir = repoStore.selectedDir;
+    if (dir === undefined) return {};
+    const repo = repoStore.findRepoOwning(dir);
+    const wt = repo?.worktrees.find((w) => w.path === dir);
+    return wt?.gitStatuses ?? {};
+  });
 
   /** 並行 loadGitStatus で古いレスポンスが新しい結果を上書きするのを防ぐ世代カウンタ */
   let loadGen = 0;
 
+  /**
+   * active dir の git status を rpcGitStatus で取得し直して repoStore を更新する。
+   * dir 切替時 / Claude state 遷移時 / Filer の初期読み込みで呼ばれる。
+   */
   async function loadGitStatus() {
     const gen = ++loadGen;
-    if (!repoStore.selectedIsGitRepo) {
-      gitStatuses.value = {};
-      return;
-    }
-    const dir = worktreeStore.dir;
-    if (dir === undefined) {
-      gitStatuses.value = {};
-      return;
-    }
+    if (!repoStore.selectedIsGitRepo) return;
+    const dir = repoStore.selectedDir;
+    if (dir === undefined) return;
     const result = await tryCatch(rpcGitStatus({ dir }));
     if (gen !== loadGen) return;
     if (result.ok) {
-      gitStatuses.value = result.value.entries;
+      repoStore.setWorktreeGitStatuses(dir, result.value.entries);
     } else {
       const notify = useNotificationStore();
       notify.error("Failed to get git status", result.error);
-      gitStatuses.value = {};
     }
   }
 
-  /**
-   * push event 経由で受け取った最新 statuses を即時反映する。
-   * loadGen を進めることで、先行する loadGitStatus の RPC が後から返ってきても
-   * その結果で上書きされないようにする（push が truth source）。
-   */
-  function setGitStatuses(statuses: Record<string, string>) {
-    loadGen++;
-    gitStatuses.value = statuses;
-  }
-
-  return { gitStatuses, loadGitStatus, setGitStatuses };
+  return { gitStatuses, loadGitStatus };
 });
 
 if (import.meta.hot) {

--- a/apps/renderer/src/features/worktree/useGitStatusStore.ts
+++ b/apps/renderer/src/features/worktree/useGitStatusStore.ts
@@ -32,20 +32,21 @@ export const useGitStatusStore = defineStore("gitStatus", () => {
     return wt?.gitStatuses ?? {};
   });
 
-  /** 並行 loadGitStatus で古いレスポンスが新しい結果を上書きするのを防ぐ世代カウンタ */
-  let loadGen = 0;
-
   /**
    * active dir の git status を rpcGitStatus で取得し直して repoStore を更新する。
    * dir 切替時 / Claude state 遷移時 / Filer の初期読み込みで呼ばれる。
+   *
+   * 世代管理は repoStore.gitStatusGenByDir に集約。`setWorktreeGitStatuses` を
+   * 経由する push 経路と、ここでの RPC レスポンス到着が競合した場合、
+   * 開始時の世代と現在の世代を比較して RPC レスポンスが古ければ捨てる。
    */
   async function loadGitStatus() {
-    const gen = ++loadGen;
     if (!repoStore.selectedIsGitRepo) return;
     const dir = repoStore.selectedDir;
     if (dir === undefined) return;
+    const startGen = repoStore.getGitStatusGen(dir);
     const result = await tryCatch(rpcGitStatus({ dir }));
-    if (gen !== loadGen) return;
+    if (repoStore.getGitStatusGen(dir) !== startGen) return;
     if (result.ok) {
       repoStore.setWorktreeGitStatuses(dir, result.value.entries);
     } else {

--- a/apps/renderer/src/features/worktree/useGitStatusSync.ts
+++ b/apps/renderer/src/features/worktree/useGitStatusSync.ts
@@ -46,9 +46,11 @@ export function useGitStatusSync() {
 
   let cleanup: (() => void) | undefined;
   onMounted(() => {
+    // gitStatusChange は payload に dir を持つので、active 制限なしで該当 worktree の
+    // gitStatuses を直接 repoStore に反映する。サイドバー / Filer / GitGraph は
+    // すべて repoStore（または派生 computed）を読むので 1 回の書き込みで全箇所が更新される。
     cleanup = onMessage<GitStatusChangePayload>("gitStatusChange", (payload) => {
-      if (payload.dir !== worktreeStore.dir) return;
-      gitStatusStore.setGitStatuses(payload.statuses);
+      repoStore.setWorktreeGitStatuses(payload.dir, payload.statuses);
     });
   });
   onUnmounted(() => {

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -27,6 +27,18 @@ export const useRepoStore = defineStore("repo", () => {
   /** 折りたたまれている repo の rootDir 集合 */
   const collapsedRoots = ref<Set<string>>(new Set());
 
+  /**
+   * worktree.gitStatuses の per-dir 書き込み世代。
+   * `setWorktreeGitStatuses` のたびに該当 dir のカウンタを進めるため、
+   * 並行する loadGitStatus / fetchRepo の RPC レスポンスは開始時の世代を覚えておき、
+   * 帰ってきた時点で世代が進んでいれば「より新しい push / 個別更新が後勝ちで入った」
+   * と判断して捨てる。reactivity 不要なため ref ではなく素の Map で持つ。
+   */
+  const gitStatusGenByDir = new Map<string, number>();
+  function getGitStatusGen(dir: string): number {
+    return gitStatusGenByDir.get(dir) ?? 0;
+  }
+
   /** selectedDir を含む repo を逆引き。最初に dir を含む repo */
   const selectedRepo = computed(() => {
     const dir = selectedDir.value;
@@ -64,23 +76,54 @@ export const useRepoStore = defineStore("repo", () => {
     repos.value[state.rootDir] = state;
   }
 
-  /** 既存 repo の worktrees / freeBranches を更新（push event 受信時の refetch 用） */
-  function updateRepoData(rootDir: string, worktrees: WorktreeEntry[], freeBranches: string[]) {
+  /**
+   * 既存 repo の worktrees / freeBranches を更新（rpcGitWorktreeList 結果の反映）。
+   *
+   * `gitStatusesGenSnapshot` には fetch 開始時に各 wt について `getGitStatusGen` で
+   * 取った世代スナップショットを渡す。fetch 中に `setWorktreeGitStatuses` が走って
+   * 世代が進んでいる wt については、fetch レスポンスの古い `gitStatuses` を捨てて
+   * 現時点で repoStore に入っている fresher な値を保持する。
+   * 渡されなかった場合は merge せず単純差し替え（hydrate / 初回登録など世代が無意味な経路）。
+   */
+  function updateRepoData(
+    rootDir: string,
+    worktrees: WorktreeEntry[],
+    freeBranches: string[],
+    gitStatusesGenSnapshot?: Map<string, number>,
+  ) {
     const current = repos.value[rootDir];
     if (current === undefined) return;
-    repos.value[rootDir] = { ...current, worktrees, freeBranches };
+    let merged = worktrees;
+    if (gitStatusesGenSnapshot !== undefined) {
+      merged = worktrees.map((wt) => {
+        const beforeGen = gitStatusesGenSnapshot.get(wt.path);
+        const currentGen = gitStatusGenByDir.get(wt.path);
+        if (beforeGen !== undefined && currentGen !== undefined && currentGen !== beforeGen) {
+          // fetch 中に push / 単発更新が走っていた → 現値を保持
+          const fresher = current.worktrees.find((w) => w.path === wt.path);
+          if (fresher !== undefined) {
+            return { ...wt, gitStatuses: fresher.gitStatuses };
+          }
+        }
+        return wt;
+      });
+    }
+    repos.value[rootDir] = { ...current, worktrees: merged, freeBranches };
   }
 
   /**
    * 任意 dir に対応する worktree の gitStatuses だけをピンポイント更新する。
    * gitStatusChange push / 単発の rpcGitStatus 結果を反映する経路で使用。
    * dir に該当する worktree が見つからなければ no-op。
+   * 書き込み毎に per-dir 世代を進め、in-flight な loadGitStatus / fetchRepo の
+   * 古いレスポンスがこの値を上書きできないようにする。
    */
   function setWorktreeGitStatuses(dir: string, statuses: Record<string, string>) {
     const repo = findRepoOwning(dir);
     if (repo === undefined) return;
     const idx = repo.worktrees.findIndex((wt) => wt.path === dir);
     if (idx < 0) return;
+    gitStatusGenByDir.set(dir, (gitStatusGenByDir.get(dir) ?? 0) + 1);
     const next = [...repo.worktrees];
     next[idx] = { ...next[idx], gitStatuses: statuses };
     repos.value[repo.rootDir] = { ...repo, worktrees: next };
@@ -194,6 +237,7 @@ export const useRepoStore = defineStore("repo", () => {
     addRepo,
     updateRepoData,
     setWorktreeGitStatuses,
+    getGitStatusGen,
     selectDir,
     removeRepo,
     isCollapsed,

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -134,12 +134,18 @@ export const useRepoStore = defineStore("repo", () => {
   }
 
   function removeRepo(rootDir: string) {
+    const removed = repos.value[rootDir];
     delete repos.value[rootDir];
     dirOrder.value = dirOrder.value.filter((d) => d !== rootDir);
     if (collapsedRoots.value.has(rootDir)) {
       const next = new Set(collapsedRoots.value);
       next.delete(rootDir);
       collapsedRoots.value = next;
+    }
+    // 配下 wt と rootDir 自身の世代エントリを掃除（追加削除の繰り返しでメモリが膨らまないように）
+    if (removed !== undefined) {
+      gitStatusGenByDir.delete(removed.rootDir);
+      for (const wt of removed.worktrees) gitStatusGenByDir.delete(wt.path);
     }
     if (selectedDir.value !== undefined) {
       const stillOwned = findRepoOwning(selectedDir.value);

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -71,6 +71,21 @@ export const useRepoStore = defineStore("repo", () => {
     repos.value[rootDir] = { ...current, worktrees, freeBranches };
   }
 
+  /**
+   * 任意 dir に対応する worktree の gitStatuses だけをピンポイント更新する。
+   * gitStatusChange push / 単発の rpcGitStatus 結果を反映する経路で使用。
+   * dir に該当する worktree が見つからなければ no-op。
+   */
+  function setWorktreeGitStatuses(dir: string, statuses: Record<string, string>) {
+    const repo = findRepoOwning(dir);
+    if (repo === undefined) return;
+    const idx = repo.worktrees.findIndex((wt) => wt.path === dir);
+    if (idx < 0) return;
+    const next = [...repo.worktrees];
+    next[idx] = { ...next[idx], gitStatuses: statuses };
+    repos.value[repo.rootDir] = { ...repo, worktrees: next };
+  }
+
   function selectDir(dir: string) {
     selectedDir.value = dir;
   }
@@ -178,6 +193,7 @@ export const useRepoStore = defineStore("repo", () => {
     findRepoOwning,
     addRepo,
     updateRepoData,
+    setWorktreeGitStatuses,
     selectDir,
     removeRepo,
     isCollapsed,

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -107,6 +107,13 @@ export const useRepoStore = defineStore("repo", () => {
         }
         return wt;
       });
+      // bulk 反映で touch した全 wt の世代を進める。
+      // これがないと、fetchRepo 開始前から走っていた loadGitStatus が後着したとき
+      // startGen と現 gen が一致してしまい、古いレスポンスが ここで採用した
+      // 新スナップショットを上書きできてしまう。
+      for (const wt of merged) {
+        gitStatusGenByDir.set(wt.path, (gitStatusGenByDir.get(wt.path) ?? 0) + 1);
+      }
     }
     repos.value[rootDir] = { ...current, worktrees: merged, freeBranches };
   }


### PR DESCRIPTION
> [!IMPORTANT]
> ## マージブロック
>
> CI の `swift test` で `PTYRegistryTests.spawnAndExitDispatch` が低頻度 flaky を再現する。本 PR の変更は git CLI を `Process` で叩く経路（`ProcessExec.swift` / `RpcDispatcher.swift`）と renderer のみで、PTY 経路（`forkpty` + C bridge + `PTYManager`）には触れていない。flaky は PR #420 で対処された「`onExit` 前に全 text drain を吸い切る契約」が CI 環境で破れるもの。
>
> 根治を別 issue ( #450 ) で扱い、解決後に本 PR をマージする。それまでは draft で保持する。

## 概要

サイドバーの worktree 行ごとに表示されていた変更ファイルバッジが、PR #420（Electrobun → Swift 全面書き直し）以降出なくなっていた問題を修正する。原因は 2 段:

- Swift 側 `handleGitWorktreeList` が active rootDir 1 個分の status しか埋めていない
- renderer 側が「サイドバーが読む `repoStore.worktrees[i].gitStatuses`」と「Filer / GitGraph が読む `useGitStatusStore.gitStatuses`」を別 store に持ち、`gitStatusChange` push が後者にしか書き込まれていない（SSOT 違反）

両方を直し、`repoStore.repos[rootDir].worktrees[i].gitStatuses` を唯一の真実の source として全リーダーが同じ store を観測する形に統一する。

## 背景

最初に確認できた症状はサイドバーで全 worktree のバッジが空。Swift 側の修正で全 worktree 分の status を埋めれば直るかに見えたが、ユーザーから「アクティブ wt の FilerPane / GitGraph はファイル編集に追従して更新されているのに、同じ wt の **サイドバー行のバッジは反映されない**。それは worktree ごとの git status が store として状態共有されていない設計のせいでは」と指摘があった。

実際にコードを追うと、`gitStatusChange` push を受け取ったときの動作が二経路に分岐していた:

- `apps/renderer/src/features/worktree/useGitStatusSync.ts` — payload を `useGitStatusStore` に書き込む（active dir 限定フィルタ付き）。Filer / GitGraph はこれを読む
- `apps/renderer/src/features/sidebar/useSidebarData.ts` — 同じ push を受けて `fetchOwnerOfActive()` を呼び、worktree list を **全件再 RPC** して `repoStore` 側を上書きする。サイドバーはこれを読む

つまり 1 件のファイル変更で:

- `useGitStatusStore` は即時更新（push payload 直適用）
- `repoStore.worktrees[i].gitStatuses` は worktree list 全件再取得が往復した後にしか更新されない
- かつ N worktree あれば N 倍の `git status` が backend で走る

その上、Swift 側は `wt.path == req.dir`（rootDir = main）の 1 件しか status を埋めない実装だったため、active worktree が main そのものでない限り、再フェッチしても結局スナップショットは空のまま。サイドバーは永遠に更新されない。

## 変更内容

### Swift backend: 全 worktree について `git status` を並列取得

`apps/native/Sources/GozdCore/RpcDispatcher.swift` の `handleGitWorktreeList`:

- worktree 一覧取得後に `withThrowingTaskGroup` を張り、各 `wt.path` に対し `GitOps.gitStatus(dir:)` を並列実行
- 結果を `[path: statuses]` に集約して `Gozd_V1_WorktreeEntry.gitStatuses` に詰め直す
- 1 worktree でも失敗したら集約段階で throw が伝播し、`handleGitWorktreeList` 全体が fail する。renderer 側 `useSidebarData.fetchRepo` の `tryCatch` がそれを `notify.error` で可視化する（プロジェクト方針「fallbackせずエラーにする」「観察を妨げる予防的 fallback を仕込まない」遵守。`try?` での握り潰しは入れない）
- 「active worktree の status のみ返す（旧実装互換）」という誤解を招くコメントを除去

### renderer SSOT 化: `repoStore` を唯一の真実の source に

#### `apps/renderer/src/shared/repo/useRepoStore.ts`

- `setWorktreeGitStatuses(dir, statuses)` を追加。dir に該当する worktree を任意の repo から逆引きし、その `gitStatuses` だけをピンポイント更新する

#### `apps/renderer/src/features/worktree/useGitStatusStore.ts`

- `gitStatuses` を `ref` から `computed` に変更。active dir に対応する `repoStore.worktrees[i].gitStatuses` を派生させる
- `loadGitStatus()` は `rpcGitStatus({dir})` の結果を `repoStore.setWorktreeGitStatuses(dir, statuses)` に渡す
- `setGitStatuses` を削除（書き込みは `repoStore` に集約）
- 循環 import を避けるため `useWorktreeStore` への依存を切り、`repoStore.selectedDir` を直接読む（worktreeStore.dir はそれの薄いエイリアス）

#### `apps/renderer/src/features/worktree/useGitStatusSync.ts`

- `gitStatusChange` push handler を `repoStore.setWorktreeGitStatuses(payload.dir, payload.statuses)` に変更
- `payload.dir !== worktreeStore.dir` フィルタを除去。setWorktreeGitStatuses は dir-scoped なので任意 dir を受けて該当 wt のみを更新する

#### `apps/renderer/src/features/filer/FilerPane.vue`

- `handleGitStatusChange` から `gitStatusStore.setGitStatuses(statuses)` 呼び出しを削除。status 自体の更新は `useGitStatusSync` 経由で `repoStore` に書かれており、FilerPane はファイルツリーの再構築だけ行えばよい

#### `apps/renderer/src/features/sidebar/useSidebarData.ts`

- `gitStatusChange` push の handler から `fetchOwnerOfActive()` を除去。同 push は `useGitStatusSync` が `repoStore` に直接書き込むので、worktree list 全件再 RPC は不要
- `branchChange` / `worktreeChange`（worktree 構成自体が変わる）は引き続き `fetchOwnerOfActive` で全件再取得する

## データフロー（修正後）

```text
[FSWatch / file edit on active worktree]
  └─ gitStatusChange { dir, statuses }
       └─ useGitStatusSync (1 箇所のみ)
            └─ repoStore.setWorktreeGitStatuses(dir, statuses)
                 ├─ サイドバー WorktreeItem.vue       ← wt.gitStatuses
                 ├─ Filer FilerPane.vue              ← useGitStatusStore (computed)
                 ├─ GitGraph GitGraphPane.vue        ← useGitStatusStore (computed)
                 └─ ChangesPane.vue                  ← useGitStatusStore (computed)
```

```text
[初回 / branchChange / worktreeChange]
  └─ rpcGitWorktreeList → 全 worktree 並列 git status (Swift)
       └─ repoStore.updateRepoData → 全リーダー更新
```

## 今回含めない点

- **非アクティブ worktree の live 更新**: `rpcFsWatch` が `worktreeStore.dir`（active 1 個）にしか登録されないため、別 worktree でファイルが変わっても `gitStatusChange` push は来ない。本 PR のスナップショット（rpcGitWorktreeList 結果）でしか反映されない。FSWatch を全 worktree に拡張するのは「監視対象数の増加」「worktree 切り替え時の watch 維持戦略」を含む別の設計判断であり、本 PR のスコープ外

## 確認事項

- [ ] サイドバーで複数 worktree を持つ repo を開き、各 worktree 行に変更ファイル件数アイコンが出ること（main / 非 main / アクティブ / 非アクティブ問わず）
- [ ] アクティブ worktree 内のファイル編集が、サイドバー / Filer / GitGraph で **同時に** 即時反映されること（worktree list の再 RPC を経由せず）
- [ ] worktree 切替時に新 active wt のバッジが直前のスナップショットを保ちつつ `loadGitStatus` で最新化されること
- [ ] `git status` が失敗する状況下で、サイドバーが空のまま無言で表示されるのではなく、トースト通知で原因が観察できること

