### PR TITLE
fix(sidebar): refresh worktree list after issue/pr open creates worktree

### DIFF
--- a/apps/renderer/src/features/palette/features/issue-picker/IssuePickerDialog.vue
+++ b/apps/renderer/src/features/palette/features/issue-picker/IssuePickerDialog.vue
@@ -7,6 +7,14 @@ Issue selection dialog. Displays open issues in a table layout with fuzzy filter
 - Filters issues by fuzzy match on number, title, and author
 - Arrow keys navigate rows, Enter accepts, Escape closes
 - Color scheme follows `gh issue list` (green #number, gray author/date)
+
+## Concurrency
+
+`acceptSelected` calls `close()` before `accept()` so the dialog is removed
+from the DOM before the async accept callback (worktree creation) starts.
+This is the primary guard against re-entry: callbacks do not need their own
+`isCreating` flag because keydown / click events stop reaching the closed
+dialog.
 </doc>
 
 <script setup lang="ts">

--- a/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
+++ b/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
@@ -7,6 +7,7 @@
 import { tryCatch } from "@gozd/shared";
 import { useCommandRegistry } from "../../../../shared/command";
 import { useNotificationStore } from "../../../../shared/notification";
+import { useRepoStore } from "../../../../shared/repo";
 import { rpcCreateWorktree, rpcGitWorktreeList, rpcTaskAdd } from "../../../sidebar";
 import { useTerminalStore } from "../../../terminal";
 import { generateTimestamp, useWorktreeStore } from "../../../worktree";
@@ -20,6 +21,7 @@ export function registerIssueCommand(): () => void {
   const notify = useNotificationStore();
   const worktreeStore = useWorktreeStore();
   const terminalStore = useTerminalStore();
+  const repoStore = useRepoStore();
 
   const dispose = registry.register("workspace.openIssue", {
     label: "Workspace: Open Issue",
@@ -84,6 +86,10 @@ export function registerIssueCommand(): () => void {
             );
             if (!taskResult.ok) {
               notify.error("Failed to create task for worktree", taskResult.error);
+            }
+            const rootDir = repoStore.findRepoOwning(dir)?.rootDir;
+            if (rootDir !== undefined && result.value.worktree !== undefined) {
+              repoStore.appendWorktree(rootDir, result.value.worktree);
             }
             terminalStore.viewMode = "wt";
             worktreeStore.setOpen(result.value.dir);

--- a/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
+++ b/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
@@ -54,6 +54,8 @@ export function registerIssueCommand(): () => void {
             .map((wt) => [wt.task?.issueNumber, wt.path]),
         );
 
+        // この callback は IssuePickerDialog 側で close() 後に呼ばれるため、
+        // 連打による再エントリは dialog の DOM 除去で塞がれている。`isCreating` 相当のガードは不要。
         show(issuesRes.issues, viewerRes.ok ? viewerRes.login : "", (issue) => {
           const existingDir = wtByIssue.get(issue.number);
           if (existingDir !== undefined) {

--- a/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
+++ b/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
@@ -88,7 +88,9 @@ export function registerIssueCommand(): () => void {
               notify.error("Failed to create task for worktree", taskResult.error);
             }
             const rootDir = repoStore.findRepoOwning(dir)?.rootDir;
-            if (rootDir !== undefined && result.value.worktree !== undefined) {
+            if (rootDir === undefined || result.value.worktree === undefined) {
+              notify.error("Worktree created but sidebar could not be updated");
+            } else {
               repoStore.appendWorktree(rootDir, result.value.worktree);
             }
             terminalStore.viewMode = "wt";

--- a/apps/renderer/src/features/palette/features/pr-picker/PrPickerDialog.vue
+++ b/apps/renderer/src/features/palette/features/pr-picker/PrPickerDialog.vue
@@ -8,6 +8,15 @@ PR selection dialog. Displays open pull requests in a table layout with fuzzy fi
 - Arrow keys navigate rows, Enter accepts, Escape closes
 - Draft PRs are dimmed (opacity-50)
 - Color scheme follows `gh pr list` (green #number, cyan branch, gray author/date)
+
+## Concurrency
+
+`acceptSelected` calls `close()` before `accept()` so the dialog is removed
+from the DOM before the async accept callback (worktree creation) starts.
+This is the primary guard against re-entry: callbacks do not need their own
+`isCreating` flag because keydown / click events stop reaching the closed
+dialog. Additionally, `branch: pr.headRef` is deterministic, so duplicate
+creations would be rejected by `git worktree add` itself.
 </doc>
 
 <script setup lang="ts">

--- a/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
+++ b/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
@@ -7,6 +7,7 @@
 import { tryCatch } from "@gozd/shared";
 import { useCommandRegistry } from "../../../../shared/command";
 import { useNotificationStore } from "../../../../shared/notification";
+import { useRepoStore } from "../../../../shared/repo";
 import { rpcCreateWorktree, rpcGitWorktreeList, rpcTaskAdd } from "../../../sidebar";
 import { useTerminalStore } from "../../../terminal";
 import { generateTimestamp, useWorktreeStore } from "../../../worktree";
@@ -19,6 +20,7 @@ export function registerPrCommand(): () => void {
   const notify = useNotificationStore();
   const worktreeStore = useWorktreeStore();
   const terminalStore = useTerminalStore();
+  const repoStore = useRepoStore();
 
   const dispose = registry.register("workspace.openPr", {
     label: "Workspace: Open Pull Request",
@@ -78,6 +80,10 @@ export function registerPrCommand(): () => void {
             );
             if (!taskResult.ok) {
               notify.error("Failed to create task for worktree", taskResult.error);
+            }
+            const rootDir = repoStore.findRepoOwning(dir)?.rootDir;
+            if (rootDir !== undefined && result.value.worktree !== undefined) {
+              repoStore.appendWorktree(rootDir, result.value.worktree);
             }
             terminalStore.viewMode = "wt";
             worktreeStore.setOpen(result.value.dir);

--- a/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
+++ b/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
@@ -47,6 +47,9 @@ export function registerPrCommand(): () => void {
           worktreesRes.worktrees.filter((wt) => wt.branch !== "").map((wt) => [wt.branch, wt.path]),
         );
 
+        // この callback は PrPickerDialog 側で close() 後に呼ばれるため、
+        // 連打による再エントリは dialog の DOM 除去で塞がれている。さらに branch: pr.headRef が
+        // 決定論的なので git 側でも重複作成は弾かれる。`isCreating` 相当のガードは不要。
         show(prsRes.prs, viewerRes.ok ? viewerRes.login : "", (pr) => {
           const existingDir = wtByBranch.get(pr.headRef);
           if (existingDir !== undefined) {

--- a/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
+++ b/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
@@ -82,7 +82,9 @@ export function registerPrCommand(): () => void {
               notify.error("Failed to create task for worktree", taskResult.error);
             }
             const rootDir = repoStore.findRepoOwning(dir)?.rootDir;
-            if (rootDir !== undefined && result.value.worktree !== undefined) {
+            if (rootDir === undefined || result.value.worktree === undefined) {
+              notify.error("Worktree created but sidebar could not be updated");
+            } else {
               repoStore.appendWorktree(rootDir, result.value.worktree);
             }
             terminalStore.viewMode = "wt";

--- a/apps/renderer/src/features/sidebar/features/worktree/useWorktreeActions.ts
+++ b/apps/renderer/src/features/sidebar/features/worktree/useWorktreeActions.ts
@@ -41,12 +41,6 @@ export function useWorktreeActions({ showConfirm }: UseWorktreeActionsOptions) {
 
   // --- store 更新 helpers ---
 
-  function appendWorktree(rootDir: string, wt: WorktreeEntry) {
-    const repo = repoStore.repos[rootDir];
-    if (!repo) return;
-    repoStore.updateRepoData(rootDir, [...repo.worktrees, wt], repo.freeBranches);
-  }
-
   function detachWorktree(rootDir: string, wt: WorktreeEntry) {
     const repo = repoStore.repos[rootDir];
     if (!repo) return;
@@ -88,7 +82,7 @@ export function useWorktreeActions({ showConfirm }: UseWorktreeActionsOptions) {
       }),
     );
     if (result.ok && result.value.worktree !== undefined) {
-      appendWorktree(rootDir, result.value.worktree);
+      repoStore.appendWorktree(rootDir, result.value.worktree);
       terminalStore.viewMode = "wt";
       worktreeStore.setOpen(result.value.dir);
     } else {
@@ -111,7 +105,7 @@ export function useWorktreeActions({ showConfirm }: UseWorktreeActionsOptions) {
       }),
     );
     if (result.ok && result.value.worktree !== undefined) {
-      appendWorktree(rootDir, result.value.worktree);
+      repoStore.appendWorktree(rootDir, result.value.worktree);
       terminalStore.viewMode = "wt";
       worktreeStore.setOpen(result.value.dir);
     } else {

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -136,10 +136,14 @@ export const useRepoStore = defineStore("repo", () => {
     repos.value[repo.rootDir] = { ...repo, worktrees: next };
   }
 
-  /** 新規作成した worktree を repo の worktrees に追加 */
+  /**
+   * 新規作成した worktree を repo の worktrees に追加。
+   * 同一 path が既に存在する場合は no-op（store の最終防衛線として idempotent にする）。
+   */
   function appendWorktree(rootDir: string, wt: WorktreeEntry) {
     const current = repos.value[rootDir];
     if (current === undefined) return;
+    if (current.worktrees.some((w) => w.path === wt.path)) return;
     updateRepoData(rootDir, [...current.worktrees, wt], current.freeBranches);
   }
 

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -136,6 +136,13 @@ export const useRepoStore = defineStore("repo", () => {
     repos.value[repo.rootDir] = { ...repo, worktrees: next };
   }
 
+  /** 新規作成した worktree を repo の worktrees に追加 */
+  function appendWorktree(rootDir: string, wt: WorktreeEntry) {
+    const current = repos.value[rootDir];
+    if (current === undefined) return;
+    updateRepoData(rootDir, [...current.worktrees, wt], current.freeBranches);
+  }
+
   function selectDir(dir: string) {
     selectedDir.value = dir;
   }
@@ -251,6 +258,7 @@ export const useRepoStore = defineStore("repo", () => {
     updateRepoData,
     setWorktreeGitStatuses,
     getGitStatusGen,
+    appendWorktree,
     selectDir,
     removeRepo,
     isCollapsed,


### PR DESCRIPTION
## 概要

コマンドパレットの "Workspace: Open Issue" / "Workspace: Open Pull Request" から新規 worktree を作成した際に、サイドバーの worktree 一覧が即座に更新されない問題を修正する。

## 背景

サイドバーの worktree 一覧は `repoStore.repos[rootDir].worktrees` を直接読んでいる。worktree 作成後の更新フローは次の通り:

1. `worktreeStore.setOpen(newDir)` で `repoStore.selectedDir` を更新
2. `useSidebarData` の watch が `repoStore.findRepoOwning(newDir)` で owner repo を逆引き
3. owner が見つかれば `fetchRepo(owning.rootDir)` で再取得

`findRepoOwning` は `repo.worktrees.some((wt) => wt.path === dir)` で逆引きするため、**新規作成した worktree が `repos[].worktrees` に未登録の場合は owner が見つからず、`fetchRepo` が空振りする**。

サイドバーの「+」ボタン経由の作成 ( `useWorktreeActions.addWorktree` / `handleBranchLink` ) は private helper `appendWorktree` で `repoStore` を即時更新してから `setOpen` していたため正常に refresh されていたが、issue picker / PR picker のコマンド経路ではこの楽観的更新を行っていなかったためサイドバーが取り残されていた。

## 変更内容

### `useRepoStore` に `appendWorktree` を昇格

`useWorktreeActions` の private helper として実装されていた `appendWorktree(rootDir, wt)` を `useRepoStore` のメソッドに移し、すべての worktree 作成パスから共有できるようにした。あわせて path ベースの idempotent ガードを入れ、同一 path が既に存在する場合は no-op にする（store 層の最終防衛線）。

### issue / PR コマンドで作成成功時に store を更新

`registerIssueCommand.ts` / `registerPrCommand.ts` で `rpcCreateWorktree` 成功直後に `repoStore.findRepoOwning(dir)?.rootDir` で rootDir を逆引きし、`repoStore.appendWorktree(rootDir, result.value.worktree)` を呼ぶ。これにより `setOpen` 時点で `findRepoOwning` が成功し、`useSidebarData` の watch が `fetchRepo` を発火する。

### `useWorktreeActions` の重複削除

private な `appendWorktree` を削除し、`repoStore.appendWorktree` を直接呼ぶよう統一。

### サイドバー更新失敗を顕在化

`rootDir` 逆引きが失敗、または `rpcCreateWorktree` レスポンスの `worktree` が欠落した場合は `notify.error` で通知する。silent skip にすると将来 invariant が崩れた際に worktree 作成は成功しているのに sidebar だけ stale になる症状を無言で見逃すため、レビュー指摘に基づき顕在化させた。worktree 自体は作成済みなので `setOpen` は続行してユーザー作業は止めない。

### picker callback の連打安全性をコード上で明示

issue / PR picker の `acceptSelected` は `close()` → `accept()` の順で呼ぶため、accept callback の async 処理（worktree 作成）が走っている間にダイアログ DOM が除去され、keydown / click による再エントリが届かなくなる。さらに PR 経路は `branch: pr.headRef` が決定論的なため git 側でも重複作成は弾かれる。これらが連打防止の主防御であり、callback 側で `isCreating` 相当のガードを持たない設計判断の根拠になっている。

将来の reviewer に同じ residual risk を再指摘されないよう、この設計意図を `IssuePickerDialog.vue` / `PrPickerDialog.vue` の `<doc>` Concurrency セクションと、`register*Command.ts` の callback 直前コメントに明記した。

## 確認事項

- [ ] コマンドパレットから "Workspace: Open Issue" を実行 → issue 選択 → 新規 worktree がサイドバーに即座に現れる
- [ ] 同様に "Workspace: Open Pull Request" 経由でもサイドバーが更新される
- [ ] サイドバーの「+」ボタン / 既存ブランチからの worktree 化が従来通り動く（リグレッションなし）
