### PR TITLE
chore(pty): add gated trace logging for PTYRegistry CI flake diagnosis

### DIFF
--- a/.github/workflows/code_validation.yml
+++ b/.github/workflows/code_validation.yml
@@ -126,9 +126,10 @@ jobs:
         working-directory: apps/native
         # GOZD_PTY_TRACE: PTYRegistryTests.spawnAndExitDispatch が CI で稀に flaky に
         # なる issue #450 の原因特定用。DEBUG build かつこの env=1 のときのみ
-        # PTYManager 内のライフサイクルイベント（drainPTY の各 read 結果、
-        # source eventHandler の発火順、PTYFinishState の状態遷移）を stderr に
-        # 時系列出力する。再発時に CI ログから経路を逐語で復元するために残す。
+        # PTYManager 内のライフサイクルイベント（drainPTY の集約結果、source
+        # eventHandler の発火順、waitpid の戻り値・errno、PTYFinishState の状態
+        # 遷移）を stderr に時系列出力する。再発時に CI ログから経路を逐語で復元
+        # するために残す。
         env:
           GOZD_PTY_TRACE: "1"
         run: swift test

--- a/.github/workflows/code_validation.yml
+++ b/.github/workflows/code_validation.yml
@@ -124,6 +124,13 @@ jobs:
 
       - name: swift test
         working-directory: apps/native
+        # GOZD_PTY_TRACE: PTYRegistryTests.spawnAndExitDispatch が CI で稀に flaky に
+        # なる issue #450 の原因特定用。DEBUG build かつこの env=1 のときのみ
+        # PTYManager 内のライフサイクルイベント（drainPTY の各 read 結果、
+        # source eventHandler の発火順、PTYFinishState の状態遷移）を stderr に
+        # 時系列出力する。再発時に CI ログから経路を逐語で復元するために残す。
+        env:
+          GOZD_PTY_TRACE: "1"
         run: swift test
 
   # ==============================================================

--- a/apps/native/Sources/Gozd/GozdApp.swift
+++ b/apps/native/Sources/Gozd/GozdApp.swift
@@ -555,6 +555,8 @@ private func encodeExitReason(_ reason: PTYExitReason) -> [String: Any] {
     return ["kind": "signaled", "signal": Int(signal), "coreDumped": coreDumped]
   case .stopped:
     return ["kind": "stopped"]
+  case .waitpidFailed(let errno):
+    return ["kind": "waitpidFailed", "errno": Int(errno)]
   }
 }
 

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -120,6 +120,7 @@ public final class PTYManager {
 
     primaryFd = fd
     pid = childPid
+    ptyTrace("spawn", pid: childPid, "forkpty returned fd=\(fd) executable=\(executable)")
 
     // 親側のコピーを開放（子は COW で別アドレス空間）。
     freeCStrings(argEntries, envEntries, cExecutable, cCwd, argv, envp)
@@ -131,6 +132,7 @@ public final class PTYManager {
     if flags >= 0 {
       _ = fcntl(fd, F_SETFL, flags | O_NONBLOCK)
     }
+    ptyTrace("spawn", pid: childPid, "fd set O_NONBLOCK")
 
     // readSource / exitSource を **同じ per-PTY serial queue** に載せる。
     // 別 queue だと exit 通知が PTY master fd の残り出力 read より先に走るケースがあり、
@@ -148,17 +150,20 @@ public final class PTYManager {
     // 単発 read だと「event 1 回で data + EOF が同時に観測される」ケースで data を取りこぼす
     // 可能性があり、event coalescing による flaky の温床になる。drain loop で吸い切る。
     source.setEventHandler { [source] in
-      switch drainPTY(fd: fd, onData: onData) {
+      ptyTrace("read", pid: childPid, "eventHandler fired")
+      switch drainPTY(fd: fd, pid: childPid, caller: "read-source", onData: onData) {
       case .drained:
         return
       case .closed:
+        ptyTrace("read", pid: childPid, "drain → .closed → cancel + markReadClosed")
         source.cancel()
-        state.markReadClosed(onComplete: onExit)
+        state.markReadClosed(pid: childPid, onComplete: onExit)
       }
     }
     // 注意: ここで close(fd) を呼ばない。exit handler 側の final drain が fd を読むため、
     // close は `PTYFinishState.tryFinish` の completion 時に 1 度だけ実行する。
     source.resume()
+    ptyTrace("spawn", pid: childPid, "read source resumed")
     readSource = source
 
     // 子プロセスの exit 検知は kqueue ベースの DispatchSourceProcess を使う。
@@ -168,11 +173,13 @@ public final class PTYManager {
       queue: queue
     )
     exit.setEventHandler { [exit, source] in
+      ptyTrace("exit", pid: childPid, "eventHandler fired (pre-waitpid drain)")
       // exit event と read readiness の到着順に依存しないよう、waitpid 前にも drain する。
       // 子はもう書かないので、ここで読める bytes は最終出力として確定。
-      if case .closed = drainPTY(fd: fd, onData: onData) {
+      if case .closed = drainPTY(fd: fd, pid: childPid, caller: "exit-pre", onData: onData) {
+        ptyTrace("exit", pid: childPid, "pre-drain → .closed → cancel + markReadClosed")
         source.cancel()
-        state.markReadClosed(onComplete: onExit)
+        state.markReadClosed(pid: childPid, onComplete: onExit)
       }
 
       // process source の exit handler 内では子は zombie 確定。`WNOHANG` を使うと
@@ -182,17 +189,20 @@ public final class PTYManager {
       while waitpid(childPid, &status, 0) == -1 {
         if errno != EINTR { break }
       }
+      ptyTrace("exit", pid: childPid, "waitpid returned status=\(status)")
 
       // waitpid 後にもう一度 drain。exit と read の event 順序によらず最終 data を吸う。
-      if case .closed = drainPTY(fd: fd, onData: onData) {
+      if case .closed = drainPTY(fd: fd, pid: childPid, caller: "exit-post", onData: onData) {
+        ptyTrace("exit", pid: childPid, "post-drain → .closed → cancel + markReadClosed")
         source.cancel()
-        state.markReadClosed(onComplete: onExit)
+        state.markReadClosed(pid: childPid, onComplete: onExit)
       }
 
-      state.setExitReason(decodeExitStatus(status), onComplete: onExit)
+      state.setExitReason(decodeExitStatus(status), pid: childPid, onComplete: onExit)
       exit.cancel()
     }
     exit.resume()
+    ptyTrace("spawn", pid: childPid, "exit source resumed")
     exitSource = exit
   }
 
@@ -277,27 +287,40 @@ private final class PTYFinishState: @unchecked Sendable {
     }
   }
 
-  func markReadClosed(onComplete: (PTYExitReason) -> Void) {
+  func markReadClosed(pid: Int32 = 0, onComplete: (PTYExitReason) -> Void) {
     lock.lock()
+    let alreadyReadClosed = readClosed
     readClosed = true
     let canFinish = !finished && exitReason != nil
     if canFinish { finished = true }
     let reason = exitReason
     if canFinish { closeFdLocked() }
     lock.unlock()
+    ptyTrace(
+      "fin", pid: pid,
+      "markReadClosed alreadyReadClosed=\(alreadyReadClosed) exitReason=\(reason.map { "\($0)" } ?? "nil") canFinish=\(canFinish)"
+    )
     if canFinish, let reason {
+      ptyTrace("fin", pid: pid, "onComplete fired (via markReadClosed) reason=\(reason)")
       onComplete(reason)
     }
   }
 
-  func setExitReason(_ reason: PTYExitReason, onComplete: (PTYExitReason) -> Void) {
+  func setExitReason(
+    _ reason: PTYExitReason, pid: Int32 = 0, onComplete: (PTYExitReason) -> Void
+  ) {
     lock.lock()
     exitReason = reason
     let canFinish = !finished && readClosed
     if canFinish { finished = true }
     if canFinish { closeFdLocked() }
+    let observedReadClosed = readClosed
     lock.unlock()
+    ptyTrace(
+      "fin", pid: pid,
+      "setExitReason reason=\(reason) readClosed=\(observedReadClosed) canFinish=\(canFinish)")
     if canFinish {
+      ptyTrace("fin", pid: pid, "onComplete fired (via setExitReason) reason=\(reason)")
       onComplete(reason)
     }
   }
@@ -318,25 +341,45 @@ private enum PTYDrainResult {
   case closed
 }
 
-private func drainPTY(fd: Int32, onData: (Data) -> Void) -> PTYDrainResult {
+private func drainPTY(fd: Int32, pid: Int32 = 0, caller: String = "?", onData: (Data) -> Void)
+  -> PTYDrainResult
+{
+  ptyTrace("drain", pid: pid, "enter caller=\(caller) fd=\(fd)")
+  var totalBytes = 0
+  var iterations = 0
   while true {
     var buffer = [UInt8](repeating: 0, count: 4096)
     let n = buffer.withUnsafeMutableBufferPointer {
       Darwin.read(fd, $0.baseAddress, $0.count)
     }
+    iterations += 1
     if n > 0 {
+      totalBytes += n
+      ptyTrace("drain", pid: pid, "read n=\(n) totalBytes=\(totalBytes) iter=\(iterations)")
       onData(Data(bytes: buffer, count: n))
       continue
     }
     if n == 0 {
+      ptyTrace(
+        "drain", pid: pid,
+        "read n=0 EOF totalBytes=\(totalBytes) iter=\(iterations) → .closed")
       return .closed
     }
     let err = errno
-    if err == EINTR { continue }
+    if err == EINTR {
+      ptyTrace("drain", pid: pid, "read n=-1 errno=EINTR iter=\(iterations) (retry)")
+      continue
+    }
     if err == EAGAIN || err == EWOULDBLOCK {
+      ptyTrace(
+        "drain", pid: pid,
+        "read n=-1 errno=EAGAIN totalBytes=\(totalBytes) iter=\(iterations) → .drained")
       return .drained
     }
     // EIO 等は PTY hangup 扱い（slave 全 close）。再 read しても無意味なので closed として返す。
+    ptyTrace(
+      "drain", pid: pid,
+      "read n=-1 errno=\(err) totalBytes=\(totalBytes) iter=\(iterations) → .closed (hangup)")
     return .closed
   }
 }

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -129,10 +129,17 @@ public final class PTYManager {
     // また exit handler 側からの drain が「データがなければ即抜ける」形で安全に呼べる。
     // write 側は既に EAGAIN を usleep + retry で扱っているので互換。
     let flags = fcntl(fd, F_GETFL)
+    let getFlagsErrno: Int32 = flags == -1 ? errno : 0
+    var setFlagsRet: Int32 = -1
+    var setFlagsErrno: Int32 = 0
     if flags >= 0 {
-      _ = fcntl(fd, F_SETFL, flags | O_NONBLOCK)
+      setFlagsRet = fcntl(fd, F_SETFL, flags | O_NONBLOCK)
+      if setFlagsRet == -1 { setFlagsErrno = errno }
     }
-    ptyTrace("spawn", pid: childPid, "fd set O_NONBLOCK")
+    ptyTrace(
+      "spawn", pid: childPid,
+      "fcntl getFlags=\(flags) getFlagsErrno=\(getFlagsErrno) setFlagsRet=\(setFlagsRet) setFlagsErrno=\(setFlagsErrno)"
+    )
 
     // readSource / exitSource を **同じ per-PTY serial queue** に載せる。
     // 別 queue だと exit 通知が PTY master fd の残り出力 read より先に走るケースがあり、
@@ -185,11 +192,26 @@ public final class PTYManager {
       // process source の exit handler 内では子は zombie 確定。`WNOHANG` を使うと
       // 戻り値 0（reap 未完）と exit code 0 の区別が曖昧になるため、blocking
       // waitpid + EINTR retry にして status を確実に回収する。
+      // ECHILD（子が既に reap されている / 想定外）を見落とさないため、戻り値・errno・retry 回数を観測する。
       var status: Int32 = 0
-      while waitpid(childPid, &status, 0) == -1 {
-        if errno != EINTR { break }
+      var waitRet: pid_t = 0
+      var waitErrno: Int32 = 0
+      var eintrRetries = 0
+      while true {
+        waitRet = waitpid(childPid, &status, 0)
+        if waitRet != -1 {
+          waitErrno = 0
+          break
+        }
+        waitErrno = errno
+        if waitErrno != EINTR { break }
+        eintrRetries += 1
       }
-      ptyTrace("exit", pid: childPid, "waitpid returned status=\(status)")
+      ptyTrace(
+        "exit", pid: childPid,
+        "waitpid ret=\(waitRet) status=\(status) errno=\(waitErrno) eintrRetries=\(eintrRetries)")
+      let exitReason: PTYExitReason =
+        waitRet == -1 ? .waitpidFailed(errno: waitErrno) : decodeExitStatus(status)
 
       // waitpid 後にもう一度 drain。exit と read の event 順序によらず最終 data を吸う。
       if case .closed = drainPTY(fd: fd, pid: childPid, caller: "exit-post", onData: onData) {
@@ -198,7 +220,7 @@ public final class PTYManager {
         state.markReadClosed(pid: childPid, onComplete: onExit)
       }
 
-      state.setExitReason(decodeExitStatus(status), pid: childPid, onComplete: onExit)
+      state.setExitReason(exitReason, pid: childPid, onComplete: onExit)
       exit.cancel()
     }
     exit.resume()
@@ -258,6 +280,10 @@ public enum PTYExitReason: Sendable, Equatable {
   case exited(code: Int32)
   case signaled(signal: Int32, coreDumped: Bool)
   case stopped
+  /// `waitpid(2)` が `-1` で失敗したケース（例: `ECHILD`）。
+  /// `decodeExitStatus` に進ませると初期値 `status=0` が `.exited(code: 0)` と誤報されるため、
+  /// 異常を呼び出し側まで伝搬する独立ケースとして用意する。
+  case waitpidFailed(errno: Int32)
 }
 
 /// `PTYManager.spawn` の readSource / exitSource ハンドラ間で共有する終了確定状態。
@@ -344,44 +370,51 @@ private enum PTYDrainResult {
 private func drainPTY(fd: Int32, pid: Int32 = 0, caller: String = "?", onData: (Data) -> Void)
   -> PTYDrainResult
 {
-  ptyTrace("drain", pid: pid, "enter caller=\(caller) fd=\(fd)")
+  // observer effect を最小化するため、ループ内では trace を呼ばず drain 終了時に
+  // 集約結果を 1 行だけ出す。観測したい race（EVFILT_READ / NOTE_EXIT の到着順、
+  // drain と exit の時間差）はループ内 I/O が増えるとそれ自体で潰れる。
+  // 集約値: read 回数、合計バイト、EINTR 回数、終端区分（EOF / EAGAIN / hangup errno）。
   var totalBytes = 0
-  var iterations = 0
-  while true {
+  var dataReads = 0
+  var eintrCount = 0
+  let result: PTYDrainResult
+  let endReason: String
+  drainLoop: while true {
     var buffer = [UInt8](repeating: 0, count: 4096)
     let n = buffer.withUnsafeMutableBufferPointer {
       Darwin.read(fd, $0.baseAddress, $0.count)
     }
-    iterations += 1
     if n > 0 {
       totalBytes += n
-      ptyTrace("drain", pid: pid, "read n=\(n) totalBytes=\(totalBytes) iter=\(iterations)")
+      dataReads += 1
       onData(Data(bytes: buffer, count: n))
       continue
     }
     if n == 0 {
-      ptyTrace(
-        "drain", pid: pid,
-        "read n=0 EOF totalBytes=\(totalBytes) iter=\(iterations) → .closed")
-      return .closed
+      result = .closed
+      endReason = "EOF"
+      break drainLoop
     }
     let err = errno
     if err == EINTR {
-      ptyTrace("drain", pid: pid, "read n=-1 errno=EINTR iter=\(iterations) (retry)")
+      eintrCount += 1
       continue
     }
     if err == EAGAIN || err == EWOULDBLOCK {
-      ptyTrace(
-        "drain", pid: pid,
-        "read n=-1 errno=EAGAIN totalBytes=\(totalBytes) iter=\(iterations) → .drained")
-      return .drained
+      result = .drained
+      endReason = "EAGAIN"
+      break drainLoop
     }
     // EIO 等は PTY hangup 扱い（slave 全 close）。再 read しても無意味なので closed として返す。
-    ptyTrace(
-      "drain", pid: pid,
-      "read n=-1 errno=\(err) totalBytes=\(totalBytes) iter=\(iterations) → .closed (hangup)")
-    return .closed
+    result = .closed
+    endReason = "hangup-errno=\(err)"
+    break drainLoop
   }
+  ptyTrace(
+    "drain", pid: pid,
+    "caller=\(caller) fd=\(fd) dataReads=\(dataReads) totalBytes=\(totalBytes) eintr=\(eintrCount) end=\(endReason) → \(result)"
+  )
+  return result
 }
 
 private func decodeExitStatus(_ status: Int32) -> PTYExitReason {

--- a/apps/native/Sources/GozdCore/PTYTrace.swift
+++ b/apps/native/Sources/GozdCore/PTYTrace.swift
@@ -9,16 +9,22 @@ import Foundation
 // 1. `#if DEBUG` で release build からは関数実体ごと除外
 // 2. DEBUG build でも環境変数 `GOZD_PTY_TRACE=1` が無ければ即座に return
 //
-// 出力先は stderr 直書き。swift-testing は CI 上で stderr を取り込むため、
-// 別途バッファ機構を持たずに済む。各 trace 行は単一 `write(_:)` でアトミックに出るため、
-// マルチスレッドでも 1 行が分断されない（同時 write の行間順序は保証しないが、
-// 行内の整合性は保たれる）。
+// 出力先は GitHub Actions が capture するプロセスの stderr。swift-testing が
+// stderr をテスト出力に含めるかは保証外で、実質的には Actions 側のログ capture に依存する。
+//
+// 行単位の整合性（複数スレッドからの同時 write で 1 行が分断・混線しない）は
+// `FileHandle.standardError.write(contentsOf:)` 単独では保証されないため、自前の
+// NSLock で serialize する。lock の取得はマイクロ秒オーダーで、観測したい race
+// （EVFILT_READ / NOTE_EXIT の到着順）を潰す observer effect より、行が混線して
+// 観測機構の信頼性が落ちる方が実害が大きいと判断した。
+// 行間の到着順は時刻と pid タグから事後復元できるため lock 内では保証しない。
 //
 // 再発時に確認したい情報:
 //
-// - drainPTY の各 read 結果（n, errno, fd, 累積 bytes）
+// - drainPTY 集約結果（dataReads, totalBytes, eintr, 終端区分）
 // - read source / exit source の eventHandler 入退出順
-// - waitpid の status
+// - waitpid の戻り値・status・errno・EINTR retry 回数
+// - fcntl の戻り値（O_NONBLOCK 設定の成否）
 // - PTYFinishState の状態遷移（markReadClosed / setExitReason / onComplete 発火）
 //
 // childPid を tag に入れることで PTYRegistryTests のように複数 PTY を並走させた
@@ -29,6 +35,7 @@ import Foundation
     ProcessInfo.processInfo.environment["GOZD_PTY_TRACE"] == "1"
   }()
   private let ptyTraceStart = ContinuousClock.now
+  private let ptyTraceLock = NSLock()
 
   @inline(__always)
   func ptyTrace(_ tag: String, pid: Int32 = 0, _ message: @autoclosure () -> String) {
@@ -36,11 +43,14 @@ import Foundation
     let elapsed = ContinuousClock.now - ptyTraceStart
     let pidPart = pid == 0 ? "" : " pid=\(pid)"
     let line = "[PTY-TRACE +\(elapsed)\(pidPart) \(tag)] \(message())\n"
-    if let data = line.data(using: .utf8) {
-      try? FileHandle.standardError.write(contentsOf: data)
-    }
+    guard let data = line.data(using: .utf8) else { return }
+    ptyTraceLock.lock()
+    defer { ptyTraceLock.unlock() }
+    try? FileHandle.standardError.write(contentsOf: data)
   }
 #else
+  // release build でも関数定義自体は残るが、本体は空で `@inline(__always)` により
+  // call site から完全に inline 展開・除去される（ABI 上のコストは無い）。
   @inline(__always)
   func ptyTrace(_ tag: String, pid: Int32 = 0, _ message: @autoclosure () -> String) {}
 #endif

--- a/apps/native/Sources/GozdCore/PTYTrace.swift
+++ b/apps/native/Sources/GozdCore/PTYTrace.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+// PTYRegistryTests.spawnAndExitDispatch が CI 環境（macos-26 runner）で稀に flaky に
+// なる問題（issue #450）の原因特定用トレース。
+//
+// production の hot path（drainPTY のループ / setEventHandler コールバック）に呼び出しを
+// 仕込むため、二重 gate で release build には一切影響を出さない:
+//
+// 1. `#if DEBUG` で release build からは関数実体ごと除外
+// 2. DEBUG build でも環境変数 `GOZD_PTY_TRACE=1` が無ければ即座に return
+//
+// 出力先は stderr 直書き。swift-testing は CI 上で stderr を取り込むため、
+// 別途バッファ機構を持たずに済む。各 trace 行は単一 `write(_:)` でアトミックに出るため、
+// マルチスレッドでも 1 行が分断されない（同時 write の行間順序は保証しないが、
+// 行内の整合性は保たれる）。
+//
+// 再発時に確認したい情報:
+//
+// - drainPTY の各 read 結果（n, errno, fd, 累積 bytes）
+// - read source / exit source の eventHandler 入退出順
+// - waitpid の status
+// - PTYFinishState の状態遷移（markReadClosed / setExitReason / onComplete 発火）
+//
+// childPid を tag に入れることで PTYRegistryTests のように複数 PTY を並走させた
+// ケースでも時系列を分離できる。
+
+#if DEBUG
+  private let ptyTraceEnabled: Bool = {
+    ProcessInfo.processInfo.environment["GOZD_PTY_TRACE"] == "1"
+  }()
+  private let ptyTraceStart = ContinuousClock.now
+
+  @inline(__always)
+  func ptyTrace(_ tag: String, pid: Int32 = 0, _ message: @autoclosure () -> String) {
+    guard ptyTraceEnabled else { return }
+    let elapsed = ContinuousClock.now - ptyTraceStart
+    let pidPart = pid == 0 ? "" : " pid=\(pid)"
+    let line = "[PTY-TRACE +\(elapsed)\(pidPart) \(tag)] \(message())\n"
+    if let data = line.data(using: .utf8) {
+      try? FileHandle.standardError.write(contentsOf: data)
+    }
+  }
+#else
+  @inline(__always)
+  func ptyTrace(_ tag: String, pid: Int32 = 0, _ message: @autoclosure () -> String) {}
+#endif


### PR DESCRIPTION
## 概要

`PTYRegistryTests.spawnAndExitDispatch` が CI（macos-26 runner）で稀に flaky になる issue ( #450 ) について、**根治ではなく再発時の原因特定のためのトレース機構**を追加する。`PTYManager` のライフサイクルイベント（`drainPTY` の集約結果、read source / exit source の eventHandler 発火順、`waitpid` の戻り値・errno、`fcntl` の戻り値、`PTYFinishState` の状態遷移）を、CI 環境でのみ stderr に時系列出力する。

## 背景

issue ( #450 ) は CI で 1 度だけ観測された flake で、ローカルでは未再現:

- 失敗時の CI ログには `Expectation failed: (events.textFor(id: id2) → "").contains("world")` という **結果**しか残っていない
- 既存コードには print / logger / activity log が一切無く、`drainPTY` の `read` 戻り値・`errno`、handler の発火順、`PTYFinishState` の `(readClosed, exitReason, canFinish)` 遷移は事後復元不能
- PR ( #420 ) でローカル 150 連続 pass、PR ( #449 ) で 5 連続 pass、本作業中に追加で 20 連続 pass を確認しても再現せず

つまり「次の再発を待つしかないが、待っても情報が残らない」状態。原因仮説（`forkpty` の master fd EOF 遅延 / `DispatchSource` の event coalescing / macos-26 runner の I/O scheduler）を立てて推測ベースの追加 drain や sleep を入れるのは workaround で根治にならず、CLAUDE.md の「症状を消す方向に動かない」「workaround 禁止」に反する。

そのため**今回は問題解消ではなく、再発時に経路を逐語復元できる観測機構の追加**に絞る。

## 変更内容

### `apps/native/Sources/GozdCore/PTYTrace.swift`（新規）

- `ptyTrace(tag:pid:_:)` 関数を提供
- 二重 gate: `#if DEBUG` で release build からは関数定義を no-op に置き換え（`@inline(__always)` で call site から完全 inline 除去）、DEBUG build でも `GOZD_PTY_TRACE=1` env が無ければ即 return
- 出力は stderr 直書き（`FileHandle.standardError.write(contentsOf:)`）。`FileHandle` 単独では行単位の整合性を保証しないため、自前 NSLock で write を serialize する。複数 PTY 並走時の行混線を防ぐ
- `monotonic timestamp + pid` タグで時系列復元可能。出力先は GitHub Actions のプロセス stderr capture に依存

### `apps/native/Sources/GozdCore/PTYManager.swift`

主要遷移点に `ptyTrace` 呼び出しを追加:

- `forkpty` 直後（fd / executable）
- `fcntl` の戻り値（`getFlags`, `getFlagsErrno`, `setFlagsRet`, `setFlagsErrno`）。`F_GETFL` 失敗と `F_SETFL` 未実行を区別可能
- read source / exit source の `resume()` 後
- read source eventHandler の enter
- exit source eventHandler の enter / `waitpid` の戻り値・errno・EINTR retry 回数 / pre-drain・post-drain 結果
- `drainPTY` の集約結果（`dataReads`, `totalBytes`, `eintr`, 終端区分 `EOF`/`EAGAIN`/`hangup-errno=N`）。observer effect を最小化するためループ内 stderr 書き込みは廃止し、return 直前に 1 行のみ
- `PTYFinishState.markReadClosed` / `setExitReason` の状態遷移と `onComplete` 発火

`drainPTY` には `pid` と `caller`（`"read-source"` / `"exit-pre"` / `"exit-post"`）を引数追加し、どの経路の drain かを区別可能にした。

`PTYExitReason` に `.waitpidFailed(errno: Int32)` ケースを追加。`waitpid(2)` が `-1` で失敗したとき、初期値 `status=0` が `decodeExitStatus` で `.exited(code: 0)` と誤報される経路を遮断する。`encodeExitReason` も exhaustive switch のため対応ケースを追加し、renderer には `{"kind": "waitpidFailed", "errno": Int}` として配送される。

### `.github/workflows/code_validation.yml`

- `swift-test` step に `env: GOZD_PTY_TRACE: "1"` を追加
- CI では DEBUG build なので、env 設定だけで自動的にトレースが有効化される

## 検証

- ローカル `GOZD_PTY_TRACE=1 swift test --filter PTYRegistryTests/spawnAndExitDispatch` で出力を確認。両 PTY（id1 / id2）について `forkpty → fcntl → resume → read fired → drain (集約) → markReadClosed → exit handler → waitpid (詳細) → setExitReason → onComplete` の正常経路がそれぞれ pid タグ付きで出る
- env 未設定の `swift test` で 79 件全 pass。トレース無効時は従来挙動と同等であることを確認

## 再発時の見方

CI ログで `[PTY-TRACE` を grep し、失敗した id（テキストが空の方）の pid で絞って時系列を読む。確認するポイント:

- `drain` 行の `dataReads=0` で `end=EOF` か（= 子の出力が kernel buffer に残らずに EOF 観測 → `forkpty` 後 / `fcntl` 前のタイミング問題か kernel 側の buffering 問題）
- `drain` 行の `end=hangup-errno=N` か（= EIO 等で取りこぼし）
- `read source` の eventHandler が一度も `fired` しないか（= kqueue が data ready を通知していない）
- `exit-pre` / `exit-post` の drain で初めて `dataReads>0` になっているか（= read / exit の到着順問題）
- `waitpid ret=-1 errno=...` か（= 想定外 reap）
- `fcntl getFlagsErrno=...` / `setFlagsErrno=...` が 0 以外か（= `O_NONBLOCK` 設定失敗）

この情報があれば issue ( #450 ) の根治アプローチを推測ではなく観測ベースで決められる。

## 設計判断（Codex レビュー反映後）

- **observer effect 抑制**: `drainPTY` のループ内 stderr 書き込みを廃止し、return 直前 1 行集約に統合。観測したい race（`EVFILT_READ` / `NOTE_EXIT` 到着順）を観測機構が潰さないようにする
- **行整合性**: `FileHandle.standardError.write(contentsOf:)` は thread-safety を保証しないため、自前 NSLock で serialize する。lock 取得コスト（マイクロ秒オーダー）より行混線で観測精度が落ちる方が実害大と判断
- **異常の上位伝搬**: `waitpid` 失敗時に `decodeExitStatus` を経由させず、`.waitpidFailed(errno:)` で正確に伝搬する。観測機構が観測対象を歪めない原則を enum 設計にも適用

## 今回含めない点

- **根治修正**: 原因仮説が複数あり、再現条件が掴めていない段階で本体に追加 drain / retry / sleep / 設計変更を入れるのは workaround になる。次回 flake が CI で発生して trace ログが揃った時点で別 PR にする
- **テストの timeout 延長やリトライ**: 症状を見えにくくするだけで原因に届かないため対応しない
- **renderer / JS 側で `kind: "waitpidFailed"` を未知値としてどう扱うか**: 本 PR は native 側の観測精度向上が目的で、renderer 側の UI 表現は別管理。実運用で `.waitpidFailed` が発火する経路は `ECHILD` 等の異常系のみで、現状未観測。renderer 側の対応は再発・観測実績が出た時点で別 PR で扱う

## 確認事項

- [ ] env 未設定時に従来テストが全 pass する（trace 無効 = no-op）
- [ ] `GOZD_PTY_TRACE=1` 設定時に正常経路の集約トレースが両 PTY について出る
- [ ] release build には trace 関数本体が残らない（`#if DEBUG` で no-op、`@inline(__always)` で call site から除去）
- [ ] CI workflow の swift-test step で env が反映され、ログに `[PTY-TRACE` が出る
- [ ] `.waitpidFailed` 追加で `encodeExitReason` の exhaustive switch、`Equatable` 自動合成、テストの保存・比較が壊れていない
