### PR TITLE
fix(worktree-base): resolve default branch via origin/HEAD with local HEAD fallback

### DIFF
--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -134,6 +134,8 @@ public actor RpcDispatcher {
       return try await handleGitIssueList(body)
     case "/git/viewer":
       return try await handleGitViewer(body)
+    case "/git/defaultBranch":
+      return try await handleGitDefaultBranch(body)
     case "/git/createWorktree":
       return try await handleCreateWorktree(body)
     case "/git/worktreeRemove":
@@ -533,6 +535,18 @@ public actor RpcDispatcher {
     } else {
       resp.ok = false
     }
+    return try resp.jsonUTF8Data()
+  }
+
+  private func handleGitDefaultBranch(_ body: Data) async throws -> Data {
+    let req = try Gozd_V1_GitDefaultBranchRequest(jsonUTF8Data: body)
+    // origin/HEAD が未設定（remote 未追加 / fetch 未実行など）の場合は git が non-zero を返す。
+    // ここでは throw せず空文字列で返し、解決失敗のハンドリング（通知 / 中止 / fallback の選択）を
+    // 呼び出し側に委ねる。現状の caller（issue-picker / sidebar addWorktree）は空文字列を見て
+    // 通知 + early return する。
+    let branch = (try? await GitOps.defaultBranchName(dir: req.dir)) ?? ""
+    var resp = Gozd_V1_GitDefaultBranchResponse()
+    resp.branch = branch
     return try resp.jsonUTF8Data()
   }
 

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -540,14 +540,31 @@ public actor RpcDispatcher {
 
   private func handleGitDefaultBranch(_ body: Data) async throws -> Data {
     let req = try Gozd_V1_GitDefaultBranchRequest(jsonUTF8Data: body)
-    // origin/HEAD が未設定（remote 未追加 / fetch 未実行など）の場合は git が non-zero を返す。
-    // ここでは throw せず空文字列で返し、解決失敗のハンドリング（通知 / 中止 / fallback の選択）を
-    // 呼び出し側に委ねる。現状の caller（issue-picker / sidebar addWorktree）は空文字列を見て
-    // 通知 + early return する。
-    let branch = (try? await GitOps.defaultBranchName(dir: req.dir)) ?? ""
+    // worktree 作成の起点として使う ref を返す。`git worktree add -b <new> <abs> <ref>` の
+    // `<ref>` にそのまま渡せる文字列（`origin/main` / `main` 等）が caller の期待値。
+    //
+    // 1) origin/HEAD 経由で remote default branch を取得（`origin/main` 等を full ref で返す。
+    //    既存の `GitOps.defaultBranchName` は git-graph 用途で `origin/` prefix を剥がすため
+    //    ここでは流用せず、剥がさない形で扱う）
+    // 2) 失敗時は main repo root 自身の current branch に fallback（remote 未設定 / push 前 repo）
+    // 3) どちらも引けない（detached HEAD / unborn branch）場合は空文字列を返し、caller が通知 + 中止する
+    let branch = (try? await resolveStartPoint(dir: req.dir)) ?? ""
     var resp = Gozd_V1_GitDefaultBranchResponse()
     resp.branch = branch
     return try resp.jsonUTF8Data()
+  }
+
+  private func resolveStartPoint(dir: String) async throws -> String {
+    if let stdout = try? await runGit(
+      args: ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], cwd: dir)
+    {
+      let text = String(decoding: stdout, as: UTF8.self).trimmingCharacters(
+        in: .whitespacesAndNewlines)
+      if !text.isEmpty { return text }
+    }
+    let stdout = try await runGit(args: ["symbolic-ref", "--short", "HEAD"], cwd: dir)
+    return String(decoding: stdout, as: UTF8.self).trimmingCharacters(
+      in: .whitespacesAndNewlines)
   }
 
   private func handleCreateWorktree(_ body: Data) async throws -> Data {

--- a/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
+++ b/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
@@ -64,10 +64,19 @@ export function registerIssueCommand(): () => void {
             return;
           }
           void (async () => {
+            // 新規 worktree は常にデフォルトブランチを起点に作る。
+            // `dir` は active worktree のパスなので、そのまま `cwd` にして `HEAD` を渡すと
+            // active worktree のブランチ先端から派生してしまう。`rootDir`（main repo root）を
+            // 渡せば `cwd` のリポジトリ HEAD = デフォルトブランチに解決される（main は参照専用）。
+            const rootDir = repoStore.findRepoOwning(dir)?.rootDir;
+            if (rootDir === undefined) {
+              notify.error("Failed to resolve repo root for worktree creation");
+              return;
+            }
             const timestamp = generateTimestamp();
             const result = await tryCatch(
               rpcCreateWorktree({
-                dir,
+                dir: rootDir,
                 worktreeDir: timestamp,
                 branch: timestamp,
                 startPoint: "HEAD",
@@ -89,8 +98,7 @@ export function registerIssueCommand(): () => void {
             if (!taskResult.ok) {
               notify.error("Failed to create task for worktree", taskResult.error);
             }
-            const rootDir = repoStore.findRepoOwning(dir)?.rootDir;
-            if (rootDir === undefined || result.value.worktree === undefined) {
+            if (result.value.worktree === undefined) {
               notify.error("Worktree created but sidebar could not be updated");
             } else {
               repoStore.appendWorktree(rootDir, result.value.worktree);

--- a/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
+++ b/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
@@ -69,9 +69,9 @@ export function registerIssueCommand(): () => void {
             return;
           }
           void (async () => {
-            // 新規 worktree は default branch を起点に作る。`HEAD` に頼ると `cwd` の
-            // 現在 checkout されているブランチに依存してしまうため、`origin/HEAD` から
-            // default branch 名（例: `origin/main`）を解決して明示的に渡す。
+            // 新規 worktree は default branch を起点に作る。Swift 側で `origin/HEAD` を
+            // 優先し、未設定（remote 無し / push 前 repo）の場合は main repo root 自身の
+            // current branch に fallback して解決した ref を受け取り、`startPoint` に渡す。
             const rootDir = repoStore.findRepoOwning(dir)?.rootDir;
             if (rootDir === undefined) {
               notify.error("Failed to resolve repo root for worktree creation");

--- a/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
+++ b/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
@@ -8,7 +8,12 @@ import { tryCatch } from "@gozd/shared";
 import { useCommandRegistry } from "../../../../shared/command";
 import { useNotificationStore } from "../../../../shared/notification";
 import { useRepoStore } from "../../../../shared/repo";
-import { rpcCreateWorktree, rpcGitWorktreeList, rpcTaskAdd } from "../../../sidebar";
+import {
+  rpcCreateWorktree,
+  rpcGitDefaultBranch,
+  rpcGitWorktreeList,
+  rpcTaskAdd,
+} from "../../../sidebar";
 import { useTerminalStore } from "../../../terminal";
 import { generateTimestamp, useWorktreeStore } from "../../../worktree";
 import { rpcGitViewer } from "../pr-picker";
@@ -64,13 +69,20 @@ export function registerIssueCommand(): () => void {
             return;
           }
           void (async () => {
-            // 新規 worktree は常にデフォルトブランチを起点に作る。
-            // `dir` は active worktree のパスなので、そのまま `cwd` にして `HEAD` を渡すと
-            // active worktree のブランチ先端から派生してしまう。`rootDir`（main repo root）を
-            // 渡せば `cwd` のリポジトリ HEAD = デフォルトブランチに解決される（main は参照専用）。
+            // 新規 worktree は default branch を起点に作る。`HEAD` に頼ると `cwd` の
+            // 現在 checkout されているブランチに依存してしまうため、`origin/HEAD` から
+            // default branch 名（例: `origin/main`）を解決して明示的に渡す。
             const rootDir = repoStore.findRepoOwning(dir)?.rootDir;
             if (rootDir === undefined) {
               notify.error("Failed to resolve repo root for worktree creation");
+              return;
+            }
+            const branchResult = await tryCatch(rpcGitDefaultBranch({ dir: rootDir }));
+            if (!branchResult.ok || branchResult.value.branch === "") {
+              notify.error(
+                "Failed to resolve default branch",
+                branchResult.ok ? undefined : branchResult.error,
+              );
               return;
             }
             const timestamp = generateTimestamp();
@@ -79,7 +91,7 @@ export function registerIssueCommand(): () => void {
                 dir: rootDir,
                 worktreeDir: timestamp,
                 branch: timestamp,
-                startPoint: "HEAD",
+                startPoint: branchResult.value.branch,
               }),
             );
             if (!result.ok) {

--- a/apps/renderer/src/features/sidebar/features/worktree/useWorktreeActions.ts
+++ b/apps/renderer/src/features/sidebar/features/worktree/useWorktreeActions.ts
@@ -72,8 +72,9 @@ export function useWorktreeActions({ showConfirm }: UseWorktreeActionsOptions) {
   async function addWorktree(rootDir: string) {
     if (isCreating.value) return;
     isCreating.value = true;
-    // default branch（`origin/HEAD` の指す先）を起点にする。`HEAD` だと main repo root の
-    // 現在 checkout に依存してしまい、規約から外れた状態の影響を受けるため明示解決する。
+    // default branch を起点にする。Swift 側で `origin/HEAD` を優先し、未設定
+    // （remote 無し / push 前 repo）の場合は main repo root 自身の current branch に
+    // fallback した ref を受け取り、`startPoint` に渡す。
     const branchResult = await tryCatch(rpcGitDefaultBranch({ dir: rootDir }));
     if (!branchResult.ok || branchResult.value.branch === "") {
       notify.error(

--- a/apps/renderer/src/features/sidebar/features/worktree/useWorktreeActions.ts
+++ b/apps/renderer/src/features/sidebar/features/worktree/useWorktreeActions.ts
@@ -5,7 +5,7 @@ import { useNotificationStore } from "../../../../shared/notification";
 import { useRepoStore } from "../../../../shared/repo";
 import { useTerminalStore } from "../../../terminal";
 import { generateTimestamp, useWorktreeStore } from "../../../worktree";
-import { rpcCreateWorktree, rpcGitWorktreeRemove } from "../../rpc";
+import { rpcCreateWorktree, rpcGitDefaultBranch, rpcGitWorktreeRemove } from "../../rpc";
 import { worktreeDisplayName } from "../../utils";
 
 interface UseWorktreeActionsOptions {
@@ -72,13 +72,24 @@ export function useWorktreeActions({ showConfirm }: UseWorktreeActionsOptions) {
   async function addWorktree(rootDir: string) {
     if (isCreating.value) return;
     isCreating.value = true;
+    // default branch（`origin/HEAD` の指す先）を起点にする。`HEAD` だと main repo root の
+    // 現在 checkout に依存してしまい、規約から外れた状態の影響を受けるため明示解決する。
+    const branchResult = await tryCatch(rpcGitDefaultBranch({ dir: rootDir }));
+    if (!branchResult.ok || branchResult.value.branch === "") {
+      notify.error(
+        "Failed to resolve default branch",
+        branchResult.ok ? undefined : branchResult.error,
+      );
+      isCreating.value = false;
+      return;
+    }
     const timestamp = generateTimestamp();
     const result = await tryCatch(
       rpcCreateWorktree({
         dir: rootDir,
         worktreeDir: timestamp,
         branch: timestamp,
-        startPoint: "HEAD",
+        startPoint: branchResult.value.branch,
       }),
     );
     if (result.ok && result.value.worktree !== undefined) {

--- a/apps/renderer/src/features/sidebar/index.ts
+++ b/apps/renderer/src/features/sidebar/index.ts
@@ -1,5 +1,5 @@
 export { default as SidebarPane } from "./SidebarPane.vue";
-export { rpcCreateWorktree,  rpcGitWorktreeList, rpcTaskAdd } from "./rpc";
+export { rpcCreateWorktree, rpcGitDefaultBranch, rpcGitWorktreeList, rpcTaskAdd } from "./rpc";
 export type { BranchChangePayload } from "./rpc";
 export { useGozdOpenHandler } from "./useGozdOpenHandler";
 export { useRepoContextKey } from "./useRepoContextKey";

--- a/apps/renderer/src/features/sidebar/rpc.ts
+++ b/apps/renderer/src/features/sidebar/rpc.ts
@@ -4,6 +4,8 @@ import {
   CreateWorktreeResponse,
   GitBranchListRequest,
   GitBranchListResponse,
+  GitDefaultBranchRequest,
+  GitDefaultBranchResponse,
   GitWorktreeListRequest,
   GitWorktreeListResponse,
   GitWorktreeRemoveRequest,
@@ -30,6 +32,9 @@ export const rpcGitBranchList = (req: GitBranchListRequest) =>
 
 export const rpcCreateWorktree = (req: CreateWorktreeRequest) =>
   rpc("/git/createWorktree", req, CreateWorktreeRequest, CreateWorktreeResponse);
+
+export const rpcGitDefaultBranch = (req: GitDefaultBranchRequest) =>
+  rpc("/git/defaultBranch", req, GitDefaultBranchRequest, GitDefaultBranchResponse);
 
 export const rpcGitWorktreeRemove = (req: GitWorktreeRemoveRequest) =>
   rpc("/git/worktreeRemove", req, GitWorktreeRemoveRequest, GitWorktreeRemoveResponse);

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
@@ -342,9 +342,12 @@ public struct Gozd_V1_GitViewerResponse: Sendable {
   public init() {}
 }
 
-/// gitDefaultBranch: `git symbolic-ref --short refs/remotes/origin/HEAD` 相当。
-/// 新規 worktree を default branch から派生させるとき、起点 ref を一意に決めるために使う。
-/// `origin/main` のように remote 名込みのフルネームを返す。origin/HEAD が未設定の場合は空文字列。
+/// gitDefaultBranch: `git worktree add -b <new> <abs> <ref>` の `<ref>` にそのまま渡せる
+/// 「default branch ref」を返す。新規 worktree 作成時の起点を一意に決めるために使う。
+/// 解決順序は二段 fallback:
+///   1) `git symbolic-ref --short refs/remotes/origin/HEAD` で `origin/main` 等を返す（push 済み repo）
+///   2) 失敗したら `git symbolic-ref --short HEAD` で `main` 等を返す（remote 未設定 / push 前 repo）
+///   3) どちらも失敗（detached HEAD / unborn branch）なら空文字列を返し、呼び出し側が通知 + 中止する
 public struct Gozd_V1_GitDefaultBranchRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
@@ -342,6 +342,33 @@ public struct Gozd_V1_GitViewerResponse: Sendable {
   public init() {}
 }
 
+/// gitDefaultBranch: `git symbolic-ref --short refs/remotes/origin/HEAD` 相当。
+/// 新規 worktree を default branch から派生させるとき、起点 ref を一意に決めるために使う。
+/// `origin/main` のように remote 名込みのフルネームを返す。origin/HEAD が未設定の場合は空文字列。
+public struct Gozd_V1_GitDefaultBranchRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var dir: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public struct Gozd_V1_GitDefaultBranchResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var branch: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 /// createWorktree: 新規 worktree を作成
 public struct Gozd_V1_CreateWorktreeRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
@@ -1128,6 +1155,66 @@ extension Gozd_V1_GitViewerResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
   public static func ==(lhs: Gozd_V1_GitViewerResponse, rhs: Gozd_V1_GitViewerResponse) -> Bool {
     if lhs.ok != rhs.ok {return false}
     if lhs.login != rhs.login {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Gozd_V1_GitDefaultBranchRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GitDefaultBranchRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}dir\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.dir) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.dir.isEmpty {
+      try visitor.visitSingularStringField(value: self.dir, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Gozd_V1_GitDefaultBranchRequest, rhs: Gozd_V1_GitDefaultBranchRequest) -> Bool {
+    if lhs.dir != rhs.dir {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Gozd_V1_GitDefaultBranchResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GitDefaultBranchResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}branch\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.branch) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.branch.isEmpty {
+      try visitor.visitSingularStringField(value: self.branch, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Gozd_V1_GitDefaultBranchResponse, rhs: Gozd_V1_GitDefaultBranchResponse) -> Bool {
+    if lhs.branch != rhs.branch {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
@@ -137,6 +137,19 @@ export interface GitViewerResponse {
   login: string;
 }
 
+/**
+ * gitDefaultBranch: `git symbolic-ref --short refs/remotes/origin/HEAD` 相当。
+ * 新規 worktree を default branch から派生させるとき、起点 ref を一意に決めるために使う。
+ * `origin/main` のように remote 名込みのフルネームを返す。origin/HEAD が未設定の場合は空文字列。
+ */
+export interface GitDefaultBranchRequest {
+  dir: string;
+}
+
+export interface GitDefaultBranchResponse {
+  branch: string;
+}
+
 /** createWorktree: 新規 worktree を作成 */
 export interface CreateWorktreeRequest {
   dir: string;
@@ -1679,6 +1692,122 @@ export const GitViewerResponse: MessageFns<GitViewerResponse> = {
     const message = createBaseGitViewerResponse();
     message.ok = object.ok ?? false;
     message.login = object.login ?? "";
+    return message;
+  },
+};
+
+function createBaseGitDefaultBranchRequest(): GitDefaultBranchRequest {
+  return { dir: "" };
+}
+
+export const GitDefaultBranchRequest: MessageFns<GitDefaultBranchRequest> = {
+  encode(message: GitDefaultBranchRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.dir !== "") {
+      writer.uint32(10).string(message.dir);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GitDefaultBranchRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGitDefaultBranchRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.dir = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GitDefaultBranchRequest {
+    return { dir: isSet(object.dir) ? globalThis.String(object.dir) : "" };
+  },
+
+  toJSON(message: GitDefaultBranchRequest): unknown {
+    const obj: any = {};
+    if (message.dir !== "") {
+      obj.dir = message.dir;
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<GitDefaultBranchRequest>): GitDefaultBranchRequest {
+    return GitDefaultBranchRequest.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<GitDefaultBranchRequest>): GitDefaultBranchRequest {
+    const message = createBaseGitDefaultBranchRequest();
+    message.dir = object.dir ?? "";
+    return message;
+  },
+};
+
+function createBaseGitDefaultBranchResponse(): GitDefaultBranchResponse {
+  return { branch: "" };
+}
+
+export const GitDefaultBranchResponse: MessageFns<GitDefaultBranchResponse> = {
+  encode(message: GitDefaultBranchResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.branch !== "") {
+      writer.uint32(10).string(message.branch);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GitDefaultBranchResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGitDefaultBranchResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.branch = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GitDefaultBranchResponse {
+    return { branch: isSet(object.branch) ? globalThis.String(object.branch) : "" };
+  },
+
+  toJSON(message: GitDefaultBranchResponse): unknown {
+    const obj: any = {};
+    if (message.branch !== "") {
+      obj.branch = message.branch;
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<GitDefaultBranchResponse>): GitDefaultBranchResponse {
+    return GitDefaultBranchResponse.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<GitDefaultBranchResponse>): GitDefaultBranchResponse {
+    const message = createBaseGitDefaultBranchResponse();
+    message.branch = object.branch ?? "";
     return message;
   },
 };

--- a/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
@@ -138,9 +138,12 @@ export interface GitViewerResponse {
 }
 
 /**
- * gitDefaultBranch: `git symbolic-ref --short refs/remotes/origin/HEAD` 相当。
- * 新規 worktree を default branch から派生させるとき、起点 ref を一意に決めるために使う。
- * `origin/main` のように remote 名込みのフルネームを返す。origin/HEAD が未設定の場合は空文字列。
+ * gitDefaultBranch: `git worktree add -b <new> <abs> <ref>` の `<ref>` にそのまま渡せる
+ * 「default branch ref」を返す。新規 worktree 作成時の起点を一意に決めるために使う。
+ * 解決順序は二段 fallback:
+ *   1) `git symbolic-ref --short refs/remotes/origin/HEAD` で `origin/main` 等を返す（push 済み repo）
+ *   2) 失敗したら `git symbolic-ref --short HEAD` で `main` 等を返す（remote 未設定 / push 前 repo）
+ *   3) どちらも失敗（detached HEAD / unborn branch）なら空文字列を返し、呼び出し側が通知 + 中止する
  */
 export interface GitDefaultBranchRequest {
   dir: string;

--- a/packages/proto-ts/src/index.ts
+++ b/packages/proto-ts/src/index.ts
@@ -78,6 +78,8 @@ export {
   GitBranchListResponse,
   GitCommitFilesRequest,
   GitCommitFilesResponse,
+  GitDefaultBranchRequest,
+  GitDefaultBranchResponse,
   GitDiffFileRequest,
   GitDiffFileResponse,
   GitIssueListRequest,

--- a/packages/proto/gozd/v1/git_ops.proto
+++ b/packages/proto/gozd/v1/git_ops.proto
@@ -113,6 +113,16 @@ message GitViewerResponse {
   string login = 2;
 }
 
+// gitDefaultBranch: `git symbolic-ref --short refs/remotes/origin/HEAD` 相当。
+// 新規 worktree を default branch から派生させるとき、起点 ref を一意に決めるために使う。
+// `origin/main` のように remote 名込みのフルネームを返す。origin/HEAD が未設定の場合は空文字列。
+message GitDefaultBranchRequest {
+  string dir = 1;
+}
+message GitDefaultBranchResponse {
+  string branch = 1;
+}
+
 // createWorktree: 新規 worktree を作成
 message CreateWorktreeRequest {
   string dir = 1;

--- a/packages/proto/gozd/v1/git_ops.proto
+++ b/packages/proto/gozd/v1/git_ops.proto
@@ -113,9 +113,12 @@ message GitViewerResponse {
   string login = 2;
 }
 
-// gitDefaultBranch: `git symbolic-ref --short refs/remotes/origin/HEAD` 相当。
-// 新規 worktree を default branch から派生させるとき、起点 ref を一意に決めるために使う。
-// `origin/main` のように remote 名込みのフルネームを返す。origin/HEAD が未設定の場合は空文字列。
+// gitDefaultBranch: `git worktree add -b <new> <abs> <ref>` の `<ref>` にそのまま渡せる
+// 「default branch ref」を返す。新規 worktree 作成時の起点を一意に決めるために使う。
+// 解決順序は二段 fallback:
+//   1) `git symbolic-ref --short refs/remotes/origin/HEAD` で `origin/main` 等を返す（push 済み repo）
+//   2) 失敗したら `git symbolic-ref --short HEAD` で `main` 等を返す（remote 未設定 / push 前 repo）
+//   3) どちらも失敗（detached HEAD / unborn branch）なら空文字列を返し、呼び出し側が通知 + 中止する
 message GitDefaultBranchRequest {
   string dir = 1;
 }


### PR DESCRIPTION
## 概要

issue picker / サイドバーから新規 worktree を作成する際、起点が「現在 UI で開いている別 worktree の HEAD」や「main repo root の現在 checkout」に依存してしまう不具合を修正する。Swift 側で `origin/HEAD` から default branch を明示解決し、`startPoint` に `origin/main` のような remote 込みのフルネーム ref を渡す形に統一した。`origin/HEAD` が未設定のローカル only な repo（`git init` 直後、push 前、remote 未追加）でも作成できるよう、main repo root 自身の current branch への二段 fallback を持つ。

## 背景

`apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts` は元々 `rpcCreateWorktree` に `dir: worktreeStore.dir`（active worktree のパス）と `startPoint: "HEAD"` を渡していた。Swift 側 (`apps/native/Sources/GozdCore/WorktreeOps.swift`) の `createWorktree` は `git worktree add -b <branch> <absPath> HEAD` を `cwd: dir` で実行するため、`HEAD` は cwd の repo / worktree HEAD として解決される。`cwd` が active worktree のときはその worktree のブランチ先端が起点となり、「feature ブランチ A を開いて issue から worktree を作ると main ではなく A から派生する」という現象を起こしていた。

最初の修正案では `dir` を `rootDir`（main repo root）に差し替えて `cwd` を main repo root に揃える形にしたが、レビューで「`rootDir + HEAD` は『main repo root の現在 HEAD』までしか保証せず、CLAUDE.md の運用ルール『main は参照専用』に依存している。前提が崩れた瞬間に同種のバグが再発する。`origin/<defaultBranch>` を明示すべき」「同パターンが sidebar `addWorktree` にも残っている」と指摘された。

二段目の修正で新規 RPC `gitDefaultBranch` を追加して `origin/HEAD` を解決する形にしたが、ユーザー指摘で「remote 未設定 repo（`git init` 直後 / push 前）で worktree が作れなくなる」というリグレッションが判明。さらに、それまでの実装は `GitOps.defaultBranchName` を流用していたが、この関数は git-graph 用途で `origin/` prefix を剥がして `main` を返す契約だった。剥がした文字列をそのまま `startPoint` に渡すと `git worktree add -b new <abs> main` となり、ローカル `main` 起点になってしまう（remote の最新ではない）。レビュー指摘の意図（`origin/<defaultBranch>` 明示）には実は届いていなかった。本 PR では `gitDefaultBranch` ハンドラを `origin/` prefix を残す形にインライン書き直し、二段 fallback を組み込むことで両方を解消する。

pr-picker は元から `startPoint` に `origin/<headRef>` を明示しているため変更不要。`handleBranchLink`（既存ブランチを worktree 化する経路）は対象ブランチが既にコミットを持つため startPoint 不要で、論点が異なるためスコープ外。

## 変更内容

### 新規 RPC `gitDefaultBranch`

- `packages/proto/gozd/v1/git_ops.proto` に `GitDefaultBranchRequest` / `GitDefaultBranchResponse` を追加（TS / Swift 両方を `pnpm --filter @gozd/proto generate` で再生成）
- `packages/proto-ts/src/index.ts` から re-export
- `apps/renderer/src/features/sidebar/rpc.ts` に `rpcGitDefaultBranch` wrapper を追加し、サイドバーバレル経由で公開
- `apps/native/Sources/GozdCore/RpcDispatcher.swift` に `/git/defaultBranch` ハンドラを追加。二段 fallback の解決ロジックを `resolveStartPoint` private helper として実装

### default branch ref の解決ロジック

`resolveStartPoint(dir:)` の解決順序:

- `git symbolic-ref --short refs/remotes/origin/HEAD` で `origin/main` 等を返す（push 済み repo）
- 失敗時は `git symbolic-ref --short HEAD` で `main` 等を返す（remote 未設定 / push 前 repo）
- どちらも引けない（detached HEAD / unborn branch）場合は空文字列を返し、caller が通知 + 中止する

`GitOps.defaultBranchName` は git-graph 用に `origin/` prefix を剥がす契約を持つため流用せず、ハンドラ側でインライン `runGit` 呼び出しとして実装している。

### 起点 ref を明示解決に切り替え

- `apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts`: `dir` を `rootDir` に切り替え、`rpcGitDefaultBranch` で取得した ref を `startPoint` に渡す。解決失敗時は通知して early return
- `apps/renderer/src/features/sidebar/features/worktree/useWorktreeActions.ts` の `addWorktree`: 同上の方針で `startPoint: "HEAD"` を解決済み ref に切り替え

## 今回含めない点

- **`handleCreateWorktreeWithTask`（Swift 側）**: `startPoint: nil` で「既存ブランチを worktree 化」する経路であり、新規ブランチをどこから切るかという論点とは別。renderer から呼ばれているかも要確認のため別 PR で扱う
- **`handleBranchLink`（既存ブランチの worktree 化）**: 同じく既存ブランチに対する操作で startPoint 不要。今回のスコープ外

## 確認事項

- [ ] feature worktree A を開いた状態で issue を選択し、新規 worktree が `origin/<defaultBranch>` から派生していること（`git log` の起点が remote の default branch のコミット）
- [ ] サイドバーの `+` ボタンから作る worktree が同様に `origin/<defaultBranch>` から派生していること
- [ ] PR から作る worktree（pr-picker）が引き続き `origin/<headRef>` から作られること（変更なし）
- [ ] **remote 未設定の repo**（`git init` 直後で push 前 / origin remote 無し）で worktree 作成が成功し、main repo root の current branch から派生していること
- [ ] detached HEAD / unborn branch の repo で worktree 作成を試みたとき、トースト通知で「Failed to resolve default branch」が表示され、worktree が作成されないこと
