### PR TITLE
feat(terminal): sync selected worktree on terminal focus in cross-cutting views

### DIFF
--- a/apps/renderer/src/features/terminal/TerminalLeaf.vue
+++ b/apps/renderer/src/features/terminal/TerminalLeaf.vue
@@ -10,11 +10,13 @@
 
 - xterm の onFocus → store.focusPane() でフォーカス状態を更新
 - store の focusedLeafId を watch し、自身が focused になったら imperative に terminal.focus()
+- focus 時に自身の dir が選択 worktree と異なれば worktreeStore.setOpen() で追従（viewMode="all"/"claude" 用、viewMode は変更しない）
 </doc>
 
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from "vue";
 import { useContextKeys } from "../../shared/command";
+import { useWorktreeStore } from "../worktree";
 import type { ClaudeState } from "./claudeStatus";
 import { currentTheme } from "./terminalConfig";
 import { useTerminalStore } from "./useTerminalStore";
@@ -27,6 +29,7 @@ interface Props {
 
 const props = defineProps<Props>();
 const terminalStore = useTerminalStore();
+const worktreeStore = useWorktreeStore();
 const contextKeys = useContextKeys();
 
 const xtermRef = ref<InstanceType<typeof XtermTerminal>>();
@@ -84,6 +87,11 @@ watch(
 function handleTerminalFocus() {
   contextKeys.set("terminalFocus", true);
   terminalStore.focusPane(props.leafId);
+  // viewMode="all"/"claude" で別 worktree の leaf に focus した場合、選択を追従させる。
+  // viewMode="wt" では TerminalPane が selectedDir 配下の leaf しか描画しないため自然に no-op。
+  if (worktreeStore.dir !== props.dir) {
+    worktreeStore.setOpen(props.dir);
+  }
 }
 
 function handleTerminalBlur() {

--- a/apps/renderer/src/features/terminal/TerminalPane.vue
+++ b/apps/renderer/src/features/terminal/TerminalPane.vue
@@ -49,6 +49,19 @@ const currentDir = computed(() => worktreeStore.dir);
 const disposeTerminalCommands = registerTerminalCommands(currentDir, containerRef);
 onUnmounted(disposeTerminalCommands);
 
+/**
+ * activeElement が terminal コンテナ内にあるかで terminalFocus を再判定する。
+ * unconditional false にすると、terminal の focus が dir 変更を引き起こす経路
+ * （cross-cutting view で別 worktree の leaf に focus 移動）で context key が
+ * 落ちて keybinding が外れるため、DOM の真の focus 状態から逆引きする。
+ */
+function syncTerminalFocusFromActiveElement() {
+  const container = containerRef.value;
+  const active = document.activeElement;
+  const isFocused = container !== null && active !== null && container.contains(active);
+  contextKeys.set("terminalFocus", isFocused);
+}
+
 // ウィンドウの表示状態変更時に terminalFocus を同期
 // hidden 時は false にリセット、復帰時は activeElement から再判定
 // （WKWebView では復帰時に xterm の focus が再発火しない場合がある）
@@ -56,19 +69,16 @@ useEventListener(document, "visibilitychange", () => {
   if (document.hidden) {
     contextKeys.set("terminalFocus", false);
   } else {
-    const container = containerRef.value;
-    const active = document.activeElement;
-    const isFocused = container !== null && active !== null && container.contains(active);
-    contextKeys.set("terminalFocus", isFocused);
+    syncTerminalFocusFromActiveElement();
   }
 });
 
 // worktree を初めて訪問したときに visitedDirs に登録
-// worktree 切り替え時に terminalFocus をリセット
+// dir 変更時は activeElement から再判定する（terminal 起点の dir 変更なら focus は維持）
 watch(
   () => worktreeStore.dir,
   (dir) => {
-    contextKeys.set("terminalFocus", false);
+    syncTerminalFocusFromActiveElement();
     if (dir) terminalStore.visit(dir);
   },
   { immediate: true },

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -125,6 +125,8 @@ leafNode
 - **all**: `tileGridTemplate()` で全 leaf を均等タイル配置
 - **claude**: `tileGridTemplate()` で Claude 起動中の leaf のみ均等タイル配置
 
+`all` / `claude` モードでは複数 worktree の leaf が同時に表示されるため、focus を受けた leaf の `dir` が現在の選択 worktree と異なる場合、`worktreeStore.setOpen(dir)` で選択を追従させる。viewMode は変更しない（横断ビューを維持したまま、サイドバー・ファイラー・プレビューのみ追従）。`wt` モードでは選択 worktree 配下の leaf しか描画されないため、この処理は自然に no-op となる。
+
 ## OSC ハンドラ
 
 xterm.js のイベントまたは `parser.registerOscHandler()` でエスケープシーケンスを受信し、store に保存する。


### PR DESCRIPTION
## 概要

`viewMode="all"` / `viewMode="claude"` で複数 worktree のターミナルが同時に表示されているとき、focus を受けたターミナルの所属 worktree にサイドバー・ファイラー・プレビューの選択を追従させる。あわせて、worktree 切り替えに伴う `terminalFocus` context key のリセットを DOM の真の focus 状態に基づく再判定方式に揃える。

## 背景

これまで worktree の選択切り替えはサイドバーからの明示操作（`useWorktreeActions.handleWorktreeSelect`）のみだった。横断ビュー（`all` / `claude`）では複数 worktree の leaf が同居するため、Claude が動いている別の worktree のターミナルにキー入力を移しても、ファイラー / 変更ファイル / プレビューは元の worktree のままで実態とずれた表示になっていた。

ターミナルへの focus 移動（クリック・spatial navigation 等）は「今この worktree を見ている」というユーザー意図の十分なシグナルなので、これを起点に worktree 選択を追従させる。

## 変更内容

### terminal

- `TerminalLeaf.vue` の `handleTerminalFocus` で、leaf の `dir` が `worktreeStore.dir` と異なる場合に `worktreeStore.setOpen(props.dir)` を呼ぶ
- 条件は viewMode を見ない: `wt` モードでは `TerminalPane` が selectedDir 配下の leaf しか描画しないため `props.dir === worktreeStore.dir` が常に成立し、自然に no-op になる
- `setOpen` は viewMode を変更しないため、横断ビューを保ったまま選択だけ追従する（`useWorktreeActions.handleWorktreeSelect` のように `viewMode = "wt"` に戻すことは意図的にしない）

### terminal-pane（focus 起点 dir 変更との整合性）

- `TerminalPane.vue` の `worktreeStore.dir` watcher が unconditional に `terminalFocus=false` をセットしていたため、上記の focus 起点の同期で別 worktree の leaf に移動すると context key が落ちて `cmd+d` / `cmd+w` / `alt+cmd+矢印` 等の `when: "terminalFocus"` 付き keybinding が無効化される問題を解消
- `visibilitychange` ハンドラと同じ `document.activeElement` ベースの再判定ロジックを `syncTerminalFocusFromActiveElement()` に抽出し、dir watcher / visibilitychange の双方で利用
- terminal 起点の dir 変更時は activeElement が terminal コンテナ内にあるため `terminalFocus=true` を維持。サイドバー起点の場合は activeElement が外なので従来通り `false` になる

### docs

- `docs/terminal.md` の表示モードセクションに focus 追従の挙動を追記
- `TerminalLeaf.vue` の `<doc>` ブロックのフォーカス節に追記

## 確認事項

- [ ] `viewMode="all"` で別 worktree の leaf にクリック focus すると、サイドバーの選択 worktree がその leaf の dir に変わる
- [ ] focus 追従後も viewMode が `"all"` のまま維持される（`"wt"` に戻らない）
- [ ] focus 追従直後に `cmd+d` / `cmd+w` / `alt+cmd+矢印` 等の `terminalFocus` 依存 keybinding が引き続き効く
- [ ] `viewMode="claude"` でも同様に追従する
- [ ] `viewMode="wt"` での通常操作（同一 worktree 内の split 間 focus 移動）でリグレッションがない
- [ ] keybinding の `terminal.focusLeft` / `focusRight` 等で別 worktree の leaf に移動した場合も追従する
- [ ] サイドバークリックで明示的に worktree を切り替えたとき、`terminalFocus` が `false` になる（従来挙動）
- [ ] `visibilitychange` でウィンドウを再表示したときに、terminal にフォーカスがあれば `terminalFocus=true` に戻る
