### PR TITLE
chore(pnpm): drop tailwind-csstree override and packageExtension

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ macOS 26 Tahoe 以降専用（`WebPage` API は macOS 26 で追加された Swif
 
 ## pnpm ワークアラウンド
 
-`pnpm-workspace.yaml` の `overrides` / `packageExtensions` で upstream の依存宣言バグを回避している。upstream が修正されたら解除する。
+`pnpm-workspace.yaml` の `packageExtensions` で upstream の依存宣言バグを回避している。upstream が修正されたら解除する。
 
 ### settings（pnpm 本体のバグ回避）
 
@@ -179,17 +179,10 @@ macOS 26 Tahoe 以降専用（`WebPage` API は macOS 26 で追加された Swif
 | ------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- |
 | `minimumReleaseAgeStrict` | `false` | pnpm v11.0.4 以降、ユーザーが `minimumReleaseAge` を設定すると暗黙で strict=true になる ( pnpm/pnpm#11436 )。strict 経路では abbreviated metadata の `time` 欠落で `ERR_PNPM_MISSING_TIME` を rethrow し、`minimumReleaseAgeIgnoreMissingTime` の catch に届かない | pnpm/pnpm#11238 が修正されたら削除 |
 
-### overrides
-
-| パッケージ         | 強制バージョン | 理由                                                                                                                                                                        | 解除条件                                                                         |
-| ------------------ | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `tailwind-csstree` | `0.3.1`        | `eslint-plugin-better-tailwindcss` が `^0.1.4` を要求するが、0.1.5 は `@eslint/css-tree` を dependency から削除したバグ版。semver `0.x` 系で `^0.1.4` は `0.2.0` を含まない | `eslint-plugin-better-tailwindcss` が `tailwind-csstree@^0.3.x` に対応したら削除 |
-
 ### packageExtensions（phantom dependency 補完）
 
 `enableGlobalVirtualStore` により phantom dependency が顕在化するため、upstream が宣言していない依存を補完している。
 
-| パッケージ                 | 補完する依存           | 理由                                                                                                           | 解除条件                                                              |
-| -------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `tailwind-csstree@0.2.0`   | `@eslint/css-tree`     | 0.2.0 では peerDep が `@eslint/css` に変更されたが、コード内で `@eslint/css-tree` を直接 import しており未宣言 | `tailwind-csstree` が `@eslint/css-tree` を dependency に含めたら削除 |
-| `@iconify/tailwind4@1.2.3` | `@iconify-json/lucide` | 動的に `require` するが dependencies に含めていない                                                            | `@iconify/tailwind4` が dependency に含めたら削除                     |
+| パッケージ                 | 補完する依存           | 理由                                                | 解除条件                                          |
+| -------------------------- | ---------------------- | --------------------------------------------------- | ------------------------------------------------- |
+| `@iconify/tailwind4@1.2.3` | `@iconify-json/lucide` | 動的に `require` するが dependencies に含めていない | `@iconify/tailwind4` が dependency に含めたら削除 |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,10 +49,7 @@ catalogs:
       specifier: 8.0.10
       version: 8.0.10
 
-overrides:
-  tailwind-csstree: 0.3.1
-
-packageExtensionsChecksum: sha256-g5WXbbq4FZTJyRcr0LXLQUuCLjGhHqXhLQd4+65OMLI=
+packageExtensionsChecksum: sha256-h53HMDC5yYLk35ZI/M7d0dCrsSs7wd6YcKLVFnHEYQQ=
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,15 +30,9 @@ minimumReleaseAge: 4320
 minimumReleaseAgeStrict: false
 
 
-overrides:
-  tailwind-csstree: 0.3.1
-
 packageExtensions:
   '@iconify/tailwind4@1.2.3':
     dependencies:
       '@iconify-json/lucide': '*'
-  tailwind-csstree@0.2.0:
-    dependencies:
-      '@eslint/css-tree': '*'
 
 shellEmulator: true


### PR DESCRIPTION
## 概要

`pnpm-workspace.yaml` の `overrides.tailwind-csstree` と `packageExtensions.tailwind-csstree@0.2.0` を削除する。CLAUDE.md の workaround 表からも該当エントリを除去する。

## 背景

CLAUDE.md に記録している pnpm workaround が現時点で必要か確認したところ、`tailwind-csstree` 関連 2 件の根拠が消えていた。

- `overrides.tailwind-csstree: 0.3.1` の根拠は「`eslint-plugin-better-tailwindcss` が `^0.1.4` を要求し、0.1.5 がバグ版」だった。現行の `eslint-plugin-better-tailwindcss@4.5.0` は `tailwind-csstree: ^0.3.0` を要求するため、バグ版 0.1.5 / 0.2.0 にフォールバックする経路は存在しない
- `packageExtensions: tailwind-csstree@0.2.0` のキーは `@0.2.0` 厳密一致。override を外すと `tailwind-csstree` は自然に 0.3.1 に解決され、このキーはどの version とも一致しなくなる。0.3.1 でも `@eslint/css-tree` を runtime import するが、親である `better-tailwindcss@4.5.0` 自身が `@eslint/css-tree: ^4.0.1` を直接 dependencies に持つため、phantom dependency にはならない

一方、残り 2 件の workaround は upstream 未修正のため据え置く。

- `@iconify/tailwind4@1.2.3` packageExtension: 最新は依然として 1.2.3 で `@iconify-json/lucide` 未宣言
- `minimumReleaseAgeStrict: false`: pnpm/pnpm issue11238 はまだ OPEN

`pnpm install` および `pnpm lint:all` がローカルで成功することを確認済み（`tailwind-csstree@0.3.1` が override なしで自然解決）。

## 変更内容

### pnpm-workspace.yaml

- `overrides.tailwind-csstree` を削除
- `packageExtensions.tailwind-csstree@0.2.0` を削除
- 結果として `overrides` セクション自体が消え、`packageExtensions` は `@iconify/tailwind4@1.2.3` のみになる

### pnpm-lock.yaml

- 上記に伴う再生成（`tailwind-csstree@0.3.1` 解決経路は変わらない）

### CLAUDE.md

- pnpm ワークアラウンドの章のリード文から `overrides /` を削除
- `### overrides` セクションを丸ごと削除
- `packageExtensions` 表から `tailwind-csstree@0.2.0` の行を削除

## 確認事項

- [ ] `pnpm install` が override なしで `tailwind-csstree@0.3.1` を解決していること（`pnpm why tailwind-csstree -r` で確認）
- [ ] `pnpm lint:all` が成功し、`eslint-plugin-better-tailwindcss` が `@eslint/css-tree` を解決できること
- [ ] CLAUDE.md の workaround 表が `pnpm-workspace.yaml` の現状と一致すること
