### PR TITLE
build(proto): pin BSR remote plugin versions in buf.gen.yaml

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@ TS（renderer）と Swift（native）で RPC 型を共有するため、`package
 - ts-proto → `packages/proto-ts/src/generated/`（`@gozd/proto` として renderer が import）
 - swift-protobuf → `packages/proto-swift/Sources/GozdProto/`（`GozdProto` を native が import）
 
-生成物は git に commit する。`buf.gen.yaml` では BSR のリモートプラグイン (`buf.build/community/stephenh-ts-proto` / `buf.build/apple/swift`) を指定する（バージョン pin はしていない）。
+生成物は git に commit する。`buf.gen.yaml` では BSR のリモートプラグイン (`buf.build/community/stephenh-ts-proto` / `buf.build/apple/swift`) をバージョン pin して指定する。
 
 トランスポートは Connect / gRPC を使わず、`gozd-rpc://` URLSchemeHandler + Unix Socket（NDJSON）で自前実装する。Protobuf の `oneof` を discriminated union として使うのが目的。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@ TS（renderer）と Swift（native）で RPC 型を共有するため、`package
 - ts-proto → `packages/proto-ts/src/generated/`（`@gozd/proto` として renderer が import）
 - swift-protobuf → `packages/proto-swift/Sources/GozdProto/`（`GozdProto` を native が import）
 
-生成物は git に commit する。`buf.gen.yaml` では BSR のリモートプラグイン (`buf.build/community/stephenh-ts-proto` / `buf.build/apple/swift`) をバージョン pin して指定する。
+生成物は git に commit する。`buf.gen.yaml` では BSR のリモートプラグイン (`buf.build/community/stephenh-ts-proto` / `buf.build/apple/swift`) をバージョン pin して指定する（具体バージョンは `buf.gen.yaml` を参照）。
 
 トランスポートは Connect / gRPC を使わず、`gozd-rpc://` URLSchemeHandler + Unix Socket（NDJSON）で自前実装する。Protobuf の `oneof` を discriminated union として使うのが目的。
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -10,7 +10,7 @@ renderer（Vue / WebKit）と native（Swift）間の通信。`.proto` を SSOT 
 | `packages/proto-ts`    | ts-proto による生成物。`@gozd/proto` として renderer が import                 |
 | `packages/proto-swift` | swift-protobuf による生成物。`GozdProto` SPM パッケージとして native が import |
 
-生成物は git に commit する。`buf.gen.yaml` では `remote: buf.build/community/stephenh-ts-proto`（ts-proto）と `remote: buf.build/apple/swift`（swift-protobuf）を指定し、buf BSR のリモートプラグインを利用している（バージョン pin はしていない）。
+生成物は git に commit する。`buf.gen.yaml` では `remote: buf.build/community/stephenh-ts-proto`（ts-proto）と `remote: buf.build/apple/swift`（swift-protobuf）を指定し、buf BSR のリモートプラグインをバージョン pin して利用している。
 
 `.proto` ファイルはドメインごとに分割: `pty.proto` / `fs.proto` / `git_ops.proto` / `git_status.proto` / `task.proto` / `app_state.proto` / `client_message.proto` 等。新しい RPC を足すときは該当の `.proto` に request / response / event を追加し、`buf generate` で TS / Swift の生成物を更新する。
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -10,7 +10,7 @@ renderer（Vue / WebKit）と native（Swift）間の通信。`.proto` を SSOT 
 | `packages/proto-ts`    | ts-proto による生成物。`@gozd/proto` として renderer が import                 |
 | `packages/proto-swift` | swift-protobuf による生成物。`GozdProto` SPM パッケージとして native が import |
 
-生成物は git に commit する。`buf.gen.yaml` では `remote: buf.build/community/stephenh-ts-proto`（ts-proto）と `remote: buf.build/apple/swift`（swift-protobuf）を指定し、buf BSR のリモートプラグインをバージョン pin して利用している。
+生成物は git に commit する。`buf.gen.yaml` では BSR のリモートプラグイン `buf.build/community/stephenh-ts-proto`（ts-proto）と `buf.build/apple/swift`（swift-protobuf）をバージョン pin して利用する（具体バージョンは `buf.gen.yaml` を参照）。
 
 `.proto` ファイルはドメインごとに分割: `pty.proto` / `fs.proto` / `git_ops.proto` / `git_status.proto` / `task.proto` / `app_state.proto` / `client_message.proto` 等。新しい RPC を足すときは該当の `.proto` に request / response / event を追加し、`buf generate` で TS / Swift の生成物を更新する。
 

--- a/packages/proto/buf.gen.yaml
+++ b/packages/proto/buf.gen.yaml
@@ -1,7 +1,7 @@
 version: v2
 clean: true
 plugins:
-  - remote: buf.build/community/stephenh-ts-proto
+  - remote: buf.build/community/stephenh-ts-proto:v2.11.7
     out: ../proto-ts/src/generated
     opt:
       - esModuleInterop=true
@@ -9,7 +9,7 @@ plugins:
       - outputJsonMethods=true
       - useDate=string
       - useExactTypes=false
-  - remote: buf.build/apple/swift
+  - remote: buf.build/apple/swift:v1.37.0
     out: ../proto-swift/Sources/GozdProto
     opt:
       - Visibility=Public


### PR DESCRIPTION
## 概要

`packages/proto/buf.gen.yaml` の BSR remote plugin にバージョン pin を追加し、`buf generate` の plugin 解決が「latest 漂流」しないようにする。

- `buf.build/community/stephenh-ts-proto:v2.11.7`
- `buf.build/apple/swift:v1.37.0`

ドキュメント側は「pin している」という事実のみ反映し、具体バージョンは `buf.gen.yaml` のみに記載する（SSOT）。

> [!NOTE]
> 完全な byte-level 再現性ではなく、upstream version の固定。Buf 公式が省略を推奨している `revision` フィールド（同 version 内での Buf 側 rebuild/repackage 番号）は pin していないため、bug fix rebuild は自動で拾う運用。

## 背景

PR ( #457 ) の Codex レビューで「`buf.gen.yaml` でプラグインを pin している」というドキュメント記述が事実と乖離していると指摘され、いったん docs を「pin していない」事実に合わせた。本 PR は issue ( #458 ) の対応として、コード側を pin する方向に揃え、ドキュメントの記述と実態を再度一致させる。

採用バージョンの決め方:

- `buf` CLI が「latest」と返したバージョンを採用（`buf.build/community/stephenh-ts-proto` は v2.11.7、`buf.build/apple/swift` は v1.37.0）
- pin 後に `buf generate` を流し、`packages/proto-ts/src/generated/` と `packages/proto-swift/Sources/GozdProto/` に diff が出ないことを確認（既存 commit 済みの生成物がこの版で生成されたものと一致）
- `pnpm typecheck:all` 通過

ベストプラクティス調査:

- Buf 公式が「latest 解決を避けるためにプラグインを pin せよ」と推奨。bufbuild 自身も `protovalidate-go/buf.gen.yaml` で同形式の pin を採用している
- `revision` フィールド（例: `:v2.11.7-1`）は公式が「ほとんどの場合は省略推奨。同 version 内の最新 revision が自動取得され bug fix が入る」と明示しているため省略する
- Renovate には buf-plugin 用の純正 manager が存在しない。custom datasource 経由で自動化可能だが、helpwave 製プロキシへの依存または自前 host が必要なため今回は導入しない（生成物の陳腐化が実害になった時点で再検討）

## 変更内容

### packages/proto

- `buf.gen.yaml` の `remote:` 2 つに `:vX.Y.Z` 形式のバージョン pin を追加

### docs

- `docs/architecture.md` / `docs/rpc.md` の「BSR のリモートプラグインを名前指定しているだけで pin していない」記述を「バージョン pin して指定している」に修正
- 具体バージョン番号はドキュメントには書かない（`buf.gen.yaml` を SSOT とする）。両ドキュメントとも「具体バージョンは `buf.gen.yaml` を参照」と明示し、コピペで unpinned 設定を作らないよう plugin 名のみを記載

## 今回含めない点

- **別 PR で対応**: Renovate 等による自動更新の仕組み追加。BSR plugin は Renovate 純正 manager 対象外で、自動化には custom datasource + 外部 / 自前プロキシが必要。bufbuild 公式リポジトリも自動化していない現状を踏まえ、今は手動運用に留める

## 確認事項

- [ ] `buf generate` を流して `packages/proto-ts/src/generated/` と `packages/proto-swift/Sources/GozdProto/` に diff が出ない
- [ ] `pnpm typecheck:all` が通る
