### PR TITLE
fix(terminal): tile ビューで選択中以外の leaf をフェードする

### DIFF
--- a/apps/renderer/src/features/terminal/TerminalLeaf.vue
+++ b/apps/renderer/src/features/terminal/TerminalLeaf.vue
@@ -11,6 +11,11 @@
 - xterm の onFocus → store.focusPane() でフォーカス状態を更新
 - store の focusedLeafId を watch し、自身が focused になったら imperative に terminal.focus()
 - focus 時に自身の dir が選択 worktree と異なれば worktreeStore.setOpen() で追従（viewMode="all"/"claude" 用、viewMode は変更しない）
+
+## active 表示
+
+- 選択中 worktree（worktreeStore.dir）配下かつ layout.focusedLeafId と一致する leaf のみ opacity-100
+- それ以外は opacity-50 でフェード。tile モード（all / claude）では複数 worktree の leaf が同時表示されるが、active は常に 1 つだけになる
 </doc>
 
 <script setup lang="ts">
@@ -34,7 +39,11 @@ const contextKeys = useContextKeys();
 
 const xtermRef = ref<InstanceType<typeof XtermTerminal>>();
 
+// tile モード（all / claude）では各 worktree が独立に focusedLeafId を持つため、
+// 単純比較だと worktree ごとに 1 つずつ active 表示になってしまう。
+// 選択中の worktree （worktreeStore.dir）配下の focusedLeafId だけを active と見なす。
 const isFocused = computed(() => {
+  if (worktreeStore.dir !== props.dir) return false;
   const layout = terminalStore.layoutsByDir[props.dir];
   if (layout === undefined) return false;
   return layout.focusedLeafId === props.leafId;

--- a/apps/renderer/src/features/terminal/TerminalLeaf.vue
+++ b/apps/renderer/src/features/terminal/TerminalLeaf.vue
@@ -15,7 +15,8 @@
 ## active 表示
 
 - 選択中 worktree（worktreeStore.dir）配下かつ layout.focusedLeafId と一致する leaf のみ opacity-100
-- それ以外は opacity-50 でフェード。tile モード（all / claude）では複数 worktree の leaf が同時表示されるが、active は常に 1 つだけになる
+- それ以外は opacity-50 でフェード。tile モード（all / claude）では複数 worktree の leaf が同時表示されるが、active になるのは選択中 worktree の focused leaf 1 つだけ
+- 初期化前で worktreeStore.dir が未確定の場合や、claude モードで選択中 worktree に Claude-active leaf が存在しない場合は active が 0 になりうる
 </doc>
 
 <script setup lang="ts">

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -127,7 +127,7 @@ leafNode
 
 `all` / `claude` モードでは複数 worktree の leaf が同時に表示されるため、focus を受けた leaf の `dir` が現在の選択 worktree と異なる場合、`worktreeStore.setOpen(dir)` で選択を追従させる。viewMode は変更しない（横断ビューを維持したまま、サイドバー・ファイラー・プレビューのみ追従）。`wt` モードでは選択 worktree 配下の leaf しか描画されないため、この処理は自然に no-op となる。
 
-active leaf の判定は「選択中 worktree（`worktreeStore.dir`）配下」かつ「`layout.focusedLeafId` と一致」の AND で行う。`layoutsByDir` は dir ごとに独立した `focusedLeafId` を持つため、単純比較だと tile モードで worktree ごとに 1 つずつ active 表示になってしまう。worktree 単位の選択を条件に加えることで、横断ビューでも常に 1 つの leaf だけが `opacity-100` で他は `opacity-50` にフェードする。
+active leaf の判定は「選択中 worktree（`worktreeStore.dir`）配下」かつ「`layout.focusedLeafId` と一致」の AND で行う。`layoutsByDir` は dir ごとに独立した `focusedLeafId` を持つため、単純比較だと tile モードで worktree ごとに 1 つずつ active 表示になってしまう。worktree 単位の選択を条件に加えることで、横断ビューでも `opacity-100` で表示される leaf は最大 1 つに収まり、それ以外は `opacity-50` にフェードする。`worktreeStore.dir` 未確定時や、`claude` モードで選択中 worktree に Claude-active leaf が存在しない場合は active が 0 になりうる。
 
 ## OSC ハンドラ
 

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -127,6 +127,8 @@ leafNode
 
 `all` / `claude` モードでは複数 worktree の leaf が同時に表示されるため、focus を受けた leaf の `dir` が現在の選択 worktree と異なる場合、`worktreeStore.setOpen(dir)` で選択を追従させる。viewMode は変更しない（横断ビューを維持したまま、サイドバー・ファイラー・プレビューのみ追従）。`wt` モードでは選択 worktree 配下の leaf しか描画されないため、この処理は自然に no-op となる。
 
+active leaf の判定は「選択中 worktree（`worktreeStore.dir`）配下」かつ「`layout.focusedLeafId` と一致」の AND で行う。`layoutsByDir` は dir ごとに独立した `focusedLeafId` を持つため、単純比較だと tile モードで worktree ごとに 1 つずつ active 表示になってしまう。worktree 単位の選択を条件に加えることで、横断ビューでも常に 1 つの leaf だけが `opacity-100` で他は `opacity-50` にフェードする。
+
 ## OSC ハンドラ
 
 xterm.js のイベントまたは `parser.registerOscHandler()` でエスケープシーケンスを受信し、store に保存する。


### PR DESCRIPTION
## 概要

ターミナル表示モード `all` / `claude`（マルチ worktree タイル表示）で、選択中の worktree の focused leaf 以外もすべて `opacity-100` で active 表示されてしまう挙動を修正する。`wt` モードと同様、選択中以外の leaf は `opacity-50` でフェードするようにした。

## 背景

`TerminalLeaf.vue` の `isFocused` 判定は `layout.focusedLeafId === leafId` のみを見ていた。`layoutsByDir` は worktree（dir）ごとに独立した `focusedLeafId` を保持しているため、`wt` モードでは選択中 worktree 配下の leaf しか描画されず問題は表面化しないが、`all` / `claude` のマルチビューでは worktree の数だけ「focused」な leaf が同時に存在し、すべてフェードされず active 表示になっていた。

`handleTerminalFocus` 内で別 worktree の leaf に focus が移ると `worktreeStore.setOpen(props.dir)` が選択 worktree を追従させているため、「選択中 worktree 配下」かつ「その dir の `focusedLeafId`」を AND 条件にすれば、tile モードでも active leaf は最大 1 つになる。`wt` モードは `worktreeStore.dir` 配下しか描画しないので追加条件は no-op で破壊しない。

## 変更内容

### terminal

- `apps/renderer/src/features/terminal/TerminalLeaf.vue`: `isFocused` の判定に `worktreeStore.dir === props.dir` の条件を追加
- `<doc>` ブロックに「active 表示」セクションを追加し、tile モードでの判定ルールと、`worktreeStore.dir` 未確定時 / `claude` モードで選択中 worktree に Claude-active leaf がない場合は active が 0 になりうる点を明記
- `docs/terminal.md` の表示モード節に同様の判定ルールとエッジケースを追記

## 確認事項

- [ ] `wt` モードで focused leaf のみ `opacity-100`、他は `opacity-50` で従来通りフェードすること
- [ ] `all` モードで複数 worktree の leaf が並んでも、選択中 worktree の focused leaf 1 つだけが active 表示になること
- [ ] `claude` モードで同様に active が 1 つだけになること
- [ ] 別 worktree の leaf をクリックすると、選択 worktree が追従しその leaf が active 表示に切り替わること
