### PR TITLE
refactor(claude-status): consolidate done-state clearing on wt selection

### DIFF
--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -59,14 +59,8 @@ const { fetchRepo } = useSidebarData();
 
 const { confirmRef, confirmMessage, showConfirm, closeConfirm, executeConfirm } = useDialogs();
 
-const {
-  isCreating,
-  isActive,
-  handleWorktreeSelect,
-  addWorktree,
-  handleWorktreeRemove,
-  handleBranchLink,
-} = useWorktreeActions({ showConfirm });
+const { isCreating, handleWorktreeSelect, addWorktree, handleWorktreeRemove, handleBranchLink } =
+  useWorktreeActions({ showConfirm });
 
 const {
   editingTaskId,
@@ -111,11 +105,8 @@ useIntervalFn(() => {
 const sidebarMenuRef = ref<InstanceType<typeof SidebarMenu>>();
 
 function onWorktreeSelect(wt: import("@gozd/proto").WorktreeEntry) {
-  terminalStore.viewMode = "wt";
-  if (isActive(wt)) {
-    terminalStore.clearDoneStates(wt.path);
-    return;
-  }
+  // 同 wt 再クリック時の done 消化は worktreeStore.setOpen の selectionVersion 経由で
+  // useSidebarData の watch が処理する。ここでは isActive 分岐せず常に setOpen を呼ぶ。
   handleWorktreeSelect(wt);
 }
 
@@ -130,7 +121,16 @@ function onRemoveRepo(rootDir: string) {
       const targets = new Set<string>([rootDir, ...repo.worktrees.map((wt) => wt.path)]);
       for (const dir of targets) terminalStore.remove(dir);
     }
+    const prevSelected = worktreeStore.dir;
     repoStore.removeRepo(rootDir);
+    // 削除した repo に active wt が属していた場合、removeRepo は dirOrder の先頭に
+    // selectedDir を直接フォールバックする（setOpen を経由しない）。selectionVersion
+    // を進めて新 active wt の done を useSidebarData に消化させるため、ここで明示的に
+    // setOpen を再呼びする。selectedDir が変わっていない（別 repo を削除した）場合は no-op。
+    const nextSelected = worktreeStore.dir;
+    if (nextSelected !== undefined && nextSelected !== prevSelected) {
+      worktreeStore.setOpen(nextSelected);
+    }
   });
 }
 

--- a/apps/renderer/src/features/sidebar/features/worktree/useWorktreeActions.ts
+++ b/apps/renderer/src/features/sidebar/features/worktree/useWorktreeActions.ts
@@ -26,10 +26,6 @@ export function useWorktreeActions({ showConfirm }: UseWorktreeActionsOptions) {
 
   const isCreating = ref(false);
 
-  function isActive(wt: WorktreeEntry): boolean {
-    return worktreeStore.dir === wt.path;
-  }
-
   function handleWorktreeSelect(wt: WorktreeEntry) {
     terminalStore.viewMode = "wt";
     // setOpen は冪等。同一 wt の再選択でも selectionVersion が発火し、
@@ -151,7 +147,6 @@ export function useWorktreeActions({ showConfirm }: UseWorktreeActionsOptions) {
 
   return {
     isCreating,
-    isActive,
     handleWorktreeSelect,
     addWorktree,
     handleWorktreeRemove,

--- a/apps/renderer/src/features/sidebar/features/worktree/useWorktreeActions.ts
+++ b/apps/renderer/src/features/sidebar/features/worktree/useWorktreeActions.ts
@@ -32,10 +32,8 @@ export function useWorktreeActions({ showConfirm }: UseWorktreeActionsOptions) {
 
   function handleWorktreeSelect(wt: WorktreeEntry) {
     terminalStore.viewMode = "wt";
-    if (isActive(wt)) {
-      terminalStore.clearDoneStates(wt.path);
-      return;
-    }
+    // setOpen は冪等。同一 wt の再選択でも selectionVersion が発火し、
+    // useTerminalStore 側の watch が done を消化する。
     worktreeStore.setOpen(wt.path);
   }
 

--- a/apps/renderer/src/features/sidebar/useSidebarData.ts
+++ b/apps/renderer/src/features/sidebar/useSidebarData.ts
@@ -89,14 +89,31 @@ export function useSidebarData() {
     { immediate: true },
   );
 
-  // active dir 切り替え時: done バッジ消化 + 所属 repo を最新化
+  // active dir 切り替え時: 所属 repo を最新化
   watch(
     () => worktreeStore.dir,
     (dir) => {
       if (dir === undefined) return;
-      terminalStore.clearDoneStates(dir);
       const owning = repoStore.findRepoOwning(dir);
       if (owning) void fetchRepo(owning.rootDir);
+    },
+    { immediate: true },
+  );
+
+  // wt 選択イベント（setOpen）の度に done バッジを消化する。
+  // 同 dir 再選択でも selectionVersion はインクリメントされるため、サイドバー再クリック
+  // やターミナル focus による同一 wt 再選択もここで一括消化される。
+  // claude status の所有者は terminalStore だが、両 store 参照を持つこの場所に集約する
+  // ことで、useTerminalStore → ../worktree barrel の import を増やさず cycle を避ける。
+  // immediate: true は、watch 登録より先に gozdOpen 等で setOpen が呼ばれたケース
+  // （hydrateFromAppState は setOpen を経由しないが、gozdOpen 経路はそうとは限らない）
+  // で初回選択イベントを取りこぼさないための保険。dir が undefined なら no-op。
+  watch(
+    () => worktreeStore.selectionVersion,
+    () => {
+      const dir = worktreeStore.dir;
+      if (dir === undefined) return;
+      terminalStore.clearDoneStates(dir);
     },
     { immediate: true },
   );

--- a/apps/renderer/src/features/terminal/TerminalLeaf.vue
+++ b/apps/renderer/src/features/terminal/TerminalLeaf.vue
@@ -10,7 +10,8 @@
 
 - xterm の onFocus → store.focusPane() でフォーカス状態を更新
 - store の focusedLeafId を watch し、自身が focused になったら imperative に terminal.focus()
-- focus 時に自身の dir が選択 worktree と異なれば worktreeStore.setOpen() で追従（viewMode="all"/"claude" 用、viewMode は変更しない）
+- focus 時に worktreeStore.setOpen() を呼んで選択を追従させる（viewMode は変更しない）
+- 既読消化（done → idle）は useSidebarData が selectionVersion を watch して処理するため、ここでは setOpen を呼ぶだけでよい
 
 ## active 表示
 
@@ -97,11 +98,9 @@ watch(
 function handleTerminalFocus() {
   contextKeys.set("terminalFocus", true);
   terminalStore.focusPane(props.leafId);
-  // viewMode="all"/"claude" で別 worktree の leaf に focus した場合、選択を追従させる。
-  // viewMode="wt" では TerminalPane が selectedDir 配下の leaf しか描画しないため自然に no-op。
-  if (worktreeStore.dir !== props.dir) {
-    worktreeStore.setOpen(props.dir);
-  }
+  // 同 dir でも setOpen を呼ぶことで selectionVersion が発火し、useTerminalStore の
+  // watch が done を消化する。viewMode="all"/"claude" でも選択 wt が追従する。
+  worktreeStore.setOpen(props.dir);
 }
 
 function handleTerminalBlur() {

--- a/apps/renderer/src/features/terminal/useTerminalStore.ts
+++ b/apps/renderer/src/features/terminal/useTerminalStore.ts
@@ -1,8 +1,7 @@
 import { acceptHMRUpdate, defineStore } from "pinia";
-import { computed, ref, shallowRef, watch } from "vue";
+import { computed, ref, shallowRef } from "vue";
 import { useContextKeys } from "../../shared/command";
 import { onMessage } from "../../shared/rpc";
-import { useWorktreeStore } from "../worktree";
 import type { ClaudeStatus } from "./claudeStatus";
 import { isHookEvent, createClaudeStatusManager } from "./claudeStatus";
 import { createPtySessionManager } from "./ptySession";
@@ -170,21 +169,6 @@ export const useTerminalStore = defineStore("terminal", () => {
   }
 
   initSubscriptions();
-
-  // --- worktree 選択イベントの購読 ---
-
-  // worktreeStore.setOpen が呼ばれるたびに selectionVersion がインクリメントされる。
-  // wt の (再)選択は「既読」シグナルとして扱い、選択中 wt の done を idle に消化する。
-  // sidebar / TerminalLeaf / その他の wt 選択経路すべてに自動で適用される。
-  const worktreeStore = useWorktreeStore();
-  watch(
-    () => worktreeStore.selectionVersion,
-    () => {
-      const dir = worktreeStore.dir;
-      if (dir === undefined) return;
-      claude.clearDoneStates(dir);
-    },
-  );
 
   // --- pane getter ---
 

--- a/apps/renderer/src/features/terminal/useTerminalStore.ts
+++ b/apps/renderer/src/features/terminal/useTerminalStore.ts
@@ -1,7 +1,8 @@
 import { acceptHMRUpdate, defineStore } from "pinia";
-import { computed, ref, shallowRef } from "vue";
+import { computed, ref, shallowRef, watch } from "vue";
 import { useContextKeys } from "../../shared/command";
 import { onMessage } from "../../shared/rpc";
+import { useWorktreeStore } from "../worktree";
 import type { ClaudeStatus } from "./claudeStatus";
 import { isHookEvent, createClaudeStatusManager } from "./claudeStatus";
 import { createPtySessionManager } from "./ptySession";
@@ -169,6 +170,21 @@ export const useTerminalStore = defineStore("terminal", () => {
   }
 
   initSubscriptions();
+
+  // --- worktree 選択イベントの購読 ---
+
+  // worktreeStore.setOpen が呼ばれるたびに selectionVersion がインクリメントされる。
+  // wt の (再)選択は「既読」シグナルとして扱い、選択中 wt の done を idle に消化する。
+  // sidebar / TerminalLeaf / その他の wt 選択経路すべてに自動で適用される。
+  const worktreeStore = useWorktreeStore();
+  watch(
+    () => worktreeStore.selectionVersion,
+    () => {
+      const dir = worktreeStore.dir;
+      if (dir === undefined) return;
+      claude.clearDoneStates(dir);
+    },
+  );
 
   // --- pane getter ---
 

--- a/apps/renderer/src/features/worktree/useWorktreeStore.ts
+++ b/apps/renderer/src/features/worktree/useWorktreeStore.ts
@@ -24,6 +24,9 @@ export const useWorktreeStore = defineStore("worktree", () => {
   /** 同一パスでも reveal を発火させるためのバージョンカウンタ */
   const revealVersion = ref(0);
 
+  /** setOpen 呼び出しごとにインクリメント。観測側（terminal 等）が「wt 選択イベント」として購読する */
+  const selectionVersion = ref(0);
+
   const gitStatusStore = useGitStatusStore();
 
   /** 現在 UI で選択中の dir。repoStore.selectedDir の薄いエイリアス */
@@ -65,6 +68,7 @@ export const useWorktreeStore = defineStore("worktree", () => {
    */
   function setOpen(newDir: string, options: SetOpenOptions = {}) {
     repoStore.selectDir(newDir);
+    selectionVersion.value++;
     if (options.fileServerBaseUrl) {
       fileServerBaseUrl.value = options.fileServerBaseUrl;
     }
@@ -110,6 +114,7 @@ export const useWorktreeStore = defineStore("worktree", () => {
     selectedLineNumber,
     selectedGitChange,
     revealVersion,
+    selectionVersion,
     setOpen,
     selectPath,
     clearSelectedPath,

--- a/docs/claude-status.md
+++ b/docs/claude-status.md
@@ -33,7 +33,7 @@ undefined ──SessionStart──→ idle ──UserPromptSubmit──→ worki
 
 - `done` → 次の `UserPromptSubmit` で直接 `working` に遷移する（`idle` を経由しない）
 - `clearDoneStates` は worktree 選択時の既読消化。`done` → `idle` に遷移する（セッションは生きている）
-- 発火点は `worktreeStore.setOpen` 一箇所。サイドバーのクリック・ターミナル focus などすべての wt 選択経路が `setOpen` を経由し、`useWorktreeStore` の `selectionVersion` カウンタを上げる。`useTerminalStore` がそのカウンタを watch して `clearDoneStates(worktreeStore.dir)` を呼ぶ
+- 発火点は `worktreeStore.setOpen` 一箇所。サイドバーのクリック・ターミナル focus などすべての wt 選択経路が `setOpen` を経由し、`useWorktreeStore` の `selectionVersion` カウンタを上げる。`useSidebarData` がそのカウンタを watch して `terminalStore.clearDoneStates(worktreeStore.dir)` を呼ぶ（claude status の所有者は terminal だが、両 store 参照を持つ `useSidebarData` に集約することで barrel 経由の循環を避ける）
 
 ## フックイベントの対応
 

--- a/docs/claude-status.md
+++ b/docs/claude-status.md
@@ -32,7 +32,8 @@ undefined ──SessionStart──→ idle ──UserPromptSubmit──→ worki
 ```
 
 - `done` → 次の `UserPromptSubmit` で直接 `working` に遷移する（`idle` を経由しない）
-- `clearDoneStates` は worktree フォーカス時の既読消化。`done` → `idle` に遷移する（セッションは生きている）
+- `clearDoneStates` は worktree 選択時の既読消化。`done` → `idle` に遷移する（セッションは生きている）
+- 発火点は `worktreeStore.setOpen` 一箇所。サイドバーのクリック・ターミナル focus などすべての wt 選択経路が `setOpen` を経由し、`useWorktreeStore` の `selectionVersion` カウンタを上げる。`useTerminalStore` がそのカウンタを watch して `clearDoneStates(worktreeStore.dir)` を呼ぶ
 
 ## フックイベントの対応
 

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -125,7 +125,7 @@ leafNode
 - **all**: `tileGridTemplate()` で全 leaf を均等タイル配置
 - **claude**: `tileGridTemplate()` で Claude 起動中の leaf のみ均等タイル配置
 
-`all` / `claude` モードでは複数 worktree の leaf が同時に表示されるため、focus を受けた leaf の `dir` が現在の選択 worktree と異なる場合、`worktreeStore.setOpen(dir)` で選択を追従させる。viewMode は変更しない（横断ビューを維持したまま、サイドバー・ファイラー・プレビューのみ追従）。`wt` モードでは選択 worktree 配下の leaf しか描画されないため、この処理は自然に no-op となる。
+`all` / `claude` モードでは複数 worktree の leaf が同時に表示されるため、focus を受けた leaf は常に `worktreeStore.setOpen(dir)` を呼んで選択を追従させる。viewMode は変更しない（横断ビューを維持したまま、サイドバー・ファイラー・プレビューのみ追従）。`wt` モードでは同 dir に対する setOpen となり実質的に no-op だが、`selectionVersion` を発火させて `clearDoneStates` を起動するために常に呼ぶ（[claude-status.md](claude-status.md) の既読消化フロー参照）。
 
 active leaf の判定は「選択中 worktree（`worktreeStore.dir`）配下」かつ「`layout.focusedLeafId` と一致」の AND で行う。`layoutsByDir` は dir ごとに独立した `focusedLeafId` を持つため、単純比較だと tile モードで worktree ごとに 1 つずつ active 表示になってしまう。worktree 単位の選択を条件に加えることで、横断ビューでも `opacity-100` で表示される leaf は最大 1 つに収まり、それ以外は `opacity-50` にフェードする。`worktreeStore.dir` 未確定時や、`claude` モードで選択中 worktree に Claude-active leaf が存在しない場合は active が 0 になりうる。
 


### PR DESCRIPTION
## 概要

Claude の `done` ステータス既読消化（`done` → `idle`）の発火点を、worktree 選択イベント (`worktreeStore.setOpen`) 一箇所に集約する。これにより、サイドバーの wt クリックだけでなくターミナルの focus でも当該 wt の `done` が消化されるようになる。

## 背景

PR #456 でターミナル focus 時に `worktreeStore.setOpen()` で wt 選択を追従させる処理が入ったが、`done` 状態の既読消化はサイドバーの `useWorktreeActions.handleWorktreeSelect` 内に書かれたままで、ターミナルクリックでは消化されなかった。

最初は TerminalLeaf.handleTerminalFocus にも `clearDoneStates` を書き足す案を試したが、UI ごとに同じロジックを散布する形になっていた。「wt を select する処理」自体は worktreeStore.setOpen に既に集約されているため、そこを発火点にして claude status の既読消化も自動的に走らせる方が SSOT として綺麗。

## 設計

### 集約方針

- `useWorktreeStore` に `selectionVersion` カウンタを追加。`setOpen` が呼ばれるたびにインクリメント
- `useSidebarData` で `selectionVersion` を watch し、選択中 wt の `clearDoneStates(dir)` を呼ぶ
- 全ての wt 選択経路を `worktreeStore.setOpen()` に集約
  - サイドバー clickのactive wt 再クリック分岐を削除
  - TerminalLeaf focus の dir 比較ガードを外し常に setOpen
  - `removeRepo` の fallback で selectedDir が変化した場合は `setOpen` を明示的に呼ぶ

### 集約場所を `useSidebarData` にした理由

`useTerminalStore` で watch する案を最初試したが、`useTerminalStore` から `../worktree` barrel を import すると barrel 経由の循環参照が新規に追加される懸念がある。`useSidebarData` は元々 `useWorktreeStore` と `useTerminalStore` の両方を import 済みでアプリ起動時にマウントされるため、追加の barrel 依存を作らずに「wt 選択イベントの単一観測点」を実現できる。

## 変更内容

### worktree

- `useWorktreeStore`: `selectionVersion` カウンタを追加。`setOpen` 内で無条件にインクリメント

### sidebar

- `useSidebarData`: `selectionVersion` の watch を追加し、`terminalStore.clearDoneStates(worktreeStore.dir)` を呼ぶ。`{ immediate: true }` を付けて SidebarPane mount より前の setOpen 呼び出しを取りこぼさない
- `useWorktreeActions.handleWorktreeSelect`: `if (isActive) clearDoneStates; return;` 分岐を削除し、常に `setOpen(wt.path)` を呼ぶ。外部 caller が消えた `isActive` 関数も削除
- `SidebarPane.onWorktreeSelect`: active wt 再クリック時の `clearDoneStates` 直呼び分岐を削除し、常に `handleWorktreeSelect(wt)` に委譲
- `SidebarPane.onRemoveRepo`: `removeRepo` 前後で `selectedDir` を比較し、active wt が他 repo に切り替わった場合は明示的に `setOpen` を呼ぶ（removeRepo の fallback は `setOpen` を経由しないため、selectionVersion が上がらない取りこぼしを補正）

### terminal

- `TerminalLeaf.handleTerminalFocus`: `dir !== props.dir` のガードを外し、常に `setOpen(props.dir)` を呼ぶ。同 dir 再 focus でも selectionVersion を発火させて消化を走らせるため

### docs

- `docs/claude-status.md`: `clearDoneStates` の発火点と `selectionVersion` 経由の消化フロー、循環回避のため `useSidebarData` に集約した経緯を追記
- `docs/terminal.md`: focus 時の setOpen を「常に呼ぶ」前提に書き換え

## 確認事項

- [ ] サイドバーで現在選択中の wt をクリック → done バッジが消える
- [ ] サイドバーで別の wt をクリック → 切替後 wt の done バッジが消える
- [ ] viewMode=wt でターミナルクリック → 当該 wt の done バッジが消える
- [ ] viewMode=all/claude で別 wt のターミナルクリック → 当該 wt が選択され、その wt の done バッジが消える（viewMode は変わらない）
- [ ] viewMode=all/claude で同 wt の別 leaf を再 focus → 当該 wt の done バッジが消える
- [ ] active wt が属する repo を削除 → fallback 先 wt の done バッジが消える
