### PR TITLE
feat(sidebar): top-toolbar view-mode toggle (wt / claude)

### DIFF
--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -10,7 +10,7 @@
 
 ## 操作
 
-- view mode トグル: 全 repo 共通の `terminalStore.viewMode` を `"wt"` / `"claude"` で切り替え。terminal feature 側に登録された `workspace.toggleViewMode` コマンド（cmd+/）と同じ state を更新する
+- view mode トグル: active worktree / claude terminals を切り替え。`cmd+/` でも同じ操作が可能
 - worktree クリック: 表示対象 dir 切替 + done バッジ既読化
 - ⋮ メニュー: SidebarMenu に委譲（worktree 編集 / 解除、branch から worktree 化）
 - chevron: 折りたたみトグル（永続）

--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -3,13 +3,14 @@
 
 ## レイアウト構成
 
+- **トップツールバー**: 左に view mode トグル（active worktree / claude terminals）、右にリスト編集ボタン
 - **dirOrder の各 repo** に対して `RepoSection` を縦に並べる
 - 各セクションは header（chevron + folder アイコン + repo 名）+ ROOT + WORKTREES + BRANCHES
-- top-right の編集ボタン（鉛筆アイコン）でリスト編集モードをトグル
 - 編集モード中: 全 section が collapsed + drag で並び替え + ✕ で削除 + 末尾に `+ Add directory`
 
 ## 操作
 
+- view mode トグル: 全 repo 共通の `terminalStore.viewMode` を `"wt"` / `"claude"` で切り替え。terminal feature 側に登録された `workspace.toggleViewMode` コマンド（cmd+/）と同じ state を更新する
 - worktree クリック: 表示対象 dir 切替 + done バッジ既読化
 - ⋮ メニュー: SidebarMenu に委譲（worktree 編集 / 解除、branch から worktree 化）
 - chevron: 折りたたみトグル（永続）
@@ -92,15 +93,6 @@ const disposeSelectWorktree = register("workspace.selectWorktree", (args) => {
   return true;
 });
 onUnmounted(disposeSelectWorktree);
-
-const disposeToggleViewMode = register("workspace.toggleViewMode", {
-  label: "Workspace: Toggle Active Worktree / Claude Terminals",
-  handler: () => {
-    terminalStore.toggleViewMode();
-    return true;
-  },
-});
-onUnmounted(disposeToggleViewMode);
 
 // --- 経過時間表示用の現在時刻 ---
 

--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -93,6 +93,15 @@ const disposeSelectWorktree = register("workspace.selectWorktree", (args) => {
 });
 onUnmounted(disposeSelectWorktree);
 
+const disposeToggleViewMode = register("workspace.toggleViewMode", {
+  label: "Workspace: Toggle Active Worktree / Claude Terminals",
+  handler: () => {
+    terminalStore.toggleViewMode();
+    return true;
+  },
+});
+onUnmounted(disposeToggleViewMode);
+
 // --- 経過時間表示用の現在時刻 ---
 
 const now = ref(Date.now());
@@ -114,7 +123,7 @@ function onRemoveRepo(rootDir: string) {
   const name = repoStore.repos[rootDir]?.repoName ?? rootDir;
   showConfirm(`Remove "${name}" from this window?`, async () => {
     // repo 削除前に配下 worktree の terminal state / PTY を cleanup する。
-    // これを忘れると `all` / `claude` view で消したはずの repo の PTY が
+    // これを忘れると `claude` view で消したはずの repo の PTY が
     // 生き残る（visitedDirs に残るため）。
     const repo = repoStore.repos[rootDir];
     if (repo !== undefined) {
@@ -177,8 +186,32 @@ const activeRootWorktree = computed(() => {
 
 <template>
   <div class="flex size-full flex-col">
-    <!-- 編集モードトグル（独立したツールバー） -->
-    <div class="flex justify-end border-b border-zinc-800 px-2 py-1">
+    <!-- トップツールバー: view mode トグル + 編集モード -->
+    <div class="flex items-center justify-between border-b border-zinc-800 px-2 py-1">
+      <div class="flex gap-0.5">
+        <button
+          type="button"
+          aria-label="Active worktree"
+          title="Active worktree"
+          :aria-pressed="terminalStore.viewMode === 'wt'"
+          class="grid size-7 place-items-center rounded-sm text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+          :class="terminalStore.viewMode === 'wt' && 'bg-zinc-700 text-zinc-100'"
+          @click="terminalStore.viewMode = 'wt'"
+        >
+          <span class="icon-[lucide--monitor] text-base" />
+        </button>
+        <button
+          type="button"
+          aria-label="Claude terminals"
+          title="Claude terminals"
+          :aria-pressed="terminalStore.viewMode === 'claude'"
+          class="grid size-7 place-items-center rounded-sm text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+          :class="terminalStore.viewMode === 'claude' && 'bg-zinc-700 text-zinc-100'"
+          @click="terminalStore.viewMode = 'claude'"
+        >
+          <span class="icon-[lucide--bot] text-base" />
+        </button>
+      </div>
       <button
         type="button"
         :aria-label="editMode ? 'Exit edit mode' : 'Edit repositories'"
@@ -210,14 +243,12 @@ const activeRootWorktree = computed(() => {
           :is-creating="isCreating"
           :ctrl-pressed="ctrlPressed"
           :now="now"
-          :view-mode="terminalStore.viewMode"
           :get-claude-statuses="terminalStore.getClaudeStatusesByDir"
           :get-resumeable-session-count="terminalStore.getResumeableSessionCount"
           @remove-repo="onRemoveRepo"
           @select-root="handleWorktreeSelect"
           @select-worktree="onWorktreeSelect"
           @add-worktree="addWorktree"
-          @set-view-mode="terminalStore.viewMode = $event"
           @open-worktree-menu="
             (anchorEl, wt, rd) =>
               sidebarMenuRef?.openMenu(anchorEl, { type: 'worktree', worktree: wt, rootDir: rd })

--- a/apps/renderer/src/features/sidebar/features/repo/RepoSection.vue
+++ b/apps/renderer/src/features/sidebar/features/repo/RepoSection.vue
@@ -25,8 +25,6 @@ import type { ClaudeStatus } from "../../../terminal";
 import { dirName } from "../../utils";
 import { BranchList, RootWorktree, WorktreeList } from "../worktree";
 
-type ViewMode = "wt" | "all" | "claude";
-
 const props = defineProps<{
   rootDir: string;
   index: number;
@@ -41,7 +39,6 @@ const props = defineProps<{
   isCreating: boolean;
   ctrlPressed: boolean;
   now: number;
-  viewMode: ViewMode;
   getClaudeStatuses: (dir: string) => ClaudeStatus[];
   /** 永続化されているが live PTY に未接続のセッション数（resume 可能件数） */
   getResumeableSessionCount: (dir: string) => number;
@@ -54,7 +51,6 @@ const emit = defineEmits<{
   addWorktree: [rootDir: string];
   openWorktreeMenu: [anchorEl: HTMLElement, wt: WorktreeEntry, rootDir: string];
   openBranchMenu: [anchorEl: HTMLElement, branch: string, rootDir: string];
-  setViewMode: [mode: ViewMode];
 }>();
 
 defineSlots<{
@@ -171,13 +167,11 @@ function onHeaderClick() {
         :is-creating="isCreating"
         :ctrl-pressed="ctrlPressed"
         :now="now"
-        :view-mode="viewMode"
         :get-claude-statuses="getClaudeStatuses"
         :get-resumeable-session-count="getResumeableSessionCount"
         @select="emit('selectWorktree', $event)"
         @open-menu="(anchorEl, wt) => emit('openWorktreeMenu', anchorEl, wt, rootDir)"
         @add="emit('addWorktree', rootDir)"
-        @set-view-mode="emit('setViewMode', $event)"
       >
         <template #after-item="{ wt }">
           <slot name="after-worktree-item" :wt="wt" :root-dir="rootDir" />

--- a/apps/renderer/src/features/sidebar/features/worktree/WorktreeList.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/WorktreeList.vue
@@ -9,22 +9,6 @@ import type { WorktreeEntry } from "@gozd/proto";
 import type { ClaudeStatus } from "../../../terminal";
 import WorktreeItem from "./WorktreeItem.vue";
 
-type ViewMode = "wt" | "all" | "claude";
-
-const VIEW_MODE_CYCLE: ViewMode[] = ["wt", "all", "claude"];
-
-const VIEW_MODE_ICON: Record<ViewMode, string> = {
-  wt: "icon-[lucide--monitor]",
-  all: "icon-[lucide--layout-grid]",
-  claude: "icon-[lucide--bot]",
-};
-
-const VIEW_MODE_TITLE: Record<ViewMode, string> = {
-  wt: "Active worktree",
-  all: "All terminals",
-  claude: "Claude terminals",
-};
-
 defineProps<{
   worktrees: WorktreeEntry[];
   /** worktree データ未取得（初回ロード中） */
@@ -33,7 +17,6 @@ defineProps<{
   isCreating: boolean;
   ctrlPressed: boolean;
   now: number;
-  viewMode: ViewMode;
   getClaudeStatuses: (dir: string) => ClaudeStatus[];
   getResumeableSessionCount: (dir: string) => number;
 }>();
@@ -42,7 +25,6 @@ defineEmits<{
   select: [wt: WorktreeEntry];
   openMenu: [anchorEl: HTMLElement, wt: WorktreeEntry];
   add: [];
-  setViewMode: [mode: ViewMode];
 }>();
 
 defineSlots<{
@@ -52,24 +34,7 @@ defineSlots<{
 
 <template>
   <div class="mt-4 flex flex-col gap-1.5">
-    <div class="mb-1 flex items-center justify-between">
-      <h2 class="text-xs font-medium text-zinc-500">WORKTREES</h2>
-      <div class="flex gap-0.5">
-        <button
-          v-for="mode in VIEW_MODE_CYCLE"
-          :key="mode"
-          type="button"
-          class="grid size-6 place-items-center rounded-sm text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300"
-          :class="viewMode === mode && 'bg-zinc-700 text-zinc-200'"
-          :title="VIEW_MODE_TITLE[mode]"
-          :aria-label="VIEW_MODE_TITLE[mode]"
-          :aria-pressed="viewMode === mode"
-          @click="$emit('setViewMode', mode)"
-        >
-          <span class="text-sm" :class="VIEW_MODE_ICON[mode]" />
-        </button>
-      </div>
-    </div>
+    <h2 class="mb-1 text-xs font-medium text-zinc-500">WORKTREES</h2>
 
     <button
       class="grid grid-cols-[auto_1fr] gap-x-2 rounded-sm py-1.5 pl-2 text-left text-sm text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300 disabled:opacity-50"

--- a/apps/renderer/src/features/terminal/TerminalLeaf.vue
+++ b/apps/renderer/src/features/terminal/TerminalLeaf.vue
@@ -16,7 +16,7 @@
 ## active 表示
 
 - 選択中 worktree（worktreeStore.dir）配下かつ layout.focusedLeafId と一致する leaf のみ opacity-100
-- それ以外は opacity-50 でフェード。tile モード（all / claude）では複数 worktree の leaf が同時表示されるが、active になるのは選択中 worktree の focused leaf 1 つだけ
+- それ以外は opacity-50 でフェード。claude タイルモードでは複数 worktree の leaf が同時表示されるが、active になるのは選択中 worktree の focused leaf 1 つだけ
 - 初期化前で worktreeStore.dir が未確定の場合や、claude モードで選択中 worktree に Claude-active leaf が存在しない場合は active が 0 になりうる
 </doc>
 
@@ -41,7 +41,7 @@ const contextKeys = useContextKeys();
 
 const xtermRef = ref<InstanceType<typeof XtermTerminal>>();
 
-// tile モード（all / claude）では各 worktree が独立に focusedLeafId を持つため、
+// claude タイルモードでは各 worktree が独立に focusedLeafId を持つため、
 // 単純比較だと worktree ごとに 1 つずつ active 表示になってしまう。
 // 選択中の worktree （worktreeStore.dir）配下の focusedLeafId だけを active と見なす。
 const isFocused = computed(() => {
@@ -99,7 +99,7 @@ function handleTerminalFocus() {
   contextKeys.set("terminalFocus", true);
   terminalStore.focusPane(props.leafId);
   // 同 dir でも setOpen を呼ぶことで selectionVersion が発火し、useTerminalStore の
-  // watch が done を消化する。viewMode="all"/"claude" でも選択 wt が追従する。
+  // watch が done を消化する。viewMode="claude" でも選択 wt が追従する。
   worktreeStore.setOpen(props.dir);
 }
 

--- a/apps/renderer/src/features/terminal/TerminalPane.vue
+++ b/apps/renderer/src/features/terminal/TerminalPane.vue
@@ -128,7 +128,12 @@ const activeLeafIds = computed(() => {
   return collectLeafIds(layout.root);
 });
 
-/** 全 worktree の全 leafId */
+/**
+ * 全 worktree の全 leafId。テンプレートの `v-for` で全 leaf の DOM を事前生成し、
+ * 表示制御は `visibleLeafIds` + `v-show` に委ねるための列挙。
+ * claude モードで複数 worktree の leaf を同時表示する際、unmount/remount を避けて
+ * xterm の state（スクロール位置、buffer）を保つために必要。
+ */
 const allLeafIds = computed(() => {
   const ids: string[] = [];
   for (const dir of terminalStore.visitedDirs) {
@@ -180,12 +185,9 @@ const gridStyle = computed<Record<string, string>>(() => {
   };
 });
 
-/** wt モード以外ではハンドル不要 */
-const isTileMode = computed(() => terminalStore.viewMode !== "wt");
-
-/** 分割ツリーのハンドル（タイルモード時は空） */
+/** 分割ツリーのハンドル（claude タイルモード時は空） */
 const handles = computed<HandlePosition[]>(() => {
-  if (isTileMode.value) return [];
+  if (terminalStore.viewMode === "claude") return [];
   const dir = worktreeStore.dir;
   if (!dir) return [];
   const layout = terminalStore.layoutsByDir[dir];

--- a/apps/renderer/src/features/terminal/TerminalPane.vue
+++ b/apps/renderer/src/features/terminal/TerminalPane.vue
@@ -7,7 +7,7 @@ MainLayout はこのコンポーネントを配置するだけでよい。
 ## レイアウト
 
 - 単一 worktree モード（"wt"）: `treeToGridTemplate` で分割ツリーを CSS Grid に変換
-- マルチ表示モード（"all" / "claude"）: `tileGridTemplate` で均等タイル配置
+- Claude タイルモード（"claude"）: `tileGridTemplate` で Claude 起動中 leaf を均等タイル配置
 - 各 TerminalLeaf は `grid-area` で配置、非表示 leaf は `v-show:false`
 - 分割リサイズハンドルは absolute overlay
 </doc>
@@ -141,9 +141,7 @@ const allLeafIds = computed(() => {
 
 /** 表示対象の leafId set（v-show の判定に使用） */
 const visibleLeafIds = computed(() => {
-  const mode = terminalStore.viewMode;
-  if (mode === "all") return new Set(allLeafIds.value);
-  if (mode === "claude") return new Set(terminalStore.claudeActiveLeafIds);
+  if (terminalStore.viewMode === "claude") return new Set(terminalStore.claudeActiveLeafIds);
   return new Set(activeLeafIds.value);
 });
 
@@ -155,12 +153,13 @@ const EMPTY_GRID: Record<string, string> = {
 
 /** grid スタイル */
 const gridStyle = computed<Record<string, string>>(() => {
-  const mode = terminalStore.viewMode;
-
-  // タイル表示: all / claude
-  if (mode === "all" || mode === "claude") {
-    const ids = mode === "claude" ? terminalStore.claudeActiveLeafIds : allLeafIds.value;
-    const tpl = tileGridTemplate(ids, containerW.value, containerH.value);
+  // Claude タイル表示
+  if (terminalStore.viewMode === "claude") {
+    const tpl = tileGridTemplate(
+      terminalStore.claudeActiveLeafIds,
+      containerW.value,
+      containerH.value,
+    );
     return {
       gridTemplateAreas: tpl.areas,
       gridTemplateColumns: tpl.columns,

--- a/apps/renderer/src/features/terminal/registerTerminalCommands.ts
+++ b/apps/renderer/src/features/terminal/registerTerminalCommands.ts
@@ -116,6 +116,14 @@ export function registerTerminalCommands(
       label: "Terminal: Focus Down",
       handler: createFocusHandler("down"),
     }),
+
+    registry.register("workspace.toggleViewMode", {
+      label: "Workspace: Toggle Active Worktree / Claude Terminals",
+      handler: () => {
+        terminalStore.toggleViewMode();
+        return true;
+      },
+    }),
   ];
 
   return () => {

--- a/apps/renderer/src/features/terminal/useTerminalStore.ts
+++ b/apps/renderer/src/features/terminal/useTerminalStore.ts
@@ -54,9 +54,14 @@ export const useTerminalStore = defineStore("terminal", () => {
   /** split ドラッグ中の fit 抑制カウンター */
   const dragSuspendCount = ref(0);
 
-  /** ターミナル表示モード: wt=アクティブworktreeのみ, all=全leaf, claude=Claude起動中のみ */
-  type ViewMode = "wt" | "all" | "claude";
+  /** ターミナル表示モード: wt=アクティブworktreeのみ, claude=Claude起動中のみ */
+  type ViewMode = "wt" | "claude";
   const viewMode = ref<ViewMode>("wt");
+
+  /** wt ↔ claude をトグルする */
+  function toggleViewMode() {
+    viewMode.value = viewMode.value === "wt" ? "claude" : "wt";
+  }
 
   /** ptyId → Claude Code の状態（idle は undefined = エントリなし） */
   const claudeStatusByPtyId = ref<Record<number, ClaudeStatus>>({});
@@ -372,6 +377,7 @@ export const useTerminalStore = defineStore("terminal", () => {
     layoutsByDir,
     dragSuspendCount,
     viewMode,
+    toggleViewMode,
     cwdByLeafId,
     titleByLeafId,
     lastTitleUpdate,

--- a/apps/renderer/src/shared/command/defaultKeyBindings.json
+++ b/apps/renderer/src/shared/command/defaultKeyBindings.json
@@ -18,5 +18,6 @@
   { "key": "ctrl+7", "command": "workspace.selectWorktree", "args": 7 },
   { "key": "ctrl+8", "command": "workspace.selectWorktree", "args": 8 },
   { "key": "ctrl+9", "command": "workspace.selectWorktree", "args": 9 },
+  { "key": "cmd+/", "command": "workspace.toggleViewMode" },
   { "key": "cmd+,", "command": "settings.open" }
 ]


### PR DESCRIPTION
## 概要

サイドバートップツールバーに active worktree / claude terminals の view mode トグルを追加し、`cmd+/` ショートカットで切り替えられるようにする。あわせて従来の "all terminals" モードを廃止する。

## 背景

これまで view mode 切り替え UI は repo セクション内の WORKTREES ヘッダー右端に置かれており、`active worktree` / `all terminals` / `claude terminals` の 3 ボタンを各 repo が個別に表示していた。しかし `viewMode` は `useTerminalStore` が持つ単一の ref であり、全 repo 共通の state を per-repo の UI で操作する形になっていた。状態とは別の階層に UI を置いている構造。

実運用上 `all terminals`（全 worktree の全 leaf を一度に表示するタイル）はほぼ使われておらず、頻繁に切り替えるのは `wt` と `claude` の 2 択。そのため:

- "all" モードを廃止する
- 切り替え UI を per-repo から サイドバートップツールバーへ集約する
- 2 択になったので 1 ショートカットでトグルできるようにする

## 変更内容

### viewMode 廃止と縮約

- `useTerminalStore` の `ViewMode` を `"wt" | "all" | "claude"` から `"wt" | "claude"` に縮約
- `useTerminalStore.toggleViewMode()` を追加
- `TerminalPane.vue` の `"all"` 経路を削除し、claude タイル表示の判定を `viewMode === "claude"` に統一
- `isTileMode` computed を削除し、`handles` 内で直接判定するように変更（否定形による将来モード追加時の意図しない巻き込み防止）

### サイドバー UI の再配置

- 切り替えボタンを `WorktreeList`（per-repo）から `SidebarPane` トップツールバーへ移動
- `WorktreeList` / `RepoSection` から `viewMode` prop / `setViewMode` emit を削除
- 既存のリスト編集ボタン（鉛筆アイコン）の左にトグルボタンを並列配置

### コマンドとキーバインド

- `workspace.toggleViewMode` コマンドを `registerTerminalCommands` に登録（state を所有する terminal feature と同じ層に置く）
- `cmd+/` を default keybinding に追加

### ドキュメント

- `SidebarPane.vue` / `TerminalPane.vue` / `TerminalLeaf.vue` の `<doc>` ブロックを更新
- `allLeafIds` computed に DOM 維持目的のコメントを追加（claude モードで複数 worktree の leaf を同時表示する際、unmount/remount を避けて xterm の state を保つため）

## 確認事項

- [ ] サイドバートップのトグルボタンで wt ↔ claude が切り替わる
- [ ] `cmd+/` でトグルが動作する
- [ ] 各 repo の WORKTREES セクションから切り替えボタンが消えている
- [ ] claude モードで複数 worktree の Claude leaf が均等タイル表示される
- [ ] wt モードで現在 worktree の分割レイアウトが正しく描画される
- [ ] worktree 切替時に viewMode が "wt" にリセットされる挙動が保たれている
