### PR TITLE
fix(fs-watch): worktree の git status を commit 後に自動更新する

### DIFF
--- a/apps/native/Sources/GozdCore/FSWatchRegistry.swift
+++ b/apps/native/Sources/GozdCore/FSWatchRegistry.swift
@@ -185,9 +185,17 @@ public actor FSWatchRegistry {
     }
 
     if result.hasGitStatusChange {
-      let status = try? await GitOps.gitStatusFull(dir: dir)
+      let status: GitOps.StatusFull
+      do {
+        status = try await GitOps.gitStatusFull(dir: dir)
+      } catch {
+        // 観察可能性のためログを残す。renderer は次の FSEvents バッチで再 fetch するため
+        // 致命的ではないが、繰り返し発生していれば一時障害として診断したい。
+        print("[FSWatchRegistry] gitStatusFull failed for \(dir): \(error)")
+        return
+      }
       // gitStatusFull の await 中に unwatch されている可能性があるため再 check
-      guard isActive(dir: dir, generation: generation), let status else { return }
+      guard isActive(dir: dir, generation: generation) else { return }
       onGitStatusChange(originalDir, status)
     }
   }

--- a/apps/native/Sources/GozdCore/FSWatchRegistry.swift
+++ b/apps/native/Sources/GozdCore/FSWatchRegistry.swift
@@ -9,11 +9,17 @@ import Foundation
 //    `/fs/watch` で登録され、worktree を閉じる時に `/fs/unwatch` で解除する。
 //
 // 2. **イベント分類**:
-//    - `<dir>/.git/worktrees/...` 配下 → `worktreeChange`
-//    - `<dir>/.git/refs/heads/...` または `<dir>/.git/packed-refs` → `branchChange`
-//    - `<dir>/.git/index` または `<dir>/.git/HEAD` → `gitStatusChange`
-//    - その他作業ツリー（`<dir>/.git/` 配下以外） → `fsChange` + `gitStatusChange`
+//    - per-worktree git dir 配下の `HEAD` / `index` → `gitStatusChange`
+//    - common git dir 配下の `refs/heads/...` / `packed-refs` → `branchChange`
+//    - common git dir 配下の `worktrees/...` → `worktreeChange`
+//    - 作業ツリー側（git dir 配下以外） → `fsChange` + `gitStatusChange`
 //      （未追跡ファイルや作業ツリー差分も status に影響するため）
+//
+//    worktree では `.git` がファイル参照で、commit / branch 更新の実体は親 repo の
+//    `.git/worktrees/<name>/` と `.git/` に書かれる。FSEvents は登録 path 配下しか
+//    監視しないため、worktree root だけ watch しても git 更新を取りこぼす。
+//    そこで `git rev-parse --git-dir --git-common-dir` で 2 つの git dir を解決し、
+//    FSWatcher の paths に追加する。通常 clone では両者が一致するので dedupe する。
 //
 // 3. **debounce**。FSEvents は数十 ms 以内に同一バッチを連続 dispatch する。
 //    1 バッチを 1 つの push にまとめるため、Task の実行内でフラグ管理する。
@@ -37,9 +43,16 @@ public actor FSWatchRegistry {
     /// `wt.path` 等の生文字列キーと直接比較できるようにする。
     /// （entries のキーは `realpath` 解決済み path で、FSEvents の path 比較に使う）
     let originalDir: String
+    /// `git rev-parse --git-dir` の realpath。dir が git repo でない時のみ nil。
+    let perWorktreeGitDir: String?
+    /// `git rev-parse --git-common-dir` の realpath。dir が git repo でない時のみ nil。
+    /// 通常 clone では `perWorktreeGitDir` と一致する。
+    let commonGitDir: String?
   }
 
-  private struct Classification {
+  // 分岐網羅テスト容易性のため internal で公開する。dispatch は actor 内で完結するため
+  // この struct を外部から直接組み立てる用途は無い。
+  struct Classification: Equatable {
     let fsRelDirs: Set<String>
     let hasFsChange: Bool
     let hasGitStatusChange: Bool
@@ -71,15 +84,37 @@ public actor FSWatchRegistry {
   /// dir の監視を開始する。既に watch されていれば no-op。
   /// 入力 dir は realpath 解決してキーに使う（FSEvents は realpath を返すため、
   /// `/var/...` と `/private/var/...` のような symlink の差を吸収する）。
-  public func watch(dir userDir: String) throws {
+  public func watch(dir userDir: String) async throws {
     let dir = FSWatchRegistry.realpath(userDir)
     if entries[dir] != nil { return }
 
     nextGeneration += 1
     let generation = nextGeneration
 
+    // git dir を解決して FSWatcher の監視 path に追加する。
+    // worktree では `.git` がファイル参照で、commit / branch 更新の実体は親 repo 側に
+    // ある。worktree root だけ watch しても FSEvents が来ないため、両 git dir を
+    // 監視対象に入れる必要がある。
+    //
+    // gitDirs は dir が git 管理下でない時のみ nil を返す（exit 128 を識別）。
+    // それ以外の失敗（git バイナリ不在 / 出力破綻 / I/O 失敗）は throw して watch を中断
+    // させる。ここで try? に握り潰すと「worktree なのに解決失敗」がサイレントに通常 watch
+    // にフォールバックし、修正前と同じ症状（commit が反映されない）を再現してしまう。
+    // realpath 解決後の dir を渡す。FSEvents の path 比較に使う path と一貫させる。
+    let gitDirs = try await GitOps.gitDirs(dir: dir)
+    let perWorktreeGitDir = gitDirs.map { FSWatchRegistry.realpath($0.perWorktreeGitDir) }
+    let commonGitDir = gitDirs.map { FSWatchRegistry.realpath($0.commonGitDir) }
+
+    var watchPaths = [dir]
+    if let perWorktreeGitDir, !watchPaths.contains(perWorktreeGitDir) {
+      watchPaths.append(perWorktreeGitDir)
+    }
+    if let commonGitDir, !watchPaths.contains(commonGitDir) {
+      watchPaths.append(commonGitDir)
+    }
+
     let (stream, continuation) = AsyncStream<[FSWatcher.Event]>.makeStream()
-    let watcher = FSWatcher(paths: [dir])
+    let watcher = FSWatcher(paths: watchPaths)
     watcher.setHandler { events in
       continuation.yield(events)
     }
@@ -96,7 +131,9 @@ public actor FSWatchRegistry {
 
     entries[dir] = Entry(
       generation: generation, watcher: watcher, task: task, continuation: continuation,
-      originalDir: userDir)
+      originalDir: userDir,
+      perWorktreeGitDir: perWorktreeGitDir,
+      commonGitDir: commonGitDir)
   }
 
   /// dir の監視を停止する。watch されていなければ no-op。
@@ -123,9 +160,14 @@ public actor FSWatchRegistry {
   /// realpath を返すと symlink 経路（`/var` vs `/private/var` 等）で比較が外れるから。
   private func handleEvents(dir: String, generation: UInt64, events: [FSWatcher.Event]) async {
     guard isActive(dir: dir, generation: generation) else { return }
-    guard let originalDir = entries[dir]?.originalDir else { return }
+    guard let entry = entries[dir] else { return }
+    let originalDir = entry.originalDir
 
-    let result = FSWatchRegistry.classify(dir: dir, events: events)
+    let result = FSWatchRegistry.classify(
+      dir: dir,
+      perWorktreeGitDir: entry.perWorktreeGitDir,
+      commonGitDir: entry.commonGitDir,
+      events: events)
 
     // 分類は同期処理なので await を挟まないが、明示的に再 check しておく。
     guard isActive(dir: dir, generation: generation) else { return }
@@ -168,9 +210,24 @@ public actor FSWatchRegistry {
 
   /// 1 バッチの events を分類した結果を返す pure helper。dispatch は呼び出し側が行う。
   /// 分離理由: dispatch 前後に actor 上で世代 check を挟むため、副作用を持たない形にする。
-  private static func classify(dir: String, events: [FSWatcher.Event]) -> Classification {
+  ///
+  /// 判定優先順位:
+  ///   1. per-worktree git dir 配下 → `HEAD` / `index` のみ `gitStatusChange`
+  ///   2. common git dir 配下 → `refs/heads/...` / `packed-refs` を `branchChange`、
+  ///      `worktrees/...` を `worktreeChange`
+  ///   3. 作業ツリー配下（git dir 配下に該当しない場合）→ `fsChange` + `gitStatusChange`
+  ///
+  /// 通常 clone では perWorktreeGitDir == commonGitDir なので 1 と 2 を両方適用する。
+  /// その git dir は worktree root 配下に位置するため、3 のスキップも兼ねる。
+  /// worktree clone では git dir が worktree root の外にあるため、3 では git dir を
+  /// 自動的に通過しない。
+  static func classify(
+    dir: String,
+    perWorktreeGitDir: String?,
+    commonGitDir: String?,
+    events: [FSWatcher.Event]
+  ) -> Classification {
     let dirWithSlash = dir.hasSuffix("/") ? dir : dir + "/"
-    let gitPrefix = dirWithSlash + ".git/"
 
     var fsRelDirs = Set<String>()
     var hasFsChange = false
@@ -178,28 +235,46 @@ public actor FSWatchRegistry {
     var hasBranchChange = false
     var hasWorktreeChange = false
 
+    // 通常 clone では perWorktreeGitDir == commonGitDir なので、両ルールを同じ path に
+    // 適用して `HEAD` と `refs/heads/` を両方拾う必要がある。
+    // worktree clone では perWorktreeGitDir は commonGitDir の `worktrees/<name>/` 配下に
+    // 物理的にネストする。`<common>/worktrees/<name>/HEAD` は per-wt 規則だけ適用すべきで、
+    // common 規則の `worktrees/...` → worktreeChange を二重発火させると worktree list の
+    // 変更と worktree-local な状態変化を混同する。
+    let perWtSameAsCommon = perWorktreeGitDir == commonGitDir
+
     for event in events {
       let path = event.path
-      // FSEvents の path は physical realpath。dir 配下でなければ無視。
-      guard path == dir || path.hasPrefix(dirWithSlash) else { continue }
+      var matchedGitDir = false
 
-      if path.hasPrefix(gitPrefix) {
-        let rel = String(path.dropFirst(gitPrefix.count))
+      let underPerWt = relativeUnder(path: path, root: perWorktreeGitDir)
+      if let rel = underPerWt {
+        matchedGitDir = true
+        if rel == "HEAD" || rel == "index" {
+          hasGitStatusChange = true
+        }
+        // それ以外（logs/, objects/, ORIG_HEAD 等）は無視
+      }
+      // per-wt と common が別 dir のとき、per-wt にマッチした path には common 規則を
+      // 適用しない（per-wt の方が長い prefix で具体性が高いため、そちらが排他的に勝つ）。
+      let applyCommonRule = perWtSameAsCommon || underPerWt == nil
+      if applyCommonRule, let rel = relativeUnder(path: path, root: commonGitDir) {
+        matchedGitDir = true
         if rel.hasPrefix("worktrees/") {
           hasWorktreeChange = true
         } else if rel.hasPrefix("refs/heads/") || rel == "packed-refs" {
           hasBranchChange = true
-        } else if rel == "index" || rel == "HEAD" {
-          hasGitStatusChange = true
         }
-        // それ以外の .git 配下（objects/, logs/ 等）は無視
-      } else {
-        // 作業ツリー側の変更 → fsChange + gitStatusChange
-        hasFsChange = true
-        hasGitStatusChange = true
-        let relDir = relativeDir(path: path, dir: dir, dirWithSlash: dirWithSlash)
-        fsRelDirs.insert(relDir)
       }
+
+      if matchedGitDir { continue }
+
+      // 作業ツリー側の変更 → fsChange + gitStatusChange
+      guard path == dir || path.hasPrefix(dirWithSlash) else { continue }
+      hasFsChange = true
+      hasGitStatusChange = true
+      let relDir = relativeDir(path: path, dir: dir, dirWithSlash: dirWithSlash)
+      fsRelDirs.insert(relDir)
     }
 
     return Classification(
@@ -209,6 +284,16 @@ public actor FSWatchRegistry {
       hasBranchChange: hasBranchChange,
       hasWorktreeChange: hasWorktreeChange
     )
+  }
+
+  /// path が root 配下なら root からの相対パスを返す。配下でなければ nil。
+  /// `path == root` のときは `""` を返す。
+  private static func relativeUnder(path: String, root: String?) -> String? {
+    guard let root else { return nil }
+    if path == root { return "" }
+    let rootWithSlash = root.hasSuffix("/") ? root : root + "/"
+    guard path.hasPrefix(rootWithSlash) else { return nil }
+    return String(path.dropFirst(rootWithSlash.count))
   }
 
   /// イベントの絶対 path から、dir に対する **親ディレクトリ** の相対パスを返す。

--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -423,7 +423,7 @@ private func runGitWithStdinOnce(gitPath: String, args: [String], cwd: String, s
   // 内部で `ProcessInfo.processInfo.environment` を遅延読みするが、その経路は
   // `getenv`/`environ` の thread-unsafety が並列 spawn 時に EFAULT (Code=14) を
   // 引く要因になり得る。spawn 前に snapshot を取って渡せば内部 lazy read を回避できる。
-  process.environment = ProcessInfo.processInfo.environment
+  process.environment = gozdGitEnv()
 
   let stdinPipe = Pipe()
   let stdoutPipe = Pipe()
@@ -454,6 +454,22 @@ private func runGitWithStdinOnce(gitPath: String, args: [String], cwd: String, s
     stderr: String(decoding: stderrData, as: UTF8.self))
 }
 
+/// gozd 用 git 環境変数を組み立てる。`ProcessInfo.processInfo.environment` を snapshot し、
+/// `GIT_OPTIONAL_LOCKS=0` を上書き設定する。
+///
+/// `GIT_OPTIONAL_LOCKS=0` は read-only な git コマンド (`status` 等) が index stat refresh
+/// 用に行う **opportunistic な `index.lock` 取得を抑止**する。gozd は FSEvents 駆動で
+/// バックグラウンドに `git status` 等を頻繁に叩くため、この設定が無いとユーザーが foreground
+/// で叩いた `git commit` / `git add` と lock 競合し、ユーザー側が exit 128
+/// (`Unable to create '.../index.lock': File exists`) で即死する。
+/// git 自身がこのシナリオ（バックグラウンドツール並走）のために提供している env で、
+/// VS Code / GitHub Desktop 等の主要 GUI クライアントも同じ設定を入れている。
+private func gozdGitEnv() -> [String: String] {
+  var env = ProcessInfo.processInfo.environment
+  env["GIT_OPTIONAL_LOCKS"] = "0"
+  return env
+}
+
 func runGit(args: [String], cwd: String) async throws -> Data {
   do {
     return try await runGitOnce(gitPath: await resolveGitPath(), args: args, cwd: cwd)
@@ -468,7 +484,7 @@ private func runGitOnce(gitPath: String, args: [String], cwd: String) async thro
   process.executableURL = URL(fileURLWithPath: gitPath)
   process.arguments = args
   process.currentDirectoryURL = URL(fileURLWithPath: cwd)
-  process.environment = ProcessInfo.processInfo.environment
+  process.environment = gozdGitEnv()
 
   let stdoutPipe = Pipe()
   let stderrPipe = Pipe()

--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -185,24 +185,33 @@ public enum GitOps {
   ///   呼び出し側で `try?` で握り潰すと「worktree なのに git dir が解決できない」障害が
   ///   サイレントに通常 watch にフォールバックされ、commit 反映バグが復活する。
   public static func gitDirs(dir: String) async throws -> GitDirs? {
-    let stdout: Data
+    // `git rev-parse` は `-z` / `--null` 等の NUL 区切り出力モードを持たず、複数フラグを
+    // 同時指定すると newline 区切りで返す。改行を含むパス（`<repo\nname>/.git` 等の
+    // 病的ケース）で fragile になるため、フラグを 1 つずつ別 spawn して各呼び出しが
+    // 単一行のみ返す形にする。spawn コストは worktree オープン時のみで実用上問題ない。
+    let perWorktree: String
+    let common: String
     do {
-      stdout = try await runGit(
-        args: ["rev-parse", "--path-format=absolute", "--git-dir", "--git-common-dir"], cwd: dir)
+      perWorktree = try await singleRevParse(flag: "--git-dir", cwd: dir)
+      common = try await singleRevParse(flag: "--git-common-dir", cwd: dir)
     } catch let GitError.commandFailed(exitCode, _) where exitCode == 128 {
       // exit 128 = "not a git repository"。git の規約。
       return nil
     }
-    let lines = String(decoding: stdout, as: UTF8.self)
-      .split(whereSeparator: { $0 == "\n" })
-      .map { $0.trimmingCharacters(in: .whitespaces) }
-      .filter { !$0.isEmpty }
-    // `--git-dir --git-common-dir` の出力は厳密に 2 行。違ったら git の出力契約破綻。
-    guard lines.count == 2, let perWorktree = lines.first, let common = lines.last else {
-      throw GitError.unexpectedOutput(
-        "git rev-parse --git-dir --git-common-dir: expected 2 lines, got \(lines.count): \(lines)")
-    }
     return GitDirs(perWorktreeGitDir: perWorktree, commonGitDir: common)
+  }
+
+  /// `git rev-parse --path-format=absolute <flag>` を 1 回 spawn し、単一行の trim 済み path を返す。
+  /// 出力が空ならば不正として throw。
+  private static func singleRevParse(flag: String, cwd: String) async throws -> String {
+    let stdout = try await runGit(
+      args: ["rev-parse", "--path-format=absolute", flag], cwd: cwd)
+    let text = String(decoding: stdout, as: UTF8.self)
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !text.isEmpty else {
+      throw GitError.unexpectedOutput("git rev-parse \(flag): empty output")
+    }
+    return text
   }
 
   /// 全 worktree が共有する main repo の作業ディレクトリを返す。

--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -167,6 +167,44 @@ public enum GitOps {
       in: .whitespacesAndNewlines)
   }
 
+  public struct GitDirs: Equatable, Sendable {
+    /// `git rev-parse --git-dir` の絶対パス。
+    /// 通常 clone では `<repo>/.git`、worktree では `<parent>/.git/worktrees/<name>` を指す。
+    public let perWorktreeGitDir: String
+    /// `git rev-parse --git-common-dir` の絶対パス。
+    /// 通常 clone では `perWorktreeGitDir` と一致。worktree では親 `<parent>/.git` を指す。
+    public let commonGitDir: String
+  }
+
+  /// per-worktree git dir と common git dir の絶対パスを 1 回の `git rev-parse` で取る。
+  /// FSEvents の path 比較に使うため呼び出し側で realpath 解決すること。
+  ///
+  /// - dir が git 管理下でない場合は **nil** を返す（git rev-parse は exit 128）。
+  ///   これは「git repo ではない」という事実を nil で表す正常パスで、エラーではない。
+  /// - git バイナリ不在 / 出力形式破綻 / その他 I/O 失敗は throw する。
+  ///   呼び出し側で `try?` で握り潰すと「worktree なのに git dir が解決できない」障害が
+  ///   サイレントに通常 watch にフォールバックされ、commit 反映バグが復活する。
+  public static func gitDirs(dir: String) async throws -> GitDirs? {
+    let stdout: Data
+    do {
+      stdout = try await runGit(
+        args: ["rev-parse", "--path-format=absolute", "--git-dir", "--git-common-dir"], cwd: dir)
+    } catch let GitError.commandFailed(exitCode, _) where exitCode == 128 {
+      // exit 128 = "not a git repository"。git の規約。
+      return nil
+    }
+    let lines = String(decoding: stdout, as: UTF8.self)
+      .split(whereSeparator: { $0 == "\n" })
+      .map { $0.trimmingCharacters(in: .whitespaces) }
+      .filter { !$0.isEmpty }
+    // `--git-dir --git-common-dir` の出力は厳密に 2 行。違ったら git の出力契約破綻。
+    guard lines.count == 2, let perWorktree = lines.first, let common = lines.last else {
+      throw GitError.unexpectedOutput(
+        "git rev-parse --git-dir --git-common-dir: expected 2 lines, got \(lines.count): \(lines)")
+    }
+    return GitDirs(perWorktreeGitDir: perWorktree, commonGitDir: common)
+  }
+
   /// 全 worktree が共有する main repo の作業ディレクトリを返す。
   /// 非 bare repo では `git rev-parse --git-common-dir` の親ディレクトリ。
   /// gozd の `~/.local/share/gozd/worktrees/<repo>-<hash>/<timestamp>` のような worktree から
@@ -328,6 +366,9 @@ private let emptyTreeHash = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 public enum GitError: Error, Equatable {
   case commandFailed(exitCode: Int32, stderr: String)
   case launchFailed(String)
+  /// git は exit 0 で正常終了したが stdout のフォーマットが想定外。
+  /// `commandFailed` は `exitCode != 0` を含意するため流用せず別 case にする。
+  case unexpectedOutput(String)
 }
 
 // MARK: - private helpers

--- a/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
@@ -76,6 +76,15 @@ struct FSWatchRegistryTests {
       ["worktree", "add", "-b", "feature", worktreeRoot.path], cwd: mainRepo)
     let worktreeRootResolved = URL(fileURLWithPath: worktreeRoot.path).resolvingSymlinksInPath()
 
+    // watch 開始前にファイル作成と add まで済ませる。watch 中の handleEvents は
+    // `gitStatusFull` を spawn し、`git status` は read-only だが index stat refresh で
+    // 同じ per-worktree git dir の `index.lock` を取りにいく場合がある。そこに `git add`
+    // / `git commit` をぶつけると lock 競合で test が flake する。watch 中に撃つ git ops
+    // は単一の `git commit` だけに絞り、gitStatusChange の発火経路を確実に踏ませる。
+    let file = worktreeRootResolved.appendingPathComponent("a.txt")
+    try "hello".write(to: file, atomically: true, encoding: .utf8)
+    try await runGitCmd(["add", "a.txt"], cwd: worktreeRootResolved)
+
     let collector = EventNameCollector()
     let registry = FSWatchRegistry(
       onFsChange: { _, _ in collector.append("fsChange") },
@@ -88,9 +97,6 @@ struct FSWatchRegistryTests {
     try await Task.sleep(for: .milliseconds(300))
     collector.clear()
 
-    let file = worktreeRootResolved.appendingPathComponent("a.txt")
-    try "hello".write(to: file, atomically: true, encoding: .utf8)
-    try await runGitCmd(["add", "a.txt"], cwd: worktreeRootResolved)
     try await runGitCmd(["commit", "-m", "add a"], cwd: worktreeRootResolved)
 
     try await waitForEvent(collector, matching: { $0 == "gitStatusChange" })
@@ -278,6 +284,15 @@ private func makeTempDir() throws -> URL {
   return URL(fileURLWithPath: raw.path).resolvingSymlinksInPath()
 }
 
+private struct GitCmdError: Error, CustomStringConvertible {
+  let args: [String]
+  let exitCode: Int32
+  let stderr: String
+  var description: String {
+    "git \(args.joined(separator: " ")) failed (exit \(exitCode)): \(stderr)"
+  }
+}
+
 private func runGitCmd(_ args: [String], cwd: URL) async throws {
   let p = Process()
   p.executableURL = URL(fileURLWithPath: "/usr/bin/env")
@@ -290,14 +305,28 @@ private func runGitCmd(_ args: [String], cwd: URL) async throws {
   env["GIT_COMMITTER_NAME"] = "test"
   env["GIT_COMMITTER_EMAIL"] = "test@example.com"
   p.environment = env
+  let stderrPipe = Pipe()
   p.standardOutput = Pipe()
-  p.standardError = Pipe()
+  p.standardError = stderrPipe
   try p.run()
   p.waitUntilExit()
+  if p.terminationStatus != 0 {
+    let stderr = String(
+      decoding: stderrPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+    throw GitCmdError(args: args, exitCode: p.terminationStatus, stderr: stderr)
+  }
 }
 
 private func initGitRepo(at dir: URL) async throws {
   try await runGitCmd(["init", "-q", "-b", "main"], cwd: dir)
+}
+
+private struct EventTimeout: Error, CustomStringConvertible {
+  let timeout: Duration
+  let observed: [String]
+  var description: String {
+    "waitForEvent timed out after \(timeout). Observed events: \(observed)"
+  }
 }
 
 private func waitForEvent(
@@ -310,6 +339,9 @@ private func waitForEvent(
     if collector.snapshot().contains(where: predicate) { return }
     try await Task.sleep(for: .milliseconds(50))
   }
+  // タイムアウトを silent return せず throw する。「期待イベントが届かなかった」のか
+  // 「タイムアウトで打ち切った」のかを呼び出し側が区別できるようにする。
+  throw EventTimeout(timeout: timeout, observed: collector.snapshot())
 }
 
 private final class EventNameCollector: @unchecked Sendable {

--- a/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
@@ -30,14 +30,11 @@ struct FSWatchRegistryTests {
     #expect(events.contains { $0.hasPrefix("fsChange:") })
   }
 
-  @Test("`.git/refs/heads/...` 変更で branchChange が分類される")
+  @Test("git repo の `.git/refs/heads/...` 変更で branchChange が分類される")
   func classifiesBranchChange() async throws {
     let tmpDir = try makeTempDir()
     defer { try? FileManager.default.removeItem(at: tmpDir) }
-
-    let refsHeads = tmpDir.appendingPathComponent(".git/refs/heads")
-    try FileManager.default.createDirectory(
-      at: refsHeads, withIntermediateDirectories: true)
+    try await initGitRepo(at: tmpDir)
 
     let collector = EventNameCollector()
     let registry = FSWatchRegistry(
@@ -50,12 +47,55 @@ struct FSWatchRegistryTests {
     try await registry.watch(dir: tmpDir.path)
     try await Task.sleep(for: .milliseconds(300))
 
-    let branchFile = refsHeads.appendingPathComponent("feature-x")
-    try "0123456789abcdef".write(to: branchFile, atomically: true, encoding: .utf8)
+    let branchFile = tmpDir.appendingPathComponent(".git/refs/heads/feature-x")
+    try "0123456789abcdef0123456789abcdef01234567\n"
+      .write(to: branchFile, atomically: true, encoding: .utf8)
 
     try await waitForEvent(collector, matching: { $0 == "branchChange" })
     let events = collector.snapshot()
     #expect(events.contains("branchChange"))
+  }
+
+  @Test("worktree 内 commit で gitStatusChange が分類される（実体は親 repo の .git/worktrees/）")
+  func classifiesGitStatusChangeForWorktreeCommit() async throws {
+    let mainRepo = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: mainRepo) }
+    try await initGitRepo(at: mainRepo)
+
+    // 初回 commit を作って HEAD を確立する。
+    let seed = mainRepo.appendingPathComponent("seed.txt")
+    try "seed".write(to: seed, atomically: true, encoding: .utf8)
+    try await runGitCmd(["add", "seed.txt"], cwd: mainRepo)
+    try await runGitCmd(["commit", "-m", "seed"], cwd: mainRepo)
+
+    // worktree を分岐させる。
+    let worktreeRoot = mainRepo.deletingLastPathComponent()
+      .appendingPathComponent("wt-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: worktreeRoot) }
+    try await runGitCmd(
+      ["worktree", "add", "-b", "feature", worktreeRoot.path], cwd: mainRepo)
+    let worktreeRootResolved = URL(fileURLWithPath: worktreeRoot.path).resolvingSymlinksInPath()
+
+    let collector = EventNameCollector()
+    let registry = FSWatchRegistry(
+      onFsChange: { _, _ in collector.append("fsChange") },
+      onGitStatusChange: { _, _ in collector.append("gitStatusChange") },
+      onBranchChange: { _ in collector.append("branchChange") },
+      onWorktreeChange: { _ in collector.append("worktreeChange") }
+    )
+
+    try await registry.watch(dir: worktreeRootResolved.path)
+    try await Task.sleep(for: .milliseconds(300))
+    collector.clear()
+
+    let file = worktreeRootResolved.appendingPathComponent("a.txt")
+    try "hello".write(to: file, atomically: true, encoding: .utf8)
+    try await runGitCmd(["add", "a.txt"], cwd: worktreeRootResolved)
+    try await runGitCmd(["commit", "-m", "add a"], cwd: worktreeRootResolved)
+
+    try await waitForEvent(collector, matching: { $0 == "gitStatusChange" })
+    let events = collector.snapshot()
+    #expect(events.contains("gitStatusChange"))
   }
 
   @Test("unwatch 後はイベントが届かない")
@@ -89,6 +129,146 @@ struct FSWatchRegistryTests {
   }
 }
 
+// MARK: - classify pure unit tests
+
+@Suite("FSWatchRegistry.classify")
+struct ClassifyTests {
+  // 共通の Event 生成 helper。flags / id は分類に影響しないので 0 固定。
+  private func ev(_ path: String) -> FSWatcher.Event {
+    FSWatcher.Event(path: path, flags: 0, id: 0)
+  }
+
+  @Test("worktree 配置: per-worktree git dir 配下の HEAD は gitStatusChange のみ")
+  func worktreePerWorktreeHead() {
+    let dir = "/wt/foo"
+    let perWt = "/parent/.git/worktrees/foo"
+    let common = "/parent/.git"
+    let result = FSWatchRegistry.classify(
+      dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
+      events: [ev("\(perWt)/HEAD")])
+    #expect(result.hasGitStatusChange)
+    #expect(!result.hasFsChange)
+    #expect(!result.hasBranchChange)
+    #expect(!result.hasWorktreeChange)
+  }
+
+  @Test("worktree 配置: common git dir 配下の refs/heads/main は branchChange")
+  func worktreeCommonBranchRef() {
+    let dir = "/wt/foo"
+    let perWt = "/parent/.git/worktrees/foo"
+    let common = "/parent/.git"
+    let result = FSWatchRegistry.classify(
+      dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
+      events: [ev("\(common)/refs/heads/main")])
+    #expect(result.hasBranchChange)
+    #expect(!result.hasFsChange)
+    #expect(!result.hasGitStatusChange)
+    #expect(!result.hasWorktreeChange)
+  }
+
+  @Test("worktree 配置: common git dir 配下の packed-refs は branchChange")
+  func worktreeCommonPackedRefs() {
+    let dir = "/wt/foo"
+    let perWt = "/parent/.git/worktrees/foo"
+    let common = "/parent/.git"
+    let result = FSWatchRegistry.classify(
+      dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
+      events: [ev("\(common)/packed-refs")])
+    #expect(result.hasBranchChange)
+  }
+
+  @Test("worktree 配置: 兄弟 worktree の worktrees/<other> 追加は worktreeChange")
+  func worktreeCommonSiblingAdded() {
+    // 自分の per-wt git dir は foo。兄弟 bar が追加されると `<common>/worktrees/bar/...` に
+    // ファイルが生まれる。これは worktree list の変更なので worktreeChange を発火させる。
+    let dir = "/wt/foo"
+    let perWt = "/parent/.git/worktrees/foo"
+    let common = "/parent/.git"
+    let result = FSWatchRegistry.classify(
+      dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
+      events: [ev("\(common)/worktrees/bar/HEAD")])
+    #expect(result.hasWorktreeChange)
+    #expect(!result.hasGitStatusChange)
+  }
+
+  @Test("worktree 配置: 自身の per-wt 内部 (例: locked) は worktreeChange を発火させない")
+  func worktreeCommonSelfInternalNotWorktreeChange() {
+    // `<common>/worktrees/foo/locked` は per-wt git dir 配下なので per-wt 規則のみ適用。
+    // worktree list の変更ではないため worktreeChange は出ない。
+    let dir = "/wt/foo"
+    let perWt = "/parent/.git/worktrees/foo"
+    let common = "/parent/.git"
+    let result = FSWatchRegistry.classify(
+      dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
+      events: [ev("\(perWt)/locked")])
+    #expect(!result.hasWorktreeChange)
+    #expect(!result.hasGitStatusChange)  // locked は HEAD/index ではないので status も無し
+  }
+
+  @Test("worktree 配置: 作業ツリー配下のファイルは fsChange + gitStatusChange")
+  func worktreeWorkTreeFile() {
+    let dir = "/wt/foo"
+    let perWt = "/parent/.git/worktrees/foo"
+    let common = "/parent/.git"
+    let result = FSWatchRegistry.classify(
+      dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
+      events: [ev("\(dir)/src/a.ts")])
+    #expect(result.hasFsChange)
+    #expect(result.hasGitStatusChange)
+    #expect(result.fsRelDirs == ["src"])
+  }
+
+  @Test("通常 clone: per-worktree == common == <dir>/.git でも HEAD と refs/heads が両方分類される")
+  func normalCloneDualClassification() {
+    let dir = "/repo"
+    let gitDir = "\(dir)/.git"
+    let result = FSWatchRegistry.classify(
+      dir: dir, perWorktreeGitDir: gitDir, commonGitDir: gitDir,
+      events: [
+        ev("\(gitDir)/HEAD"),
+        ev("\(gitDir)/refs/heads/main"),
+      ])
+    #expect(result.hasGitStatusChange)
+    #expect(result.hasBranchChange)
+    // 通常 clone でも .git 配下は作業ツリー判定に乗せない
+    #expect(!result.hasFsChange)
+  }
+
+  @Test("通常 clone: .git 配下の関心外ファイル（objects/）は何も発火させない")
+  func normalCloneIgnoresObjects() {
+    let dir = "/repo"
+    let gitDir = "\(dir)/.git"
+    let result = FSWatchRegistry.classify(
+      dir: dir, perWorktreeGitDir: gitDir, commonGitDir: gitDir,
+      events: [ev("\(gitDir)/objects/ab/cdef")])
+    #expect(!result.hasFsChange)
+    #expect(!result.hasGitStatusChange)
+    #expect(!result.hasBranchChange)
+    #expect(!result.hasWorktreeChange)
+  }
+
+  @Test("git dir nil（非 repo）: 作業ツリー配下のファイルは fsChange + gitStatusChange")
+  func nonRepoFallsToWorkTreeBranch() {
+    let dir = "/somewhere"
+    let result = FSWatchRegistry.classify(
+      dir: dir, perWorktreeGitDir: nil, commonGitDir: nil,
+      events: [ev("\(dir)/note.txt")])
+    #expect(result.hasFsChange)
+    #expect(result.hasGitStatusChange)
+  }
+
+  @Test("dir 配下でも git dir 配下でもない event は無視")
+  func unrelatedPathIgnored() {
+    let dir = "/repo"
+    let gitDir = "\(dir)/.git"
+    let result = FSWatchRegistry.classify(
+      dir: dir, perWorktreeGitDir: gitDir, commonGitDir: gitDir,
+      events: [ev("/elsewhere/x.txt")])
+    #expect(!result.hasFsChange)
+    #expect(!result.hasGitStatusChange)
+  }
+}
+
 // MARK: - Helpers
 
 private func makeTempDir() throws -> URL {
@@ -96,6 +276,28 @@ private func makeTempDir() throws -> URL {
     .appendingPathComponent("gozd-fswatchregistry-\(UUID().uuidString)")
   try FileManager.default.createDirectory(at: raw, withIntermediateDirectories: true)
   return URL(fileURLWithPath: raw.path).resolvingSymlinksInPath()
+}
+
+private func runGitCmd(_ args: [String], cwd: URL) async throws {
+  let p = Process()
+  p.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+  p.arguments = ["git"] + args
+  p.currentDirectoryURL = cwd
+  // テスト用 commit のために identity を上書きする。
+  var env = ProcessInfo.processInfo.environment
+  env["GIT_AUTHOR_NAME"] = "test"
+  env["GIT_AUTHOR_EMAIL"] = "test@example.com"
+  env["GIT_COMMITTER_NAME"] = "test"
+  env["GIT_COMMITTER_EMAIL"] = "test@example.com"
+  p.environment = env
+  p.standardOutput = Pipe()
+  p.standardError = Pipe()
+  try p.run()
+  p.waitUntilExit()
+}
+
+private func initGitRepo(at dir: URL) async throws {
+  try await runGitCmd(["init", "-q", "-b", "main"], cwd: dir)
 }
 
 private func waitForEvent(


### PR DESCRIPTION
## 概要

worktree 内で `git commit` してもサイドバーの git status 表示が自動更新されない症状を直す。

`FSWatchRegistry` が worktree root だけを監視しており、worktree の `.git` メタデータが書かれる場所を見ていなかったのが原因。`git rev-parse --git-dir` / `--git-common-dir` で per-worktree git dir と common git dir を解決して `FSWatcher` の paths に追加し、`classify` を絶対パス prefix 判定に書き換える。

加えて、レビュー対応の過程で発見した以下の問題も併せて直す:

- Electron → Swift native 移行 ( b84cd17 ) で `process.env.GIT_OPTIONAL_LOCKS = "0"` の設定が脱落していた問題（元 PR #357 ・元 issue #318 の復元）
- CodeRabbit 指摘によるテスト診断性とコード堅牢性の改善

## 背景

worktree の `.git` はファイル参照（`gitdir: <親 repo>/.git/worktrees/<name>`）で、commit が実際に書き換えるのは:

- `<親 repo>/.git/worktrees/<name>/HEAD`
- `<親 repo>/.git/worktrees/<name>/index`
- `<親 repo>/.git/refs/heads/...`（ブランチ更新は commondir 側に共有）
- `<親 repo>/.git/packed-refs`

これらは worktree root 配下に **存在しない** ため、`FSWatcher(paths: [worktreeRoot])` だけでは FSEvents が発火せず、`gitStatusChange` も `branchChange` も push されない。worktree 切替時の明示 `loadGitStatus()` でカバーされていたためバグが表面化しにくかった。

worktree の git dir 構造の調査結果:

- per-worktree git dir（`<common>/worktrees/<name>/`）には HEAD / index / logs / refs / ORIG_HEAD が **専有**
- common git dir（親 repo の `.git/`）には refs/heads / packed-refs / worktrees/ が **共有**

このため、両方の git dir を watch する必要がある。

## 変更内容

### `GitOps.gitDirs(dir:)` を新設

per-worktree と common の絶対パスを `git rev-parse --git-dir` / `--git-common-dir` で個別に取得する（CodeRabbit 指摘による安全化、後述）。

- exit 128（not a git repository）は **nil** で返す（git 管理下でない dir に対する正常パス）
- それ以外の失敗（git バイナリ不在 / 出力形式破綻 / I/O 失敗）は throw する
- 出力形式破綻専用の `GitError.unexpectedOutput(String)` を追加。`commandFailed(exitCode: 0, ...)` の流用（型意味違反）を避ける

### `FSWatchRegistry` の `watch` で git dir を解決して watch paths に追加

`FSWatcher(paths:)` には worktree root + per-worktree git dir + common git dir の 3 つを dedupe して渡す。通常 clone では per-worktree == common なので 1 つに縮退する。

### `classify` を絶対パス prefix 判定に書き換え

これまでの「`<dir>/.git/<rel>` 起点の相対パス判定」を捨て、event path がどの git dir 配下かを **絶対パス prefix** で仕分ける。

- per-worktree git dir 配下の `HEAD` / `index` → `gitStatusChange`
- common git dir 配下の `refs/heads/...` / `packed-refs` → `branchChange`、`worktrees/...` → `worktreeChange`
- どちらの git dir 配下でもない作業ツリー path → `fsChange` + `gitStatusChange`

per-worktree と common が異なる worktree 配置では、per-wt にマッチした path は common 規則をスキップする（per-wt が `<common>/worktrees/<name>` という長い prefix で具体性が高く、自身の HEAD が common の `worktrees/...` → `worktreeChange` と二重発火するのを防ぐ）。通常 clone（per-wt == common）では両ルールを同じ path に適用する。

### `GIT_OPTIONAL_LOCKS=0` の復元（移行漏れ）

Electron 時代に PR #357 / 元 issue #318 で導入されていた `process.env.GIT_OPTIONAL_LOCKS = "0"` 設定が、Swift native 移行 ( b84cd17 ) で `apps/desktop/src/index.ts` ごと消失していた。`GitOps.runGit` / `runGitWithStdin` の env に per-spawn 設定として復元する。

これが無いと gozd の background `git status` がユーザー手動 `git commit` / `git add` の `index.lock` と競合し、ユーザー側が exit 128 (`Unable to create '.../index.lock': File exists`) で即死する。Swift では PTY が `ProcessInfo.processInfo.environment` を直接読むため、global 汚染を最初からしなければ旧 aae3d03 の PTY exclusion は不要。

### CodeRabbit nitpick 対応

- `runGitCmd` (test helper) が git の失敗と stderr を握り潰していた → `terminationStatus != 0` で `GitCmdError` (args / exit code / stderr 同梱) を throw
- `waitForEvent` (test helper) がタイムアウト時に silent return → `EventTimeout` を throw して呼び出し側が区別可能に
- `FSWatchRegistry.handleEvents` の `try? await GitOps.gitStatusFull` のエラー握り潰し → do/catch で `print("[FSWatchRegistry] ...")` ログ
- `gitDirs` の `git rev-parse` 出力分解が改行に脆弱 → flag を 1 つずつ別 spawn する形に変更（`git rev-parse` には `-z` / `--null` 等の NUL 区切り出力モードが無いため、当初提案された `-z` フラグでは解決できないことを確認した上での代替実装）

### テスト

- `FSWatchRegistry.classify` を internal に格上げし、純粋単体テストを 9 ケース追加（worktree 配置 / 通常 clone / 兄弟 worktree 追加 / 自身の per-wt 内部 / 非 repo / 配下外 path）
- 統合テストを実 `git init` ベースに更新。worktree 経由の commit が `gitStatusChange` を出すシナリオを追加（lock 競合対策として watch 開始前に file write + `git add` まで済ませる構成）
- 全 97 テスト pass

## 確認事項

- [ ] worktree 内で `git commit` 後、サイドバーの git status バッジ・ファイル色が即座に更新される
- [ ] worktree 内で `git checkout -b <new>` 等のブランチ切替後、サイドバーのブランチ表示が即座に更新される（`branchChange` 経路）
- [ ] `git worktree add <path>` で別 worktree を追加した時、worktree 一覧が更新される（`worktreeChange` 経路）
- [ ] 通常 clone（worktree 化していない main repo を直接開いた場合）でも commit / branch 切替が反映される
- [ ] git 管理下でない dir を `/fs/watch` した場合に watch が成功し、ファイル変更で `fsChange` が出る（既存テスト網羅）
- [ ] worktree 内で gozd を開いた状態でターミナルから `git rebase` 等を行い、`Unable to create '.../index.lock': File exists` で失敗しない（`GIT_OPTIONAL_LOCKS=0` 復元の効果）
