### PR TITLE
chore(oxfmt): exclude generated and pnpm-managed files via .oxfmtrc.json

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "ignorePatterns": ["pnpm-workspace.yaml"]
+}

--- a/apps/renderer/src/features/filer/index.ts
+++ b/apps/renderer/src/features/filer/index.ts
@@ -1,5 +1,5 @@
 export { default as FilerPane } from "./FilerPane.vue";
-export { rpcFsReadFile, rpcFsReadFileAbsolute,   } from "./rpc";
+export { rpcFsReadFile, rpcFsReadFileAbsolute } from "./rpc";
 export type { FsChangePayload } from "./rpc";
 export { getFileIconName, getIconUrl } from "./useFileIcon";
 export { useFsWatchSync } from "./useFsWatchSync";

--- a/packages/eslint-plugin/src/rules/barrelImport.ts
+++ b/packages/eslint-plugin/src/rules/barrelImport.ts
@@ -83,20 +83,15 @@ interface ScopeInfo {
  *
  * fullPath により、異なる親の下にある同名子スコープを区別できる。
  */
-function extractAllScopes(
-  filePath: string,
-  scopePattern: RegExp,
-): ScopeInfo[] {
+function extractAllScopes(filePath: string, scopePattern: RegExp): ScopeInfo[] {
   const scopes: ScopeInfo[] = [];
   let searchFrom = 0;
   while (searchFrom < filePath.length) {
     const remaining = filePath.slice(searchFrom);
     const match = scopePattern.exec(remaining);
     if (!match) break;
-    const matchEnd = searchFrom + match.index + match[1].length;
     // match[0] の先頭が "/" の場合、match.index + 1 からスコープが始まる
-    const scopeStart =
-      match[0].startsWith("/") ? match.index + 1 : match.index;
+    const scopeStart = match[0].startsWith("/") ? match.index + 1 : match.index;
     scopes.push({
       scope: match[1],
       fullPath: filePath.slice(0, searchFrom + scopeStart + match[1].length),
@@ -109,10 +104,7 @@ function extractAllScopes(
 /**
  * パスから最深スコープを抽出する。
  */
-function extractDeepestScope(
-  filePath: string,
-  scopePattern: RegExp,
-): ScopeInfo | undefined {
+function extractDeepestScope(filePath: string, scopePattern: RegExp): ScopeInfo | undefined {
   const scopes = extractAllScopes(filePath, scopePattern);
   return scopes[scopes.length - 1];
 }
@@ -181,18 +173,15 @@ const rule: Rule.RuleModule = {
   meta: {
     type: "problem",
     docs: {
-      description:
-        "スコープディレクトリ配下のモジュールはバレルファイル経由でのみ import 可能",
+      description: "スコープディレクトリ配下のモジュールはバレルファイル経由でのみ import 可能",
     },
     messages: {
       noDirectImport:
         "'{{importSource}}' の直接 import は禁止されています。'{{scopeName}}' のバレルファイル経由で import してください。",
-      noDependency:
-        "'{{fromScope}}' から '{{toScope}}' への依存は禁止されています。",
+      noDependency: "'{{fromScope}}' から '{{toScope}}' への依存は禁止されています。",
       noCrossModuleDependency:
         "'{{scopeName}}' スコープはモジュール間の依存が禁止されています（isolateModules）。",
-      invalidConfig:
-        "barrel-import: {{detail}}",
+      invalidConfig: "barrel-import: {{detail}}",
     },
     schema: [
       {
@@ -202,7 +191,7 @@ const rule: Rule.RuleModule = {
             type: "array",
             items: { type: "string" },
             description:
-              "拡張子付き import でバレルとして許可するファイル名のリスト。拡張子なしのディレクトリ import は常に許可される（デフォルト: [\"index.ts\", \"index.tsx\"]）",
+              '拡張子付き import でバレルとして許可するファイル名のリスト。拡張子なしのディレクトリ import は常に許可される（デフォルト: ["index.ts", "index.tsx"]）',
           },
           scopes: {
             type: "object",
@@ -222,8 +211,7 @@ const rule: Rule.RuleModule = {
                 },
                 isolateModules: {
                   type: "boolean",
-                  description:
-                    "true の場合、同スコープ内でもモジュール間の import を禁止する",
+                  description: "true の場合、同スコープ内でもモジュール間の import を禁止する",
                 },
               },
               required: ["directories", "dependsOn"],
@@ -301,9 +289,7 @@ const rule: Rule.RuleModule = {
       if (!importSource.startsWith(".")) return;
 
       // import 先の絶対パスを解決
-      const resolvedPath = normalizePath(
-        path.resolve(path.dirname(filename), importSource),
-      );
+      const resolvedPath = normalizePath(path.resolve(path.dirname(filename), importSource));
 
       // import 先の全スコープを抽出（浅い順）
       const toScopeInfos = extractAllScopes(resolvedPath, scopePattern);
@@ -317,9 +303,7 @@ const rule: Rule.RuleModule = {
       if (fromScopeInfos.length > 0) {
         const fromRootDir = getScopeDir(fromScopeInfos[0].scope);
         const toRootDir = getScopeDir(toRoot.scope);
-        if (
-          !isDependencyAllowed(fromRootDir, toRootDir, scopes, dirToScope)
-        ) {
+        if (!isDependencyAllowed(fromRootDir, toRootDir, scopes, dirToScope)) {
           const fromScopeName = dirToScope.get(fromRootDir) ?? fromRootDir;
           const toScopeName = dirToScope.get(toRootDir) ?? toRootDir;
           context.report({
@@ -375,9 +359,7 @@ const rule: Rule.RuleModule = {
       // バレル経由のチェック
       // 内部にいる → 子スコープのバレル（最深スコープ）経由ならOK
       // 外部にいる → ルートスコープのバレルのみOK（子スコープは親の内部実装）
-      const allowedScope = isInsideRootScope
-        ? toDeepest.scope
-        : toRoot.scope;
+      const allowedScope = isInsideRootScope ? toDeepest.scope : toRoot.scope;
       if (isBarrelImport(importSource, allowedScope, barrelFiles)) return;
 
       // それ以外は禁止

--- a/packages/proto-ts/.oxfmtrc.json
+++ b/packages/proto-ts/.oxfmtrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "ignorePatterns": ["src/generated/"]
+}

--- a/packages/proto-ts/src/index.ts
+++ b/packages/proto-ts/src/index.ts
@@ -32,11 +32,7 @@ export {
   ClaudeSessionListByProjectRequest,
   ClaudeSessionListByProjectResponse,
 } from "./generated/gozd/v1/claude_session";
-export {
-  ClientMessage,
-  HookMessage,
-  OpenMessage,
-} from "./generated/gozd/v1/client_message";
+export { ClientMessage, HookMessage, OpenMessage } from "./generated/gozd/v1/client_message";
 export {
   FileEntry,
   FileReadResult,
@@ -108,14 +104,8 @@ export {
   GitWorktreeRemoveResponse,
 } from "./generated/gozd/v1/git_ops";
 export { GitStatusRequest, GitStatusResponse } from "./generated/gozd/v1/git_status";
-export {
-  OpenExternalRequest,
-  OpenExternalResponse,
-} from "./generated/gozd/v1/open_external";
-export {
-  PickAndOpenRequest,
-  PickAndOpenResponse,
-} from "./generated/gozd/v1/open_target";
+export { OpenExternalRequest, OpenExternalResponse } from "./generated/gozd/v1/open_external";
+export { PickAndOpenRequest, PickAndOpenResponse } from "./generated/gozd/v1/open_target";
 export {
   ProjectConfigLoadRequest,
   ProjectConfigLoadResponse,
@@ -161,7 +151,4 @@ export {
   VoicevoxSpeakRequest,
   VoicevoxSpeakResponse,
 } from "./generated/gozd/v1/voicevox";
-export {
-  WindowCloseRequest,
-  WindowCloseResponse,
-} from "./generated/gozd/v1/window";
+export { WindowCloseRequest, WindowCloseResponse } from "./generated/gozd/v1/window";


### PR DESCRIPTION
## 概要

`pnpm fix:all` の oxfmt 適用範囲を絞るため、ルートと `packages/proto-ts/` に `.oxfmtrc.json` を追加し、生成物・pnpm 管理ファイルを除外した。あわせて barrel ファイルの整形と未使用変数の削除を行った。

## 背景

`pnpm fix:all` を流したところ、次の 2 つの「往復差分」が発生することが分かった。

- `pnpm-workspace.yaml`: pnpm 本体は catalog 書き戻し時に常にシングルクォートで出力する。oxfmt がダブルクォートに整形しても、`pnpm add` 等を実行すれば pnpm が再びシングルクォートで上書きする
- `packages/proto-ts/src/generated/**`: `buf generate` の `clean: true` 領域で、`.proto` を SSOT とする生成物。oxfmt がスタイルを変えても次回 `buf generate` で消える

どちらもフォーマッタが触る意義がないため、設定ファイルで除外する。CLI 引数で除外するのではなく `.oxfmtrc.json` の `ignorePatterns` で宣言し、fix script を毎回いじらずに済むようにする。

調査の中で oxfmt の `ignorePatterns` は `ignore` クレートの `GitignoreBuilder` で評価されることを確認した（ `oxc-project/oxc` `apps/oxfmt/src/cli/walk.rs` 107 行付近）。`.gitignore` と同じ感覚で `src/generated/` のように末尾スラッシュ表記が使える。

## 変更内容

### oxfmt 設定追加

- ルート `.oxfmtrc.json`: `pnpm-workspace.yaml` を `ignorePatterns` で除外
- `packages/proto-ts/.oxfmtrc.json`: `src/generated/` を `ignorePatterns` で除外

### oxfmt 整形

- `apps/renderer/src/features/filer/index.ts`: 末尾の余分なカンマを削除
- `packages/proto-ts/src/index.ts`: 人間管理 barrel の export ブロックを 1 行化（生成物 barrel ではなく `src/generated/` を re-export する人手記述ファイル）

### barrel-import ルールの dead code 削除

- `packages/eslint-plugin/src/rules/barrelImport.ts`: `extractAllScopes` 内の `matchEnd` ローカル変数は計算結果が一度も参照されておらず、`fullPath` の `slice` 末尾は同行で別途組み立てている。oxlint が「未使用宣言の削除は副作用判断が必要」として autofix 対象外とするため手動で削除した

## 確認事項

- [ ] `pnpm fix:all` を再実行しても `pnpm-workspace.yaml` と `packages/proto-ts/src/generated/**` に差分が出ないこと
- [ ] `pnpm typecheck:all` / `pnpm lint:all` がグリーン
- [ ] `barrel-import` ルールが従来どおり動作すること（`matchEnd` 削除は dead code 整理のみ）
