### PR TITLE
fix(fs-watch): restore push/fetch sync via refs/remotes classification

### DIFF
--- a/apps/native/Sources/GozdCore/FSWatchRegistry.swift
+++ b/apps/native/Sources/GozdCore/FSWatchRegistry.swift
@@ -10,7 +10,13 @@ import Foundation
 //
 // 2. **イベント分類**:
 //    - per-worktree git dir 配下の `HEAD` / `index` → `gitStatusChange`
-//    - common git dir 配下の `refs/heads/...` / `packed-refs` → `branchChange`
+//    - common git dir 配下の `refs/heads/...` → `branchChange`
+//    - common git dir 配下の `refs/remotes/...` → `gitStatusChange`
+//      （`git push` 成功時にローカルの remote-tracking ref が書き換わる。
+//      ahead/behind の更新を git-graph に伝えるための SSOT）
+//    - common git dir 配下の `packed-refs` → `branchChange` + `gitStatusChange`
+//      （pack 後はローカル ref と remote-tracking ref のどちらが書き換わったか
+//      ファイル名だけでは判別できないため、両方を発火させる）
 //    - common git dir 配下の `worktrees/...` → `worktreeChange`
 //    - 作業ツリー側（git dir 配下以外） → `fsChange` + `gitStatusChange`
 //      （未追跡ファイルや作業ツリー差分も status に影響するため）
@@ -221,8 +227,11 @@ public actor FSWatchRegistry {
   ///
   /// 判定優先順位:
   ///   1. per-worktree git dir 配下 → `HEAD` / `index` のみ `gitStatusChange`
-  ///   2. common git dir 配下 → `refs/heads/...` / `packed-refs` を `branchChange`、
-  ///      `worktrees/...` を `worktreeChange`
+  ///   2. common git dir 配下 →
+  ///      - `refs/heads/...` を `branchChange`
+  ///      - `refs/remotes/...` を `gitStatusChange`（push / fetch 後の ahead/behind 更新）
+  ///      - `packed-refs` を `branchChange` + `gitStatusChange`（local / remote 両方を含み得るため）
+  ///      - `worktrees/...` を `worktreeChange`
   ///   3. 作業ツリー配下（git dir 配下に該当しない場合）→ `fsChange` + `gitStatusChange`
   ///
   /// 通常 clone では perWorktreeGitDir == commonGitDir なので 1 と 2 を両方適用する。
@@ -270,8 +279,18 @@ public actor FSWatchRegistry {
         matchedGitDir = true
         if rel.hasPrefix("worktrees/") {
           hasWorktreeChange = true
-        } else if rel.hasPrefix("refs/heads/") || rel == "packed-refs" {
+        } else if rel.hasPrefix("refs/heads/") {
           hasBranchChange = true
+        } else if rel.hasPrefix("refs/remotes/") {
+          // push / fetch 成功でローカルの remote-tracking ref が書き換わる。
+          // git-graph は gitStatusChange の `# branch.ab` で ahead/behind 更新を検知する。
+          hasGitStatusChange = true
+        } else if rel == "packed-refs" {
+          // pack 後は loose ref がまとめられるが、ファイル名からは local ref と
+          // remote-tracking ref のどちらが書き換わったか判別できない。
+          // 両方の subscriber に通知する（worktree 一覧再取得 + ahead/behind 再取得）。
+          hasBranchChange = true
+          hasGitStatusChange = true
         }
       }
 

--- a/apps/native/Sources/GozdCore/FSWatchRegistry.swift
+++ b/apps/native/Sources/GozdCore/FSWatchRegistry.swift
@@ -234,6 +234,13 @@ public actor FSWatchRegistry {
   ///      - `worktrees/...` を `worktreeChange`
   ///   3. 作業ツリー配下（git dir 配下に該当しない場合）→ `fsChange` + `gitStatusChange`
   ///
+  /// 意図的に未対応の ref 種別:
+  ///   - `refs/tags/...`: タグ更新で git-graph 表示の即時反映が必要になった時点で
+  ///     `gitStatusChange` 系か別 event（`tagChange` 等）を新設する。現状の git-graph は
+  ///     タグを `git for-each-ref` で取得しており、`# branch.ab` の SSOT 哲学の射程外
+  ///   - `refs/stash` / `refs/notes/...`: 現状の UI が表示していないため発火不要
+  ///   これらは silent drop だが、将来 UI が表示する時に必ずここに分岐を足す
+  ///
   /// 通常 clone では perWorktreeGitDir == commonGitDir なので 1 と 2 を両方適用する。
   /// その git dir は worktree root 配下に位置するため、3 のスキップも兼ねる。
   /// worktree clone では git dir が worktree root の外にあるため、3 では git dir を

--- a/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
@@ -172,8 +172,10 @@ struct ClassifyTests {
     #expect(!result.hasWorktreeChange)
   }
 
-  @Test("worktree 配置: common git dir 配下の packed-refs は branchChange")
+  @Test("worktree 配置: common git dir 配下の packed-refs は branchChange + gitStatusChange")
   func worktreeCommonPackedRefs() {
+    // packed-refs は local ref と remote-tracking ref のどちらの pack かファイル名から
+    // 判別不能なので両 subscriber に通知する。
     let dir = "/wt/foo"
     let perWt = "/parent/.git/worktrees/foo"
     let common = "/parent/.git"
@@ -181,6 +183,26 @@ struct ClassifyTests {
       dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
       events: [ev("\(common)/packed-refs")])
     #expect(result.hasBranchChange)
+    #expect(result.hasGitStatusChange)
+    #expect(!result.hasFsChange)
+    #expect(!result.hasWorktreeChange)
+  }
+
+  @Test("worktree 配置: common git dir 配下の refs/remotes/origin/main は gitStatusChange")
+  func worktreeCommonRemoteRef() {
+    // git push / fetch 成功でローカルの remote-tracking ref が書き換わる。
+    // git-graph の ahead/behind を更新するための gitStatusChange 経路。
+    // worktree 一覧構造は変わらないため branchChange は発火させない。
+    let dir = "/wt/foo"
+    let perWt = "/parent/.git/worktrees/foo"
+    let common = "/parent/.git"
+    let result = FSWatchRegistry.classify(
+      dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
+      events: [ev("\(common)/refs/remotes/origin/main")])
+    #expect(result.hasGitStatusChange)
+    #expect(!result.hasBranchChange)
+    #expect(!result.hasFsChange)
+    #expect(!result.hasWorktreeChange)
   }
 
   @Test("worktree 配置: 兄弟 worktree の worktrees/<other> 追加は worktreeChange")

--- a/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
@@ -205,6 +205,50 @@ struct ClassifyTests {
     #expect(!result.hasWorktreeChange)
   }
 
+  @Test("worktree 配置: refs/remotes/origin/HEAD（symbolic ref）も gitStatusChange")
+  func worktreeCommonRemoteHeadSymRef() {
+    // `origin/HEAD` は固定名の symbolic ref。`hasPrefix("refs/remotes/")` で同分岐に
+    // 落ちる事を保証し、将来「branch 一覧変化」として再分類したくなった時の足場にする。
+    let dir = "/wt/foo"
+    let perWt = "/parent/.git/worktrees/foo"
+    let common = "/parent/.git"
+    let result = FSWatchRegistry.classify(
+      dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
+      events: [ev("\(common)/refs/remotes/origin/HEAD")])
+    #expect(result.hasGitStatusChange)
+    #expect(!result.hasBranchChange)
+  }
+
+  @Test("worktree 配置: branch 名にスラッシュを含む refs/remotes/origin/feature/sub も gitStatusChange")
+  func worktreeCommonRemoteRefNestedName() {
+    // `feature/sub` のようなスラッシュ区切り branch 名。`hasPrefix` 判定なので通るはずだが、
+    // 将来 `==` 等価判定にリグレッションした時に検知できるよう明示的に踏む。
+    let dir = "/wt/foo"
+    let perWt = "/parent/.git/worktrees/foo"
+    let common = "/parent/.git"
+    let result = FSWatchRegistry.classify(
+      dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
+      events: [ev("\(common)/refs/remotes/origin/feature/sub")])
+    #expect(result.hasGitStatusChange)
+    #expect(!result.hasBranchChange)
+  }
+
+  @Test("worktree 配置: refs/tags/ は意図的に silent drop（未対応 ref 種別）")
+  func worktreeCommonTagsSilentDrop() {
+    // 現状の git-graph はタグを `git for-each-ref` で取得しており、`# branch.ab` SSOT の
+    // 射程外。タグ表示の即時反映が UI 要件になった時点でここに分岐を足す。
+    let dir = "/wt/foo"
+    let perWt = "/parent/.git/worktrees/foo"
+    let common = "/parent/.git"
+    let result = FSWatchRegistry.classify(
+      dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
+      events: [ev("\(common)/refs/tags/v1.0.0")])
+    #expect(!result.hasGitStatusChange)
+    #expect(!result.hasBranchChange)
+    #expect(!result.hasFsChange)
+    #expect(!result.hasWorktreeChange)
+  }
+
   @Test("worktree 配置: 兄弟 worktree の worktrees/<other> 追加は worktreeChange")
   func worktreeCommonSiblingAdded() {
     // 自分の per-wt git dir は foo。兄弟 bar が追加されると `<common>/worktrees/bar/...` に


### PR DESCRIPTION
## 概要

`FSWatchRegistry.classify` の common git dir 規則に分岐を追加し、`git push` / `git fetch` 成功時にローカルの remote-tracking ref が更新されてもイベントが renderer に届かなかった問題を修正する。あわせて未対応 ref 種別の扱いを docstring に明記し、境界条件のテストを追加した。

## 背景

`git push` 後に git-graph 上のカレントブランチと remote ブランチの head がずれたまま更新されない、という現象がユーザーから報告された。`git commit` は即座に反映されるのに push 後だけずれる。

調査の結果:

- 旧 TS / Bun 実装 ( commit e1586ba / PR #241 ) では `fs.watchFile(remoteRefPath, { interval: 500ms }, ...)` で `refs/remotes/origin/<branch>` を mtime ポーリングしており、`git push` で書き換わるとほぼリアルタイムに git status を再取得していた。能動的な `git fetch` を回していたわけではなく、ローカル fs 上のファイル更新を拾っていただけ
- PR #420 ( Swift rewrite ) で FSEvents ベースの dir 単位 watch に変えた際、common git dir 自体は watch paths に入っているのに ( FSWatchRegistry:108-114 )、`classify` の分類規則から `refs/remotes/...` が抜け落ちていた。FSEvents 経由でイベントは届いていたが、`matchedGitDir = true` のままどのフラグも立たず silent drop されていた
- `packed-refs` は `branchChange` のみで拾っていたが、pack 後はファイル名から local ref / remote-tracking ref のどちらが書き換わったか判別できないため、ahead/behind 更新が必要なケースを取りこぼしていた

つまり「監視 path のセットアップ」と「分類規則」が非対称になっていた。追加の watch 拡張や能動的な fetch は不要で、`classify` を直すだけで足りる。

別軸の負債（同ファイル `:200` の `gitStatusFull` 失敗時 `print` 握り潰し）は #471 として分離した。

## 変更内容

### `apps/native/Sources/GozdCore/FSWatchRegistry.swift`

`classify` の common git dir 規則:

- `refs/remotes/...` → `gitStatusChange`
  - `branchChange` ではなく `gitStatusChange` 側に流す。`branchChange` は renderer 側で worktree 一覧の N 件再取得に展開されるため push 1 回で N 倍負荷になる。git-graph が必要としているのは `gitStatusFull` の `# branch.ab` （ahead/behind）であり、worktree 一覧構造は変わらない
- `packed-refs` → `branchChange` + `gitStatusChange` の二重発火
  - pack されると local ref / remote-tracking ref のどちらの更新かファイル名から判別不能なため両 subscriber に通知する
  - renderer 側は冪等な再 fetch で受け止める設計（ヘッダコメント item 4）が前提

ヘッダコメントと `classify` の docstring も新ルールに合わせて更新。

### docstring: 意図的に未対応の ref 種別を明記

`refs/tags/` / `refs/stash` / `refs/notes/...` は現状の git-graph が `# branch.ab` SSOT 経路に乗せていないため silent drop。「UI 要件が立った時点でここに分岐を足す」という編集者向けの誘導を docstring に残した。

### `apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift`

- `worktreeCommonRemoteRef`: `refs/remotes/origin/main` で `gitStatusChange` のみが立ち他フラグが立たないことを検証
- `worktreeCommonRemoteHeadSymRef`: `refs/remotes/origin/HEAD`（symbolic ref 固定名）も同分岐に落ちることを pin
- `worktreeCommonRemoteRefNestedName`: `refs/remotes/origin/feature/sub`（スラッシュを含む branch 名）も `hasPrefix` 判定で通ることを pin。`==` 等価判定への退行を検知
- `worktreeCommonTagsSilentDrop`: `refs/tags/v1.0.0` が全フラグ false で silent drop されることを明示。UI 要件追加時に「テスト失敗 → 分岐を足す」フローを誘導する pin
- 既存 `worktreeCommonPackedRefs`: 「`branchChange` のみ」だった assert を「両発火 + 他フラグ false」まで厳密化

## 今回含めない点

- **別 PR で対応**: `FSWatchRegistry.swift:200` の `gitStatusFull` 失敗時 `print` 握り潰し ( #471 )。観察可能性の負債で本 PR とはスコープが異なるため分離
- **今回は対応しない**: 「他人が push したものを能動的に取りに行く」用途の定期 `git fetch`。ネットワーク・認証 prompt・rate limit の副作用がありオプトイン設計が必要。今回の症状（自分の push 直後の不一致）は本 PR の修正で解消するため不要

## 確認事項

- [ ] 通常 clone での `git push` 後、git-graph の ahead/behind が即座に更新される
- [ ] worktree clone での `git push` 後、common git dir 配下の `refs/remotes/...` 更新が拾われる
- [ ] `git pack-refs --all` 実行時に worktree 一覧と git-graph の両方が更新される
- [ ] 既存 `branchChange` 経路（ローカルブランチの commit / branch 切り替え）が壊れていない
- [ ] `swift test --filter FSWatchRegistry` が pass する（手元で 18 件 pass を確認済み）
