### PR TITLE
fix(webview): WebView のデフォルト右クリックメニュー（Reload など）を抑制

### DIFF
--- a/apps/native/Sources/Gozd/GozdApp.swift
+++ b/apps/native/Sources/Gozd/GozdApp.swift
@@ -50,6 +50,9 @@ struct ContentView: View {
 
   var body: some View {
     WebView(runtime.page)
+      // デフォルトの右クリックメニューに出る Reload を抑制する。
+      // 意図しない reload で renderer 状態が消えるのを防ぐ。
+      .webViewContextMenu { _ in EmptyView() }
       .task {
         // ロード経路は 3 つ:
         //   1. dev: $GOZD_DEV_VITE_URL があれば Vite dev server をロード（HMR）


### PR DESCRIPTION
## 概要

WebView の右クリックで表示されるデフォルトコンテキストメニュー（Reload）を抑制する。SwiftUI macOS 26 の `webViewContextMenu(menu:)` モディファイアに空の `EmptyView()` を渡してデフォルト項目セットを置き換える。

## 背景

ユーザーから「アプリ上で右クリックすると Reload が出る、意図せず reload しないようにしたい」と指摘があった。

調査の結果、Reload メニューは renderer / native どちらのコードにも設定箇所がなく、`WebPage` 内部の WKWebView がデフォルトで生成しているネイティブ NSMenu であることが判明した。

代替案として以下を検討したが、いずれも採用しなかった。

- **JS の `contextmenu` イベントで `preventDefault()`**: Electron / Chromium と異なり WebKit 側でネイティブ NSMenu を確実には抑制できない（webview/webview の関連 issue でも同様の報告あり）
- **WKWebView をサブクラス化して `willOpenMenu` を override**: 非公式なメニュー identifier に依存し、macOS バージョン間で壊れるリスクがある。SwiftUI の `WebView` 配線も書き直しになる

最新の Apple 公式ドキュメントを確認したところ、SwiftUI macOS 26（Tahoe）以降には `View.webViewContextMenu(menu:)` モディファイアが追加されており、デフォルトのコンテキストメニュー項目セットを完全に置き換えられる。gozd は既に macOS 26 専用なので availability 制約もなく、これが正攻法であると判断した。

参考:

- [webViewContextMenu(menu:) | Apple Developer Documentation](https://developer.apple.com/documentation/swiftui/view/webviewcontextmenu(menu:))

## 変更内容

### apps/native

- `apps/native/Sources/Gozd/GozdApp.swift` の `WebView(runtime.page)` に `.webViewContextMenu { _ in EmptyView() }` を追加し、デフォルトの Reload メニュー項目を抑制する

## 確認事項

- [ ] `pnpm dev` で起動した dev `.app` 上で右クリックしても Reload メニューが出ないことを確認する
- [ ] テキスト選択時の右クリック挙動を確認する。コピー操作はキーボード `Cmd+C` で従来通り動作することを確認する
