### PR TITLE
feat(terminal): split viewMode into user intent and effective computed

### DIFF
--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -176,7 +176,8 @@ const activeRootWorktree = computed(() => {
           aria-label="Claude terminals"
           title="Claude terminals"
           :aria-pressed="terminalStore.viewMode === 'claude'"
-          class="grid size-7 place-items-center rounded-sm text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+          :disabled="terminalStore.claudeActiveLeafIds.length === 0"
+          class="grid size-7 place-items-center rounded-sm text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-zinc-400"
           :class="terminalStore.viewMode === 'claude' && 'bg-zinc-700 text-zinc-100'"
           @click="terminalStore.viewMode = 'claude'"
         >

--- a/apps/renderer/src/features/terminal/registerTerminalCommands.ts
+++ b/apps/renderer/src/features/terminal/registerTerminalCommands.ts
@@ -72,6 +72,11 @@ export function registerTerminalCommands(
       handler: () => {
         const active = getFocusedLayout();
         if (active === undefined) return false;
+        // claude ビューでは Claude 起動中の leaf しかタイル表示されない。
+        // split で生まれる新 pane は素の PTY なので、先に wt ビューへ戻して可視化する。
+        if (terminalStore.viewMode === "claude") {
+          terminalStore.viewMode = "wt";
+        }
         terminalStore.splitPane(active.dir, "horizontal");
         return true;
       },
@@ -82,6 +87,9 @@ export function registerTerminalCommands(
       handler: () => {
         const active = getFocusedLayout();
         if (active === undefined) return false;
+        if (terminalStore.viewMode === "claude") {
+          terminalStore.viewMode = "wt";
+        }
         terminalStore.splitPane(active.dir, "vertical");
         return true;
       },

--- a/apps/renderer/src/features/terminal/registerTerminalCommands.ts
+++ b/apps/renderer/src/features/terminal/registerTerminalCommands.ts
@@ -72,11 +72,11 @@ export function registerTerminalCommands(
       handler: () => {
         const active = getFocusedLayout();
         if (active === undefined) return false;
-        // claude ビューでは Claude 起動中の leaf しかタイル表示されない。
-        // split で生まれる新 pane は素の PTY なので、先に wt ビューへ戻して可視化する。
-        if (terminalStore.viewMode === "claude") {
-          terminalStore.viewMode = "wt";
-        }
+        // split で増える新 pane は素の PTY（Claude 未起動）なので claude タイル対象外。
+        // 既存 Claude leaf が残っていると claude ビュー実効値が解除されないため、
+        // ここでユーザー意図を wt へ明示的に切り替える。同 PR 設計上の既存パターン
+        // （useWorktreeActions / register*Command など）と同じ方針。
+        terminalStore.viewMode = "wt";
         terminalStore.splitPane(active.dir, "horizontal");
         return true;
       },
@@ -87,9 +87,7 @@ export function registerTerminalCommands(
       handler: () => {
         const active = getFocusedLayout();
         if (active === undefined) return false;
-        if (terminalStore.viewMode === "claude") {
-          terminalStore.viewMode = "wt";
-        }
+        terminalStore.viewMode = "wt";
         terminalStore.splitPane(active.dir, "vertical");
         return true;
       },

--- a/apps/renderer/src/features/terminal/useTerminalStore.ts
+++ b/apps/renderer/src/features/terminal/useTerminalStore.ts
@@ -1,6 +1,6 @@
 import { tryCatch } from "@gozd/shared";
 import { acceptHMRUpdate, defineStore } from "pinia";
-import { computed, ref, shallowRef } from "vue";
+import { computed, ref, shallowRef, watch } from "vue";
 import { useContextKeys } from "../../shared/command";
 import { useNotificationStore } from "../../shared/notification";
 import { onMessage } from "../../shared/rpc";
@@ -185,6 +185,16 @@ export const useTerminalStore = defineStore("terminal", () => {
 
   /** Claude セッションが存在する（idle / working / asking / done）leafId 一覧 */
   const claudeActiveLeafIds = computed(() => claude.getClaudeActiveLeafIds());
+
+  // claude ビュー中に表示対象が空になったら wt ビューへ自動復帰する。
+  // claude leaf が 0 だと tileGridTemplate の中身が空になり画面が真っ黒に見えるため、
+  // 表示する leaf がある wt ビューに戻して fallback とする。
+  watch(
+    () => viewMode.value === "claude" && claudeActiveLeafIds.value.length === 0,
+    (shouldRevert) => {
+      if (shouldRevert) viewMode.value = "wt";
+    },
+  );
 
   // --- RPC 購読 ---
 

--- a/apps/renderer/src/features/terminal/useTerminalStore.ts
+++ b/apps/renderer/src/features/terminal/useTerminalStore.ts
@@ -1,6 +1,6 @@
 import { tryCatch } from "@gozd/shared";
 import { acceptHMRUpdate, defineStore } from "pinia";
-import { computed, ref, shallowRef, watch } from "vue";
+import { computed, ref, shallowRef } from "vue";
 import { useContextKeys } from "../../shared/command";
 import { useNotificationStore } from "../../shared/notification";
 import { onMessage } from "../../shared/rpc";
@@ -56,12 +56,12 @@ export const useTerminalStore = defineStore("terminal", () => {
 
   /** ターミナル表示モード: wt=アクティブworktreeのみ, claude=Claude起動中のみ */
   type ViewMode = "wt" | "claude";
-  const viewMode = ref<ViewMode>("wt");
-
-  /** wt ↔ claude をトグルする */
-  function toggleViewMode() {
-    viewMode.value = viewMode.value === "wt" ? "claude" : "wt";
-  }
+  /**
+   * ユーザーが選択した表示モード（永続意図）。SSOT。
+   * 表示側は `viewMode`（実効値）を読む。`viewMode = "wt"` などの直接代入は
+   * computed の setter 経由でこの ref に転送される。
+   */
+  const userViewMode = ref<ViewMode>("wt");
 
   /** ptyId → Claude Code の状態（idle は undefined = エントリなし） */
   const claudeStatusByPtyId = ref<Record<number, ClaudeStatus>>({});
@@ -186,15 +186,32 @@ export const useTerminalStore = defineStore("terminal", () => {
   /** Claude セッションが存在する（idle / working / asking / done）leafId 一覧 */
   const claudeActiveLeafIds = computed(() => claude.getClaudeActiveLeafIds());
 
-  // claude ビュー中に表示対象が空になったら wt ビューへ自動復帰する。
-  // claude leaf が 0 だと tileGridTemplate の中身が空になり画面が真っ黒に見えるため、
-  // 表示する leaf がある wt ビューに戻して fallback とする。
-  watch(
-    () => viewMode.value === "claude" && claudeActiveLeafIds.value.length === 0,
-    (shouldRevert) => {
-      if (shouldRevert) viewMode.value = "wt";
+  /**
+   * 表示用の実効モード。`userViewMode === "claude"` でも Claude leaf が 0 件なら
+   * `wt` として解釈する。これにより:
+   *  - claude ビュー中に split で素 PTY を増やしても、新 pane が見える wt として描画
+   *  - Claude セッション全終了で空タイル（真っ黒）にならない
+   *  - 各コマンド handler / store watch で「if claude then wt」を書く必要がない
+   * setter は `userViewMode` への代入を転送し、既存の `terminalStore.viewMode = "wt"`
+   * のような呼び出し（SidebarPane / useWorktreeActions / register*Command 等）を
+   * 改変なしで動かす。
+   */
+  const viewMode = computed<ViewMode>({
+    get: () => {
+      if (userViewMode.value === "claude" && claudeActiveLeafIds.value.length === 0) {
+        return "wt";
+      }
+      return userViewMode.value;
     },
-  );
+    set: (mode) => {
+      userViewMode.value = mode;
+    },
+  });
+
+  /** wt ↔ claude をトグルする（ユーザー意図側を切替）。 */
+  function toggleViewMode() {
+    userViewMode.value = userViewMode.value === "wt" ? "claude" : "wt";
+  }
 
   // --- RPC 購読 ---
 

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -125,6 +125,11 @@ leafNode
 - **all**: `tileGridTemplate()` で全 leaf を均等タイル配置
 - **claude**: `tileGridTemplate()` で Claude 起動中の leaf のみ均等タイル配置
 
+`claude` モード中に下記の遷移が起きた場合は自動的に `wt` モードへ復帰する。`tileGridTemplate()` の対象が空になって画面が真っ黒になる事象を回避し、新規 pane を即座に可視化するため。
+
+- ターミナル分割（`terminal.splitHorizontal` / `terminal.splitVertical`）: split で生まれる新 pane は素の PTY なので `claude` ビューの対象外。split コマンドの handler が `viewMode = "wt"` に切り替えてから `splitPane` を呼ぶ
+- Claude セッションが全て終了して `claudeActiveLeafIds.length === 0` になった場合: store 内の watch が `viewMode = "wt"` に戻す
+
 `all` / `claude` モードでは複数 worktree の leaf が同時に表示されるため、focus を受けた leaf は常に `worktreeStore.setOpen(dir)` を呼んで選択を追従させる。viewMode は変更しない（横断ビューを維持したまま、サイドバー・ファイラー・プレビューのみ追従）。`wt` モードでは同 dir に対する setOpen となり実質的に no-op だが、`selectionVersion` を発火させて `clearDoneStates` を起動するために常に呼ぶ（[claude-status.md](claude-status.md) の既読消化フロー参照）。
 
 active leaf の判定は「選択中 worktree（`worktreeStore.dir`）配下」かつ「`layout.focusedLeafId` と一致」の AND で行う。`layoutsByDir` は dir ごとに独立した `focusedLeafId` を持つため、単純比較だと tile モードで worktree ごとに 1 つずつ active 表示になってしまう。worktree 単位の選択を条件に加えることで、横断ビューでも `opacity-100` で表示される leaf は最大 1 つに収まり、それ以外は `opacity-50` にフェードする。`worktreeStore.dir` 未確定時や、`claude` モードで選択中 worktree に Claude-active leaf が存在しない場合は active が 0 になりうる。

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -125,10 +125,9 @@ leafNode
 - **all**: `tileGridTemplate()` で全 leaf を均等タイル配置
 - **claude**: `tileGridTemplate()` で Claude 起動中の leaf のみ均等タイル配置
 
-`claude` モード中に下記の遷移が起きた場合は自動的に `wt` モードへ復帰する。`tileGridTemplate()` の対象が空になって画面が真っ黒になる事象を回避し、新規 pane を即座に可視化するため。
+`viewMode` はユーザー意図 (`userViewMode`) と表示用実効値 (`viewMode` computed) の 2 段で管理する。実効値は `userViewMode === "claude" && claudeActiveLeafIds.length === 0 ? "wt" : userViewMode`。これにより `claude` モード中に Claude セッションが全終了しても `tileGridTemplate()` の対象が空にならず、画面が真っ黒になる事象を回避する（Claude が再起動すれば `userViewMode` は `claude` のままなので自動復帰する）。`viewMode = "wt"` のような外部からの代入は computed の setter 経由で `userViewMode` に転送される。
 
-- ターミナル分割（`terminal.splitHorizontal` / `terminal.splitVertical`）: split で生まれる新 pane は素の PTY なので `claude` ビューの対象外。split コマンドの handler が `viewMode = "wt"` に切り替えてから `splitPane` を呼ぶ
-- Claude セッションが全て終了して `claudeActiveLeafIds.length === 0` になった場合: store 内の watch が `viewMode = "wt"` に戻す
+加えて、ターミナル分割コマンド（`terminal.splitHorizontal` / `terminal.splitVertical`）は split 直前に `userViewMode = "wt"` を明示する。新規 pane は素の PTY なので claude タイル対象外であり、ユーザーが分割操作を行った時点で意図は「アクティブ worktree のレイアウトを編集」に変わったとみなす。
 
 `all` / `claude` モードでは複数 worktree の leaf が同時に表示されるため、focus を受けた leaf は常に `worktreeStore.setOpen(dir)` を呼んで選択を追従させる。viewMode は変更しない（横断ビューを維持したまま、サイドバー・ファイラー・プレビューのみ追従）。`wt` モードでは同 dir に対する setOpen となり実質的に no-op だが、`selectionVersion` を発火させて `clearDoneStates` を起動するために常に呼ぶ（[claude-status.md](claude-status.md) の既読消化フロー参照）。
 


### PR DESCRIPTION
## 概要

ターミナルの `claude` ビューモードを次のように改善する。

- claude ビュー中にターミナル分割すると `wt` ビューに切り替わり、新規 pane を表示する
- Claude セッションが全終了したら `claude` ビューを実効的に `wt` として描画する（ユーザー意図は保持し、Claude 再起動時に自動復帰する）

実装としては `useTerminalStore.viewMode` を「ユーザー意図 (`userViewMode`)」と「表示用実効値 (`viewMode` computed)」の 2 段に分離する設計を採用した。

## 背景

`useTerminalStore.viewMode` には `"wt" | "claude"` の 2 つの表示モードがあり、`claude` モードでは `tileGridTemplate()` が「Claude 起動中の leaf」のみを均等タイル配置する。これにより以下の問題が発生していた。

- claude ビュー中に分割コマンドを実行しても、新たに spawn される pane は素の PTY（Claude 未起動）なのでタイル表示の対象外になる。ユーザーは分割したつもりが画面に何も増えないように見える
- Claude プロセスが全て終了すると `claudeActiveLeafIds.length` が 0 になり、`tileGridTemplate()` に渡す leafId が空で画面が真っ黒に近い状態になる

初回実装は「split handler で `viewMode = "wt"` に書き戻す」「`claudeActiveLeafIds` を `watch` して 0 件遷移時に `viewMode = "wt"` に書き戻す」という 2 つの書き換えを追加していたが、これは既存コード内に同パターン（`terminalStore.viewMode = "wt"` の直接代入）が 7 箇所（`useWorktreeActions` / `registerIssueCommand` / `registerPrCommand` / `SidebarPane`）あり、入口ごとに不変条件を書き戻して回る周辺吸収案だった。レビュー指摘を受けて store 側の SSOT を見直す根本修正にリファクタリングした。

## 変更内容

### `apps/renderer/src/features/terminal/useTerminalStore.ts`

- 内部 ref を `userViewMode` にリネーム（ユーザーの永続意図を保持）
- `viewMode` を computed として再定義
  - getter: `userViewMode === "claude" && claudeActiveLeafIds.length === 0` のとき `"wt"` を返す。それ以外は `userViewMode` をそのまま返す
  - setter: 受け取った値を `userViewMode` に転送
- これにより既存の `terminalStore.viewMode = "wt"` 直接代入（7 箇所）は改変なしで動作する
- `toggleViewMode` は `userViewMode` を直接トグル

### `apps/renderer/src/features/terminal/registerTerminalCommands.ts`

- `terminal.splitHorizontal` / `terminal.splitVertical` の handler で、split 直前に `terminalStore.viewMode = "wt"` を unconditional に呼ぶ。既存 7 箇所と同じ「ユーザーが特定 worktree 視点に切り替えたい」操作の延長として一貫させる
- 当初実装にあった `if (viewMode === "claude")` ガードは削除（unconditional でも wt のままなら no-op）

### `docs/terminal.md`

- 表示モード節に「ユーザー意図と実効値の 2 段管理」「split が `userViewMode` を `wt` に切り替える」挙動を追記

## 確認事項

- [ ] claude ビュー中にターミナル分割すると wt ビューに切り替わり、新 pane が表示されること
- [ ] claude ビュー中に最後の Claude セッションを終了させると wt ビューに自動復帰すること（実効値が `wt` を返す）
- [ ] その後に新しく Claude を起動すると claude ビューに自動復帰すること（`userViewMode === "claude"` が保持されているため）
- [ ] wt ビュー中に分割しても挙動が変わらないこと（regression なし）
- [ ] 手動で wt ↔ claude をトグルする操作が従来通り動くこと
- [ ] サイドバー / ワークツリーアクション / コマンドパレット経由の `viewMode = "wt"` 代入が引き続き動くこと
