### PR TITLE
feat(changes): render changed files as a collapsible tree

### DIFF
--- a/apps/renderer/src/features/changes/ChangesPane.vue
+++ b/apps/renderer/src/features/changes/ChangesPane.vue
@@ -140,8 +140,14 @@ const fileChanges = computed<GitFileChange[]>(() => {
 
 const fileCount = computed(() => fileChanges.value.length);
 
-/** GitHub PR 風のディレクトリツリー（chain 圧縮済み） */
-const tree = computed(() => buildChangesTree(fileChanges.value));
+/**
+ * GitHub PR 風のディレクトリツリー（chain 圧縮済み）。
+ *
+ * `buildChangesTree` は不正 path（空 segment / 重複 / file⇔folder 衝突）で throw する。
+ * computed 内の throw はペイン全体を白画面化するため、Result でラップしてテンプレート側で
+ * エラー表示分岐に倒す。
+ */
+const treeResult = computed(() => tryCatch(() => buildChangesTree(fileChanges.value)));
 
 /** 折りたたみ中フォルダの fullPath 集合（デフォルトは全展開） */
 const collapsedFolders = ref<Set<string>>(new Set());
@@ -313,13 +319,17 @@ watch(
       <div class="text-xs text-zinc-500">Loading...</div>
     </div>
 
-    <div v-else-if="tree.length === 0" class="flex-1 overflow-y-auto p-2">
+    <div v-else-if="!treeResult.ok" class="flex-1 overflow-y-auto p-2">
+      <div class="text-xs text-red-400">Failed to build tree: {{ String(treeResult.error) }}</div>
+    </div>
+
+    <div v-else-if="treeResult.value.length === 0" class="flex-1 overflow-y-auto p-2">
       <div class="text-xs text-zinc-500">No changes</div>
     </div>
 
     <div v-else class="flex-1 overflow-y-auto py-1">
       <ChangesTreeItem
-        v-for="node in tree"
+        v-for="node in treeResult.value"
         :key="node.kind === 'folder' ? `d:${node.anchorPath}` : `f:${node.change.newFilePath}`"
         :node="node"
         :depth="0"

--- a/apps/renderer/src/features/changes/ChangesPane.vue
+++ b/apps/renderer/src/features/changes/ChangesPane.vue
@@ -1,7 +1,16 @@
 <doc lang="md">
-Changed files list. Shows HEAD vs working directory by default, or a selected commit's changes from the git graph.
+Changed files tree. Shows HEAD vs working directory by default, or a selected commit's changes from the git graph.
 
-## Behavior
+## Display
+
+- Files are rendered as a directory tree, GitHub PR diff style
+- A folder whose only child is another folder is concatenated with the child (e.g. `.github/workflows`).
+  Concatenation stops as soon as a folder contains a file or more than one entry
+- Folders default to expanded; clicking a folder row toggles collapse. State is kept in `Set<string>` keyed by full path
+- Each file row shows a material-icon-theme icon, the file name colored by change type, and the change type
+  badge (M/A/D/R/U) at the trailing edge
+
+## Data source
 
 - Default (Uncommitted Changes selected): shows git status converted to GitFileChange[]
 - Normal commit selected: fetches changed files via `gitCommitFiles` RPC
@@ -28,7 +37,6 @@ Changed files list. Shows HEAD vs working directory by default, or a selected co
 import type { GitCommit, GitFileChange } from "@gozd/proto";
 import { tryCatch } from "@gozd/shared";
 import { computed, ref, watch } from "vue";
-import { getFileIconName, getIconUrl } from "../filer";
 import { rpcGitCommitFiles, useGitGraphStore } from "../git-graph";
 import {
   UNCOMMITTED_HASH,
@@ -37,6 +45,8 @@ import {
   useWorktreeStore,
 } from "../worktree";
 import type { GitChangeKind } from "../worktree";
+import { buildChangesTree } from "./changesTree";
+import ChangesTreeItem from "./ChangesTreeItem.vue";
 
 const emit = defineEmits<{
   select: [relPath: string];
@@ -128,31 +138,22 @@ const fileChanges = computed<GitFileChange[]>(() => {
   return commitFiles.value;
 });
 
-/** newFilePath でソート済み */
-const sortedFiles = computed(() =>
-  [...fileChanges.value].sort((a, b) => a.newFilePath.localeCompare(b.newFilePath)),
-);
+const fileCount = computed(() => fileChanges.value.length);
 
-const fileCount = computed(() => sortedFiles.value.length);
+/** GitHub PR 風のディレクトリツリー（chain 圧縮済み） */
+const tree = computed(() => buildChangesTree(fileChanges.value));
 
-const CHANGE_COLOR_MAP: Record<GitFileChange["type"], string> = {
-  M: "text-yellow-400",
-  A: "text-green-400",
-  D: "text-red-400",
-  R: "text-blue-400",
-  U: "text-green-400",
-};
+/** 折りたたみ中フォルダの fullPath 集合（デフォルトは全展開） */
+const collapsedFolders = ref<Set<string>>(new Set());
 
-/** パスからファイル名部分を抽出 */
-function fileName(filePath: string): string {
-  const lastSlash = filePath.lastIndexOf("/");
-  return lastSlash === -1 ? filePath : filePath.slice(lastSlash + 1);
-}
-
-/** パスからディレクトリ部分を抽出 */
-function dirPath(filePath: string): string {
-  const lastSlash = filePath.lastIndexOf("/");
-  return lastSlash === -1 ? "" : filePath.slice(0, lastSlash);
+function toggleFolder(fullPath: string) {
+  const next = new Set(collapsedFolders.value);
+  if (next.has(fullPath)) {
+    next.delete(fullPath);
+  } else {
+    next.add(fullPath);
+  }
+  collapsedFolders.value = next;
 }
 
 /**
@@ -312,35 +313,20 @@ watch(
       <div class="text-xs text-zinc-500">Loading...</div>
     </div>
 
-    <div v-else-if="sortedFiles.length === 0" class="flex-1 overflow-y-auto p-2">
+    <div v-else-if="tree.length === 0" class="flex-1 overflow-y-auto p-2">
       <div class="text-xs text-zinc-500">No changes</div>
     </div>
 
-    <div v-else class="flex-1 overflow-y-auto">
-      <div
-        v-for="change in sortedFiles"
-        :key="change.newFilePath"
-        class="flex cursor-pointer items-center gap-1.5 px-3 py-0.5 text-xs hover:bg-zinc-800/60"
-        @click="emit('select', change.newFilePath)"
-      >
-        <span
-          class="w-4 shrink-0 text-center font-mono text-[10px] font-bold"
-          :class="CHANGE_COLOR_MAP[change.type]"
-        >
-          {{ change.type }}
-        </span>
-        <img
-          :src="getIconUrl(getFileIconName(fileName(change.newFilePath)))"
-          class="size-4 shrink-0"
-          alt=""
-        />
-        <span class="shrink-0" :class="CHANGE_COLOR_MAP[change.type]">
-          {{ fileName(change.newFilePath) }}
-        </span>
-        <span v-if="dirPath(change.newFilePath)" class="truncate text-zinc-600">
-          {{ dirPath(change.newFilePath) }}
-        </span>
-      </div>
+    <div v-else class="flex-1 overflow-y-auto py-1">
+      <ChangesTreeItem
+        v-for="node in tree"
+        :key="node.kind === 'folder' ? `d:${node.fullPath}` : `f:${node.change.newFilePath}`"
+        :node="node"
+        :depth="0"
+        :collapsed="collapsedFolders"
+        @select="emit('select', $event)"
+        @toggle-folder="toggleFolder"
+      />
     </div>
   </div>
 </template>

--- a/apps/renderer/src/features/changes/ChangesPane.vue
+++ b/apps/renderer/src/features/changes/ChangesPane.vue
@@ -36,7 +36,8 @@ Changed files tree. Shows HEAD vs working directory by default, or a selected co
 <script setup lang="ts">
 import type { GitCommit, GitFileChange } from "@gozd/proto";
 import { tryCatch } from "@gozd/shared";
-import { computed, ref, watch } from "vue";
+import { computed, ref, watch, watchEffect } from "vue";
+import { useNotificationStore } from "../../shared/notification";
 import { rpcGitCommitFiles, useGitGraphStore } from "../git-graph";
 import {
   UNCOMMITTED_HASH,
@@ -46,6 +47,7 @@ import {
 } from "../worktree";
 import type { GitChangeKind } from "../worktree";
 import { buildChangesTree } from "./changesTree";
+import type { ChangesTreeNode } from "./changesTree";
 import ChangesTreeItem from "./ChangesTreeItem.vue";
 
 const emit = defineEmits<{
@@ -55,6 +57,7 @@ const emit = defineEmits<{
 const worktreeStore = useWorktreeStore();
 const gitGraphStore = useGitGraphStore();
 const gitStatusStore = useGitStatusStore();
+const notify = useNotificationStore();
 
 /** コミット選択時に取得した変更ファイル一覧 */
 const commitFiles = ref<GitFileChange[]>([]);
@@ -144,10 +147,20 @@ const fileCount = computed(() => fileChanges.value.length);
  * GitHub PR 風のディレクトリツリー（chain 圧縮済み）。
  *
  * `buildChangesTree` は不正 path（空 segment / 重複 / file⇔folder 衝突）で throw する。
- * computed 内の throw はペイン全体を白画面化するため、Result でラップしてテンプレート側で
- * エラー表示分岐に倒す。
+ * computed は pure / 同期である必要があるため、ツリー構築と失敗時のトースト通知は
+ * 副作用を持てる `watchEffect` 側に閉じ込め、テンプレートには素の `ref<T[]>` を渡す。
  */
-const treeResult = computed(() => tryCatch(() => buildChangesTree(fileChanges.value)));
+const tree = ref<ChangesTreeNode[]>([]);
+
+watchEffect(() => {
+  const result = tryCatch(() => buildChangesTree(fileChanges.value));
+  if (result.ok) {
+    tree.value = result.value;
+    return;
+  }
+  tree.value = [];
+  notify.error("Failed to build changes tree", result.error);
+});
 
 /** 折りたたみ中フォルダの fullPath 集合（デフォルトは全展開） */
 const collapsedFolders = ref<Set<string>>(new Set());
@@ -319,17 +332,13 @@ watch(
       <div class="text-xs text-zinc-500">Loading...</div>
     </div>
 
-    <div v-else-if="!treeResult.ok" class="flex-1 overflow-y-auto p-2">
-      <div class="text-xs text-red-400">Failed to build tree: {{ String(treeResult.error) }}</div>
-    </div>
-
-    <div v-else-if="treeResult.value.length === 0" class="flex-1 overflow-y-auto p-2">
+    <div v-else-if="tree.length === 0" class="flex-1 overflow-y-auto p-2">
       <div class="text-xs text-zinc-500">No changes</div>
     </div>
 
     <div v-else class="flex-1 overflow-y-auto py-1">
       <ChangesTreeItem
-        v-for="node in treeResult.value"
+        v-for="node in tree"
         :key="node.kind === 'folder' ? `d:${node.anchorPath}` : `f:${node.change.newFilePath}`"
         :node="node"
         :depth="0"

--- a/apps/renderer/src/features/changes/ChangesPane.vue
+++ b/apps/renderer/src/features/changes/ChangesPane.vue
@@ -320,7 +320,7 @@ watch(
     <div v-else class="flex-1 overflow-y-auto py-1">
       <ChangesTreeItem
         v-for="node in tree"
-        :key="node.kind === 'folder' ? `d:${node.fullPath}` : `f:${node.change.newFilePath}`"
+        :key="node.kind === 'folder' ? `d:${node.anchorPath}` : `f:${node.change.newFilePath}`"
         :node="node"
         :depth="0"
         :collapsed="collapsedFolders"

--- a/apps/renderer/src/features/changes/ChangesTreeItem.vue
+++ b/apps/renderer/src/features/changes/ChangesTreeItem.vue
@@ -35,10 +35,18 @@ const isExpanded = computed(
 const iconUrl = computed(() => {
   const node = props.node;
   if (node.kind === "folder") {
-    return getIconUrl(getFolderIconName(node.leafName, isExpanded.value));
+    const leafName = node.displaySegments.at(-1);
+    if (leafName === undefined) {
+      throw new Error("Folder node has no display segments");
+    }
+    return getIconUrl(getFolderIconName(leafName, isExpanded.value));
   }
   return getIconUrl(getFileIconName(node.name));
 });
+
+const folderDisplayName = computed(() =>
+  props.node.kind === "folder" ? props.node.displaySegments.join("/") : "",
+);
 
 function onClick() {
   if (props.node.kind === "folder") {
@@ -70,7 +78,7 @@ function onChildToggle(fullPath: string) {
           :class="isExpanded ? 'icon-[lucide--chevron-down]' : 'icon-[lucide--chevron-right]'"
         />
         <img :src="iconUrl" class="size-4 shrink-0" alt="" />
-        <span class="truncate text-zinc-300">{{ node.displayName }}</span>
+        <span class="truncate text-zinc-300">{{ folderDisplayName }}</span>
       </template>
       <template v-else>
         <span class="size-3.5 shrink-0" />

--- a/apps/renderer/src/features/changes/ChangesTreeItem.vue
+++ b/apps/renderer/src/features/changes/ChangesTreeItem.vue
@@ -29,25 +29,20 @@ const CHANGE_COLOR_MAP: Record<GitFileChange["type"], string> = {
 };
 
 const isExpanded = computed(
-  () => props.node.kind === "folder" && !props.collapsed.has(props.node.fullPath),
+  () => props.node.kind === "folder" && !props.collapsed.has(props.node.anchorPath),
 );
 
-const folderIconUrl = computed(() => {
-  if (props.node.kind !== "folder") return "";
-  // chain 圧縮された displayName の最深 segment をアイコン解決に使う
-  const segments = props.node.displayName.split("/");
-  const leaf = segments[segments.length - 1] ?? props.node.displayName;
-  return getIconUrl(getFolderIconName(leaf, isExpanded.value));
-});
-
-const fileIconUrl = computed(() => {
-  if (props.node.kind !== "file") return "";
-  return getIconUrl(getFileIconName(props.node.name));
+const iconUrl = computed(() => {
+  const node = props.node;
+  if (node.kind === "folder") {
+    return getIconUrl(getFolderIconName(node.leafName, isExpanded.value));
+  }
+  return getIconUrl(getFileIconName(node.name));
 });
 
 function onClick() {
   if (props.node.kind === "folder") {
-    emit("toggleFolder", props.node.fullPath);
+    emit("toggleFolder", props.node.anchorPath);
   } else {
     emit("select", props.node.change.newFilePath);
   }
@@ -74,12 +69,12 @@ function onChildToggle(fullPath: string) {
           class="size-3.5 shrink-0 text-zinc-500"
           :class="isExpanded ? 'icon-[lucide--chevron-down]' : 'icon-[lucide--chevron-right]'"
         />
-        <img :src="folderIconUrl" class="size-4 shrink-0" alt="" />
+        <img :src="iconUrl" class="size-4 shrink-0" alt="" />
         <span class="truncate text-zinc-300">{{ node.displayName }}</span>
       </template>
       <template v-else>
         <span class="size-3.5 shrink-0" />
-        <img :src="fileIconUrl" class="size-4 shrink-0" alt="" />
+        <img :src="iconUrl" class="size-4 shrink-0" alt="" />
         <span class="truncate" :class="CHANGE_COLOR_MAP[node.change.type]">
           {{ node.name }}
         </span>
@@ -95,7 +90,7 @@ function onChildToggle(fullPath: string) {
     <template v-if="node.kind === 'folder' && isExpanded">
       <ChangesTreeItem
         v-for="child in node.children"
-        :key="child.kind === 'folder' ? `d:${child.fullPath}` : `f:${child.change.newFilePath}`"
+        :key="child.kind === 'folder' ? `d:${child.anchorPath}` : `f:${child.change.newFilePath}`"
         :node="child"
         :depth="depth + 1"
         :collapsed="collapsed"

--- a/apps/renderer/src/features/changes/ChangesTreeItem.vue
+++ b/apps/renderer/src/features/changes/ChangesTreeItem.vue
@@ -1,0 +1,107 @@
+<doc lang="md">
+Recursive tree node for the changes pane. Renders folders (with collapse/expand) and file leaves with git change badges.
+</doc>
+
+<script setup lang="ts">
+import type { GitFileChange } from "@gozd/proto";
+import { computed } from "vue";
+import { getFileIconName, getFolderIconName, getIconUrl } from "../filer";
+import type { ChangesTreeNode } from "./changesTree";
+
+const props = defineProps<{
+  node: ChangesTreeNode;
+  depth: number;
+  /** 折りたたまれているフォルダの fullPath 集合 */
+  collapsed: Set<string>;
+}>();
+
+const emit = defineEmits<{
+  select: [relPath: string];
+  toggleFolder: [fullPath: string];
+}>();
+
+const CHANGE_COLOR_MAP: Record<GitFileChange["type"], string> = {
+  M: "text-yellow-400",
+  A: "text-green-400",
+  D: "text-red-400",
+  R: "text-blue-400",
+  U: "text-green-400",
+};
+
+const isExpanded = computed(
+  () => props.node.kind === "folder" && !props.collapsed.has(props.node.fullPath),
+);
+
+const folderIconUrl = computed(() => {
+  if (props.node.kind !== "folder") return "";
+  // chain 圧縮された displayName の最深 segment をアイコン解決に使う
+  const segments = props.node.displayName.split("/");
+  const leaf = segments[segments.length - 1] ?? props.node.displayName;
+  return getIconUrl(getFolderIconName(leaf, isExpanded.value));
+});
+
+const fileIconUrl = computed(() => {
+  if (props.node.kind !== "file") return "";
+  return getIconUrl(getFileIconName(props.node.name));
+});
+
+function onClick() {
+  if (props.node.kind === "folder") {
+    emit("toggleFolder", props.node.fullPath);
+  } else {
+    emit("select", props.node.change.newFilePath);
+  }
+}
+
+function onChildSelect(relPath: string) {
+  emit("select", relPath);
+}
+function onChildToggle(fullPath: string) {
+  emit("toggleFolder", fullPath);
+}
+</script>
+
+<template>
+  <div>
+    <button
+      type="button"
+      class="flex w-full cursor-pointer items-center gap-1 px-1 py-0.5 text-left text-xs hover:bg-zinc-800/60"
+      :style="{ paddingLeft: `${depth * 12 + 8}px` }"
+      @click="onClick"
+    >
+      <template v-if="node.kind === 'folder'">
+        <span
+          class="size-3.5 shrink-0 text-zinc-500"
+          :class="isExpanded ? 'icon-[lucide--chevron-down]' : 'icon-[lucide--chevron-right]'"
+        />
+        <img :src="folderIconUrl" class="size-4 shrink-0" alt="" />
+        <span class="truncate text-zinc-300">{{ node.displayName }}</span>
+      </template>
+      <template v-else>
+        <span class="size-3.5 shrink-0" />
+        <img :src="fileIconUrl" class="size-4 shrink-0" alt="" />
+        <span class="truncate" :class="CHANGE_COLOR_MAP[node.change.type]">
+          {{ node.name }}
+        </span>
+        <span
+          class="ml-auto shrink-0 font-mono text-[10px] font-bold"
+          :class="CHANGE_COLOR_MAP[node.change.type]"
+        >
+          {{ node.change.type }}
+        </span>
+      </template>
+    </button>
+
+    <template v-if="node.kind === 'folder' && isExpanded">
+      <ChangesTreeItem
+        v-for="child in node.children"
+        :key="child.kind === 'folder' ? `d:${child.fullPath}` : `f:${child.change.newFilePath}`"
+        :node="child"
+        :depth="depth + 1"
+        :collapsed="collapsed"
+        @select="onChildSelect"
+        @toggle-folder="onChildToggle"
+      />
+    </template>
+  </div>
+</template>

--- a/apps/renderer/src/features/changes/changesTree.ts
+++ b/apps/renderer/src/features/changes/changesTree.ts
@@ -1,0 +1,103 @@
+import type { GitFileChange } from "@gozd/proto";
+
+export type ChangesTreeNode =
+  | {
+      kind: "folder";
+      /** ディレクトリ表示名。chain 圧縮時は "a/b/c" 形式 */
+      displayName: string;
+      /** ルートからのフルパス（chain 圧縮の最深 segment まで） */
+      fullPath: string;
+      children: ChangesTreeNode[];
+    }
+  | {
+      kind: "file";
+      name: string;
+      change: GitFileChange;
+    };
+
+type RawFolder = {
+  kind: "folder";
+  name: string;
+  fullPath: string;
+  childMap: Map<string, RawFolder | RawFile>;
+};
+type RawFile = {
+  kind: "file";
+  name: string;
+  change: GitFileChange;
+};
+
+/** GitFileChange[] から表示用ツリーを組み立てる。子が単一フォルダのみのフォルダは親と連結する。 */
+export function buildChangesTree(changes: readonly GitFileChange[]): ChangesTreeNode[] {
+  const root: RawFolder = { kind: "folder", name: "", fullPath: "", childMap: new Map() };
+
+  for (const change of changes) {
+    insertChange(root, change);
+  }
+
+  return finalizeChildren(root);
+}
+
+function insertChange(root: RawFolder, change: GitFileChange) {
+  const segments = change.newFilePath.split("/");
+  const fileName = segments.pop();
+  if (fileName === undefined || fileName === "") return;
+
+  let current = root;
+  for (const segment of segments) {
+    const existing = current.childMap.get(segment);
+    if (existing && existing.kind === "folder") {
+      current = existing;
+      continue;
+    }
+    const fullPath = current.fullPath === "" ? segment : `${current.fullPath}/${segment}`;
+    const folder: RawFolder = {
+      kind: "folder",
+      name: segment,
+      fullPath,
+      childMap: new Map(),
+    };
+    current.childMap.set(segment, folder);
+    current = folder;
+  }
+  current.childMap.set(fileName, { kind: "file", name: fileName, change });
+}
+
+function finalizeChildren(folder: RawFolder): ChangesTreeNode[] {
+  const folders: ChangesTreeNode[] = [];
+  const files: ChangesTreeNode[] = [];
+  for (const child of folder.childMap.values()) {
+    if (child.kind === "folder") {
+      folders.push(collapseFolder(child));
+    } else {
+      files.push({ kind: "file", name: child.name, change: child.change });
+    }
+  }
+  folders.sort((a, b) => compareName(a, b));
+  files.sort((a, b) => compareName(a, b));
+  return [...folders, ...files];
+}
+
+function collapseFolder(raw: RawFolder): ChangesTreeNode {
+  let current = raw;
+  let displayName = raw.name;
+  // 子が単一フォルダのみの場合、その子と連結する（GitHub 風 chain 圧縮）
+  while (current.childMap.size === 1) {
+    const [onlyChild] = current.childMap.values();
+    if (onlyChild === undefined || onlyChild.kind !== "folder") break;
+    displayName = `${displayName}/${onlyChild.name}`;
+    current = onlyChild;
+  }
+  return {
+    kind: "folder",
+    displayName,
+    fullPath: current.fullPath,
+    children: finalizeChildren(current),
+  };
+}
+
+function compareName(a: ChangesTreeNode, b: ChangesTreeNode): number {
+  const aName = a.kind === "folder" ? a.displayName : a.name;
+  const bName = b.kind === "folder" ? b.displayName : b.name;
+  return aName.localeCompare(bName);
+}

--- a/apps/renderer/src/features/changes/changesTree.ts
+++ b/apps/renderer/src/features/changes/changesTree.ts
@@ -5,8 +5,14 @@ export type ChangesTreeNode =
       kind: "folder";
       /** ディレクトリ表示名。chain 圧縮時は "a/b/c" 形式 */
       displayName: string;
-      /** ルートからのフルパス（chain 圧縮の最深 segment まで） */
-      fullPath: string;
+      /** chain 圧縮の最深 segment 名（folder アイコン解決用） */
+      leafName: string;
+      /**
+       * 折りたたみ・key 用の anchor。chain 圧縮の **最浅** segment の fullPath を使う。
+       * fileChanges の増減で chain 境界が伸縮しても anchor が動かないため、
+       * ユーザーが畳んだ状態を保てる。
+       */
+      anchorPath: string;
       children: ChangesTreeNode[];
     }
   | {
@@ -40,13 +46,26 @@ export function buildChangesTree(changes: readonly GitFileChange[]): ChangesTree
 
 function insertChange(root: RawFolder, change: GitFileChange) {
   const segments = change.newFilePath.split("/");
-  const fileName = segments.pop();
-  if (fileName === undefined || fileName === "") return;
+  // 末尾 `/` や 空 segment（`a//b`）は git 出力としてあり得ない不変条件。
+  // silently 落とすと「changes に出るはずのファイルが UI に出ない」観察不能事象になるため throw する
+  if (segments.some((s) => s === "")) {
+    throw new Error(`Invalid file path: ${JSON.stringify(change.newFilePath)}`);
+  }
+  const [fileName, ...reversedDirs] = segments.slice().reverse();
+  if (fileName === undefined) {
+    throw new Error(`Empty file path in change`);
+  }
+  const dirs = reversedDirs.reverse();
 
   let current = root;
-  for (const segment of segments) {
+  for (const segment of dirs) {
     const existing = current.childMap.get(segment);
-    if (existing && existing.kind === "folder") {
+    if (existing !== undefined) {
+      if (existing.kind !== "folder") {
+        throw new Error(
+          `Path collision: file and folder share the name ${JSON.stringify(segment)}`,
+        );
+      }
       current = existing;
       continue;
     }
@@ -59,6 +78,9 @@ function insertChange(root: RawFolder, change: GitFileChange) {
     };
     current.childMap.set(segment, folder);
     current = folder;
+  }
+  if (current.childMap.has(fileName)) {
+    throw new Error(`Duplicate change for path: ${JSON.stringify(change.newFilePath)}`);
   }
   current.childMap.set(fileName, { kind: "file", name: fileName, change });
 }
@@ -81,17 +103,20 @@ function finalizeChildren(folder: RawFolder): ChangesTreeNode[] {
 function collapseFolder(raw: RawFolder): ChangesTreeNode {
   let current = raw;
   let displayName = raw.name;
+  let leafName = raw.name;
   // 子が単一フォルダのみの場合、その子と連結する（GitHub 風 chain 圧縮）
   while (current.childMap.size === 1) {
     const [onlyChild] = current.childMap.values();
     if (onlyChild === undefined || onlyChild.kind !== "folder") break;
     displayName = `${displayName}/${onlyChild.name}`;
+    leafName = onlyChild.name;
     current = onlyChild;
   }
   return {
     kind: "folder",
     displayName,
-    fullPath: current.fullPath,
+    leafName,
+    anchorPath: raw.fullPath,
     children: finalizeChildren(current),
   };
 }

--- a/apps/renderer/src/features/changes/changesTree.ts
+++ b/apps/renderer/src/features/changes/changesTree.ts
@@ -3,10 +3,11 @@ import type { GitFileChange } from "@gozd/proto";
 export type ChangesTreeNode =
   | {
       kind: "folder";
-      /** ディレクトリ表示名。chain 圧縮時は "a/b/c" 形式 */
-      displayName: string;
-      /** chain 圧縮の最深 segment 名（folder アイコン解決用） */
-      leafName: string;
+      /**
+       * chain 圧縮されたセグメント列。表示は join("/")、folder アイコン解決は最深要素を使う。
+       * displayName / leafName を別フィールドにすると更新漏れが起きるため SSOT としてここに集約する。
+       */
+      displaySegments: string[];
       /**
        * 折りたたみ・key 用の anchor。chain 圧縮の **最浅** segment の fullPath を使う。
        * fileChanges の増減で chain 境界が伸縮しても anchor が動かないため、
@@ -51,11 +52,11 @@ function insertChange(root: RawFolder, change: GitFileChange) {
   if (segments.some((s) => s === "")) {
     throw new Error(`Invalid file path: ${JSON.stringify(change.newFilePath)}`);
   }
-  const [fileName, ...reversedDirs] = segments.slice().reverse();
+  const fileName = segments.at(-1);
   if (fileName === undefined) {
     throw new Error(`Empty file path in change`);
   }
-  const dirs = reversedDirs.reverse();
+  const dirs = segments.slice(0, -1);
 
   let current = root;
   for (const segment of dirs) {
@@ -102,27 +103,24 @@ function finalizeChildren(folder: RawFolder): ChangesTreeNode[] {
 
 function collapseFolder(raw: RawFolder): ChangesTreeNode {
   let current = raw;
-  let displayName = raw.name;
-  let leafName = raw.name;
+  const displaySegments = [raw.name];
   // 子が単一フォルダのみの場合、その子と連結する（GitHub 風 chain 圧縮）
   while (current.childMap.size === 1) {
     const [onlyChild] = current.childMap.values();
     if (onlyChild === undefined || onlyChild.kind !== "folder") break;
-    displayName = `${displayName}/${onlyChild.name}`;
-    leafName = onlyChild.name;
+    displaySegments.push(onlyChild.name);
     current = onlyChild;
   }
   return {
     kind: "folder",
-    displayName,
-    leafName,
+    displaySegments,
     anchorPath: raw.fullPath,
     children: finalizeChildren(current),
   };
 }
 
 function compareName(a: ChangesTreeNode, b: ChangesTreeNode): number {
-  const aName = a.kind === "folder" ? a.displayName : a.name;
-  const bName = b.kind === "folder" ? b.displayName : b.name;
+  const aName = a.kind === "folder" ? a.displaySegments.join("/") : a.name;
+  const bName = b.kind === "folder" ? b.displaySegments.join("/") : b.name;
   return aName.localeCompare(bName);
 }

--- a/apps/renderer/src/features/filer/index.ts
+++ b/apps/renderer/src/features/filer/index.ts
@@ -1,5 +1,5 @@
 export { default as FilerPane } from "./FilerPane.vue";
 export { rpcFsReadFile, rpcFsReadFileAbsolute } from "./rpc";
 export type { FsChangePayload } from "./rpc";
-export { getFileIconName, getIconUrl } from "./useFileIcon";
+export { getFileIconName, getFolderIconName, getIconUrl } from "./useFileIcon";
 export { useFsWatchSync } from "./useFsWatchSync";


### PR DESCRIPTION
## 概要

右下の Changes ペインを、フラットなファイル一覧から GitHub PR の差分ビュー風のディレクトリツリー表示に変更しました。

## 背景

これまでの Changes ペインは `GitFileChange[]` を `newFilePath` で sort してフラットに描画するだけで、ディレクトリ階層の情報が「右側のグレーの dirPath 文字列」としてしか表示されていませんでした。worktree でファイル数が増えると視覚的に階層が掴みづらく、関連ファイルがどこに集まっているかが一目で分からない問題があります。

GitHub の PR diff の "Files changed" タブのように、ディレクトリ単位で折りたためるツリー表示にすれば、変更の集中している領域が見つけやすくなり、無関係ディレクトリを畳んで集中もできます。

## 変更内容

### Changes ペインのツリー描画

- `apps/renderer/src/features/changes/changesTree.ts` を追加し、`GitFileChange[]` から表示用ツリーを構築する
- 子が単一サブフォルダのみのフォルダはその子と "/" で連結する（例: `.github/workflows`）。子がファイルを含むか、複数エントリを持った時点で chain 圧縮は止まる
- フォルダ → ファイルの順で表示し、各層内では `localeCompare` で並べる

### ツリーノード描画コンポーネント

- `apps/renderer/src/features/changes/ChangesTreeItem.vue` を再帰コンポーネントとして追加
- フォルダ行は chevron + material-icon-theme のフォルダアイコン + `displayName`（chain 圧縮済み）
- ファイル行は file アイコン + 変更タイプ色のファイル名 + 末尾に変更タイプバッジ（M/A/D/R/U）
- `depth * 12 + 8px` の左パディングで階層を表現

### ChangesPane の差し替え

- 既存の flat `v-for` 描画を撤去し、`buildChangesTree(fileChanges)` の computed と `ChangesTreeItem` に置換
- 折りたたみ状態は `collapsedFolders: Set<string>` を fullPath キーで保持し、デフォルトは全展開
- `<doc>` ブロックに表示仕様（chain 圧縮、折りたたみ、変更タイプバッジ位置）を追記

### filer の barrel 追加

- `getFolderIconName` を `@/features/filer` から re-export し、ChangesTreeItem からバレル経由で import 可能にした

## 確認事項

- [ ] Uncommitted Changes 選択時にツリーが組み上がり、各ファイルクリックで diff プレビューが開く
- [ ] 単一フォルダ chain（例: `.github/workflows/foo.yml`）が 1 行 `.github/workflows` として連結表示される
- [ ] フォルダ行のクリックで折りたたみが切り替わる（chevron が回転、子要素が表示/非表示）
- [ ] git-graph で別 commit を選択すると Changes ツリーが新しい commit の差分で再構築される
- [ ] Shift+click 範囲選択でも range の差分がツリー表示される
