### PR TITLE
fix(notification): include error message line in toast cause detail

### DIFF
--- a/apps/renderer/CLAUDE.md
+++ b/apps/renderer/CLAUDE.md
@@ -2,7 +2,7 @@
 
 - 例外処理では必ず `useNotificationStore` の `error(message, cause?)` / `info(message, cause?)` でトースト通知する。`console.error` で握りつぶさない
 - store 内部で `console.error` / `console.info` を出力するため、呼び出し側で console を呼ぶ必要はない
-- cause にエラーオブジェクトを渡すとコンソールにスタックトレースが出る。トースト本文をクリックすると `cause` の詳細（`Error` なら stack、それ以外は文字列化）を展開表示し、Copy ボタンで内容をクリップボードにコピーできる
+- cause にエラーオブジェクトを渡すとコンソールにスタックトレースが出る。トースト本文をクリックすると `cause` の詳細（`Error` なら `name: message` 行 + stack、それ以外は文字列化）を展開表示し、Copy ボタンで内容をクリップボードにコピーできる。WebKit/JavaScriptCore の `Error.stack` は先頭の `name: message` 行を含まないため、含まれていなければ補完する
 
 ## イベントリスナー
 

--- a/apps/renderer/src/features/layout/NotificationToastItem.vue
+++ b/apps/renderer/src/features/layout/NotificationToastItem.vue
@@ -92,9 +92,14 @@ const detail = computed(() => {
     const head = `${cause.name}: ${cause.message}`;
     const stack = cause.stack;
     if (stack === undefined || stack === "") return head;
-    // WebKit/JavaScriptCore の stack は "Error: message" の先頭行を含まず frame だけを返す。
-    // V8 形式（先頭に head を含む）と区別して、含まれていなければ補完する。
-    return stack.startsWith(head) ? stack : `${head}\n${stack}`;
+    // V8 系の stack は先頭行に "name: message" を含み（message が改行を含めばその 1 行目のみ）、
+    // WebKit/JavaScriptCore の stack はフレームのみで "name: message" 行を持たない。
+    // stack.startsWith(head) で判定すると message が改行を含むときに V8 でも false になり二重表示になるため、
+    // 先頭行が `<name>:` で始まるかで V8 形式と判定し、その場合は先頭行を捨てて head + 残り frame に正規化する。
+    const [firstLine = "", ...rest] = stack.split("\n");
+    const frames = firstLine.startsWith(`${cause.name}:`) ? rest : [firstLine, ...rest];
+    const body = frames.join("\n");
+    return body === "" ? head : `${head}\n${body}`;
   }
   if (typeof cause === "string") return cause;
   return safeStringify(cause);

--- a/apps/renderer/src/features/layout/NotificationToastItem.vue
+++ b/apps/renderer/src/features/layout/NotificationToastItem.vue
@@ -90,7 +90,11 @@ const detail = computed(() => {
   const { cause } = props;
   if (cause instanceof Error) {
     const head = `${cause.name}: ${cause.message}`;
-    return cause.stack !== undefined && cause.stack !== "" ? cause.stack : head;
+    const stack = cause.stack;
+    if (stack === undefined || stack === "") return head;
+    // WebKit/JavaScriptCore の stack は "Error: message" の先頭行を含まず frame だけを返す。
+    // V8 形式（先頭に head を含む）と区別して、含まれていなければ補完する。
+    return stack.startsWith(head) ? stack : `${head}\n${stack}`;
   }
   if (typeof cause === "string") return cause;
   return safeStringify(cause);


### PR DESCRIPTION
## 概要

エラートーストの cause 詳細パネルで、`Error` インスタンスを渡しても本来の `name: message` 行が表示されず、minified スタックフレーム1行（例: `Dr@gozd-app://localhost/assets/index-XXXX.js:1:74982`）しか見えない問題を修正する。

## 背景

「PR から worktree 作成ができない」と報告を受けてエラーの cause を共有してもらったところ、内容が次の 1 行だけだった。

```text
Dr@gozd-app://localhost/assets/index-TL5d_Or4.js:1:74982
```

このスタックには Error.message が含まれず、git の stderr など実際の失敗理由が完全に消えていた。原因を辿ると `NotificationToastItem.vue` の `detail` computed が、`cause.stack` が存在すれば `stack` のみを返し、無いときだけ `name: message` の `head` を返す排他ロジックになっていた。

V8 では `Error.stack` の先頭に `name: message` 行が含まれるため `stack` 単独でも message が見えるが、本プロジェクトが動く WebKit/JavaScriptCore の `Error.stack` はフレームのみで `name: message` 行を持たない。結果として WebKit 上では `Error.message` が常にトーストから抜け落ちていた。

初回修正案は `stack.startsWith(head) ? stack : head + "\n" + stack` という prefix 比較だったが、レビューで「`Error.message` に改行を含むケース（まさに git の複数行 stderr を `new Error(stderr)` で包む本 PR の主用途）で V8 でも `startsWith` が false になり、`head` と stack 先頭行が重複表示される」と指摘を受け、判定方法を「stack 先頭行が `name:` で始まるか」に切り替えて再構築する方式へ変更した。

doc ブロックの記述（`name + message + stack` を表示する）も従来の実装と乖離していたため、本 PR で実装側を doc に合わせる。

## 変更内容

### `apps/renderer/src/features/layout/NotificationToastItem.vue`

- `detail` computed を書き換え。`stack.split("\n")` で先頭行を取り出し、`<name>:` で始まれば V8 形式（`name: message` を含む head 行）と判定して捨て、それ以外は WebKit 形式として全行を frame 扱いする。最終的に常に `head + "\n" + frames` の正規化されたフォーマットを返す
- 配列のインデックスアクセスは禁止規約に従い `const [firstLine = "", ...rest] = ...` の destructure で取り出す
- message が改行を含む V8 / message が空文字 / WebKit のフレームのみの stack いずれも head 重複なく安定表示できる

### `apps/renderer/CLAUDE.md`

- notification の cause 表示仕様を「`Error` なら `name: message` 行 + stack」と明示し、WebKit の stack に message 行が含まれない事情を注記

## 確認事項

- [ ] WebKit (本番 `.app`) で `Error` を cause に渡したトーストを展開すると、先頭に `Error: <message>` 行が表示される
- [ ] V8 系（Chromium devtools / Vite dev）でも先頭の `name: message` 行が二重表示されない
- [ ] git stderr のような複数行 `message` を持つ Error でも head と frame が重複しない
- [ ] cause が string / Object / 壊れた toString のケースに変化がない
