### PR TITLE
fix(worktree): restore origin/<ref> prefetch dropped in PR #420 Swift port

### DIFF
--- a/apps/native/Sources/GozdCore/WorktreeOps.swift
+++ b/apps/native/Sources/GozdCore/WorktreeOps.swift
@@ -3,18 +3,29 @@ import Foundation
 // worktree / branch を変更する書き込み系操作。
 // 読み取り系（list / log）は GitOps、副作用持ち（create / remove / delete）はここ。
 public enum WorktreeOps {
-  /// `git worktree add [<startPoint>] <absPath> [-b <branch>]` 相当。
+  /// `git worktree add [<startPoint>] <absPath> [-B <branch>]` 相当。
   /// `worktreeDir` はリーフ名（typically タイムスタンプ）。1 path component のみ許可（`/`, `..`, `.` は拒否）。
   /// リポジトリ汚染を避けるため `~/.local/share/gozd/worktrees/<projectKey>/<worktreeDir>` に絶対パスとして配置する。
   /// `dir` は main repo / worktree subdir のどれでも可。内部で main repo root に解決して projectKey を統一する。
-  /// startPoint があれば -b で新規ブランチを作る。なければ既存ブランチを使う。
+  /// startPoint があれば -B で新規 or リセットしてブランチ作成、なければ既存ブランチを使う。
+  /// startPoint が `origin/<ref>` 形式なら remote-tracking ref をローカルに用意するため
+  /// 先行で `git fetch origin <ref>` を実行する。PR picker は GitHub 直問い合わせの head ref を
+  /// startPoint に渡すため、ローカル clone が stale な場合に必要。
   public static func createWorktree(
     dir: String, worktreeDir: String, branch: String, startPoint: String?
   ) async throws -> WorktreeInfo {
     let absPath = try ensureWorktreePath(projectDir: dir, leaf: worktreeDir)
     var args = ["worktree", "add"]
     if let startPoint, !startPoint.isEmpty {
-      args.append("-b")
+      let originPrefix = "origin/"
+      if startPoint.hasPrefix(originPrefix) {
+        let remoteBranch = String(startPoint.dropFirst(originPrefix.count))
+        _ = try await runGit(args: ["fetch", "origin", remoteBranch], cwd: dir)
+      }
+      // -B: ローカルブランチが既存なら startPoint にリセット、未存在なら作成。
+      // 他 worktree で checkout 中のブランチは git 側が `fatal: cannot force update ...` を
+      // 返すのでそのまま throw して呼び出し側の notify.error に stderr を流す。
+      args.append("-B")
       args.append(branch)
       args.append(absPath)
       args.append(startPoint)

--- a/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
+++ b/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
@@ -48,8 +48,7 @@ export function registerPrCommand(): () => void {
         );
 
         // この callback は PrPickerDialog 側で close() 後に呼ばれるため、
-        // 連打による再エントリは dialog の DOM 除去で塞がれている。さらに branch: pr.headRef が
-        // 決定論的なので git 側でも重複作成は弾かれる。`isCreating` 相当のガードは不要。
+        // 連打による再エントリは dialog の DOM 除去で塞がれている。`isCreating` 相当のガードは不要。
         show(prsRes.prs, viewerRes.ok ? viewerRes.login : "", (pr) => {
           const existingDir = wtByBranch.get(pr.headRef);
           if (existingDir !== undefined) {


### PR DESCRIPTION
## 概要

コマンドパレットの "Workspace: Open Pull Request" から PR を選んで worktree を作成しようとすると `Failed to create worktree / fatal: invalid reference: origin/<headRef>` で失敗する不具合を修正する。

修正は `WorktreeOps.createWorktree` 内で `startPoint` が `origin/<ref>` 形式のときに先行で `git fetch origin <ref>` を実行する。あわせて、リモートに新しい commit があるブランチ（PR が更新された / 過去に同名で worktree を作って削除した後の残骸ブランチ等）でも作成が通るように `git worktree add` を `-b` から `-B` に変更する。

## 背景

`gh pr list` で得られる PR 一覧は GitHub 側のリアルタイム情報であるため、ローカルに `origin/<headRef>` の remote-tracking ref が存在しない PR が混じる。新規に作成された Renovate PR や、closed→reopened されたケース、ローカル clone が一度も fetch されていない repo を初めて開いた直後などで再現する。

この再現性に行き着いた経緯として、当初は `gh` 経由で取れているのに `git worktree add` が `invalid reference` で fail することの整合性が不明瞭だったが、原因は `gh` と `git` のデータソースが異なる（GitHub 直 vs ローカル refs）という当然のことで、両者の橋渡しを担うはずだった事前 fetch ステップがコード上に存在しないことが分かった。

PR #420 のマージ ( cf1f076 ) で旧 Electrobun + TypeScript 実装から Swift / SwiftUI へ全面移植した際に、旧 `apps/desktop/src/git/worktree.ts:75-87` にあった「`startPoint` が `origin/` 始まりなら `git fetch origin <branch>` を先に走らせる」処理が新 `apps/native/Sources/GozdCore/WorktreeOps.swift` に移植されず欠落した。旧実装はさらに `-B`（存在すれば reset / 未存在なら作成）も使っていたが、新実装では `-b`（新規作成のみ）に簡略化されており、ローカルブランチが既に存在する場合の作成も失敗する状態だった。

責務の層として renderer 側に `rpcGitFetch` を新設して palette open 時に並列 fetch する案も検討したが、これは PR picker / issue picker / sidebar の 3 経路で同じ workaround を量産する形になり、`startPoint = origin/X` という proto RPC 仕様の意味を「caller が事前 fetch 済み前提」に勝手にすり替える形になるため不採用とした。fetch を行う責務は `WorktreeOps.createWorktree` の内側に集約する。

## 変更内容

### worktree 作成

- `apps/native/Sources/GozdCore/WorktreeOps.swift`
  - `createWorktree` が `startPoint` を受け取った時、`origin/` プレフィックスがあれば `git fetch origin <rest>` を先行実行
  - `git worktree add` を `-b` から `-B` に変更（存在ブランチは startPoint にリセット、未存在は作成）
  - doc コメントを実態（`-B`、先行 fetch、他 worktree checkout 衝突時は git stderr をそのまま throw）に追従更新

### コメントの修正

- `apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts`
  - 「branch: pr.headRef が決定論的なので git 側でも重複作成は弾かれる」というコメントを削除（実態として `wtByBranch` 分岐 (54-60 行) で既存 worktree への切り替えが先に効くため重複作成は元から発生しない。`-B` 採用後はさらに git 側で弾かれもしない）

## 確認事項

- [ ] PR picker から、ローカルに `origin/<headRef>` が無い PR を選んで worktree を作成できる
- [ ] PR picker から、過去に worktree を作って削除した後のローカルブランチが残っているケースで再作成できる
- [ ] PR picker から、別 worktree で checkout 中のブランチに対応する PR を選んだとき、git の `fatal: cannot force update the branch ...` がトーストに通知され、cause 展開で stderr 全文が確認できる
- [ ] issue picker および通常の worktree 追加経路（startPoint に `origin/main` 等の default branch ref が渡る側）の挙動に退行が無い
- [ ] fetch 失敗時（認証切れ / ネット切断 / 該当 ref が remote から削除済み）に Failed to create worktree トーストが出て、cause に fetch の stderr が乗る
