### PR TITLE
fix(cli-resolver): resolve git/gh via user login shell only

### DIFF
--- a/apps/native/Sources/Gozd/GozdApp.swift
+++ b/apps/native/Sources/Gozd/GozdApp.swift
@@ -503,27 +503,48 @@ final class AppRuntime {
     var dir = probeDir
     var repoName = (probeDir as NSString).lastPathComponent
     var isGitRepo = false
-    if let toplevel = try? await GitOps.repoTopLevel(dir: probeDir), !toplevel.isEmpty {
-      dir = toplevel
-      isGitRepo = true
-      // worktree から開いた場合 toplevel はその worktree 自身（gozd の場合 timestamp 名）。
-      // 表示用 repoName は main repo の basename を使う（git-common-dir の親）。
-      // 失敗時のみ toplevel basename にフォールバック。
-      if let mainRoot = try? await GitOps.mainRepoRoot(dir: probeDir), !mainRoot.isEmpty {
-        repoName = (mainRoot as NSString).lastPathComponent
-      } else {
-        repoName = (toplevel as NSString).lastPathComponent
-      }
-      // file 指定で probeDir が toplevel と異なる場合、selection.relPath を toplevel
-      // からの相対パスに更新する
-      if !selection.isEmpty, probeDir != toplevel {
-        let absFile = (probeDir as NSString).appendingPathComponent(
-          selection["relPath"] as? String ?? "")
-        if absFile.hasPrefix(toplevel) {
-          let rel = String(absFile.dropFirst(toplevel.count))
-          selection["relPath"] = rel.hasPrefix("/") ? String(rel.dropFirst()) : rel
+    var resolverError: String?
+    // `commandFailed`（probeDir が git 管理外 / detached HEAD 等のドメイン失敗）は
+    // `isGitRepo = false` で扱う既存挙動を維持する。`launchFailed`（git CLI 解決失敗、
+    // すなわち `CommandResolver` がユーザーシェル経由で git を見つけられない病的環境）は
+    // payload に `error` キーを積んで renderer に通知し、`useGozdOpenHandler` 側で
+    // `notify.error` を出させる。`try?` で両者を一律 nil 化すると、Finder 起動の `.app` で
+    // 静かに「git repo ではない」扱いに化けるため新契約と片肺になる。
+    do {
+      let toplevel = try await GitOps.repoTopLevel(dir: probeDir)
+      if !toplevel.isEmpty {
+        dir = toplevel
+        isGitRepo = true
+        // worktree から開いた場合 toplevel はその worktree 自身（gozd の場合 timestamp 名）。
+        // 表示用 repoName は main repo の basename を使う（git-common-dir の親）。
+        // 失敗時のみ toplevel basename にフォールバック。
+        do {
+          let mainRoot = try await GitOps.mainRepoRoot(dir: probeDir)
+          repoName =
+            mainRoot.isEmpty
+            ? (toplevel as NSString).lastPathComponent
+            : (mainRoot as NSString).lastPathComponent
+        } catch GitError.commandFailed {
+          repoName = (toplevel as NSString).lastPathComponent
+        }
+        // file 指定で probeDir が toplevel と異なる場合、selection.relPath を toplevel
+        // からの相対パスに更新する
+        if !selection.isEmpty, probeDir != toplevel {
+          let absFile = (probeDir as NSString).appendingPathComponent(
+            selection["relPath"] as? String ?? "")
+          if absFile.hasPrefix(toplevel) {
+            let rel = String(absFile.dropFirst(toplevel.count))
+            selection["relPath"] = rel.hasPrefix("/") ? String(rel.dropFirst()) : rel
+          }
         }
       }
+    } catch GitError.launchFailed(let message) {
+      resolverError = message
+    } catch GitError.commandFailed {
+      // 非 git ディレクトリ / detached HEAD など。isGitRepo = false のまま続行。
+    } catch {
+      // CancellationError 等の想定外。renderer に通知し isGitRepo = false で続行。
+      resolverError = String(describing: error)
     }
 
     var payload: [String: Any] = [
@@ -535,6 +556,9 @@ final class AppRuntime {
     ]
     if !selection.isEmpty {
       payload["selection"] = selection
+    }
+    if let resolverError {
+      payload["error"] = resolverError
     }
     return payload
   }

--- a/apps/native/Sources/GozdCore/GitHubOps.swift
+++ b/apps/native/Sources/GozdCore/GitHubOps.swift
@@ -61,10 +61,10 @@ public enum GitHubOps {
     }
     """
 
-  public static func prList(dir: String) async -> [PullRequestInfo]? {
-    guard let (owner, repo) = await repoOwnerName(dir: dir) else { return nil }
+  public static func prList(dir: String) async throws -> [PullRequestInfo]? {
+    guard let (owner, repo) = try await repoOwnerName(dir: dir) else { return nil }
     guard
-      let data = try? await runGh(
+      let data = try await runGhOrNilOnCommandFailure(
         args: graphqlArgs(owner: owner, repo: repo, query: prQuery), cwd: dir)
     else { return nil }
     guard
@@ -112,10 +112,10 @@ public enum GitHubOps {
     }
   }
 
-  public static func issueList(dir: String) async -> [IssueInfo]? {
-    guard let (owner, repo) = await repoOwnerName(dir: dir) else { return nil }
+  public static func issueList(dir: String) async throws -> [IssueInfo]? {
+    guard let (owner, repo) = try await repoOwnerName(dir: dir) else { return nil }
     guard
-      let data = try? await runGh(
+      let data = try await runGhOrNilOnCommandFailure(
         args: graphqlArgs(owner: owner, repo: repo, query: issueQuery), cwd: dir)
     else { return nil }
     guard
@@ -160,9 +160,9 @@ public enum GitHubOps {
     ]
   }
 
-  private static func repoOwnerName(dir: String) async -> (owner: String, repo: String)? {
+  private static func repoOwnerName(dir: String) async throws -> (owner: String, repo: String)? {
     guard
-      let data = try? await runGh(
+      let data = try await runGhOrNilOnCommandFailure(
         args: ["repo", "view", "--json", "owner,name", "--jq", ".owner.login + \"/\" + .name"],
         cwd: dir)
     else { return nil }
@@ -177,13 +177,28 @@ public enum GitHubOps {
   }
 
   /// `gh api user --jq .login` で認証中ユーザーの login を返す。未認証なら nil。
-  public static func viewer(dir: String) async -> String? {
-    guard let data = try? await runGh(args: ["api", "user", "--jq", ".login"], cwd: dir) else {
-      return nil
-    }
+  public static func viewer(dir: String) async throws -> String? {
+    guard
+      let data = try await runGhOrNilOnCommandFailure(
+        args: ["api", "user", "--jq", ".login"], cwd: dir)
+    else { return nil }
     let text = String(decoding: data, as: UTF8.self)
       .trimmingCharacters(in: .whitespacesAndNewlines)
     return text.isEmpty ? nil : text
+  }
+
+  /// `runGh` の `commandFailed`（gh は走ったが non-zero exit: 未認証、repo not found 等）
+  /// を nil に変換するヘルパー。`launchFailed`（gh CLI 解決失敗 / 起動失敗）は rethrow し、
+  /// 上位 (RPC dispatcher) で HTTP error として renderer に流す。
+  /// `try?` を直接使うと両者を区別できず、`gh` 未解決でも UI 上「PR 0 件」に化けるため、
+  /// `commandFailed` のみを silent 化する。
+  private static func runGhOrNilOnCommandFailure(args: [String], cwd: String) async throws -> Data?
+  {
+    do {
+      return try await runGh(args: args, cwd: cwd)
+    } catch GitError.commandFailed {
+      return nil
+    }
   }
 }
 
@@ -217,8 +232,11 @@ public struct IssueInfo: Sendable, Equatable {
 // `gh` の絶対パスは `CommandResolver` で解決する。`.app` を Finder/Dock から起動すると
 // launchd 由来の最小 PATH しか継承されないため `/usr/bin/env gh` では `gh` を解決
 // できない。`CommandResolver` がユーザーログインシェル経由で `command -v gh` を実行
-// して絶対パスを取得し、結果はキャッシュされる。見つからない場合は launchFailed を
-// throw して上位（`prList` / `issueList` / `viewer`）が `try?` で nil 化する。
+// して絶対パスを取得し、結果はキャッシュされる。見つからない場合は `launchFailed` を
+// throw する。上位の `prList` / `issueList` / `viewer` は `runGhOrNilOnCommandFailure`
+// で包んでおり、`commandFailed`（未認証 / repo not found 等）のみ nil 化し
+// `launchFailed` はそのまま rethrow → `RpcDispatcher` の handler から HTTP error として
+// renderer に流れ、`notify.error` で表示される。
 //
 // `launchFailed` を検知した場合、キャッシュが stale な可能性があるため 1 回だけ
 // invalidate + 再 resolve して retry する。

--- a/apps/native/Sources/GozdCore/GitHubOps.swift
+++ b/apps/native/Sources/GozdCore/GitHubOps.swift
@@ -246,17 +246,24 @@ public struct IssueInfo: Sendable, Equatable {
 // 出力が pipe buffer (~64KB) を超えると deadlock する。
 private func runGh(args: [String], cwd: String) async throws -> Data {
   do {
-    return try await runGhOnce(args: args, cwd: cwd)
+    return try await runGhOnce(ghPath: try await resolveGhPath(), args: args, cwd: cwd)
   } catch GitError.launchFailed {
     await CommandResolver.shared.invalidate("gh")
-    return try await runGhOnce(args: args, cwd: cwd)
+    return try await runGhOnce(ghPath: try await resolveGhPath(), args: args, cwd: cwd)
   }
 }
 
-private func runGhOnce(args: [String], cwd: String) async throws -> Data {
-  guard let ghPath = await CommandResolver.shared.resolve("gh") else {
-    throw GitError.launchFailed("gh CLI not found in PATH or user login shell")
+/// `gh` の絶対パスを resolve する。解決失敗時は `launchFailed` を throw する。
+/// `resolveGitPath` と同じシグネチャに揃え、解決経路と spawn 経路を呼び出し側で分離する
+/// （リトライ時の invalidate + 再 resolve が同じ層で完結する）。
+private func resolveGhPath() async throws -> String {
+  guard let path = await CommandResolver.shared.resolve("gh") else {
+    throw GitError.launchFailed("gh CLI not found in user login shell or PATH")
   }
+  return path
+}
+
+private func runGhOnce(ghPath: String, args: [String], cwd: String) async throws -> Data {
   let process = Process()
   process.executableURL = URL(fileURLWithPath: ghPath)
   process.arguments = args

--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -11,8 +11,14 @@ import os
 //
 // 2. **`CommandResolver` 経由で `git` の絶対パスを解決**: `.app` を Finder/Dock 起動
 //    すると launchd 由来の最小 PATH しか継承されないため `/usr/bin/env` の PATH 解決
-//    では Homebrew 版 git を選べない。`CommandResolver` がユーザーログインシェル経由で
-//    解決した絶対パスを使い、見つからない場合のみ Apple stub `/usr/bin/git` に倒す。
+//    では Homebrew / mise 版 git を選べない。`CommandResolver` がユーザーログインシェル
+//    経由で `command -v git` を実行し、ターミナルで叩く git と同一バイナリを返す。
+//    解決に失敗した場合は `launchFailed` を throw して呼び出し側 (notify.error) に
+//    通知する。Apple stub `/usr/bin/git` への暗黙 fallback は行わない: ターミナルで
+//    Homebrew git を使っているユーザーに対して `.app` だけ CLT git に倒すと、Keychain
+//    ACL が binary path 単位のため credential が引き継がれず、認証プロンプトが
+//    再発する。CLT only ユーザーはログインシェル経由でも `/usr/bin/git` が返るため
+//    fallback 無しでも救われる。
 //
 // 3. **stdout / stderr は子プロセス生存中に readabilityHandler で drain する**:
 //    `terminationHandler` 内で `readDataToEndOfFile()` する設計だと、出力が
@@ -91,18 +97,32 @@ public enum GitOps {
   }
 
   /// HEAD と default branch（origin/HEAD）の log を返す。
+  ///
+  /// default branch 周りの `commandFailed`（origin 未設定 / unborn branch 等のドメイン失敗）は
+  /// 空文字列 / 空配列に倒すが、`launchFailed`（git CLI 解決失敗）は rethrow して上位の
+  /// `notify.error` まで通す。`try?` で両者を区別せず潰すと、git-graph が「空」と「gozd が
+  /// git を解決できていない」を見分けられなくなる。
   public static func logBoth(dir: String, maxCount: UInt32, firstParentOnly: Bool) async throws
     -> LogResult
   {
-    async let headTask = log(dir: dir, ref: "HEAD", maxCount: maxCount, firstParentOnly: firstParentOnly)
-    let defaultBranch = (try? await defaultBranchName(dir: dir)) ?? ""
+    async let headTask = log(
+      dir: dir, ref: "HEAD", maxCount: maxCount, firstParentOnly: firstParentOnly)
+    let defaultBranch: String
+    do {
+      defaultBranch = try await defaultBranchName(dir: dir)
+    } catch GitError.commandFailed {
+      defaultBranch = ""
+    }
     let head = try await headTask
     var defaultCommits: [CommitInfo] = []
     if !defaultBranch.isEmpty {
-      defaultCommits =
-        (try? await log(
+      do {
+        defaultCommits = try await log(
           dir: dir, ref: "origin/\(defaultBranch)", maxCount: maxCount,
-          firstParentOnly: firstParentOnly)) ?? []
+          firstParentOnly: firstParentOnly)
+      } catch GitError.commandFailed {
+        defaultCommits = []
+      }
     }
     return LogResult(
       headCommits: head, defaultBranchCommits: defaultCommits, defaultBranch: defaultBranch)
@@ -391,12 +411,13 @@ private func parseNulSeparatedPaths(_ data: Data) -> Set<String> {
 
 // `runProcessCollectingOutput` は `ProcessExec.swift` に共通化した。
 
-/// `git` の絶対パスを resolve する。1 次解決失敗時のみ Apple stub `/usr/bin/git` に倒す。
-private func resolveGitPath() async -> String {
-  if let path = await CommandResolver.shared.resolve("git") {
-    return path
+/// `git` の絶対パスを resolve する。解決失敗時は `launchFailed` を throw する。
+/// Apple stub `/usr/bin/git` への暗黙 fallback は行わない（モジュール先頭コメント参照）。
+private func resolveGitPath() async throws -> String {
+  guard let path = await CommandResolver.shared.resolve("git") else {
+    throw GitError.launchFailed("git CLI not found in user login shell or PATH")
   }
-  return "/usr/bin/git"
+  return path
 }
 
 /// stdin にデータを渡して git を起動する。`runGit` と同じ戻り値契約。
@@ -405,11 +426,11 @@ private func resolveGitPath() async -> String {
 func runGitWithStdin(args: [String], cwd: String, stdin: Data) async throws -> Data {
   do {
     return try await runGitWithStdinOnce(
-      gitPath: await resolveGitPath(), args: args, cwd: cwd, stdin: stdin)
+      gitPath: try await resolveGitPath(), args: args, cwd: cwd, stdin: stdin)
   } catch GitError.launchFailed {
     await CommandResolver.shared.invalidate("git")
     return try await runGitWithStdinOnce(
-      gitPath: await resolveGitPath(), args: args, cwd: cwd, stdin: stdin)
+      gitPath: try await resolveGitPath(), args: args, cwd: cwd, stdin: stdin)
   }
 }
 
@@ -473,10 +494,10 @@ private func gozdGitEnv() -> [String: String] {
 
 func runGit(args: [String], cwd: String) async throws -> Data {
   do {
-    return try await runGitOnce(gitPath: await resolveGitPath(), args: args, cwd: cwd)
+    return try await runGitOnce(gitPath: try await resolveGitPath(), args: args, cwd: cwd)
   } catch GitError.launchFailed {
     await CommandResolver.shared.invalidate("git")
-    return try await runGitOnce(gitPath: await resolveGitPath(), args: args, cwd: cwd)
+    return try await runGitOnce(gitPath: try await resolveGitPath(), args: args, cwd: cwd)
   }
 }
 

--- a/apps/native/Sources/GozdCore/ProcessExec.swift
+++ b/apps/native/Sources/GozdCore/ProcessExec.swift
@@ -21,21 +21,32 @@ import os
 
 /// 外部 CLI の絶対パスを解決してキャッシュする actor。
 ///
-/// 解決手順:
+/// 解決手順: **ユーザーログインシェル経由でのみ解決する**。
+/// `getpwuid_r(getuid())->pw_shell` でユーザーのログインシェルを取得し、
+/// `<shell> -i -l -c '<script>'` で起動して `command -v <name>` の絶対パスを得る。
+/// これが「ユーザーがターミナルで叩く時に使われる CLI」と一致する唯一の経路。
 ///
-/// 1. **現在の PATH で 1 次解決**: `ProcessInfo.processInfo.environment["PATH"]` を
-///    分割して各 dir に candidate が存在するか走査。dev 経路（ターミナル PATH 継承）や
-///    `git` のように Apple stub 経路で見つかる場合はここで終わる。
+/// `-i -l` 両方付ける理由: `mise activate` / `asdf` 等は `.zshrc` 経由で activate
+/// されるケースが多く、`-l` (login) 単独では `.zshrc` を読まない。VSCode の
+/// shell environment resolver も同じ理由で `-i -l -c` を採用している。
 ///
-/// 2. **ユーザーログインシェル経由で 2 次解決**: 1 次で見つからない場合、
-///    `getpwuid_r(getuid())->pw_shell` でユーザーのログインシェルを取得し、
-///    `<shell> -i -l -c '<script>'` で起動して `command -v <name>` の絶対パスを得る。
+/// 結果は alias / function ではなく絶対パスかつ executable であることを検証する。
 ///
-///    `-i -l` 両方付ける理由: `mise activate` / `asdf` 等は `.zshrc` 経由で activate
-///    されるケースが多く、`-l` (login) 単独では `.zshrc` を読まない。VSCode の
-///    shell environment resolver も同じ理由で `-i -l -c` を採用している。
+/// **現プロセス PATH を使わない理由**: macOS の `/usr/bin/<dev tool>` は libxcselect
+/// 経由の shim で、Homebrew / mise / Apple stub のいずれも別バイナリ。Finder/Dock 起動の
+/// `.app` は launchd PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) しか継承しないため、現
+/// プロセス PATH を解決手段に混ぜると Apple stub が必ず先頭マッチして「ターミナルでは
+/// Homebrew git、`.app` では Apple stub」という非対称が生じる。Keychain ACL が binary
+/// path に紐付くため、認証情報も別世界扱いになる（ターミナルで作った credential が
+/// `.app` から見えない）。ログインシェル経由なら CLT only / Homebrew / mise どの層
+/// でも「ユーザーが普段使う CLI」を返すので、この非対称が原理的に発生しない。
 ///
-///    結果は alias / function ではなく絶対パスかつ executable であることを検証する。
+/// **fallback を持たない理由**: macOS の `getpwuid_r` は `pw_shell` が欠落していても
+/// `/usr/bin/false` 等の default を供給するため、login user で shell が取れない状態は
+/// 実用上発生しない。残る失敗ケース（exotic shell で `-i -l -c '<cmd>'` を解釈しない
+/// 等）は「ユーザーが意図的に exotic 環境を選んだ」状態で、ここで silent に
+/// `/usr/bin/<tool>` に倒す方がユーザー意図と乖離する。解決失敗時は `launchFailed` を
+/// 投げて呼び出し側 (notify.error) に通知する方が筋が良い。
 ///
 /// 解決結果は actor 内のキャッシュに保存する。`invalidate(_:)` で無効化することで
 /// stale cache（mise/asdf upgrade で versioned path が消えた等）に再解決の余地を残す。
@@ -67,24 +78,7 @@ public actor CommandResolver {
   }
 
   private static func lookup(_ name: String) async -> String? {
-    if let direct = lookupInCurrentPath(name) {
-      return direct
-    }
     return await lookupViaLoginShell(name)
-  }
-
-  /// 現在プロセスの PATH を分割して走査。`/usr/bin/env` と同じ挙動。
-  /// 空 PATH 要素は cwd 解釈になるが、セキュリティ理由から走査しない。
-  private static func lookupInCurrentPath(_ name: String) -> String? {
-    let pathEnv = ProcessInfo.processInfo.environment["PATH"] ?? ""
-    if pathEnv.isEmpty { return nil }
-    for dir in pathEnv.split(separator: ":", omittingEmptySubsequences: true) {
-      let candidate = (String(dir) as NSString).appendingPathComponent(name)
-      if let validated = validateExecutablePath(candidate) {
-        return validated
-      }
-    }
-    return nil
   }
 
   /// `getpwuid_r(getuid())->pw_shell` でユーザーのログインシェルを取得。
@@ -120,8 +114,8 @@ public actor CommandResolver {
   /// 対応シェル: `-i -l -c` フラグおよび POSIX `command -v` を解釈する shell（bash / zsh /
   /// dash / fish 等）を想定。これらに該当しないログインシェル（tcsh / nushell / xonsh の
   /// 一部呼び出し方法等）の場合は本関数が nil を返す。呼び出し側はそれを受けて
-  /// `runGh` / `runGit` で `launchFailed` を throw し、`prList` / `issueList` 等は `try?`
-  /// で nil 化する。
+  /// `runGh` / `runGit` で `launchFailed` を throw し、上位 (RPC dispatcher) で
+  /// HTTP error として renderer に通知される。renderer 側で `notify.error` を表示する。
   private static func lookupViaLoginShell(_ name: String) async -> String? {
     let shell = userLoginShell()
     let token = UUID().uuidString

--- a/apps/native/Sources/GozdCore/ProcessExec.swift
+++ b/apps/native/Sources/GozdCore/ProcessExec.swift
@@ -53,6 +53,12 @@ import os
 public actor CommandResolver {
   public static let shared = CommandResolver()
 
+  /// SIGKILL / 解決失敗の事実を Console.app から追えるよう `os.Logger` で記録する。
+  /// `lookupInCurrentPath` 撤去で `lookupViaLoginShell` が単一経路に格上げされ、
+  /// silent timeout が起きるとユーザーには `launchFailed` としか見えないため、
+  /// (a) `pw_shell` が exotic / (b) `command -v` 不解釈 / (c) rc hang を切り分け可能にする。
+  private static let logger = Logger(subsystem: "dev.miyaoka.gozd", category: "command-resolver")
+
   private var cache: [String: String] = [:]
   private var inflight: [String: Task<String?, Never>] = [:]
 
@@ -138,29 +144,60 @@ public actor CommandResolver {
     process.standardOutput = stdoutPipe
     process.standardError = stderrPipe
 
-    let timeoutTask = Task { [process] in
+    let timeoutTask = Task { [process, shell, name] in
       try? await Task.sleep(nanoseconds: 10 * 1_000_000_000)
       if process.isRunning {
         let pid = process.processIdentifier
-        if pid > 0 { _ = kill(pid, SIGKILL) }
+        if pid > 0 {
+          _ = kill(pid, SIGKILL)
+          logger.error(
+            """
+            lookupViaLoginShell timed out after 10s for '\(name, privacy: .public)' \
+            via shell '\(shell, privacy: .public)'; sent SIGKILL. \
+            shell rc may be hanging or shell may not parse `-i -l -c '<cmd>'`.
+            """)
+        }
       }
     }
     defer { timeoutTask.cancel() }
 
-    let (stdoutData, _): (Data, Data)
+    let (stdoutData, stderrData): (Data, Data)
     do {
-      (stdoutData, _) = try await runProcessCollectingOutput(
+      (stdoutData, stderrData) = try await runProcessCollectingOutput(
         process: process,
         stdoutPipe: stdoutPipe,
         stderrPipe: stderrPipe
       )
     } catch {
+      logger.error(
+        """
+        lookupViaLoginShell failed to launch shell '\(shell, privacy: .public)' \
+        for '\(name, privacy: .public)': \(error.localizedDescription, privacy: .public)
+        """)
       return nil
     }
 
-    guard process.terminationStatus == 0 else { return nil }
+    guard process.terminationStatus == 0 else {
+      let stderrText = String(decoding: stderrData, as: UTF8.self)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+      logger.error(
+        """
+        lookupViaLoginShell exit \(process.terminationStatus) for '\(name, privacy: .public)' \
+        via shell '\(shell, privacy: .public)': \(stderrText, privacy: .public)
+        """)
+      return nil
+    }
     let text = String(decoding: stdoutData, as: UTF8.self)
-    return extractAndValidatePath(text, begin: beginMarker, end: endMarker)
+    if let path = extractAndValidatePath(text, begin: beginMarker, end: endMarker) {
+      return path
+    }
+    logger.error(
+      """
+      lookupViaLoginShell could not parse `command -v \(name, privacy: .public)` output \
+      via shell '\(shell, privacy: .public)'. Shell may not support `-i -l -c` or \
+      `command -v`, or may have returned an alias / function instead of an absolute path.
+      """)
+    return nil
   }
 
   /// marker 間から「絶対パスかつ実行可能なファイル」となる行を抽出する。

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -530,7 +530,7 @@ public actor RpcDispatcher {
   private func handleGitPrList(_ body: Data) async throws -> Data {
     let req = try Gozd_V1_GitPrListRequest(jsonUTF8Data: body)
     var resp = Gozd_V1_GitPrListResponse()
-    if let prs = await GitHubOps.prList(dir: req.dir) {
+    if let prs = try await GitHubOps.prList(dir: req.dir) {
       resp.ok = true
       resp.prs = prs.map { p in
         var pb = Gozd_V1_GitPullRequest()
@@ -557,7 +557,7 @@ public actor RpcDispatcher {
   private func handleGitIssueList(_ body: Data) async throws -> Data {
     let req = try Gozd_V1_GitIssueListRequest(jsonUTF8Data: body)
     var resp = Gozd_V1_GitIssueListResponse()
-    if let issues = await GitHubOps.issueList(dir: req.dir) {
+    if let issues = try await GitHubOps.issueList(dir: req.dir) {
       resp.ok = true
       resp.issues = issues.map { i in
         var pb = Gozd_V1_GitIssue()
@@ -581,7 +581,7 @@ public actor RpcDispatcher {
   private func handleGitViewer(_ body: Data) async throws -> Data {
     let req = try Gozd_V1_GitViewerRequest(jsonUTF8Data: body)
     var resp = Gozd_V1_GitViewerResponse()
-    if let login = await GitHubOps.viewer(dir: req.dir) {
+    if let login = try await GitHubOps.viewer(dir: req.dir) {
       resp.ok = true
       resp.login = login
     } else {
@@ -600,19 +600,32 @@ public actor RpcDispatcher {
     //    ここでは流用せず、剥がさない形で扱う）
     // 2) 失敗時は main repo root 自身の current branch に fallback（remote 未設定 / push 前 repo）
     // 3) どちらも引けない（detached HEAD / unborn branch）場合は空文字列を返し、caller が通知 + 中止する
-    let branch = (try? await resolveStartPoint(dir: req.dir)) ?? ""
+    //
+    // `commandFailed`（origin/HEAD 未設定 / detached HEAD 等のドメイン失敗）のみ空文字列に
+    // 倒し、`launchFailed`（git CLI 解決失敗）は throw して renderer に通知する。
+    let branch: String
+    do {
+      branch = try await resolveStartPoint(dir: req.dir)
+    } catch GitError.commandFailed {
+      branch = ""
+    }
     var resp = Gozd_V1_GitDefaultBranchResponse()
     resp.branch = branch
     return try resp.jsonUTF8Data()
   }
 
   private func resolveStartPoint(dir: String) async throws -> String {
-    if let stdout = try? await runGit(
-      args: ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], cwd: dir)
-    {
+    // origin/HEAD 未設定（remote 無し / `git remote set-head` 未実行）は `commandFailed`
+    // で来るので、それだけ受け流して current branch にフォールバックする。`launchFailed`
+    // は rethrow して呼び出し側に伝える。
+    do {
+      let stdout = try await runGit(
+        args: ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], cwd: dir)
       let text = String(decoding: stdout, as: UTF8.self).trimmingCharacters(
         in: .whitespacesAndNewlines)
       if !text.isEmpty { return text }
+    } catch GitError.commandFailed {
+      // 次の HEAD fallback に進む
     }
     let stdout = try await runGit(args: ["symbolic-ref", "--short", "HEAD"], cwd: dir)
     return String(decoding: stdout, as: UTF8.self).trimmingCharacters(

--- a/apps/renderer/src/features/sidebar/useGozdOpenHandler.ts
+++ b/apps/renderer/src/features/sidebar/useGozdOpenHandler.ts
@@ -22,6 +22,13 @@ interface GozdOpenPayload {
   repoName: string;
   isGitRepo: boolean;
   switchToDir: string;
+  /**
+   * native 側で git バイナリの解決自体に失敗した場合（`GitError.launchFailed`）に積まれる。
+   * `commandFailed`（probeDir が git 管理外 / detached HEAD 等）は積まず、`isGitRepo = false`
+   * として既存挙動を維持する。両者を区別することで、ユーザーシェル経由でも git を解決できない
+   * 病的環境を「git repo ではない」と silent に化けさせず notify.error で可視化する。
+   */
+  error?: string;
 }
 
 export function useGozdOpenHandler() {
@@ -31,9 +38,12 @@ export function useGozdOpenHandler() {
   const notify = useNotificationStore();
 
   async function handle(payload: GozdOpenPayload) {
-    const { dir, selection, channel, repoName, isGitRepo, switchToDir } = payload;
+    const { dir, selection, channel, repoName, isGitRepo, switchToDir, error } = payload;
     if (channel) {
       appStore.setChannel(channel);
+    }
+    if (error !== undefined && error !== "") {
+      notify.error("Failed to resolve git binary", error);
     }
     const targetDir = switchToDir !== "" ? switchToDir : dir;
     // proto3 scalar では undefined が表現できないため、空 selection は未指定として扱う


### PR DESCRIPTION
## 概要

外部 CLI (`git` / `gh`) の絶対パス解決を、現プロセス PATH の走査からユーザーログインシェル経由解決のみに統一する。同時に `launchFailed` (CLI 解決自体の失敗) と `commandFailed` (CLI が走った上での非ゼロ exit) を呼び出し側で意味的に分離し、前者を必ず renderer の `notify.error` まで通す契約に揃える。

## 背景

PR #482 マージ後、PR ピッカーから worktree を作成するときに git 認証プロンプトが出る、という報告から調査を開始。ターミナルから普段使う git では認証が通っているのに `.app` 内では再認証を要求されることから「シェルの正しい git が指定できていない」が論点だった。

調査の結果、原因は `CommandResolver` の解決順序にあった。`lookupInCurrentPath` (現プロセス PATH 走査) が 1 次解決として実装されており、`.app` を Finder/Dock から起動すると launchd PATH = `/usr/bin:/bin:/usr/sbin:/sbin` しか継承されないため、Homebrew git をインストールしているユーザーであっても `/usr/bin/git` (Apple stub) で即マッチして `lookupViaLoginShell` まで到達しない構造になっていた。さらに `GitOps.swift` の `resolveGitPath` には `?? "/usr/bin/git"` という暗黙 fallback まで存在し、解決失敗時にも Apple stub に倒れる二重防衛になっていた。

macOS Keychain ACL は credential helper バイナリの絶対パスに紐付くため、Homebrew の `git-credential-osxkeychain` と CLT の同名 helper は別 ACL 扱いになる。ターミナルで使う git (Homebrew) と `.app` で呼ぶ git (Apple stub → CLT) が別バイナリだと、Homebrew git で保存した credential が `.app` から見えず認証プロンプトが再発する。

`GitOps.swift:12-15` のコメントは「ユーザーログインシェル経由で解決した絶対パスを使い、見つからない場合のみ Apple stub に倒す」と書いていたが、実装は逆順 (PATH 1 次 → login shell が fallback → 最終的に stub) になっており、コメントの意図と実装が乖離していた。今回は実装側を直す形でこのギャップを解消する。

加えて、`runGit` / `runGh` の呼び出し側 (`GitHubOps.prList` / `issueList` / `viewer` / `repoOwnerName`、`RpcDispatcher.handleGitDefaultBranch` / `resolveStartPoint`、`GitOps.logBoth`) に `try?` で失敗を一律 silent nil 化するパターンが残っていた。これは `gh` 未解決と「PR が無い」を UI 上区別不能にしていた既存の workaround で、本 PR の契約変更 (`launchFailed` は必ず renderer まで通す) を活かす形で `commandFailed` のみ nil 化する設計に揃える。

## 変更内容

### CLI 解決の本体設計 (`ProcessExec.swift`)

- `CommandResolver.lookup` を `lookupViaLoginShell` のみに単純化
- `lookupInCurrentPath` 関数と現プロセス PATH 走査経路を撤去
- モジュール冒頭ドキュメントに「fallback を持たない理由」を明記 (macOS の `getpwuid_r` が `pw_shell` 欠落時に `/usr/bin/false` を default 値として供給するため、login user で shell が取れない状態は実用上発生しない)

### `git` バイナリ解決 (`GitOps.swift`)

- `resolveGitPath` の `?? "/usr/bin/git"` 暗黙 fallback を撤去
- `throws` 化して解決失敗時は `GitError.launchFailed` を throw
- `runGit` / `runGitWithStdin` の呼び出し側を `try await resolveGitPath()` に修正
- モジュール冒頭ドキュメントを実装と一致させ、Keychain ACL が binary path 紐付きである旨を追記

### エラー意味論の二分 (`launchFailed` vs `commandFailed`)

- `GitHubOps.swift`: `prList` / `issueList` / `viewer` / `repoOwnerName` の 4 関数を `throws` 化し、`runGhOrNilOnCommandFailure` ヘルパーで `commandFailed` のみ nil 化 / `launchFailed` は rethrow
- `RpcDispatcher.swift`: `handleGitPrList` / `handleGitIssueList` / `handleGitViewer` の呼び出しに `try await` 追加
- `RpcDispatcher.swift`: `handleGitDefaultBranch` / `resolveStartPoint` の `try?` 2 箇所を `do { try } catch GitError.commandFailed` に展開
- `GitOps.swift`: `logBoth` 内の `(try? await defaultBranchName(...)) ?? ""` および `(try? await log(...)) ?? []` の 2 箇所も同パターンに展開

### ドキュメントコメントの整合

- `ProcessExec.swift:121-135` の旧コメント (「上位は `try?` で nil 化する」) を新契約に書き直し
- `GitHubOps.swift:232-242` のモジュール末尾コメントを `runGhOrNilOnCommandFailure` 経由の新契約に整合させる

## 確認事項

- [ ] `.app` を Finder/Dock から起動し、PR ピッカーから worktree を作成して認証プロンプトが出ないこと (Homebrew git ユーザー)
- [ ] dev (`pnpm dev`) からの起動でも従来通り動作すること
- [ ] PR ピッカー / Issue ピッカー / worktree 操作で従来のドメイン失敗 (gh 未認証 / repo not found / detached HEAD 等) は引き続き UI 上「データ無し」として扱われ、`launchFailed` 経路だけが `notify.error` に流れること
- [ ] git-graph (`logBoth`) で origin 未設定リポジトリが「空の右ペイン」で表示されること (`commandFailed` 経路維持)
