### PR TITLE
fix(worktree): prevent upstream auto-setup on worktree creation

### DIFF
--- a/apps/native/Sources/GozdCore/WorktreeOps.swift
+++ b/apps/native/Sources/GozdCore/WorktreeOps.swift
@@ -27,6 +27,7 @@ public enum WorktreeOps {
       // 返すのでそのまま throw して呼び出し側の notify.error に stderr を流す。
       args.append("-B")
       args.append(branch)
+      args.append("--no-track")
       args.append(absPath)
       args.append(startPoint)
     } else {

--- a/apps/native/Sources/GozdCore/WorktreeOps.swift
+++ b/apps/native/Sources/GozdCore/WorktreeOps.swift
@@ -3,7 +3,7 @@ import Foundation
 // worktree / branch を変更する書き込み系操作。
 // 読み取り系（list / log）は GitOps、副作用持ち（create / remove / delete）はここ。
 public enum WorktreeOps {
-  /// `git worktree add [<startPoint>] <absPath> [-B <branch>]` 相当。
+  /// `git worktree add [-B <branch>] [--no-track] <path> [<commit-ish>]` 相当。
   /// `worktreeDir` はリーフ名（typically タイムスタンプ）。1 path component のみ許可（`/`, `..`, `.` は拒否）。
   /// リポジトリ汚染を避けるため `~/.local/share/gozd/worktrees/<projectKey>/<worktreeDir>` に絶対パスとして配置する。
   /// `dir` は main repo / worktree subdir のどれでも可。内部で main repo root に解決して projectKey を統一する。


### PR DESCRIPTION
## 概要

worktree 作成時に `--no-track` を付与し、ブランチへの upstream 自動設定を防止する。

## 背景

gozd で worktree を新規作成すると `git worktree add -B <branch> <path> origin/main` が実行される。git の `branch.autoSetupMerge`（デフォルト `true`）により、remote-tracking ref（`origin/main`）を起点にしたブランチには upstream が自動設定されていた。

dotfiles の `git up`（`bdc` = deletable branches の自動削除）は `get-merged-branches` で「upstream なし + HEAD にマージ済み」のブランチを削除対象とするが、upstream が設定されたブランチは条件から漏れて削除されない。一方 `get-gone-branches`（remote が gone なブランチ）にも該当しないため、どちらにも引っかからず残り続けていた。

gozd の worktree ブランチはタイムスタンプ名の一時的な作業用であり、remote を track する必要がない。

## 変更内容

### WorktreeOps

- `createWorktree` の `git worktree add -B` に `--no-track` を追加
- doc comment の構文記述を実際の `git worktree add -h` 出力に合わせて修正

## 確認事項

- [ ] gozd で new worktree → `git branch -vv` で upstream が設定されていないことを確認
- [ ] `git up` で作成した worktree ブランチが削除対象になることを確認
