### PR TITLE
fix(filer): material-icon-theme の派生アイコン (.clone.svg) を正しく解決する

### DIFF
--- a/apps/renderer/src/features/changes/ChangesTreeItem.vue
+++ b/apps/renderer/src/features/changes/ChangesTreeItem.vue
@@ -5,7 +5,7 @@ Recursive tree node for the changes pane. Renders folders (with collapse/expand)
 <script setup lang="ts">
 import type { GitFileChange } from "@gozd/proto";
 import { computed } from "vue";
-import { getFileIconName, getFolderIconName, getIconUrl } from "../filer";
+import { getFileIconUrl, getFolderIconUrl } from "../filer";
 import type { ChangesTreeNode } from "./changesTree";
 
 const props = defineProps<{
@@ -39,9 +39,9 @@ const iconUrl = computed(() => {
     if (leafName === undefined) {
       throw new Error("Folder node has no display segments");
     }
-    return getIconUrl(getFolderIconName(leafName, isExpanded.value));
+    return getFolderIconUrl(leafName, isExpanded.value);
   }
-  return getIconUrl(getFileIconName(node.name));
+  return getFileIconUrl(node.name);
 });
 
 const folderDisplayName = computed(() =>

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -26,7 +26,7 @@ import type { GitChangeKind } from "../worktree";
 import { getDeletedEntries, sortEntries } from "./filerUtils";
 import type { FileEntry } from "./filerUtils";
 import { rpcFsReadDir } from "./rpc";
-import { getFileIconName, getFolderIconName, getIconUrl } from "./useFileIcon";
+import { getFileIconUrl, getFolderIconUrl } from "./useFileIcon";
 
 const GIT_CHANGE_COLOR_MAP: Record<GitChangeKind, string> = {
   modified: "text-yellow-400",
@@ -86,9 +86,9 @@ const isDeleted = computed(() => props.gitChange === "deleted");
 /** material-icon-theme のアイコン URL */
 const iconUrl = computed(() => {
   if (props.isDirectory) {
-    return getIconUrl(getFolderIconName(props.name, expanded.value));
+    return getFolderIconUrl(props.name, expanded.value);
   }
-  return getIconUrl(getFileIconName(props.name));
+  return getFileIconUrl(props.name);
 });
 
 async function toggle() {
@@ -273,27 +273,7 @@ function onChildSelect(childPath: string) {
       <!-- ファイル用のスペーサー -->
       <span v-else class="size-4 shrink-0" />
 
-      <img
-        v-if="iconUrl"
-        :src="iconUrl"
-        class="size-4 shrink-0"
-        :class="isIgnored ? 'opacity-50' : ''"
-        alt=""
-      />
-      <span
-        v-else
-        class="size-4 shrink-0"
-        :class="
-          isDirectory
-            ? expanded
-              ? 'icon-[lucide--folder-open]'
-              : 'icon-[lucide--folder]'
-            : isDeleted
-              ? 'icon-[lucide--file-x]'
-              : 'icon-[lucide--file]'
-        "
-        :style="{ color: isIgnored ? undefined : isDirectory ? '#facc15' : '#a1a1aa' }"
-      />
+      <img :src="iconUrl" class="size-4 shrink-0" :class="isIgnored ? 'opacity-50' : ''" alt="" />
       <span class="truncate">{{ name }}</span>
     </button>
 

--- a/apps/renderer/src/features/filer/iconUrlMap.test.ts
+++ b/apps/renderer/src/features/filer/iconUrlMap.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { buildIconUrlByName } from "./iconUrlMap";
+
+describe("buildIconUrlByName", () => {
+  test("通常の iconPath から basename を抽出して URL を引く", () => {
+    const result = buildIconUrlByName(
+      {
+        "folder-docs": { iconPath: "./../icons/folder-docs.svg" },
+      },
+      new Map([["folder-docs", "/hashed/folder-docs.svg"]]),
+    );
+    expect(result.get("folder-docs")).toBe("/hashed/folder-docs.svg");
+  });
+
+  test(".clone サフィックス付きの iconPath を解決する（regression: folder-development など）", () => {
+    const result = buildIconUrlByName(
+      {
+        "folder-development": { iconPath: "./../icons/folder-development.clone.svg" },
+        "folder-development-open": { iconPath: "./../icons/folder-development-open.clone.svg" },
+      },
+      new Map([
+        ["folder-development.clone", "/hashed/folder-development.clone.svg"],
+        ["folder-development-open.clone", "/hashed/folder-development-open.clone.svg"],
+      ]),
+    );
+    expect(result.get("folder-development")).toBe("/hashed/folder-development.clone.svg");
+    expect(result.get("folder-development-open")).toBe("/hashed/folder-development-open.clone.svg");
+  });
+
+  test("iconPath が .svg で終わらない場合は throw する（material-icon-theme 仕様変更の検知）", () => {
+    expect(() =>
+      buildIconUrlByName(
+        { "folder-foo": { iconPath: "./../icons/folder-foo.svg?v=2" } },
+        new Map([["folder-foo", "/hashed/folder-foo.svg"]]),
+      ),
+    ).toThrow(/cannot extract basename/);
+  });
+
+  test("iconPath が指す basename の SVG が無い場合は throw する", () => {
+    expect(() =>
+      buildIconUrlByName(
+        { "folder-missing": { iconPath: "./../icons/folder-missing.svg" } },
+        new Map([["folder-other", "/hashed/folder-other.svg"]]),
+      ),
+    ).toThrow(/SVG.*not found/);
+  });
+});

--- a/apps/renderer/src/features/filer/iconUrlMap.ts
+++ b/apps/renderer/src/features/filer/iconUrlMap.ts
@@ -9,8 +9,7 @@ export function buildIconUrlByName(
   const result = new Map<string, string>();
   for (const [name, def] of Object.entries(iconDefinitions)) {
     // iconPath: "./../icons/folder-development.clone.svg" → basename "folder-development.clone"
-    const match = def.iconPath.match(/\/([^/]+)\.svg$/);
-    const basename = match?.[1];
+    const [, basename] = def.iconPath.match(/\/([^/]+)\.svg$/) ?? [];
     if (basename === undefined) {
       throw new Error(
         `material-icon-theme: cannot extract basename from iconPath ${JSON.stringify(

--- a/apps/renderer/src/features/filer/iconUrlMap.ts
+++ b/apps/renderer/src/features/filer/iconUrlMap.ts
@@ -1,0 +1,30 @@
+/**
+ * manifest.iconDefinitions と SVG URL マップから「アイコン名 → URL」マップを構築する。
+ * iconPath の basename を SVG ルックアップキーに使うことで `.clone` サフィックス等の派生規則にも追従する。
+ */
+export function buildIconUrlByName(
+  iconDefinitions: Record<string, { iconPath: string }>,
+  svgUrlByBasename: Map<string, string>,
+): Map<string, string> {
+  const result = new Map<string, string>();
+  for (const [name, def] of Object.entries(iconDefinitions)) {
+    // iconPath: "./../icons/folder-development.clone.svg" → basename "folder-development.clone"
+    const match = def.iconPath.match(/\/([^/]+)\.svg$/);
+    const basename = match?.[1];
+    if (basename === undefined) {
+      throw new Error(
+        `material-icon-theme: cannot extract basename from iconPath ${JSON.stringify(
+          def.iconPath,
+        )} for icon ${JSON.stringify(name)}`,
+      );
+    }
+    const url = svgUrlByBasename.get(basename);
+    if (url === undefined) {
+      throw new Error(
+        `material-icon-theme: SVG ${JSON.stringify(`${basename}.svg`)} not found for icon ${JSON.stringify(name)}`,
+      );
+    }
+    result.set(name, url);
+  }
+  return result;
+}

--- a/apps/renderer/src/features/filer/index.ts
+++ b/apps/renderer/src/features/filer/index.ts
@@ -1,5 +1,5 @@
 export { default as FilerPane } from "./FilerPane.vue";
 export { rpcFsReadFile, rpcFsReadFileAbsolute } from "./rpc";
 export type { FsChangePayload } from "./rpc";
-export { getFileIconName, getFolderIconName, getIconUrl } from "./useFileIcon";
+export { getFileIconUrl, getFolderIconUrl } from "./useFileIcon";
 export { useFsWatchSync } from "./useFsWatchSync";

--- a/apps/renderer/src/features/filer/useFileIcon.ts
+++ b/apps/renderer/src/features/filer/useFileIcon.ts
@@ -1,4 +1,5 @@
-import { generateManifest } from "material-icon-theme";
+import { generateManifest, type Manifest } from "material-icon-theme";
+import { buildIconUrlByName } from "./iconUrlMap";
 
 /**
  * material-icon-theme のマニフェストからアイコン URL を解決する。
@@ -11,6 +12,14 @@ import { generateManifest } from "material-icon-theme";
  *   ファイル: fileNames → fileExtensions → languageIds → デフォルト
  *   フォルダ: folderNames(Expanded) → デフォルト
  */
+
+function requireManifestKey(manifest: Manifest, key: "file" | "folder" | "folderExpanded"): string {
+  const value = manifest[key];
+  if (value === undefined) {
+    throw new Error(`material-icon-theme: manifest.${key} is undefined`);
+  }
+  return value;
+}
 
 const manifest = generateManifest();
 
@@ -30,23 +39,12 @@ for (const [path, url] of Object.entries(svgModules)) {
   }
 }
 
-/** manifest が宣言するアイコン名 → URL */
-const iconUrlByName = new Map<string, string>();
-for (const [name, def] of Object.entries(manifest.iconDefinitions ?? {})) {
-  // iconPath: "./../icons/folder-development.clone.svg" → basename "folder-development.clone"
-  const match = def.iconPath.match(/\/([^/]+)\.svg$/);
-  const basename = match?.[1];
-  if (basename === undefined) continue;
-  const url = svgUrlByBasename.get(basename);
-  if (url === undefined) continue;
-  iconUrlByName.set(name, url);
-}
+const iconUrlByName = buildIconUrlByName(manifest.iconDefinitions ?? {}, svgUrlByBasename);
 
-const DEFAULT_FILE_ICON_NAME = manifest.file ?? "file";
-const DEFAULT_FOLDER_ICON_NAME = manifest.folder ?? "folder";
-const DEFAULT_FOLDER_OPEN_ICON_NAME = manifest.folderExpanded ?? "folder-open";
+const DEFAULT_FILE_ICON_NAME = requireManifestKey(manifest, "file");
+const DEFAULT_FOLDER_ICON_NAME = requireManifestKey(manifest, "folder");
+const DEFAULT_FOLDER_OPEN_ICON_NAME = requireManifestKey(manifest, "folderExpanded");
 
-// material-icon-theme が自身のデフォルトアイコンを解決できない場合は manifest 自体の問題なので即座に失敗させる
 function requireIconUrl(name: string): string {
   const url = iconUrlByName.get(name);
   if (url === undefined) {
@@ -54,10 +52,6 @@ function requireIconUrl(name: string): string {
   }
   return url;
 }
-
-const DEFAULT_FILE_ICON_URL = requireIconUrl(DEFAULT_FILE_ICON_NAME);
-const DEFAULT_FOLDER_ICON_URL = requireIconUrl(DEFAULT_FOLDER_ICON_NAME);
-const DEFAULT_FOLDER_OPEN_ICON_URL = requireIconUrl(DEFAULT_FOLDER_OPEN_ICON_NAME);
 
 const fileNameMap = new Map<string, string>();
 for (const [name, icon] of Object.entries(manifest.fileNames ?? {})) {
@@ -187,15 +181,12 @@ function resolveFolderIconName(folderName: string, isOpen: boolean): string {
 
 /** ファイル名から material-icon-theme の SVG URL を返す */
 function getFileIconUrl(fileName: string): string {
-  return iconUrlByName.get(resolveFileIconName(fileName)) ?? DEFAULT_FILE_ICON_URL;
+  return requireIconUrl(resolveFileIconName(fileName));
 }
 
 /** フォルダ名から material-icon-theme の SVG URL を返す */
 function getFolderIconUrl(folderName: string, isOpen: boolean): string {
-  const name = resolveFolderIconName(folderName, isOpen);
-  const url = iconUrlByName.get(name);
-  if (url !== undefined) return url;
-  return isOpen ? DEFAULT_FOLDER_OPEN_ICON_URL : DEFAULT_FOLDER_ICON_URL;
+  return requireIconUrl(resolveFolderIconName(folderName, isOpen));
 }
 
 export { getFileIconUrl, getFolderIconUrl };

--- a/apps/renderer/src/features/filer/useFileIcon.ts
+++ b/apps/renderer/src/features/filer/useFileIcon.ts
@@ -1,37 +1,69 @@
 import { generateManifest } from "material-icon-theme";
 
 /**
- * material-icon-theme のマニフェストから統合アイコンマッピングを構築する。
- * 解決優先順位: fileNames → fileExtensions → languageIds → デフォルト
+ * material-icon-theme のマニフェストからアイコン URL を解決する。
+ *
+ * SSOT は `manifest.iconDefinitions[name].iconPath`。
+ * `iconPath` の basename が実 SVG ファイル名と一致するため、ファイル名から逆引きせず
+ * iconDefinitions を介して URL を引く。`.clone` サフィックス等の派生規則にも透過的に追従する。
+ *
+ * 解決優先順位:
+ *   ファイル: fileNames → fileExtensions → languageIds → デフォルト
+ *   フォルダ: folderNames(Expanded) → デフォルト
  */
 
 const manifest = generateManifest();
 
-/** SVG を URL として一括取り込み（Vite がビルド時にハッシュ付きパスに変換） */
+/** Vite が SVG をハッシュ付き URL に変換した結果（basename → URL） */
+const svgUrlByBasename = new Map<string, string>();
 const svgModules = import.meta.glob<string>("/node_modules/material-icon-theme/icons/*.svg", {
   eager: true,
   import: "default",
   query: "?url",
   exhaustive: true,
 });
-
-/** アイコン名 → SVG URL のマップ */
-const iconUrlMap = new Map<string, string>();
 for (const [path, url] of Object.entries(svgModules)) {
-  // "/node_modules/material-icon-theme/icons/typescript.svg" → "typescript"
+  // "/node_modules/material-icon-theme/icons/folder-development.clone.svg" → "folder-development.clone"
   const match = path.match(/\/([^/]+)\.svg$/);
   if (match?.[1]) {
-    iconUrlMap.set(match[1], url);
+    svgUrlByBasename.set(match[1], url);
   }
 }
 
-/** ファイル名（小文字） → アイコン名 */
+/** manifest が宣言するアイコン名 → URL */
+const iconUrlByName = new Map<string, string>();
+for (const [name, def] of Object.entries(manifest.iconDefinitions ?? {})) {
+  // iconPath: "./../icons/folder-development.clone.svg" → basename "folder-development.clone"
+  const match = def.iconPath.match(/\/([^/]+)\.svg$/);
+  const basename = match?.[1];
+  if (basename === undefined) continue;
+  const url = svgUrlByBasename.get(basename);
+  if (url === undefined) continue;
+  iconUrlByName.set(name, url);
+}
+
+const DEFAULT_FILE_ICON_NAME = manifest.file ?? "file";
+const DEFAULT_FOLDER_ICON_NAME = manifest.folder ?? "folder";
+const DEFAULT_FOLDER_OPEN_ICON_NAME = manifest.folderExpanded ?? "folder-open";
+
+// material-icon-theme が自身のデフォルトアイコンを解決できない場合は manifest 自体の問題なので即座に失敗させる
+function requireIconUrl(name: string): string {
+  const url = iconUrlByName.get(name);
+  if (url === undefined) {
+    throw new Error(`material-icon-theme: icon ${JSON.stringify(name)} not resolvable`);
+  }
+  return url;
+}
+
+const DEFAULT_FILE_ICON_URL = requireIconUrl(DEFAULT_FILE_ICON_NAME);
+const DEFAULT_FOLDER_ICON_URL = requireIconUrl(DEFAULT_FOLDER_ICON_NAME);
+const DEFAULT_FOLDER_OPEN_ICON_URL = requireIconUrl(DEFAULT_FOLDER_OPEN_ICON_NAME);
+
 const fileNameMap = new Map<string, string>();
 for (const [name, icon] of Object.entries(manifest.fileNames ?? {})) {
   fileNameMap.set(name.toLowerCase(), icon);
 }
 
-/** 拡張子 → アイコン名 */
 const fileExtensionMap = new Map<string, string>();
 for (const [ext, icon] of Object.entries(manifest.fileExtensions ?? {})) {
   fileExtensionMap.set(ext, icon);
@@ -109,11 +141,6 @@ for (const [langId, icon] of Object.entries(manifest.languageIds ?? {})) {
   languageIdMap.set(langId, icon);
 }
 
-const DEFAULT_FILE_ICON = manifest.file ?? "file";
-const DEFAULT_FOLDER_ICON = manifest.folder ?? "folder";
-const DEFAULT_FOLDER_OPEN_ICON = manifest.folderExpanded ?? "folder-open";
-
-/** フォルダ名（小文字） → アイコン名 */
 const folderNameMap = new Map<string, string>();
 for (const [name, icon] of Object.entries(manifest.folderNames ?? {})) {
   folderNameMap.set(name.toLowerCase(), icon);
@@ -124,15 +151,13 @@ for (const [name, icon] of Object.entries(manifest.folderNamesExpanded ?? {})) {
   folderNameOpenMap.set(name.toLowerCase(), icon);
 }
 
-/** ファイル名からアイコン名を解決する */
-function getFileIconName(fileName: string): string {
+function resolveFileIconName(fileName: string): string {
   const lower = fileName.toLowerCase();
 
-  // ファイル名完全一致
   const byName = fileNameMap.get(lower);
   if (byName) return byName;
 
-  // 拡張子マッチ（複合拡張子も対応: .test.ts → test.ts → ts）
+  // 複合拡張子も対応: .test.ts → test.ts → ts
   const parts = lower.split(".");
   for (let i = 1; i < parts.length; i++) {
     const ext = parts.slice(i).join(".");
@@ -140,7 +165,6 @@ function getFileIconName(fileName: string): string {
     if (byExt) return byExt;
   }
 
-  // 拡張子 → 言語ID → アイコン名
   const ext = parts[parts.length - 1];
   if (ext) {
     const langId = EXTENSION_LANGUAGE_ID_MAP[ext];
@@ -150,21 +174,28 @@ function getFileIconName(fileName: string): string {
     }
   }
 
-  return DEFAULT_FILE_ICON;
+  return DEFAULT_FILE_ICON_NAME;
 }
 
-/** フォルダ名からアイコン名を解決する */
-function getFolderIconName(folderName: string, isOpen: boolean): string {
+function resolveFolderIconName(folderName: string, isOpen: boolean): string {
   const lower = folderName.toLowerCase();
   if (isOpen) {
-    return folderNameOpenMap.get(lower) ?? DEFAULT_FOLDER_OPEN_ICON;
+    return folderNameOpenMap.get(lower) ?? DEFAULT_FOLDER_OPEN_ICON_NAME;
   }
-  return folderNameMap.get(lower) ?? DEFAULT_FOLDER_ICON;
+  return folderNameMap.get(lower) ?? DEFAULT_FOLDER_ICON_NAME;
 }
 
-/** アイコン名から SVG の URL を返す */
-function getIconUrl(iconName: string): string | undefined {
-  return iconUrlMap.get(iconName);
+/** ファイル名から material-icon-theme の SVG URL を返す */
+function getFileIconUrl(fileName: string): string {
+  return iconUrlByName.get(resolveFileIconName(fileName)) ?? DEFAULT_FILE_ICON_URL;
 }
 
-export { getFileIconName, getFolderIconName, getIconUrl };
+/** フォルダ名から material-icon-theme の SVG URL を返す */
+function getFolderIconUrl(folderName: string, isOpen: boolean): string {
+  const name = resolveFolderIconName(folderName, isOpen);
+  const url = iconUrlByName.get(name);
+  if (url !== undefined) return url;
+  return isOpen ? DEFAULT_FOLDER_OPEN_ICON_URL : DEFAULT_FOLDER_ICON_URL;
+}
+
+export { getFileIconUrl, getFolderIconUrl };

--- a/apps/renderer/src/features/filer/useFileIcon.ts
+++ b/apps/renderer/src/features/filer/useFileIcon.ts
@@ -33,10 +33,13 @@ const svgModules = import.meta.glob<string>("/node_modules/material-icon-theme/i
 });
 for (const [path, url] of Object.entries(svgModules)) {
   // "/node_modules/material-icon-theme/icons/folder-development.clone.svg" → "folder-development.clone"
-  const match = path.match(/\/([^/]+)\.svg$/);
-  if (match?.[1]) {
-    svgUrlByBasename.set(match[1], url);
+  const [, basename] = path.match(/\/([^/]+)\.svg$/) ?? [];
+  if (basename === undefined) {
+    throw new Error(
+      `material-icon-theme: cannot extract basename from SVG path ${JSON.stringify(path)}`,
+    );
   }
+  svgUrlByBasename.set(basename, url);
 }
 
 const iconUrlByName = buildIconUrlByName(manifest.iconDefinitions ?? {}, svgUrlByBasename);
@@ -149,22 +152,22 @@ function resolveFileIconName(fileName: string): string {
   const lower = fileName.toLowerCase();
 
   const byName = fileNameMap.get(lower);
-  if (byName) return byName;
+  if (byName !== undefined) return byName;
 
   // 複合拡張子も対応: .test.ts → test.ts → ts
   const parts = lower.split(".");
   for (let i = 1; i < parts.length; i++) {
     const ext = parts.slice(i).join(".");
     const byExt = fileExtensionMap.get(ext);
-    if (byExt) return byExt;
+    if (byExt !== undefined) return byExt;
   }
 
-  const ext = parts[parts.length - 1];
-  if (ext) {
+  const [ext = ""] = parts.slice(-1);
+  if (ext !== "") {
     const langId = EXTENSION_LANGUAGE_ID_MAP[ext];
-    if (langId) {
+    if (langId !== undefined) {
       const byLang = languageIdMap.get(langId);
-      if (byLang) return byLang;
+      if (byLang !== undefined) return byLang;
     }
   }
 

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -25,7 +25,7 @@
 import { storeToRefs } from "pinia";
 import { computed, onUnmounted, ref, watch } from "vue";
 import { onMessage } from "../../shared/rpc";
-import { getFileIconName, getIconUrl, rpcFsReadFile, rpcFsReadFileAbsolute } from "../filer";
+import { getFileIconUrl, rpcFsReadFile, rpcFsReadFileAbsolute } from "../filer";
 import type { FsChangePayload } from "../filer";
 import { useGitGraphStore } from "../git-graph";
 import { UNCOMMITTED_HASH, useWorktreeStore } from "../worktree";
@@ -376,7 +376,7 @@ function fileName(filePath: string): string {
 
 const headerIconUrl = computed(() => {
   if (!selectedPath.value) return undefined;
-  return getIconUrl(getFileIconName(fileName(selectedPath.value)));
+  return getFileIconUrl(fileName(selectedPath.value));
 });
 </script>
 

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -374,9 +374,11 @@ function fileName(filePath: string): string {
   return filePath.split("/").pop() ?? filePath;
 }
 
-// selectedPath が undefined のときは `<template v-if="selectedPath">` 側で描画されないため、
-// デフォルトアイコン URL を返しておけば足りる（type を常に string に絞る目的）
-const headerIconUrl = computed(() => getFileIconUrl(fileName(selectedPath.value ?? "")));
+const headerIconUrl = computed(() => {
+  const path = selectedPath.value;
+  if (path === undefined) return undefined;
+  return getFileIconUrl(fileName(path));
+});
 </script>
 
 <template>

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -374,10 +374,9 @@ function fileName(filePath: string): string {
   return filePath.split("/").pop() ?? filePath;
 }
 
-const headerIconUrl = computed(() => {
-  if (!selectedPath.value) return undefined;
-  return getFileIconUrl(fileName(selectedPath.value));
-});
+// selectedPath が undefined のときは `<template v-if="selectedPath">` 側で描画されないため、
+// デフォルトアイコン URL を返しておけば足りる（type を常に string に絞る目的）
+const headerIconUrl = computed(() => getFileIconUrl(fileName(selectedPath.value ?? "")));
 </script>
 
 <template>
@@ -385,8 +384,7 @@ const headerIconUrl = computed(() => {
     <!-- ヘッダー（常に表示） -->
     <div class="flex items-center gap-2 border-b border-zinc-700 px-3 py-2">
       <template v-if="selectedPath">
-        <img v-if="headerIconUrl" :src="headerIconUrl" class="size-4 shrink-0" alt="" />
-        <span v-else class="icon-[lucide--file-text] text-zinc-400" />
+        <img :src="headerIconUrl" class="size-4 shrink-0" alt="" />
         <span class="truncate text-sm text-zinc-300" :title="selectedPath">{{
           fileName(selectedPath)
         }}</span>


### PR DESCRIPTION
## 概要

material-icon-theme の派生アイコン（`folder-development` など 32 件）が空アイコンになっていた問題を修正する。URL 解決ロジックを `manifest.iconDefinitions[name].iconPath` 経由に切り替え、SVG ファイル名から逆算する方式を廃止する。あわせて `FileTreeItem.vue` の lucide フォールバックを削除する。

## 背景

Changes ビューで `docs/development` のフォルダアイコンが空の四角になっていた。一見「chain 圧縮された中間ディレクトリの leaf 選択ロジックが悪い」ように見えたが、調査の結果これは誤りで、real cause は別のところにあった。

### `.clone.svg` ファイル名と manifest 名の不一致

material-icon-theme は派生アイコン（既存アイコンと視覚デザインを共有する別名アイコン）の SVG ファイル名に `.clone` サフィックスを付けて配布している。

- 例: `folder-development.clone.svg` / `folder-development-open.clone.svg`
- 該当ファイルは 32 件（`folder-deprecated`, `folder-eas`, `folder-instructions`, `folder-ngrx-*`, `folder-redux-*`, `folder-scrap`, `folder-gitea-workflows`, `folder-development` の open/closed 計 32）

`useFileIcon.ts` は `import.meta.glob` で取り込んだ SVG のファイル名から regex でキーを抽出していたため、`.clone` 付きファイルは `folder-development.clone` というキーで登録されていた。一方 manifest が返すアイコン名は `folder-development`（`.clone` 抜き）。両者が一致せず URL が undefined になり、broken image が出ていた。

### filetree でバグが目立たなかった理由

filetree 側で同じバグが目立たなかったのは、`FileTreeItem.vue` に「`iconUrl` が undefined のときに lucide フォルダアイコンを `#facc15`（黄）で出す」フォールバックがあったため。これは material-icon-theme 導入前（lucide が primary だった時代、コミット `02bdeaf`）の名残で、material-icon-theme 統合時（コミット `5649b7e`）に整理されないまま残っていた。

`development` フォルダが黄色く見えていたのは「成功して色付きアイコンが出ていた」のではなく「URL 解決失敗 → フォールバック発火」の結果。Changes ビューには同じフォールバックがなかったため、broken image が露出していた。

## 変更内容

### `useFileIcon.ts`

- URL 解決を `manifest.iconDefinitions[name].iconPath` 経由に変更
- `iconPath` の basename を SVG マップから引く方式に統一（`.clone` 等のサフィックスを意識する必要がなくなる）
- API を `getFileIconUrl(name): string` / `getFolderIconUrl(name, isOpen): string` に統合（戻り値は必ず `string`）
- 旧 API の `getFileIconName` / `getFolderIconName` / `getIconUrl` を削除
- module load 時にデフォルトアイコンが解決できなければ throw（manifest 自体の破損を即座に検知）

### `FileTreeItem.vue`

- lucide フォールバック（`<span v-else>` の黄色フォルダ / 灰色ファイル）を削除
- `iconUrl` が常に `string` を返すため `v-if="iconUrl"` 分岐も削除

### `ChangesTreeItem.vue` / `PreviewPane.vue`

- import と関数呼び出しを新 API に置換

## 確認事項

- [ ] Changes ビューで `.clone` 持ちフォルダ（`docs/development` 等）が material-icon-theme の正しい色付きアイコンで表示される
- [ ] filer ペインの同フォルダも同じく正しい色付きアイコンで表示される
- [ ] 他のフォルダ・ファイル（非 `.clone`）のアイコンに regression がない
- [ ] PreviewPane のヘッダーアイコンに regression がない
