### PR TITLE
fix(repo-store): worktree 削除時に削除済みパスへ RPC が走り続ける問題を修正

### DIFF
--- a/apps/native/Sources/GozdCore/FSWatchRegistry.swift
+++ b/apps/native/Sources/GozdCore/FSWatchRegistry.swift
@@ -71,6 +71,11 @@ public actor FSWatchRegistry {
   private let onBranchChange: BranchChangeHandler
   private let onWorktreeChange: WorktreeChangeHandler
   private var entries: [String: Entry] = [:]
+  /// watch 時に renderer から渡された原文 dir → realpath 解決後のキー の逆引き。
+  /// unwatch 時にディレクトリが既に削除されていると `realpath(3)` が失敗してフォールバックで
+  /// 入力 path をそのまま返すため、watch 時のキーと一致せず entries が leak する。
+  /// この逆引きを使えば「watch 時に解決した resolved key」で確実に削除できる。
+  private var resolvedKeyByOriginalDir: [String: String] = [:]
   /// watch ごとに増える世代番号。unwatch 後に積まれていた stale event の dispatch を
   /// 抑止するため、event 配送前後に entries[dir]?.generation と一致するか check する。
   private var nextGeneration: UInt64 = 0
@@ -92,7 +97,12 @@ public actor FSWatchRegistry {
   /// `/var/...` と `/private/var/...` のような symlink の差を吸収する）。
   public func watch(dir userDir: String) async throws {
     let dir = FSWatchRegistry.realpath(userDir)
-    if entries[dir] != nil { return }
+    if entries[dir] != nil {
+      // 同一 resolved dir に複数 userDir で watch 要求が来ても、各 userDir → resolved の
+      // 逆引きを残しておく（後続 unwatch が realpath 失敗で fallback した時に備える）。
+      resolvedKeyByOriginalDir[userDir] = dir
+      return
+    }
 
     nextGeneration += 1
     let generation = nextGeneration
@@ -140,12 +150,16 @@ public actor FSWatchRegistry {
       originalDir: userDir,
       perWorktreeGitDir: perWorktreeGitDir,
       commonGitDir: commonGitDir)
+    resolvedKeyByOriginalDir[userDir] = dir
   }
 
   /// dir の監視を停止する。watch されていなければ no-op。
+  /// 削除済みパスでは `realpath(3)` がフォールバックで入力 path を返すため、
+  /// watch 時に保存した逆引きを優先してキーを引く（leak 防止）。
   public func unwatch(dir userDir: String) {
-    let dir = FSWatchRegistry.realpath(userDir)
-    guard let entry = entries.removeValue(forKey: dir) else { return }
+    let resolvedKey = resolvedKeyByOriginalDir.removeValue(forKey: userDir)
+      ?? FSWatchRegistry.realpath(userDir)
+    guard let entry = entries.removeValue(forKey: resolvedKey) else { return }
     entry.watcher.stop()
     entry.continuation.finish()
     entry.task.cancel()
@@ -207,7 +221,10 @@ public actor FSWatchRegistry {
   }
 
   public func isWatching(dir userDir: String) -> Bool {
-    entries[FSWatchRegistry.realpath(userDir)] != nil
+    if let resolved = resolvedKeyByOriginalDir[userDir] {
+      return entries[resolved] != nil
+    }
+    return entries[FSWatchRegistry.realpath(userDir)] != nil
   }
 
   /// POSIX `realpath(3)` で symlink を解決した絶対パスを返す。

--- a/apps/native/Sources/GozdCore/FSWatchRegistry.swift
+++ b/apps/native/Sources/GozdCore/FSWatchRegistry.swift
@@ -156,6 +156,13 @@ public actor FSWatchRegistry {
   /// dir の監視を停止する。watch されていなければ no-op。
   /// 削除済みパスでは `realpath(3)` がフォールバックで入力 path を返すため、
   /// watch 時に保存した逆引きを優先してキーを引く（leak 防止）。
+  ///
+  /// **セマンティクス**: 同一 resolved dir に複数 userDir で watch が重ねられて
+  /// いた場合、いずれか 1 つの userDir で unwatch を呼ぶと entry 自体が解放され、
+  /// 残りの全 userDir 逆引きも一括で invalidate される。つまり「`watch` は冪等で
+  /// 逆引きを増やすだけ、`unwatch` は全 userDir 参照を巻き取って 1 度で解放」。
+  /// renderer 側で 1 worktree に対して複数 userDir で watch を投げる前提は無いため、
+  /// この簡略セマンティクスで十分（参照カウントは持たない）。
   public func unwatch(dir userDir: String) {
     let resolvedKey = resolvedKeyByOriginalDir.removeValue(forKey: userDir)
       ?? FSWatchRegistry.realpath(userDir)

--- a/apps/native/Sources/GozdCore/FSWatchRegistry.swift
+++ b/apps/native/Sources/GozdCore/FSWatchRegistry.swift
@@ -163,6 +163,10 @@ public actor FSWatchRegistry {
     entry.watcher.stop()
     entry.continuation.finish()
     entry.task.cancel()
+    // 同一 resolved dir を指していた他の userDir 逆引きも掃除する。
+    // 同一 resolved に複数 userDir（symlink パスと非 symlink パスなど）で watch が
+    // 重ねられた状態で、片方しか unwatch されないと逆引きエントリが leak するため。
+    resolvedKeyByOriginalDir = resolvedKeyByOriginalDir.filter { $0.value != resolvedKey }
   }
 
   /// dispatch 時点で entry がまだ生きており、世代が一致するかを判定する。

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -7,26 +7,30 @@
 - material-icon-theme のアイコンを表示
 - git status に応じた色分け（modified=黄、added=緑、deleted=赤、renamed=青）と削除ファイルの打ち消し線
 
-## 更新
+## 更新（イベント駆動）
 
-- 親から `notifyChange` / `notifyGitStatusChange` を呼ばれてツリーを差分更新
-- `reveal(targetPath)` でパスのセグメントを再帰的に辿って展開し、対象ノードをスクロールインビュー
+- filer event store の fsChange を watch して自分の path 該当時に再読み込み
+- filer event store の gitStatusChange を watch して展開中なら children を再構築
+- worktreeStore.revealVersion を watch して selectedPath が自分または配下なら展開＋スクロール
+- 親→子の命令呼び出し（defineExpose）は使わず、各ノードが自律的にイベントを処理する設計
 </doc>
 
 <script setup lang="ts">
-import { computed, nextTick, ref, useTemplateRef } from "vue";
+import { tryCatch } from "@gozd/shared";
+import { computed, ref, useTemplateRef, watch } from "vue";
 import { useNotificationStore } from "../../shared/notification";
 import {
-  useWorktreeStore,
   resolveDirectoryGitChange,
   resolveFileGitChange,
   resolveGitChangeKind,
+  useWorktreeStore,
 } from "../worktree";
 import type { GitChangeKind } from "../worktree";
 import { getDeletedEntries, sortEntries } from "./filerUtils";
 import type { FileEntry } from "./filerUtils";
 import { rpcFsReadDir } from "./rpc";
 import { getFileIconUrl, getFolderIconUrl } from "./useFileIcon";
+import { useFilerEventStore } from "./useFilerEventStore";
 
 const GIT_CHANGE_COLOR_MAP: Record<GitChangeKind, string> = {
   modified: "text-yellow-400",
@@ -56,11 +60,11 @@ const emit = defineEmits<{
 
 const notify = useNotificationStore();
 const worktreeStore = useWorktreeStore();
+const filerEventStore = useFilerEventStore();
 
 const buttonRef = useTemplateRef<HTMLButtonElement>("button");
 const expanded = ref(false);
 const children = ref<FileEntry[]>();
-const childRefs = ref<InstanceType<typeof import("./FileTreeItem.vue").default>[]>([]);
 const loading = ref(false);
 
 /** gitStatuses マップからリアルタイムに変更種別を算出する */
@@ -113,26 +117,26 @@ async function loadChildren() {
     loading.value = false;
     return;
   }
-  try {
-    const res = await rpcFsReadDir({ dir, path: props.path });
-    const entries = res.entries.map((e) => ({
-      name: e.name,
-      isDirectory: e.type === "directory",
-      isIgnored: false,
-    }));
-    children.value = mergeWithGitStatus(entries);
-  } catch (e) {
+  const result = await tryCatch(rpcFsReadDir({ dir, path: props.path }));
+  if (!result.ok) {
     // 削除ディレクトリの場合、readDir は失敗するので削除エントリのみ表示
     const deletedEntries = getDeletedEntries(props.path, props.gitStatuses);
     if (deletedEntries.length > 0) {
       children.value = sortEntries(deletedEntries);
     } else {
-      notify.error(`Failed to read directory: ${props.path}`, e);
+      notify.error(`Failed to read directory: ${props.path}`, result.error);
       children.value = [];
     }
-  } finally {
     loading.value = false;
+    return;
   }
+  const entries = result.value.entries.map((e) => ({
+    name: e.name,
+    isDirectory: e.type === "directory",
+    isIgnored: false,
+  }));
+  children.value = mergeWithGitStatus(entries);
+  loading.value = false;
 }
 
 /** readDir の結果に git 変更情報と削除ファイルをマージする */
@@ -155,57 +159,46 @@ function mergeWithGitStatus(entries: FileEntry[]): FileEntry[] {
   return sortEntries([...withGitChange, ...deletedEntries]);
 }
 
-/**
- * ファイル変更通知を受けて、該当するディレクトリの内容を再読み込みする。
- * 自身のパスに一致すれば再読み込み、さもなくば子に伝播する。
- */
-function notifyChange(relDir: string) {
-  if (!props.isDirectory) return;
-
-  // 自身のディレクトリが変更対象
-  if (relDir === props.path) {
+// fsChange を購読し、自分の path が変更対象なら再読み込み（折りたたみ中はキャッシュ破棄）。
+// 自分の path 配下のノードは独立に同じ store を watch しているため、再帰伝播は不要。
+watch(
+  () => filerEventStore.fsChangeEvent,
+  (event) => {
+    if (event === undefined) return;
+    if (!props.isDirectory) return;
+    if (event.relDir !== props.path) return;
     if (expanded.value) {
       void loadChildren();
     } else {
       // 折りたたみ中なら次回展開時に再読み込みするためキャッシュを破棄
       children.value = undefined;
     }
-    return;
-  }
+  },
+);
 
-  // 自身の配下のパスなら子に伝播
-  if (relDir.startsWith(props.path + "/")) {
-    for (const child of childRefs.value) {
-      child.notifyChange(relDir);
+// gitStatusChange を購読し、展開中の children を再構築する（削除仮想エントリの追加/除去）。
+// computed の再計算だけでは entries の追加削除を反映できないため、明示的に再読み込みする。
+watch(
+  () => filerEventStore.gitStatusChangeVersion,
+  () => {
+    if (!props.isDirectory) return;
+    if (expanded.value && children.value !== undefined) {
+      void loadChildren();
+    } else {
+      // 折りたたみ中なら次回展開時に再読み込みするためキャッシュを破棄
+      children.value = undefined;
     }
-  }
-}
+  },
+);
 
 /**
- * git status 変更通知を受けて、展開中のディレクトリの children を再構築する。
- * 削除仮想エントリの追加/除去は children の再構築が必要なため、
- * computed の再計算だけでは対応できない。
+ * revealVersion 変化で worktreeStore.selectedPath を見て、自分が target または target の祖先なら処理。
+ * 祖先の場合は展開するだけ。子は v-for でマウント後に自分の revealVersion watch (immediate)
+ * で target を処理する再帰チェーン。
  */
-function notifyGitStatusChange() {
-  if (!props.isDirectory) return;
-
-  if (expanded.value && children.value !== undefined) {
-    void loadChildren();
-  } else {
-    // 折りたたみ中なら次回展開時に再読み込みするためキャッシュを破棄
-    children.value = undefined;
-  }
-
-  for (const child of childRefs.value) {
-    child.notifyGitStatusChange();
-  }
-}
-
-/**
- * 指定パスまでツリーを展開し、対象ノードをビューポートにスクロールする。
- * パスのセグメントを再帰的に辿り、各ディレクトリを非同期で展開する。
- */
-async function reveal(targetPath: string): Promise<void> {
+async function handleReveal() {
+  const targetPath = worktreeStore.selectedPath;
+  if (targetPath === undefined) return;
   // 自身がターゲットの場合、展開してスクロールインビュー
   if (targetPath === props.path) {
     if (props.isDirectory && !expanded.value) {
@@ -217,34 +210,27 @@ async function reveal(targetPath: string): Promise<void> {
     buttonRef.value?.scrollIntoView({ block: "nearest" });
     return;
   }
-
   // ディレクトリでないか、ターゲットが自身の配下でない場合は何もしない
   if (!props.isDirectory) return;
   if (!targetPath.startsWith(props.path + "/")) return;
-
-  // 展開する（未展開かつ子が未読み込みの場合は読み込む）
+  // 自身の配下に target がある場合、自分は展開するだけ（target そのものへの scroll は
+  // 子の watch が処理する）。子は v-for で children を読み込むとマウントされ、
+  // immediate watch が現在の revealVersion で発火する
   if (!expanded.value) {
     expanded.value = true;
     if (children.value === undefined) {
       await loadChildren();
     }
   }
-
-  // childRefs は v-for の template ref なので、DOM 更新を待つ
-  await nextTick();
-
-  // 次のパスセグメントに一致する子を探して再帰
-  const nextSegment = targetPath.slice(props.path.length + 1).split("/")[0];
-  const childIndex = children.value?.findIndex((c) => c.name === nextSegment);
-  if (childIndex !== undefined && childIndex >= 0) {
-    const child = childRefs.value[childIndex];
-    if (child) {
-      await child.reveal(targetPath);
-    }
-  }
 }
 
-defineExpose({ notifyChange, notifyGitStatusChange, reveal });
+watch(
+  () => worktreeStore.revealVersion,
+  () => {
+    void handleReveal();
+  },
+  { immediate: true },
+);
 
 function onChildSelect(childPath: string) {
   emit("select", childPath);
@@ -288,7 +274,6 @@ function onChildSelect(childPath: string) {
       </div>
       <FileTreeItem
         v-for="child in children"
-        ref="childRefs"
         :key="`${child.name}-${child.isDirectory}`"
         :name="child.name"
         :path="`${path}/${child.name}`"

--- a/apps/renderer/src/features/filer/FilerPane.vue
+++ b/apps/renderer/src/features/filer/FilerPane.vue
@@ -94,7 +94,9 @@ async function loadRoot() {
   if (!readResult.ok) {
     notify.error("Failed to read root directory", readResult.error);
     rootEntries.value = [];
-    // 世代チェック後に到達しているが、await を挟まない以上同期だが防御として揃える。
+    // 世代チェック (line 上の `if (mySeq !== loadRootSeq) return;`) を通過した時点で
+    // `mySeq === loadRootSeq` は確定だが、将来この早期 return の位置が変わった場合に
+    //備えて重複ガードを置く。N+1 の `loading = true` を誤って消さない防御。
     if (mySeq === loadRootSeq) loading.value = false;
     return;
   }
@@ -171,6 +173,12 @@ async function handleGitStatusChange() {
   }
 }
 
+// **watch 登録順依存**: `dir` watch を `revealVersion` watch より前に登録する必要がある。
+// Vue は watch を登録順に発火させるため、setOpen({ selection }) で dir 変化と
+// revealVersion ++ が同 tick で起きたとき、先に dir watch が `pendingRevealPath = undefined`
+// で旧パスをクリアし、その後 revealVersion watch が新パスを積み直す順序になる。
+// 入れ替えると revealVersion watch が先に走り、`pendingRevealPath` に積んだ直後の
+// dir watch がそれを消してしまう（reveal が空振り）。登場順を変更する際は注意。
 watch(
   dir,
   (newDir) => {
@@ -189,6 +197,9 @@ watch(
 // immediate: true で初回 mount 時に既存 selectedPath があれば pendingRevealPath に積み、
 // loadRoot 末尾で消化させる。これにより gozdOpen で渡された initial selection も
 // この 1 経路に集約できる（旧 consumeInitialSelection 経路は廃止）。
+// **invariant 依存**: revealVersion の bump は selection.value の更新と同期している
+// （useWorktreeStore の selectPath() でのみ実行される）。両者が同 tick で揃わない経路を
+// 増やすと古いパスで reveal が走る。
 watch(
   () => worktreeStore.revealVersion,
   () => {

--- a/apps/renderer/src/features/filer/FilerPane.vue
+++ b/apps/renderer/src/features/filer/FilerPane.vue
@@ -89,27 +89,22 @@ async function loadRoot() {
     gitStatusStore.loadGitStatus(),
   ]);
   // await 中に loadRoot が再度呼ばれた場合、この呼び出しの結果は破棄する。
-  // 旧呼び出しが新 dir 用の rootEntries や initialSelection を上書きするのを防ぐ。
-  if (mySeq !== loadRootSeq) {
-    return;
-  }
+  // 旧呼び出しが新 dir 用の rootEntries や pendingRevealPath を上書きするのを防ぐ。
+  if (mySeq !== loadRootSeq) return;
   if (!readResult.ok) {
     notify.error("Failed to read root directory", readResult.error);
     rootEntries.value = [];
-    loading.value = false;
+    // 世代チェック後に到達しているが、await を挟まない以上同期だが防御として揃える。
+    if (mySeq === loadRootSeq) loading.value = false;
     return;
   }
   rootEntries.value = mergeWithGitStatus(toFileEntries(readResult.value.entries), "");
-  loading.value = false;
+  if (mySeq === loadRootSeq) loading.value = false;
 
-  // rootEntries 読み込み完了後に保留中の処理を実行
-  // v-for の FileTreeItem がマウントされるのを nextTick で待つ
+  // rootEntries 読み込み完了後に保留中の reveal を実行。
+  // v-for の FileTreeItem がマウントされるのを nextTick で待つ。
   await nextTick();
   if (mySeq !== loadRootSeq) return;
-  const consumed = worktreeStore.consumeInitialSelection();
-  if (consumed?.kind === "directory") {
-    void reveal(consumed.relPath);
-  }
   if (pendingRevealPath) {
     const path = pendingRevealPath;
     pendingRevealPath = undefined;
@@ -191,12 +186,16 @@ watch(
 
 // revealVersion の変化（selectPath 経由 / gozdOpen 経由など）で選択中パスを reveal する。
 // 親から ref を expose せず worktreeStore 直接購読にすることで defineExpose を不要にする。
+// immediate: true で初回 mount 時に既存 selectedPath があれば pendingRevealPath に積み、
+// loadRoot 末尾で消化させる。これにより gozdOpen で渡された initial selection も
+// この 1 経路に集約できる（旧 consumeInitialSelection 経路は廃止）。
 watch(
   () => worktreeStore.revealVersion,
   () => {
     const path = worktreeStore.selectedPath;
     if (path) void reveal(path);
   },
+  { immediate: true },
 );
 
 const unsubscribeFsChange = onMessage<FsChangePayload>("fsChange", ({ relDir }) =>

--- a/apps/renderer/src/features/filer/FilerPane.vue
+++ b/apps/renderer/src/features/filer/FilerPane.vue
@@ -162,7 +162,18 @@ async function handleGitStatusChange() {
   // ここではファイルツリーの再構築（新規 / 削除ファイル反映）だけを行う。
   const dirPath = dir.value;
   if (dirPath === undefined) return;
+  // await 中に dir 変更 / loadRoot 再起動が走るとこの呼び出しは stale 扱いにする。
+  // loadRootSeq を共有することで、loadRoot の世代チェックと整合する race ガードに揃える。
+  const mySeq = loadRootSeq;
   const result = await tryCatch(rpcFsReadDir({ dir: dirPath, path: "." }));
+  if (mySeq !== loadRootSeq || dir.value !== dirPath) {
+    // 旧 dir 用の結果で新 dir の rootEntries を踏み潰すのを防ぐ。
+    // 子側の notify は新 dir で再マウントされた FileTreeItem に対するものなので呼ぶ。
+    for (const item of treeItemRefs.value) {
+      item.notifyGitStatusChange();
+    }
+    return;
+  }
   if (!result.ok) {
     notify.error("Failed to rebuild root entries", result.error);
   } else {

--- a/apps/renderer/src/features/filer/FilerPane.vue
+++ b/apps/renderer/src/features/filer/FilerPane.vue
@@ -10,6 +10,7 @@
 </doc>
 
 <script setup lang="ts">
+import { tryCatch } from "@gozd/shared";
 import { storeToRefs } from "pinia";
 import { nextTick, onUnmounted, ref, watch } from "vue";
 import { useNotificationStore } from "../../shared/notification";
@@ -81,25 +82,25 @@ async function loadRoot() {
     }
     return;
   }
-  try {
-    const [res] = await Promise.all([
-      rpcFsReadDir({ dir: dirPath, path: "." }),
-      gitStatusStore.loadGitStatus(),
-    ]);
-    // await 中に loadRoot が再度呼ばれた場合、この呼び出しの結果は破棄する。
-    // 旧呼び出しが新 dir 用の rootEntries や initialSelection を上書きするのを防ぐ。
-    if (mySeq !== loadRootSeq) return;
-    rootEntries.value = mergeWithGitStatus(toFileEntries(res.entries), "");
-  } catch (e) {
-    if (mySeq !== loadRootSeq) return;
-    notify.error("Failed to read root directory", e);
-    rootEntries.value = [];
-  } finally {
-    if (mySeq === loadRootSeq) {
-      loading.value = false;
-    }
+  // rpcFsReadDir と loadGitStatus を並列で投げ、readDir 失敗時のみエラー通知する。
+  // loadGitStatus 側のエラーは store 内で個別に通知済み（cause を握り潰さない）。
+  const [readResult] = await Promise.all([
+    tryCatch(rpcFsReadDir({ dir: dirPath, path: "." })),
+    gitStatusStore.loadGitStatus(),
+  ]);
+  // await 中に loadRoot が再度呼ばれた場合、この呼び出しの結果は破棄する。
+  // 旧呼び出しが新 dir 用の rootEntries や initialSelection を上書きするのを防ぐ。
+  if (mySeq !== loadRootSeq) {
+    return;
   }
-  if (mySeq !== loadRootSeq) return;
+  if (!readResult.ok) {
+    notify.error("Failed to read root directory", readResult.error);
+    rootEntries.value = [];
+    loading.value = false;
+    return;
+  }
+  rootEntries.value = mergeWithGitStatus(toFileEntries(readResult.value.entries), "");
+  loading.value = false;
 
   // rootEntries 読み込み完了後に保留中の処理を実行
   // v-for の FileTreeItem がマウントされるのを nextTick で待つ
@@ -141,8 +142,6 @@ async function reveal(targetPath: string): Promise<void> {
   }
 }
 
-defineExpose({ reveal });
-
 /**
  * ファイル変更通知を受けてツリーを更新するコールバック。
  * FileTreeItem の reloadDir を呼ぶため、ref 経由で子コンポーネントにアクセスする。
@@ -166,11 +165,11 @@ async function handleGitStatusChange() {
   // ここではファイルツリーの再構築（新規 / 削除ファイル反映）だけを行う。
   const dirPath = dir.value;
   if (dirPath === undefined) return;
-  try {
-    const res = await rpcFsReadDir({ dir: dirPath, path: "." });
-    rootEntries.value = mergeWithGitStatus(toFileEntries(res.entries), "");
-  } catch (e) {
-    notify.error("Failed to rebuild root entries", e);
+  const result = await tryCatch(rpcFsReadDir({ dir: dirPath, path: "." }));
+  if (!result.ok) {
+    notify.error("Failed to rebuild root entries", result.error);
+  } else {
+    rootEntries.value = mergeWithGitStatus(toFileEntries(result.value.entries), "");
   }
   for (const item of treeItemRefs.value) {
     item.notifyGitStatusChange();
@@ -188,6 +187,16 @@ watch(
     }
   },
   { immediate: true },
+);
+
+// revealVersion の変化（selectPath 経由 / gozdOpen 経由など）で選択中パスを reveal する。
+// 親から ref を expose せず worktreeStore 直接購読にすることで defineExpose を不要にする。
+watch(
+  () => worktreeStore.revealVersion,
+  () => {
+    const path = worktreeStore.selectedPath;
+    if (path) void reveal(path);
+  },
 );
 
 const unsubscribeFsChange = onMessage<FsChangePayload>("fsChange", ({ relDir }) =>

--- a/apps/renderer/src/features/filer/FilerPane.vue
+++ b/apps/renderer/src/features/filer/FilerPane.vue
@@ -96,7 +96,7 @@ async function loadRoot() {
     rootEntries.value = [];
     // 世代チェック (line 上の `if (mySeq !== loadRootSeq) return;`) を通過した時点で
     // `mySeq === loadRootSeq` は確定だが、将来この早期 return の位置が変わった場合に
-    //備えて重複ガードを置く。N+1 の `loading = true` を誤って消さない防御。
+    // 備えて重複ガードを置く。N+1 の `loading = true` を誤って消さない防御。
     if (mySeq === loadRootSeq) loading.value = false;
     return;
   }
@@ -173,12 +173,11 @@ async function handleGitStatusChange() {
   }
 }
 
-// **watch 登録順依存**: `dir` watch を `revealVersion` watch より前に登録する必要がある。
-// Vue は watch を登録順に発火させるため、setOpen({ selection }) で dir 変化と
-// revealVersion ++ が同 tick で起きたとき、先に dir watch が `pendingRevealPath = undefined`
-// で旧パスをクリアし、その後 revealVersion watch が新パスを積み直す順序になる。
-// 入れ替えると revealVersion watch が先に走り、`pendingRevealPath` に積んだ直後の
-// dir watch がそれを消してしまう（reveal が空振り）。登場順を変更する際は注意。
+// dir watch は `flush: 'sync'` を指定して、setOpen({ selection }) で dir 変化と
+// revealVersion ++ が同 tick で起きたとき必ず先に発火させる。
+// （revealVersion watch はデフォルトの async flush なので、sync watch の後に走る）
+// これにより「dir watch が pendingRevealPath をクリア → revealVersion watch が積み直す」
+// 順序が watch の登録順ではなく flush タイミングで構造的に保証される。
 watch(
   dir,
   (newDir) => {
@@ -189,7 +188,7 @@ watch(
       void loadRoot();
     }
   },
-  { immediate: true },
+  { immediate: true, flush: "sync" },
 );
 
 // revealVersion の変化（selectPath 経由 / gozdOpen 経由など）で選択中パスを reveal する。
@@ -197,6 +196,8 @@ watch(
 // immediate: true で初回 mount 時に既存 selectedPath があれば pendingRevealPath に積み、
 // loadRoot 末尾で消化させる。これにより gozdOpen で渡された initial selection も
 // この 1 経路に集約できる（旧 consumeInitialSelection 経路は廃止）。
+// flush はデフォルト（pre）。上の dir watch が flush: 'sync' で先行発火するため、dir 変化を
+// 伴う setOpen でも `pendingRevealPath` クリア後に新パスを積み直す順序が保証される。
 // **invariant 依存**: revealVersion の bump は selection.value の更新と同期している
 // （useWorktreeStore の selectPath() でのみ実行される）。両者が同 tick で揃わない経路を
 // 増やすと古いパスで reveal が走る。

--- a/apps/renderer/src/features/filer/FilerPane.vue
+++ b/apps/renderer/src/features/filer/FilerPane.vue
@@ -4,15 +4,15 @@
 ## 動作
 
 - ワークスペースのディレクトリが設定されるとルートエントリを読み込み、FileTreeItem を再帰的にレンダリング
-- fsChange / gitStatusChange の RPC メッセージを購読し、変更があったディレクトリのみ差分更新
+- fsChange / gitStatusChange の RPC メッセージを購読し、ルート再構築 + filer event store 経由で子に通知
 - git 削除ファイルは仮想エントリとしてツリーに挿入
-- `reveal(targetPath)` で指定パスまでツリーを展開しスクロール
+- 各 FileTreeItem は filer event store + worktreeStore.revealVersion を自律的に watch する設計
 </doc>
 
 <script setup lang="ts">
 import { tryCatch } from "@gozd/shared";
 import { storeToRefs } from "pinia";
-import { nextTick, onUnmounted, ref, watch } from "vue";
+import { onUnmounted, ref, watch } from "vue";
 import { useNotificationStore } from "../../shared/notification";
 import { onMessage } from "../../shared/rpc";
 import { resolveGitChangeKind, useGitStatusStore, useWorktreeStore } from "../worktree";
@@ -22,23 +22,30 @@ import type { FileEntry } from "./filerUtils";
 import FileTreeItem from "./FileTreeItem.vue";
 import { rpcFsReadDir } from "./rpc";
 import type { FsChangePayload } from "./rpc";
+import { useFilerEventStore } from "./useFilerEventStore";
 
 const worktreeStore = useWorktreeStore();
 const { dir, selectedPath } = storeToRefs(worktreeStore);
 const gitStatusStore = useGitStatusStore();
 const { gitStatuses } = storeToRefs(gitStatusStore);
 const notify = useNotificationStore();
+const filerEventStore = useFilerEventStore();
 
 const rootEntries = ref<FileEntry[]>();
 const loading = ref(false);
-/** rootEntries 未読み込み時に保留する reveal 対象パス */
-let pendingRevealPath: string | undefined;
 /**
  * loadRoot の呼び出し世代カウンタ。await 境界で旧呼び出しが新呼び出しの結果を上書きしないよう、
  * 各呼び出しが自身の世代を保持して mismatch なら早期 return する。
  * dir 比較だけだと A → B → A のとき同じ dir 値で旧呼び出しと新呼び出しを区別できないため使う。
  */
 let loadRootSeq = 0;
+/**
+ * handleGitStatusChange 専用の世代カウンタ。同一 dir 内で gitStatusChange push が
+ * 連続発火した場合、`rpcFsReadDir` レスポンス順序が逆転して古い entries が新しい
+ * entries を踏み潰す race を防ぐ。`loadRootSeq` と独立に持つことで、loadRoot の
+ * 世代軸と互いに干渉しない SSOT として機能する。
+ */
+let gitStatusChangeSeq = 0;
 
 /** proto の FsReadDirEntry を FileEntry に変換する */
 function toFileEntries(entries: { name: string; type: string; isIgnored: boolean }[]): FileEntry[] {
@@ -89,12 +96,12 @@ async function loadRoot() {
     gitStatusStore.loadGitStatus(),
   ]);
   // await 中に loadRoot が再度呼ばれた場合、この呼び出しの結果は破棄する。
-  // 旧呼び出しが新 dir 用の rootEntries や pendingRevealPath を上書きするのを防ぐ。
+  // 旧呼び出しが新 dir 用の rootEntries を上書きするのを防ぐ。
   if (mySeq !== loadRootSeq) return;
   if (!readResult.ok) {
     notify.error("Failed to read root directory", readResult.error);
     rootEntries.value = [];
-    // 世代チェック (line 上の `if (mySeq !== loadRootSeq) return;`) を通過した時点で
+    // 世代チェック (上の `if (mySeq !== loadRootSeq) return;`) を通過した時点で
     // `mySeq === loadRootSeq` は確定だが、将来この早期 return の位置が変わった場合に
     // 備えて重複ガードを置く。N+1 の `loading = true` を誤って消さない防御。
     if (mySeq === loadRootSeq) loading.value = false;
@@ -102,123 +109,58 @@ async function loadRoot() {
   }
   rootEntries.value = mergeWithGitStatus(toFileEntries(readResult.value.entries), "");
   if (mySeq === loadRootSeq) loading.value = false;
-
-  // rootEntries 読み込み完了後に保留中の reveal を実行。
-  // v-for の FileTreeItem がマウントされるのを nextTick で待つ。
-  await nextTick();
-  if (mySeq !== loadRootSeq) return;
-  if (pendingRevealPath) {
-    const path = pendingRevealPath;
-    pendingRevealPath = undefined;
-    void reveal(path);
-  }
 }
 
 function onSelect(path: string) {
   worktreeStore.selectPath(path);
 }
 
-/**
- * 指定パスまでファイルツリーを展開し、対象ノードをスクロールインビューする。
- * ルートエントリの中から先頭セグメントに一致するアイテムを探して FileTreeItem.reveal に委譲する。
- */
-async function reveal(targetPath: string): Promise<void> {
-  if (!rootEntries.value) {
-    // ルート読み込み中なら完了後に再試行する
-    pendingRevealPath = targetPath;
-    return;
-  }
-
-  const firstSegment = targetPath.split("/")[0];
-  const index = rootEntries.value.findIndex((e) => e.name === firstSegment);
-  if (index < 0) return;
-
-  const item = treeItemRefs.value[index];
-  if (item) {
-    await item.reveal(targetPath);
-  }
-}
-
-/**
- * ファイル変更通知を受けてツリーを更新するコールバック。
- * FileTreeItem の reloadDir を呼ぶため、ref 経由で子コンポーネントにアクセスする。
- */
-const treeItemRefs = ref<InstanceType<typeof FileTreeItem>[]>([]);
-
 function handleFsChange(relDir: string) {
-  // ルートディレクトリの変更（"" or "."）
+  // ルートディレクトリの変更（"" or "."）は loadRoot で全件再構築
   if (relDir === "" || relDir === ".") {
     void loadRoot();
     return;
   }
-  // 子ディレクトリの変更 → 該当する FileTreeItem に通知
-  for (const item of treeItemRefs.value) {
-    item.notifyChange(relDir);
-  }
+  // 子ディレクトリの変更は filer event store 経由で各 FileTreeItem に通知
+  filerEventStore.emitFsChange(relDir);
 }
 
 async function handleGitStatusChange() {
-  // gitStatuses 自体は useGitStatusSync が repoStore に書き込み済み。
-  // ここではファイルツリーの再構築（新規 / 削除ファイル反映）だけを行う。
+  // 子 FileTreeItem は store を watch して自分の path 配下のキャッシュを破棄/再読み込みする
+  filerEventStore.emitGitStatusChange();
+  // ルート rootEntries の再構築は FilerPane の責務として残す（gitStatuses 反映 + 削除エントリ）
   const dirPath = dir.value;
   if (dirPath === undefined) return;
-  // await 中に dir 変更 / loadRoot 再起動が走るとこの呼び出しは stale 扱いにする。
-  // loadRootSeq を共有することで、loadRoot の世代チェックと整合する race ガードに揃える。
-  const mySeq = loadRootSeq;
+  // dir 切替 race と同一 dir 内連続発火 race の両方を世代でガード。
+  // 専用カウンタ gitStatusChangeSeq + loadRootSeq + dir.value の 3 軸チェックで
+  // 「自分が投げた呼び出しの後により新しいものが来ていない」ことを構造的に保証する。
+  const myGitStatusSeq = ++gitStatusChangeSeq;
+  const myLoadSeq = loadRootSeq;
   const result = await tryCatch(rpcFsReadDir({ dir: dirPath, path: "." }));
-  if (mySeq !== loadRootSeq || dir.value !== dirPath) {
-    // 旧 dir 用の結果で新 dir の rootEntries を踏み潰すのを防ぐ。
-    // 子側の notify は新 dir で再マウントされた FileTreeItem に対するものなので呼ぶ。
-    for (const item of treeItemRefs.value) {
-      item.notifyGitStatusChange();
-    }
+  if (myGitStatusSeq !== gitStatusChangeSeq || myLoadSeq !== loadRootSeq || dir.value !== dirPath) {
     return;
   }
   if (!result.ok) {
     notify.error("Failed to rebuild root entries", result.error);
-  } else {
-    rootEntries.value = mergeWithGitStatus(toFileEntries(result.value.entries), "");
+    return;
   }
-  for (const item of treeItemRefs.value) {
-    item.notifyGitStatusChange();
-  }
+  rootEntries.value = mergeWithGitStatus(toFileEntries(result.value.entries), "");
 }
 
 // dir watch は `flush: 'sync'` を指定して、setOpen({ selection }) で dir 変化と
 // revealVersion ++ が同 tick で起きたとき必ず先に発火させる。
-// （revealVersion watch はデフォルトの async flush なので、sync watch の後に走る）
-// これにより「dir watch が pendingRevealPath をクリア → revealVersion watch が積み直す」
-// 順序が watch の登録順ではなく flush タイミングで構造的に保証される。
+// （各 FileTreeItem の revealVersion watch はデフォルトの async flush なので、sync watch の後に走る）
+// これにより「dir watch が rootEntries を初期化して loadRoot を起動 → 子マウント後の
+// revealVersion watch (immediate) が target を処理」の順序が flush ステージで構造的に保証される。
 watch(
   dir,
   (newDir) => {
     if (newDir) {
       rootEntries.value = undefined;
-      // 旧 dir 向けの保留 reveal が次の loadRoot 末尾で誤適用されないようクリアする
-      pendingRevealPath = undefined;
       void loadRoot();
     }
   },
   { immediate: true, flush: "sync" },
-);
-
-// revealVersion の変化（selectPath 経由 / gozdOpen 経由など）で選択中パスを reveal する。
-// 親から ref を expose せず worktreeStore 直接購読にすることで defineExpose を不要にする。
-// immediate: true で初回 mount 時に既存 selectedPath があれば pendingRevealPath に積み、
-// loadRoot 末尾で消化させる。これにより gozdOpen で渡された initial selection も
-// この 1 経路に集約できる（旧 consumeInitialSelection 経路は廃止）。
-// flush はデフォルト（pre）。上の dir watch が flush: 'sync' で先行発火するため、dir 変化を
-// 伴う setOpen でも `pendingRevealPath` クリア後に新パスを積み直す順序が保証される。
-// **invariant 依存**: revealVersion の bump は selection.value の更新と同期している
-// （useWorktreeStore の selectPath() でのみ実行される）。両者が同 tick で揃わない経路を
-// 増やすと古いパスで reveal が走る。
-watch(
-  () => worktreeStore.revealVersion,
-  () => {
-    const path = worktreeStore.selectedPath;
-    if (path) void reveal(path);
-  },
-  { immediate: true },
 );
 
 const unsubscribeFsChange = onMessage<FsChangePayload>("fsChange", ({ relDir }) =>
@@ -246,7 +188,6 @@ onUnmounted(() => {
       <template v-else>
         <FileTreeItem
           v-for="entry in rootEntries"
-          ref="treeItemRefs"
           :key="`${entry.name}-${entry.isDirectory}`"
           :name="entry.name"
           :path="entry.name"

--- a/apps/renderer/src/features/filer/useFilerEventStore.ts
+++ b/apps/renderer/src/features/filer/useFilerEventStore.ts
@@ -1,0 +1,40 @@
+import { acceptHMRUpdate, defineStore } from "pinia";
+import { ref } from "vue";
+
+/**
+ * filer 内部のイベント配信 store。
+ *
+ * 親 (FilerPane) → 子 (FileTreeItem) の命令的呼び出し（defineExpose / ref 経由）を避け、
+ * 各 FileTreeItem が自律的にイベントを watch する設計に揃えるための bus。
+ * - `fsChange` / `gitStatusChange` の push を受けた FilerPane が emit する
+ * - 各 FileTreeItem が watch して自分の path に該当するか判定し、必要なら再読み込み
+ *
+ * `version` カウンタを併設しているのは、同一 `relDir` が連続発火しても watch を必ず
+ * 発火させるため（オブジェクト reference の同一性で watch がスキップされるのを防ぐ）。
+ */
+export const useFilerEventStore = defineStore("filer-event", () => {
+  /** 最後の fsChange イベント。relDir は worktree 相対パス（"" / "." はルート扱い） */
+  const fsChangeEvent = ref<{ version: number; relDir: string }>();
+  let fsChangeVersion = 0;
+  function emitFsChange(relDir: string) {
+    fsChangeVersion++;
+    fsChangeEvent.value = { version: fsChangeVersion, relDir };
+  }
+
+  /** gitStatusChange の発火カウンタ。実データ（gitStatuses）は useGitStatusStore にある */
+  const gitStatusChangeVersion = ref(0);
+  function emitGitStatusChange() {
+    gitStatusChangeVersion.value++;
+  }
+
+  return {
+    fsChangeEvent,
+    gitStatusChangeVersion,
+    emitFsChange,
+    emitGitStatusChange,
+  };
+});
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useFilerEventStore, import.meta.hot));
+}

--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -254,10 +254,7 @@ watchEffect(() => {
       </button>
 
       <div class="shrink-0 overflow-hidden" :style="{ width: `${navigatorWidth}px` }">
-        <NavigatorPane
-          :reveal-path="worktreeStore.selectedPath"
-          :reveal-version="worktreeStore.revealVersion"
-        />
+        <NavigatorPane />
       </div>
     </div>
 

--- a/apps/renderer/src/features/navigator/NavigatorPane.vue
+++ b/apps/renderer/src/features/navigator/NavigatorPane.vue
@@ -6,25 +6,18 @@ Filer（上）と Changes（下）を垂直分割で表示するコンテナ。
 - Filer が flex-1 で残りスペースを取り、Changes が固定高さ
 - ResizeHandle で上下の比率をリサイズ可能
 - git リポジトリでない場合は Filer のみ表示
-- `revealPath` / `revealVersion` props の変化で FilerPane のツリーを自動展開
+- FilerPane の reveal は worktreeStore.revealVersion を内部で購読しているため props 経由不要
 - ChangesPane の `select` emit を `worktreeStore.selectPath()` に接続
 </doc>
 
 <script setup lang="ts">
 import { useElementSize } from "@vueuse/core";
-import { nextTick, ref, useTemplateRef, watch, watchEffect } from "vue";
+import { ref, useTemplateRef, watchEffect } from "vue";
 import { useRepoStore } from "../../shared/repo";
 import { ChangesPane } from "../changes";
 import { FilerPane } from "../filer";
 import { ResizeHandle } from "../layout";
 import { useWorktreeStore } from "../worktree";
-
-interface Props {
-  revealPath?: string;
-  revealVersion?: number;
-}
-
-const props = defineProps<Props>();
 
 const HANDLE_HEIGHT = 8;
 const FILER_MIN_HEIGHT = 100;
@@ -32,7 +25,6 @@ const CHANGES_MIN_HEIGHT = 60;
 
 const repoStore = useRepoStore();
 const worktreeStore = useWorktreeStore();
-const filerPaneRef = useTemplateRef<InstanceType<typeof FilerPane>>("filerPane");
 const filerWrapperRef = useTemplateRef<HTMLElement>("filerWrapper");
 const containerRef = useTemplateRef<HTMLElement>("container");
 const { height: containerHeight } = useElementSize(containerRef);
@@ -57,13 +49,6 @@ function getFilerHeight(): number {
 function onChangesSelect(relPath: string) {
   worktreeStore.selectPath(relPath);
 }
-
-// revealPath / revealVersion の変化で FilerPane のツリーを展開する
-watch([() => props.revealPath, () => props.revealVersion], async ([path]) => {
-  if (!path) return;
-  await nextTick();
-  await filerPaneRef.value?.reveal(path);
-});
 </script>
 
 <template>
@@ -80,7 +65,7 @@ watch([() => props.revealPath, () => props.revealVersion], async ([path]) => {
         </span>
       </div>
       <div class="min-h-0 flex-1 overflow-hidden">
-        <FilerPane ref="filerPane" />
+        <FilerPane />
       </div>
     </div>
 

--- a/apps/renderer/src/features/sidebar/useSidebarData.ts
+++ b/apps/renderer/src/features/sidebar/useSidebarData.ts
@@ -204,7 +204,9 @@ export function useSidebarData() {
     // ここから DI する。これで外部 git worktree remove で active dir が rootDir に
     // 切り替わったケースがトーストで観察可能になる。subscription より前に置くことで、
     // 初期 fetchRepo（hydrate 経由）が万一 fallback を発火しても取りこぼさない。
+    // onUnmounted で undefined に戻して旧参照を残さない（HMR / テストでの leak 防止）。
     repoStore.setAutoFallbackNotifier((message) => notify.info(message));
+    cleanups.push(() => repoStore.setAutoFallbackNotifier(undefined));
 
     // branchChange / worktreeChange は worktree 構成自体が変わるので worktree list の
     // 全件再取得が必要。gitStatusChange は payload に dir + statuses を持ち、

--- a/apps/renderer/src/features/sidebar/useSidebarData.ts
+++ b/apps/renderer/src/features/sidebar/useSidebarData.ts
@@ -200,16 +200,18 @@ export function useSidebarData() {
 
   const cleanups: Array<() => void> = [];
   onMounted(() => {
+    // shared/repo は notification を直接呼べないため、auto-fallback 発火時の通知経路を
+    // ここから DI する。これで外部 git worktree remove で active dir が rootDir に
+    // 切り替わったケースがトーストで観察可能になる。subscription より前に置くことで、
+    // 初期 fetchRepo（hydrate 経由）が万一 fallback を発火しても取りこぼさない。
+    repoStore.setAutoFallbackNotifier((message) => notify.info(message));
+
     // branchChange / worktreeChange は worktree 構成自体が変わるので worktree list の
     // 全件再取得が必要。gitStatusChange は payload に dir + statuses を持ち、
     // useGitStatusSync が repoStore.setWorktreeGitStatuses で該当 wt のみ更新するため
     // ここで全件 refetch を走らせない（N 倍の git status 実行を避ける）。
     cleanups.push(onMessage<BranchChangePayload>("branchChange", () => fetchOwnerOfActive()));
     cleanups.push(onMessage<WorktreeChangePayload>("worktreeChange", () => fetchOwnerOfActive()));
-    // shared/repo は notification を直接呼べないため、auto-fallback 発火時の通知経路を
-    // ここから DI する。これで外部 git worktree remove で active dir が rootDir に
-    // 切り替わったケースがトーストで観察可能になる。
-    repoStore.setAutoFallbackNotifier((message) => notify.info(message));
     void hydrateAppState();
   });
   onUnmounted(() => {

--- a/apps/renderer/src/features/sidebar/useSidebarData.ts
+++ b/apps/renderer/src/features/sidebar/useSidebarData.ts
@@ -206,6 +206,10 @@ export function useSidebarData() {
     // ここで全件 refetch を走らせない（N 倍の git status 実行を避ける）。
     cleanups.push(onMessage<BranchChangePayload>("branchChange", () => fetchOwnerOfActive()));
     cleanups.push(onMessage<WorktreeChangePayload>("worktreeChange", () => fetchOwnerOfActive()));
+    // shared/repo は notification を直接呼べないため、auto-fallback 発火時の通知経路を
+    // ここから DI する。これで外部 git worktree remove で active dir が rootDir に
+    // 切り替わったケースがトーストで観察可能になる。
+    repoStore.setAutoFallbackNotifier((message) => notify.info(message));
     void hydrateAppState();
   });
   onUnmounted(() => {

--- a/apps/renderer/src/features/worktree/useWorktreeStore.ts
+++ b/apps/renderer/src/features/worktree/useWorktreeStore.ts
@@ -18,9 +18,6 @@ export const useWorktreeStore = defineStore("worktree", () => {
   /** プレビュー対象の選択状態。worktree 横断で 1 つだけ保持し、dir が変わるたびにクリアする */
   const selection = ref<Selection>();
 
-  /** ツリー初期化後に適用する選択対象（setOpen で保持、consumeInitialSelection で消費） */
-  const initialSelection = ref<OpenTargetSelection>();
-
   /** 同一パスでも reveal を発火させるためのバージョンカウンタ */
   const revealVersion = ref(0);
 
@@ -44,15 +41,14 @@ export const useWorktreeStore = defineStore("worktree", () => {
     return resolveFileGitChange(selectedPath.value, gitStatusStore.gitStatuses);
   });
 
-  // dir が変わるたびに selection / initialSelection を即座に落とす。setOpen を経由しない
-  // 経路（repoStore.removeRepo 内の selectedDir 直書きなど）でも一貫してクリアされる。
-  // flush: 'sync' により、setOpen が同期で続けて selectPath / initialSelection を書き込む際に
+  // dir が変わるたびに selection を即座に落とす。setOpen を経由しない経路
+  // （repoStore.removeRepo 内の selectedDir 直書きなど）でも一貫してクリアされる。
+  // flush: 'sync' により、setOpen が同期で続けて selectPath を書き込む際に
   // 「クリア → 新値書き込み」の順序が崩れない。
   watch(
     dir,
     () => {
       selection.value = undefined;
-      initialSelection.value = undefined;
     },
     { flush: "sync" },
   );
@@ -65,6 +61,10 @@ export const useWorktreeStore = defineStore("worktree", () => {
   /**
    * worktree 切替（同 repo 内）専用。新 dir は既に repoStore に登録済みであることが前提。
    * 新規 repo の追加は App.vue の gozdOpen ハンドラが行う。
+   *
+   * `options.selection` 経由の reveal は、`selectPath` で `revealVersion` を進めることで
+   * FilerPane 側の `revealVersion` watch から発火させる（reveal 経路の SSOT）。
+   * ツリー未ロード時の保留は FilerPane 内の `pendingRevealPath` でカバーされる。
    */
   function setOpen(newDir: string, options: SetOpenOptions = {}) {
     repoStore.selectDir(newDir);
@@ -72,26 +72,11 @@ export const useWorktreeStore = defineStore("worktree", () => {
     if (options.fileServerBaseUrl) {
       fileServerBaseUrl.value = options.fileServerBaseUrl;
     }
-    // initialSelection は setOpen のたびに最新の options.selection で置き換える。
-    // 同一 dir で setOpen が連続した場合に、前回呼び出し時の保留分が
-    // consumeInitialSelection に取り残されて誤適用されるのを防ぐ。
-    initialSelection.value = options.selection;
     if (options.selection) {
       // ツリーロード前でもヘッダー等が即時反映されるよう selection も同期で書き込む。
+      // revealVersion ++ により FilerPane の watch が reveal を実行する。
       selectPath(options.selection.relPath);
     }
-  }
-
-  /** ファイラーのツリー初期化後に呼ぶ。initialSelection があれば消費して返す */
-  function consumeInitialSelection(): OpenTargetSelection | undefined {
-    const sel = initialSelection.value;
-    if (sel) {
-      initialSelection.value = undefined;
-      if (sel.kind === "file") {
-        selectPath(sel.relPath);
-      }
-    }
-    return sel;
   }
 
   function selectPath(path: string, lineNumber?: number) {
@@ -118,7 +103,6 @@ export const useWorktreeStore = defineStore("worktree", () => {
     setOpen,
     selectPath,
     clearSelectedPath,
-    consumeInitialSelection,
   };
 });
 

--- a/apps/renderer/src/features/worktree/useWorktreeStore.ts
+++ b/apps/renderer/src/features/worktree/useWorktreeStore.ts
@@ -18,7 +18,13 @@ export const useWorktreeStore = defineStore("worktree", () => {
   /** プレビュー対象の選択状態。worktree 横断で 1 つだけ保持し、dir が変わるたびにクリアする */
   const selection = ref<Selection>();
 
-  /** 同一パスでも reveal を発火させるためのバージョンカウンタ */
+  /**
+   * 同一パスでも reveal を発火させるためのバージョンカウンタ。
+   * **invariant**: `revealVersion` の bump は必ず `selection.value` の同期更新と
+   * セットで行う（= 必ず `selectPath()` 経由で更新する）。
+   * 購読側（FilerPane の watch）は `revealVersion` を trigger にして `selectedPath`
+   * を直接読むため、両者が同 tick で一致していないと古いパスで reveal が走る。
+   */
   const revealVersion = ref(0);
 
   /** setOpen 呼び出しごとにインクリメント。観測側（terminal 等）が「wt 選択イベント」として購読する */

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -21,6 +21,14 @@ interface RepoState {
 export const useRepoStore = defineStore("repo", () => {
   const repos = ref<Record<string, RepoState>>({});
   const dirOrder = ref<string[]>([]);
+  /**
+   * shared 層内で `selectedDir.value =` を直書きする正当な経路は以下に限定する。
+   * 新たな書き換え経路を増やす前に、`worktreeStore.setOpen` の副作用
+   * （selectionVersion bump / initialSelection クリア）と整合するか確認すること。
+   * - `selectDir()`: 通常の選択（feature 層の setOpen 経由含む）
+   * - `removeRepo()`: repo まるごと削除時の fallback
+   * - `updateRepoData()`: 配下 wt 削除時の rootDir fallback
+   */
   const selectedDir = ref<string>();
   /** 折りたたまれている repo の rootDir 集合 */
   const collapsedRoots = ref<Set<string>>(new Set());
@@ -112,17 +120,24 @@ export const useRepoStore = defineStore("repo", () => {
         gitStatusGenByDir.set(wt.path, (gitStatusGenByDir.get(wt.path) ?? 0) + 1);
       }
     }
-    // selectedDir がこの repo の worktree を指していて、かつ更新後の worktrees から
-    // 消えている場合は同 repo の rootDir に倒す。これがないと FilerPane /
-    // useFsWatchSync / useGitStatusSync が削除済みパスに対して fs/readDir, fs/watch,
-    // git/status を投げ続けて outsideDir / launchFailed エラーが出る。
-    // mutation 前に判定するのは「最初から別 repo の dir だった」case を除外するため。
+    // selectedDir がこの repo に属していた（current.worktrees に含まれていた）かつ
+    // 更新後の worktrees から消えている場合のみ、同 repo の rootDir に倒す。これがないと
+    // FilerPane / useFsWatchSync / useGitStatusSync が削除済みパスに対して
+    // fs/readDir, fs/watch, git/status を投げ続け outsideDir / launchFailed エラーが出る。
+    // `current.worktrees` には rpcGitWorktreeList の仕様により main rootDir 自身も含まれる
+    // ため、selectedDir === rootDir のケースも自然に「属していた」と扱われる（rootDir が
+    // worktree list に残り続ける限り fallback は no-op）。
+    // 別 repo に属する dir が active な場合は `some` が false になるため巻き込まれない。
     const orphanedActiveDir =
       selectedDir.value !== undefined &&
       current.worktrees.some((w) => w.path === selectedDir.value) &&
       !merged.some((w) => w.path === selectedDir.value);
     repos.value[rootDir] = { ...current, worktrees: merged };
     if (orphanedActiveDir) {
+      // 外部 git worktree remove 経由だとユーザー操作なしに active dir が切り替わる。
+      // shared 層から useNotificationStore は呼べないため、最低限の観察可能性として
+      // console.info を残す（後追い調査・サポート時の手掛かり）。
+      console.info(`[repo] active worktree removed; switched selectedDir to repo root: ${rootDir}`);
       selectedDir.value = rootDir;
     }
   }

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -149,10 +149,13 @@ export const useRepoStore = defineStore("repo", () => {
     // 別 repo に属する dir が active な場合は `some` が false になるため巻き込まれない。
     //
     // path 比較は文字列完全一致で正しい。invariant: `wt.path` も `selectedDir` も
-    // どちらも native 側で `git worktree list --porcelain` の正規化された絶対パス
-    // （symlink 解決済み、trailing slash なし）由来。`gozdOpen` push の dir も
-    // 同じ git 出力経由なので形式は揃う。新しい dir 取得経路を追加する際は
-    // 必ず同じ正規化を経由させること。
+    // どちらも `git worktree list --porcelain` および `git rev-parse --show-toplevel`
+    // の出力をそのまま使う。git は記録された原文の絶対パスを返すだけで symlink 解決は
+    // しないが、両者とも同じ git 出力経路を踏むため文字列フォーマットは揃う（trailing
+    // slash なし、git が記録した形式そのまま）。ユーザーが symlink パスで起動した場合
+    // も両者が symlink を含む同一形式で一致する。
+    // 新しい dir 取得経路を追加する際は必ず同じ git 出力経路を踏ませること。
+    // 別形式（realpath 解決後など）を混ぜると比較が空振りして fallback が発火しなくなる。
     const orphanedActiveDir =
       selectedDir.value !== undefined &&
       current.worktrees.some((w) => w.path === selectedDir.value) &&

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -34,6 +34,24 @@ export const useRepoStore = defineStore("repo", () => {
   const collapsedRoots = ref<Set<string>>(new Set());
 
   /**
+   * auto-fallback 発火時の通知ハンドラ。feature 層から `setAutoFallbackNotifier()` で注入する。
+   * shared 間の依存禁止 + shared → feature 依存禁止のため、`useNotificationStore` を
+   * 直接呼べない。`useCommandRegistry` の `setErrorHandler` と同じ DI 流儀。
+   * 未設定時は console.info にフォールバックして観察可能性を最低限担保する。
+   */
+  let autoFallbackNotifier: ((message: string) => void) | undefined;
+  function setAutoFallbackNotifier(notifier: (message: string) => void): void {
+    autoFallbackNotifier = notifier;
+  }
+  function notifyAutoFallback(message: string): void {
+    if (autoFallbackNotifier !== undefined) {
+      autoFallbackNotifier(message);
+      return;
+    }
+    console.info(message);
+  }
+
+  /**
    * worktree.gitStatuses の per-dir 書き込み世代。
    * `setWorktreeGitStatuses` のたびに該当 dir のカウンタを進めるため、
    * 並行する loadGitStatus / fetchRepo の RPC レスポンスは開始時の世代を覚えておき、
@@ -135,9 +153,8 @@ export const useRepoStore = defineStore("repo", () => {
     repos.value[rootDir] = { ...current, worktrees: merged };
     if (orphanedActiveDir) {
       // 外部 git worktree remove 経由だとユーザー操作なしに active dir が切り替わる。
-      // shared 層から useNotificationStore は呼べないため、最低限の観察可能性として
-      // console.info を残す（後追い調査・サポート時の手掛かり）。
-      console.info(`[repo] active worktree removed; switched selectedDir to repo root: ${rootDir}`);
+      // feature 層が DI した notifier 経由でユーザーに通知する。未注入なら console.info。
+      notifyAutoFallback(`Active worktree was removed; switched to repo root.`);
       selectedDir.value = rootDir;
     }
   }
@@ -292,6 +309,7 @@ export const useRepoStore = defineStore("repo", () => {
     toggleCollapsed,
     buildAppStateSnapshot,
     hydrateFromAppState,
+    setAutoFallbackNotifier,
   };
 });
 

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -38,9 +38,10 @@ export const useRepoStore = defineStore("repo", () => {
    * shared 間の依存禁止 + shared → feature 依存禁止のため、`useNotificationStore` を
    * 直接呼べない。`useCommandRegistry` の `setErrorHandler` と同じ DI 流儀。
    * 未設定時は console.info にフォールバックして観察可能性を最低限担保する。
+   * `undefined` を渡せばリセット（HMR / unmount で旧参照を残さないため）。
    */
   let autoFallbackNotifier: ((message: string) => void) | undefined;
-  function setAutoFallbackNotifier(notifier: (message: string) => void): void {
+  function setAutoFallbackNotifier(notifier: ((message: string) => void) | undefined): void {
     autoFallbackNotifier = notifier;
   }
   function notifyAutoFallback(message: string): void {
@@ -146,6 +147,12 @@ export const useRepoStore = defineStore("repo", () => {
     // ため、selectedDir === rootDir のケースも自然に「属していた」と扱われる（rootDir が
     // worktree list に残り続ける限り fallback は no-op）。
     // 別 repo に属する dir が active な場合は `some` が false になるため巻き込まれない。
+    //
+    // path 比較は文字列完全一致で正しい。invariant: `wt.path` も `selectedDir` も
+    // どちらも native 側で `git worktree list --porcelain` の正規化された絶対パス
+    // （symlink 解決済み、trailing slash なし）由来。`gozdOpen` push の dir も
+    // 同じ git 出力経由なので形式は揃う。新しい dir 取得経路を追加する際は
+    // 必ず同じ正規化を経由させること。
     const orphanedActiveDir =
       selectedDir.value !== undefined &&
       current.worktrees.some((w) => w.path === selectedDir.value) &&
@@ -155,7 +162,10 @@ export const useRepoStore = defineStore("repo", () => {
       // 外部 git worktree remove 経由だとユーザー操作なしに active dir が切り替わる。
       // feature 層が DI した notifier 経由でユーザーに通知する。未注入なら console.info。
       // 複数 repo 同時開き時にどの repo の root に切り替わったか分かるよう repoName を含める。
-      notifyAutoFallback(`Active worktree was removed; switched to "${current.repoName}" root.`);
+      // クォートを使うと repoName 内のクォート文字でメッセージが崩れるため使わない。
+      // 空文字列は hydrate 経路で混入し得るので汎用ラベルにフォールバックする。
+      const repoLabel = current.repoName !== "" ? current.repoName : "the repo";
+      notifyAutoFallback(`Active worktree was removed; switched to ${repoLabel} root.`);
       selectedDir.value = rootDir;
     }
   }

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -23,8 +23,9 @@ export const useRepoStore = defineStore("repo", () => {
   const dirOrder = ref<string[]>([]);
   /**
    * shared 層内で `selectedDir.value =` を直書きする正当な経路は以下に限定する。
-   * 新たな書き換え経路を増やす前に、`worktreeStore.setOpen` の副作用
-   * （selectionVersion bump / initialSelection クリア）と整合するか確認すること。
+   * 新たな書き換え経路を増やす前に、`worktreeStore.setOpen` 側の副作用一覧
+   * （selectionVersion bump / 必要なら selection / revealVersion の同期更新）と整合
+   * するか確認すること（feature 層側の責務に踏み込む変更が必要な可能性）。
    * - `selectDir()`: 通常の選択（feature 層の setOpen 経由含む）
    * - `removeRepo()`: repo まるごと削除時の fallback
    * - `updateRepoData()`: 配下 wt 削除時の rootDir fallback

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -112,7 +112,19 @@ export const useRepoStore = defineStore("repo", () => {
         gitStatusGenByDir.set(wt.path, (gitStatusGenByDir.get(wt.path) ?? 0) + 1);
       }
     }
+    // selectedDir がこの repo の worktree を指していて、かつ更新後の worktrees から
+    // 消えている場合は同 repo の rootDir に倒す。これがないと FilerPane /
+    // useFsWatchSync / useGitStatusSync が削除済みパスに対して fs/readDir, fs/watch,
+    // git/status を投げ続けて outsideDir / launchFailed エラーが出る。
+    // mutation 前に判定するのは「最初から別 repo の dir だった」case を除外するため。
+    const orphanedActiveDir =
+      selectedDir.value !== undefined &&
+      current.worktrees.some((w) => w.path === selectedDir.value) &&
+      !merged.some((w) => w.path === selectedDir.value);
     repos.value[rootDir] = { ...current, worktrees: merged };
+    if (orphanedActiveDir) {
+      selectedDir.value = rootDir;
+    }
   }
 
   /**

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -154,7 +154,8 @@ export const useRepoStore = defineStore("repo", () => {
     if (orphanedActiveDir) {
       // 外部 git worktree remove 経由だとユーザー操作なしに active dir が切り替わる。
       // feature 層が DI した notifier 経由でユーザーに通知する。未注入なら console.info。
-      notifyAutoFallback(`Active worktree was removed; switched to repo root.`);
+      // 複数 repo 同時開き時にどの repo の root に切り替わったか分かるよう repoName を含める。
+      notifyAutoFallback(`Active worktree was removed; switched to "${current.repoName}" root.`);
       selectedDir.value = rootDir;
     }
   }


### PR DESCRIPTION
## 概要

git worktree 削除（in-app・外部の git 操作いずれも）後に、削除済み worktree パスへ `fs/readDir` / `fs/watch` / `git/status` RPC が投げ続けられ `outsideDir` / `launchFailed` エラーが連発する問題を修正する。`useRepoStore.updateRepoData` で「アクティブな worktree が消えた場合は同 repo の `rootDir` にフォールバックする」invariant を維持するようにした。

## 背景

ユーザーから次のエラーが連発する報告:

- `Failed to read root directory: outsideDir(requestedPath: ".")`
- `Failed to get git status: launchFailed("The file "<deleted-leaf>" doesn't exist.")`
- `Failed to start FS watch: launchFailed("The file "<deleted-leaf>" doesn't exist.")`

原因は `repoStore.selectedDir` が削除済み worktree のパスを指したままになること:

- in-app の `handleWorktreeRemove` → `detachWorktree` → `updateRepoData` で worktrees 一覧は更新されるが `selectedDir` は変えない
- 外部 git 操作の場合は FSEvents → `worktreeChange` push → `fetchOwnerOfActive` → `fetchRepo` → `updateRepoData` 経路で同じ問題

`selectedDir` が孤立したパスを指したままだと `useFsWatchSync` / `useGitStatusSync` / `FilerPane` の watcher が dir 変化を検知できず、push event やステータス再取得のタイミングで削除済みパスに対する RPC が発火する。`removeRepo` には類似の救済ロジックがすでに存在するが、worktree 単位の削除には未適用だった。

## 変更内容

### apps/renderer/src/shared/repo/useRepoStore.ts

- `updateRepoData` 内で「mutation 前に `selectedDir` がこの repo の worktree を指していた、かつ mutation 後の worktrees に含まれない」場合に `selectedDir` を `rootDir` に倒すロジックを追加
- mutation 前に判定することで、最初から別 repo に属する dir まで誤って巻き込むのを防ぐ
- `worktreeStore.setOpen` は shared → feature 依存禁止により呼べないため `selectedDir` 直書き。`selectionVersion` の bump は user-explicit-select 用途であり、auto-fallback には不要

## 確認事項

- [ ] in-app で active な worktree を削除 → エラーが出ず `rootDir` に切り替わる
- [ ] ターミナルから `git worktree remove` 実行 → エラーが出ず `rootDir` に切り替わる
- [ ] active 以外の worktree を削除した場合は `selectedDir` が変わらない
- [ ] 別 repo の worktree が削除されたとき、自分の active dir は誤って switch されない
