### PR TITLE
fix(fs-watch): propagate branch.head and add SSOT push observability to fix rename UI stale

### DIFF
--- a/apps/native/Sources/Gozd/GozdApp.swift
+++ b/apps/native/Sources/Gozd/GozdApp.swift
@@ -180,7 +180,8 @@ final class AppRuntime {
       claudeSettingsWriteError = nil
     } catch {
       claudeSettingsWriteError = error
-      print("[ClaudeHooks] settings write failed: \(error)")
+      FileHandle.standardError.write(
+        Data("[ClaudeHooks] settings write failed: \(error)\n".utf8))
     }
 
     // dev / build 共通の env overlay。dev では GOZD_DEV_PROJECT_ROOT 配下のソースを参照する。
@@ -583,7 +584,8 @@ final class WebPageHolder {
 @MainActor
 func pushToRenderer(page: WebPage?, type: String, payload: [String: Any]) async {
   guard let page else {
-    print("[GozdApp] push dropped (page not ready): type=\(type)")
+    FileHandle.standardError.write(
+      Data("[GozdApp] push dropped (page not ready): type=\(type)\n".utf8))
     return
   }
   do {
@@ -592,7 +594,8 @@ func pushToRenderer(page: WebPage?, type: String, payload: [String: Any]) async 
       arguments: ["type": type, "payload": payload]
     )
   } catch {
-    print("[GozdApp] push failed: type=\(type) error=\(error)")
+    FileHandle.standardError.write(
+      Data("[GozdApp] push failed: type=\(type) error=\(error)\n".utf8))
   }
 }
 

--- a/apps/native/Sources/Gozd/GozdApp.swift
+++ b/apps/native/Sources/Gozd/GozdApp.swift
@@ -158,10 +158,7 @@ final class AppRuntime {
     Task { @MainActor in
       let payload = await AppRuntime.buildGozdOpenPayload(
         targetPath: targetPath, channel: channel)
-      _ = try? await page.callJavaScript(
-        "window.__gozdReceive(type, payload)",
-        arguments: ["type": "gozdOpen", "payload": payload]
-      )
+      await pushToRenderer(page: page, type: "gozdOpen", payload: payload)
     }
   }
 
@@ -193,24 +190,20 @@ final class AppRuntime {
     // WebPage push 用 callback。background queue から呼ばれるため Task @MainActor で hop。
     let onPtyText: @Sendable (UInt32, String) -> Void = { id, text in
       Task { @MainActor in
-        _ = try? await holder.page?.callJavaScript(
-          "window.__gozdReceive(type, payload)",
-          arguments: [
-            "type": "ptyText",
-            "payload": ["id": Int(id), "text": text],
-          ]
+        await pushToRenderer(
+          page: holder.page,
+          type: "ptyText",
+          payload: ["id": Int(id), "text": text]
         )
       }
     }
     let onPtyExit: @Sendable (UInt32, PTYExitReason) -> Void = { id, reason in
       let reasonPayload = encodeExitReason(reason)
       Task { @MainActor in
-        _ = try? await holder.page?.callJavaScript(
-          "window.__gozdReceive(type, payload)",
-          arguments: [
-            "type": "ptyExit",
-            "payload": ["id": Int(id), "reason": reasonPayload],
-          ]
+        await pushToRenderer(
+          page: holder.page,
+          type: "ptyExit",
+          payload: ["id": Int(id), "reason": reasonPayload]
         )
       }
     }
@@ -224,31 +217,23 @@ final class AppRuntime {
         "isInterrupt": hook.isInterrupt,
       ]
       Task { @MainActor in
-        _ = try? await holder.page?.callJavaScript(
-          "window.__gozdReceive(type, payload)",
-          arguments: ["type": "hook", "payload": payload]
-        )
+        await pushToRenderer(page: holder.page, type: "hook", payload: payload)
       }
     }
     let onOpen: @Sendable (String) -> Void = { targetPath in
       Task { @MainActor in
         let payload = await AppRuntime.buildGozdOpenPayload(
           targetPath: targetPath, channel: channel)
-        _ = try? await holder.page?.callJavaScript(
-          "window.__gozdReceive(type, payload)",
-          arguments: ["type": "gozdOpen", "payload": payload]
-        )
+        await pushToRenderer(page: holder.page, type: "gozdOpen", payload: payload)
       }
     }
 
     let onFsChange: FSWatchRegistry.FsChangeHandler = { dir, relDir in
       Task { @MainActor in
-        _ = try? await holder.page?.callJavaScript(
-          "window.__gozdReceive(type, payload)",
-          arguments: [
-            "type": "fsChange",
-            "payload": ["dir": dir, "relDir": relDir],
-          ]
+        await pushToRenderer(
+          page: holder.page,
+          type: "fsChange",
+          payload: ["dir": dir, "relDir": relDir]
         )
       }
     }
@@ -257,30 +242,31 @@ final class AppRuntime {
         "dir": dir,
         "statuses": status.statuses,
         "head": status.head,
+        "branchHead": status.branchHead,
         "hasUpstream": status.hasUpstream,
         "ahead": Int(status.ahead),
         "behind": Int(status.behind),
       ]
       Task { @MainActor in
-        _ = try? await holder.page?.callJavaScript(
-          "window.__gozdReceive(type, payload)",
-          arguments: ["type": "gitStatusChange", "payload": payload]
-        )
+        await pushToRenderer(
+          page: holder.page, type: "gitStatusChange", payload: payload)
       }
     }
-    let onBranchChange: FSWatchRegistry.BranchChangeHandler = { dir in
+    let onBranchChange: FSWatchRegistry.BranchChangeHandler = { dir, changedRefs in
       Task { @MainActor in
-        _ = try? await holder.page?.callJavaScript(
-          "window.__gozdReceive(type, payload)",
-          arguments: ["type": "branchChange", "payload": ["dir": dir]]
+        await pushToRenderer(
+          page: holder.page,
+          type: "branchChange",
+          payload: ["dir": dir, "changedRefs": changedRefs]
         )
       }
     }
     let onWorktreeChange: FSWatchRegistry.WorktreeChangeHandler = { dir in
       Task { @MainActor in
-        _ = try? await holder.page?.callJavaScript(
-          "window.__gozdReceive(type, payload)",
-          arguments: ["type": "worktreeChange", "payload": ["dir": dir]]
+        await pushToRenderer(
+          page: holder.page,
+          type: "worktreeChange",
+          payload: ["dir": dir]
         )
       }
     }
@@ -291,13 +277,11 @@ final class AppRuntime {
     let sendNotify:
       @Sendable (String, String, String, String) -> Void = { type, source, message, detail in
         Task { @MainActor in
-          _ = try? await holder.page?.callJavaScript(
-            "window.__gozdReceive(type, payload)",
-            arguments: [
-              "type": "notify",
-              "payload": [
-                "type": type, "source": source, "message": message, "detail": detail,
-              ],
+          await pushToRenderer(
+            page: holder.page,
+            type: "notify",
+            payload: [
+              "type": type, "source": source, "message": message, "detail": detail,
             ]
           )
         }
@@ -590,6 +574,26 @@ final class AppRuntime {
 @MainActor
 final class WebPageHolder {
   weak var page: WebPage?
+}
+
+/// renderer へ push する唯一の経路。`window.__gozdReceive(type, payload)` を叩く。
+/// page == nil（WebPage 未初期化）と callJavaScript 失敗の両方を stderr にログする。
+/// silent drop は禁止: 1 度の取りこぼしで UI 状態が永続的にずれるため、
+/// 観察可能性を全 push に必須として課す。
+@MainActor
+func pushToRenderer(page: WebPage?, type: String, payload: [String: Any]) async {
+  guard let page else {
+    print("[GozdApp] push dropped (page not ready): type=\(type)")
+    return
+  }
+  do {
+    _ = try await page.callJavaScript(
+      "window.__gozdReceive(type, payload)",
+      arguments: ["type": type, "payload": payload]
+    )
+  } catch {
+    print("[GozdApp] push failed: type=\(type) error=\(error)")
+  }
 }
 
 private func encodeExitReason(_ reason: PTYExitReason) -> [String: Any] {

--- a/apps/native/Sources/Gozd/GozdApp.swift
+++ b/apps/native/Sources/Gozd/GozdApp.swift
@@ -332,7 +332,8 @@ final class AppRuntime {
       }
       print("[SocketServer] listening on \(socketPath)")
     } catch {
-      print("[SocketServer] start failed: \(error)")
+      FileHandle.standardError.write(
+        Data("[SocketServer] start failed: \(error)\n".utf8))
       sendNotify(
         "error", "socket", "Failed to start Unix socket server",
         String(describing: error))

--- a/apps/native/Sources/GozdCore/FSWatchRegistry.swift
+++ b/apps/native/Sources/GozdCore/FSWatchRegistry.swift
@@ -32,11 +32,23 @@ import Foundation
 //
 // 4. **push の重複は許容**。renderer 側は冪等な再 fetch（onMessage の handler）
 //    で受け止めるので、`fsChange` と `gitStatusChange` を両方出しても問題ない。
+//
+// 5. **SSOT push + 低頻度 pull の二重防御**。FSEvents は push 経路だが、watch 開始
+//    往復中の取りこぼしや、`callJavaScript` の失敗で 1 度落とすと UI 状態が永続
+//    的にずれる。renderer 側で 2 つの保険を組んでいる:
+//    - `rpcFsWatch` 応答直後の `fsWatchReady` 再同期トリガー（watch 起動瞬間 1 回）
+//    - 60 秒間隔の `rpcGitRefsDigest` 整合性チェック（push 不達を検知して `loadLog`）
+//    どちらも「予防 retry」ではなく観察可能性の補強。不一致を検知したら必ず
+//    `console.warn` でログを残し、symptom を silent fix しない。
 public actor FSWatchRegistry {
   public typealias FsChangeHandler = @Sendable (_ dir: String, _ relDir: String) -> Void
   public typealias GitStatusChangeHandler = @Sendable (_ dir: String, _ status: GitOps.StatusFull)
     -> Void
-  public typealias BranchChangeHandler = @Sendable (_ dir: String) -> Void
+  /// branchChange ハンドラ。`changedRefs` には今回のバッチで動いた refs/heads/ 配下の
+  /// ref 名（`refs/heads/` を剥がした basename。例: `main`, `feat/foo`）を含める。
+  /// `packed-refs` の更新で個別 ref を特定できない場合は空配列。
+  /// 観察可能性のため、renderer 側がログ / バグ報告で利用できるよう payload に乗せる。
+  public typealias BranchChangeHandler = @Sendable (_ dir: String, _ changedRefs: [String]) -> Void
   public typealias WorktreeChangeHandler = @Sendable (_ dir: String) -> Void
 
   private struct Entry {
@@ -64,6 +76,9 @@ public actor FSWatchRegistry {
     let hasGitStatusChange: Bool
     let hasBranchChange: Bool
     let hasWorktreeChange: Bool
+    /// 今回のバッチで動いた refs/heads/ 配下の ref 名（`refs/heads/` を剥がした basename）。
+    /// `packed-refs` の更新が含まれる場合は空のままで、個別 ref 特定は呼び出し側で諦める。
+    let changedRefs: Set<String>
   }
 
   private let onFsChange: FsChangeHandler
@@ -209,7 +224,7 @@ public actor FSWatchRegistry {
       }
     }
     if result.hasBranchChange {
-      onBranchChange(originalDir)
+      onBranchChange(originalDir, Array(result.changedRefs).sorted())
     }
     if result.hasWorktreeChange {
       onWorktreeChange(originalDir)
@@ -286,6 +301,7 @@ public actor FSWatchRegistry {
     var hasGitStatusChange = false
     var hasBranchChange = false
     var hasWorktreeChange = false
+    var changedRefs = Set<String>()
 
     // 通常 clone では perWorktreeGitDir == commonGitDir なので、両ルールを同じ path に
     // 適用して `HEAD` と `refs/heads/` を両方拾う必要がある。
@@ -316,6 +332,10 @@ public actor FSWatchRegistry {
           hasWorktreeChange = true
         } else if rel.hasPrefix("refs/heads/") {
           hasBranchChange = true
+          let refName = String(rel.dropFirst("refs/heads/".count))
+          if !refName.isEmpty {
+            changedRefs.insert(refName)
+          }
         } else if rel.hasPrefix("refs/remotes/") {
           // push / fetch 成功でローカルの remote-tracking ref が書き換わる。
           // git-graph は gitStatusChange の `# branch.ab` で ahead/behind 更新を検知する。
@@ -344,7 +364,8 @@ public actor FSWatchRegistry {
       hasFsChange: hasFsChange,
       hasGitStatusChange: hasGitStatusChange,
       hasBranchChange: hasBranchChange,
-      hasWorktreeChange: hasWorktreeChange
+      hasWorktreeChange: hasWorktreeChange,
+      changedRefs: changedRefs
     )
   }
 

--- a/apps/native/Sources/GozdCore/FSWatchRegistry.swift
+++ b/apps/native/Sources/GozdCore/FSWatchRegistry.swift
@@ -107,16 +107,30 @@ public actor FSWatchRegistry {
     self.onWorktreeChange = onWorktreeChange
   }
 
-  /// dir の監視を開始する。既に watch されていれば no-op。
+  /// dir の監視を開始する。既に watch されていれば古い entry を破棄して再構築する。
   /// 入力 dir は realpath 解決してキーに使う（FSEvents は realpath を返すため、
   /// `/var/...` と `/private/var/...` のような symlink の差を吸収する）。
+  ///
+  /// 既存 entry を no-op で返さない理由: worktree の `.git` ファイル target の変更や
+  /// `git worktree repair` 等で `perWorktreeGitDir` / `commonGitDir` の解決値が
+  /// 変わっている可能性がある。古い解決値を保持し続けると `classify` の分類が永続的
+  /// に間違う（HEAD / refs/heads / packed-refs のパスが旧 git dir を指したまま）。
+  /// 再構築のコストは `gitDirs` 1 回と FSEventStream 1 個の再生成で、unwatch を
+  /// 経由する RPC 呼び出しが必要だった旧設計より整合性のリスクが低い。
   public func watch(dir userDir: String) async throws {
     let dir = FSWatchRegistry.realpath(userDir)
-    if entries[dir] != nil {
-      // 同一 resolved dir に複数 userDir で watch 要求が来ても、各 userDir → resolved の
-      // 逆引きを残しておく（後続 unwatch が realpath 失敗で fallback した時に備える）。
-      resolvedKeyByOriginalDir[userDir] = dir
-      return
+    if let existing = entries[dir] {
+      // 既存 entry を破棄して再構築する: `gitDirs` の解決値が `git worktree repair` 等で
+      // 変わっている可能性に備える（旧 no-op 設計だと古い perWorktreeGitDir / commonGitDir
+      // が永続的に残って `classify` の分類が間違い続ける）。
+      // `_unwatch` は呼ばない。`_unwatch` は同一 resolved dir を指す全 reverse lookup を
+      // 一括 invalidate するが、再構築では同じ resolved dir を引き続き使うので別 userDir
+      // 経由の逆引きは温存したい。FSWatcher の破棄だけ inline で行い、reverse lookup は
+      // 末尾の `resolvedKeyByOriginalDir[userDir] = dir` で当該 userDir のみ最新化する。
+      existing.watcher.stop()
+      existing.continuation.finish()
+      existing.task.cancel()
+      entries.removeValue(forKey: dir)
     }
 
     nextGeneration += 1
@@ -181,14 +195,20 @@ public actor FSWatchRegistry {
   public func unwatch(dir userDir: String) {
     let resolvedKey = resolvedKeyByOriginalDir.removeValue(forKey: userDir)
       ?? FSWatchRegistry.realpath(userDir)
-    guard let entry = entries.removeValue(forKey: resolvedKey) else { return }
+    _unwatch(realpathDir: resolvedKey)
+  }
+
+  /// realpath 解決済みの dir に対して unwatch する内部 helper。`watch` での再構築経路と
+  /// public `unwatch` の両方から呼ばれる。reverse lookup の掃除もここで完結させる。
+  private func _unwatch(realpathDir dir: String) {
+    guard let entry = entries.removeValue(forKey: dir) else { return }
     entry.watcher.stop()
     entry.continuation.finish()
     entry.task.cancel()
     // 同一 resolved dir を指していた他の userDir 逆引きも掃除する。
     // 同一 resolved に複数 userDir（symlink パスと非 symlink パスなど）で watch が
     // 重ねられた状態で、片方しか unwatch されないと逆引きエントリが leak するため。
-    resolvedKeyByOriginalDir = resolvedKeyByOriginalDir.filter { $0.value != resolvedKey }
+    resolvedKeyByOriginalDir = resolvedKeyByOriginalDir.filter { $0.value != dir }
   }
 
   /// dispatch 時点で entry がまだ生きており、世代が一致するかを判定する。

--- a/apps/native/Sources/GozdCore/FSWatchRegistry.swift
+++ b/apps/native/Sources/GozdCore/FSWatchRegistry.swift
@@ -198,6 +198,17 @@ public actor FSWatchRegistry {
     _unwatch(realpathDir: resolvedKey)
   }
 
+  /// 保持している全 entry の監視を一括停止する。renderer の `onUnmounted` から
+  /// 1 度の RPC で呼び出され、FSEventStream slot を残骸として残さないための
+  /// 構造的 cleanup 経路。返り値は実際に破棄した entry 数（観察可能性用）。
+  public func unwatchAll() -> Int {
+    let dirs = Array(entries.keys)
+    for dir in dirs {
+      _unwatch(realpathDir: dir)
+    }
+    return dirs.count
+  }
+
   /// realpath 解決済みの dir に対して unwatch する内部 helper。`watch` での再構築経路と
   /// public `unwatch` の両方から呼ばれる。reverse lookup の掃除もここで完結させる。
   private func _unwatch(realpathDir dir: String) {
@@ -257,7 +268,8 @@ public actor FSWatchRegistry {
       } catch {
         // 観察可能性のためログを残す。renderer は次の FSEvents バッチで再 fetch するため
         // 致命的ではないが、繰り返し発生していれば一時障害として診断したい。
-        print("[FSWatchRegistry] gitStatusFull failed for \(dir): \(error)")
+        FileHandle.standardError.write(
+          Data("[FSWatchRegistry] gitStatusFull failed for \(dir): \(error)\n".utf8))
         return
       }
       // gitStatusFull の await 中に unwatch されている可能性があるため再 check

--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import os
 
@@ -135,6 +136,10 @@ public enum GitOps {
   public struct StatusFull: Equatable, Sendable {
     public let statuses: [String: String]
     public let head: String
+    /// `git status --porcelain=v2 --branch` の `# branch.head` の値。HEAD が指す
+    /// ブランチ名（例: `main`）。detached HEAD の場合は空文字。
+    /// `git branch -m` は OID を変えないため、rename の検知はこの値の変化で行う。
+    public let branchHead: String
     public let hasUpstream: Bool
     public let ahead: UInt32
     public let behind: UInt32
@@ -242,6 +247,21 @@ public enum GitOps {
       in: .whitespacesAndNewlines)
     if commonDir.isEmpty { return "" }
     return (commonDir as NSString).deletingLastPathComponent
+  }
+
+  /// `git for-each-ref refs/heads/ refs/remotes/` の出力の SHA-256 hex digest。
+  /// renderer 側で前回値と比較し、不一致なら push event の取りこぼしを検知する観察可能性
+  /// の補強として使う（低頻度 pull 整合性チェック）。「予防 retry」ではなく、SSOT 経路
+  /// の到達率を計測する用途。digest は安定ソートされた出力を読むため、git の内部ソート
+  /// に依存する。
+  public static func refsDigest(dir: String) async throws -> String {
+    let stdout = try await runGit(
+      args: [
+        "for-each-ref", "refs/heads/", "refs/remotes/",
+        "--format=%(refname) %(objectname)",
+      ], cwd: dir)
+    let hash = SHA256.hash(data: stdout)
+    return hash.map { String(format: "%02x", $0) }.joined()
   }
 
   /// `git symbolic-ref --short refs/remotes/origin/HEAD` 相当。`origin/main` 等を返す。
@@ -645,6 +665,7 @@ private func parseDiffNameStatus(_ data: Data) -> [FileChangeInfo] {
 private func parsePorcelainV2WithBranch(_ data: Data) -> GitOps.StatusFull {
   var statuses: [String: String] = [:]
   var head = ""
+  var branchHead = ""
   var hasUpstream = false
   var ahead: UInt32 = 0
   var behind: UInt32 = 0
@@ -673,8 +694,15 @@ private func parsePorcelainV2WithBranch(_ data: Data) -> GitOps.StatusFull {
           behind = UInt32(part.dropFirst()) ?? 0
         }
       }
+    } else if line.hasPrefix("# branch.head ") {
+      // HEAD が指す branch 名。`git branch -m` は OID を変えないため、
+      // rename を status 経路で検知する SSOT としてこの値を保持する。
+      // detached HEAD の場合は `(detached)` が返るので空文字に正規化。
+      let name = String(line.dropFirst("# branch.head ".count))
+      branchHead = name == "(detached)" ? "" : name
     } else if line.hasPrefix("# ") {
-      // branch.head 等は無視
+      // 上記以外の `# ` 行（将来追加される porcelain v2 ヘッダ）は意図的に silent drop。
+      // UI 要件が立った時点でここに分岐を足す。
       continue
     } else if line.hasPrefix("1 ") {
       // "1 XY <sub> <mH> <mI> <mW> <hH> <hI> <path>"
@@ -719,7 +747,8 @@ private func parsePorcelainV2WithBranch(_ data: Data) -> GitOps.StatusFull {
   }
 
   return GitOps.StatusFull(
-    statuses: statuses, head: head, hasUpstream: hasUpstream, ahead: ahead, behind: behind)
+    statuses: statuses, head: head, branchHead: branchHead,
+    hasUpstream: hasUpstream, ahead: ahead, behind: behind)
 }
 
 private func parsePorcelainV1(_ data: Data) -> [String: String] {

--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -252,12 +252,15 @@ public enum GitOps {
   /// `git for-each-ref refs/heads/ refs/remotes/` の出力の SHA-256 hex digest。
   /// renderer 側で前回値と比較し、不一致なら push event の取りこぼしを検知する観察可能性
   /// の補強として使う（低頻度 pull 整合性チェック）。「予防 retry」ではなく、SSOT 経路
-  /// の到達率を計測する用途。digest は安定ソートされた出力を読むため、git の内部ソート
-  /// に依存する。
+  /// の到達率を計測する用途。
+  /// `--sort=refname` を明示するのは git 公式契約。指定なしのデフォルト順は契約として保証
+  /// されないため、ref セット同じで sort 順だけ変動した場合に digest が変わって
+  /// false-positive `console.warn` を生む。明示的に refname sort を依頼する。
   public static func refsDigest(dir: String) async throws -> String {
     let stdout = try await runGit(
       args: [
         "for-each-ref", "refs/heads/", "refs/remotes/",
+        "--sort=refname",
         "--format=%(refname) %(objectname)",
       ], cwd: dir)
     let hash = SHA256.hash(data: stdout)

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -40,7 +40,7 @@ public actor RpcDispatcher {
     onOpen: @escaping OpenHandler = { _ in },
     onFsChange: @escaping FSWatchRegistry.FsChangeHandler = { _, _ in },
     onGitStatusChange: @escaping FSWatchRegistry.GitStatusChangeHandler = { _, _ in },
-    onBranchChange: @escaping FSWatchRegistry.BranchChangeHandler = { _ in },
+    onBranchChange: @escaping FSWatchRegistry.BranchChangeHandler = { _, _ in },
     onWorktreeChange: @escaping FSWatchRegistry.WorktreeChangeHandler = { _ in },
     envOverlay: GozdEnvOverlay? = nil,
     pidTracker: PidTracker? = nil
@@ -221,6 +221,8 @@ public actor RpcDispatcher {
       return try await handleGitViewer(body)
     case "/git/defaultBranch":
       return try await handleGitDefaultBranch(body)
+    case "/git/refsDigest":
+      return try await handleGitRefsDigest(body)
     case "/git/createWorktree":
       return try await handleCreateWorktree(body)
     case "/git/worktreeRemove":
@@ -647,6 +649,14 @@ public actor RpcDispatcher {
     }
     var resp = Gozd_V1_GitDefaultBranchResponse()
     resp.branch = branch
+    return try resp.jsonUTF8Data()
+  }
+
+  private func handleGitRefsDigest(_ body: Data) async throws -> Data {
+    let req = try Gozd_V1_GitRefsDigestRequest(jsonUTF8Data: body)
+    let digest = try await GitOps.refsDigest(dir: req.dir)
+    var resp = Gozd_V1_GitRefsDigestResponse()
+    resp.digest = digest
     return try resp.jsonUTF8Data()
   }
 

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -181,6 +181,8 @@ public actor RpcDispatcher {
       return try await handleFsWatch(body)
     case "/fs/unwatch":
       return try await handleFsUnwatch(body)
+    case "/fs/unwatchAll":
+      return try await handleFsUnwatchAll(body)
     case "/pty/spawn":
       return try await handlePtySpawn(body)
     case "/pty/write":
@@ -324,6 +326,14 @@ public actor RpcDispatcher {
     let req = try Gozd_V1_FsUnwatchRequest(jsonUTF8Data: body)
     await fsWatch.unwatch(dir: req.dir)
     return try Gozd_V1_FsUnwatchResponse().jsonUTF8Data()
+  }
+
+  private func handleFsUnwatchAll(_ body: Data) async throws -> Data {
+    _ = try Gozd_V1_FsUnwatchAllRequest(jsonUTF8Data: body)
+    let count = await fsWatch.unwatchAll()
+    var resp = Gozd_V1_FsUnwatchAllResponse()
+    resp.unwatchedCount = UInt32(count)
+    return try resp.jsonUTF8Data()
   }
 
   private func handlePtySpawn(_ body: Data) async throws -> Data {

--- a/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
@@ -14,7 +14,7 @@ struct FSWatchRegistryTests {
     let registry = FSWatchRegistry(
       onFsChange: { dir, _ in collector.append("fsChange:\(dir)") },
       onGitStatusChange: { _, _ in collector.append("gitStatusChange") },
-      onBranchChange: { _ in collector.append("branchChange") },
+      onBranchChange: { _, _ in collector.append("branchChange") },
       onWorktreeChange: { _ in collector.append("worktreeChange") }
     )
 
@@ -40,7 +40,7 @@ struct FSWatchRegistryTests {
     let registry = FSWatchRegistry(
       onFsChange: { _, _ in collector.append("fsChange") },
       onGitStatusChange: { _, _ in collector.append("gitStatusChange") },
-      onBranchChange: { _ in collector.append("branchChange") },
+      onBranchChange: { _, _ in collector.append("branchChange") },
       onWorktreeChange: { _ in collector.append("worktreeChange") }
     )
 
@@ -89,7 +89,7 @@ struct FSWatchRegistryTests {
     let registry = FSWatchRegistry(
       onFsChange: { _, _ in collector.append("fsChange") },
       onGitStatusChange: { _, _ in collector.append("gitStatusChange") },
-      onBranchChange: { _ in collector.append("branchChange") },
+      onBranchChange: { _, _ in collector.append("branchChange") },
       onWorktreeChange: { _ in collector.append("worktreeChange") }
     )
 
@@ -104,6 +104,75 @@ struct FSWatchRegistryTests {
     #expect(events.contains("gitStatusChange"))
   }
 
+  @Test("`git branch -m` で current branch を改名すると branchChange と gitStatusChange が両方 dispatch される")
+  func dispatchesBranchChangeAndStatusOnRename() async throws {
+    // ユーザー報告の主因シナリオ: rename で commit OID は不変だが、HEAD が指す
+    // branch 名が変わる。`git status --porcelain=v2 --branch` の `# branch.head`
+    // の変化を SSOT として renderer に流すため、gitStatusChange も発火する必要がある。
+    let tmpDir = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+    try await initGitRepo(at: tmpDir)
+    // 1 commit を作って HEAD を確立する（unborn branch だと branch -m は別経路）
+    let seed = tmpDir.appendingPathComponent("seed.txt")
+    try "seed".write(to: seed, atomically: true, encoding: .utf8)
+    try await runGitCmd(["add", "seed.txt"], cwd: tmpDir)
+    try await runGitCmd(["commit", "-m", "seed"], cwd: tmpDir)
+
+    let collector = EventNameCollector()
+    let registry = FSWatchRegistry(
+      onFsChange: { _, _ in collector.append("fsChange") },
+      onGitStatusChange: { _, _ in collector.append("gitStatusChange") },
+      onBranchChange: { _, _ in collector.append("branchChange") },
+      onWorktreeChange: { _ in collector.append("worktreeChange") }
+    )
+
+    try await registry.watch(dir: tmpDir.path)
+    try await Task.sleep(for: .milliseconds(300))
+    collector.clear()
+
+    try await runGitCmd(["branch", "-m", "renamed-feature"], cwd: tmpDir)
+
+    try await waitForEvent(collector, matching: { $0 == "branchChange" })
+    try await waitForEvent(collector, matching: { $0 == "gitStatusChange" })
+    let events = collector.snapshot()
+    #expect(events.contains("branchChange"))
+    #expect(events.contains("gitStatusChange"))
+  }
+
+  @Test("`git pack-refs --all` で packed-refs が更新されると branchChange + gitStatusChange が dispatch される")
+  func dispatchesOnPackRefs() async throws {
+    // pack 後はファイル名から local / remote のどちらが pack されたか判別不能なため、
+    // 両方の subscriber に通知する設計。pack 自体はテスト時に 0 loose ref でも実行可能。
+    let tmpDir = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+    try await initGitRepo(at: tmpDir)
+    // 1 commit + branch を作って pack 対象を確保する
+    let seed = tmpDir.appendingPathComponent("seed.txt")
+    try "seed".write(to: seed, atomically: true, encoding: .utf8)
+    try await runGitCmd(["add", "seed.txt"], cwd: tmpDir)
+    try await runGitCmd(["commit", "-m", "seed"], cwd: tmpDir)
+
+    let collector = EventNameCollector()
+    let registry = FSWatchRegistry(
+      onFsChange: { _, _ in collector.append("fsChange") },
+      onGitStatusChange: { _, _ in collector.append("gitStatusChange") },
+      onBranchChange: { _, _ in collector.append("branchChange") },
+      onWorktreeChange: { _ in collector.append("worktreeChange") }
+    )
+
+    try await registry.watch(dir: tmpDir.path)
+    try await Task.sleep(for: .milliseconds(300))
+    collector.clear()
+
+    try await runGitCmd(["pack-refs", "--all"], cwd: tmpDir)
+
+    try await waitForEvent(collector, matching: { $0 == "branchChange" })
+    try await waitForEvent(collector, matching: { $0 == "gitStatusChange" })
+    let events = collector.snapshot()
+    #expect(events.contains("branchChange"))
+    #expect(events.contains("gitStatusChange"))
+  }
+
   @Test("unwatch 後はイベントが届かない")
   func unwatchStopsDispatch() async throws {
     let tmpDir = try makeTempDir()
@@ -113,7 +182,7 @@ struct FSWatchRegistryTests {
     let registry = FSWatchRegistry(
       onFsChange: { _, _ in collector.append("fsChange") },
       onGitStatusChange: { _, _ in collector.append("gitStatusChange") },
-      onBranchChange: { _ in collector.append("branchChange") },
+      onBranchChange: { _, _ in collector.append("branchChange") },
       onWorktreeChange: { _ in collector.append("worktreeChange") }
     )
 
@@ -327,6 +396,58 @@ struct ClassifyTests {
       events: [ev("\(dir)/note.txt")])
     #expect(result.hasFsChange)
     #expect(result.hasGitStatusChange)
+  }
+
+  @Test("refs/heads/<name> 変更で changedRefs に basename が含まれる")
+  func changedRefsContainsBasename() {
+    let dir = "/repo"
+    let gitDir = "\(dir)/.git"
+    let result = FSWatchRegistry.classify(
+      dir: dir, perWorktreeGitDir: gitDir, commonGitDir: gitDir,
+      events: [ev("\(gitDir)/refs/heads/main")])
+    #expect(result.hasBranchChange)
+    #expect(result.changedRefs == ["main"])
+  }
+
+  @Test("refs/heads/<slash/contained> のスラッシュ含む branch 名も丸ごと changedRefs に入る")
+  func changedRefsKeepsSlashes() {
+    // `feat/foo` のような nested branch 名は `refs/heads/feat/foo` で表現される。
+    // basename を取るときに最初の `/` で切ってしまわないか保証する。
+    let dir = "/repo"
+    let gitDir = "\(dir)/.git"
+    let result = FSWatchRegistry.classify(
+      dir: dir, perWorktreeGitDir: gitDir, commonGitDir: gitDir,
+      events: [ev("\(gitDir)/refs/heads/feat/foo")])
+    #expect(result.hasBranchChange)
+    #expect(result.changedRefs == ["feat/foo"])
+  }
+
+  @Test("複数の refs/heads/ event は changedRefs に全部入る")
+  func changedRefsMergesMultiple() {
+    let dir = "/repo"
+    let gitDir = "\(dir)/.git"
+    let result = FSWatchRegistry.classify(
+      dir: dir, perWorktreeGitDir: gitDir, commonGitDir: gitDir,
+      events: [
+        ev("\(gitDir)/refs/heads/main"),
+        ev("\(gitDir)/refs/heads/feat/sub"),
+      ])
+    #expect(result.hasBranchChange)
+    #expect(result.changedRefs == ["main", "feat/sub"])
+  }
+
+  @Test("packed-refs だけの変更では個別 ref を特定できないため changedRefs は空")
+  func packedRefsHasNoChangedRefs() {
+    // packed-refs の中身はファイル名から判別不能。個別 ref 特定は呼び出し側で諦め、
+    // changedRefs は空のままにする（branchChange は発火するが具体名は載せない）。
+    let dir = "/repo"
+    let gitDir = "\(dir)/.git"
+    let result = FSWatchRegistry.classify(
+      dir: dir, perWorktreeGitDir: gitDir, commonGitDir: gitDir,
+      events: [ev("\(gitDir)/packed-refs")])
+    #expect(result.hasBranchChange)
+    #expect(result.hasGitStatusChange)
+    #expect(result.changedRefs.isEmpty)
   }
 
   @Test("dir 配下でも git dir 配下でもない event は無視")

--- a/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
@@ -173,6 +173,40 @@ struct FSWatchRegistryTests {
     #expect(events.contains("gitStatusChange"))
   }
 
+  @Test("同一 dir を再 watch すると古い entry を破棄して再構築する（idempotent re-entry 契約）")
+  func watchRebuildsExistingEntry() async throws {
+    // P 指摘の根本対応テスト: 旧 entry no-op 返しでは perWorktreeGitDir / commonGitDir の
+    // 解決値が永続的に古いまま残るバグがあった。再構築で新しい gitDirs 解決が反映され、
+    // かつイベント受信が継続することを確認する。
+    let tmpDir = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: tmpDir) }
+    try await initGitRepo(at: tmpDir)
+
+    let collector = EventNameCollector()
+    let registry = FSWatchRegistry(
+      onFsChange: { _, _ in collector.append("fsChange") },
+      onGitStatusChange: { _, _ in collector.append("gitStatusChange") },
+      onBranchChange: { _, _ in collector.append("branchChange") },
+      onWorktreeChange: { _ in collector.append("worktreeChange") }
+    )
+
+    try await registry.watch(dir: tmpDir.path)
+    try await Task.sleep(for: .milliseconds(300))
+
+    // 2 回目の watch（同 dir）— 旧設計の no-op ではなく再構築されることを担保する。
+    try await registry.watch(dir: tmpDir.path)
+    try await Task.sleep(for: .milliseconds(300))
+    collector.clear()
+
+    // 再構築後も branch ref の変更が dispatch される（= 新 entry が live で動いている）
+    let branchFile = tmpDir.appendingPathComponent(".git/refs/heads/feature-rebuilt")
+    try "0123456789abcdef0123456789abcdef01234567\n"
+      .write(to: branchFile, atomically: true, encoding: .utf8)
+
+    try await waitForEvent(collector, matching: { $0 == "branchChange" })
+    #expect(collector.snapshot().contains("branchChange"))
+  }
+
   @Test("unwatch 後はイベントが届かない")
   func unwatchStopsDispatch() async throws {
     let tmpDir = try makeTempDir()

--- a/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
@@ -301,14 +301,25 @@ struct ClassifyTests {
     FSWatcher.Event(path: path, flags: 0, id: 0)
   }
 
+  /// classify pure unit tests 用の path 生成。`URL(fileURLWithPath:)` + `appendingPathComponent`
+  /// で組み立てて `.path` を返す。リテラル `/` 区切りを直書きせず、CLAUDE.md の
+  /// 「Swift 側のパス処理は `URL` / `FileManager` を使い、リテラル区切り `/` をハードコード
+  /// しない」規約に揃える。テストは synthetic な path 文字列を `classify` に渡すだけだが、
+  /// 規約は test fixture にも一貫して適用する。
+  private func pathOf(_ components: String...) -> String {
+    components.reduce(URL(fileURLWithPath: "/")) { url, component in
+      url.appendingPathComponent(component)
+    }.path
+  }
+
   @Test("worktree 配置: per-worktree git dir 配下の HEAD は gitStatusChange のみ")
   func worktreePerWorktreeHead() {
-    let dir = "/wt/foo"
-    let perWt = "/parent/.git/worktrees/foo"
-    let common = "/parent/.git"
+    let dir = pathOf("wt", "foo")
+    let perWt = pathOf("parent", ".git", "worktrees", "foo")
+    let common = pathOf("parent", ".git")
     let result = FSWatchRegistry.classify(
       dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
-      events: [ev("\(perWt)/HEAD")])
+      events: [ev(pathOf("parent", ".git", "worktrees", "foo", "HEAD"))])
     #expect(result.hasGitStatusChange)
     #expect(!result.hasFsChange)
     #expect(!result.hasBranchChange)
@@ -317,12 +328,12 @@ struct ClassifyTests {
 
   @Test("worktree 配置: common git dir 配下の refs/heads/main は branchChange")
   func worktreeCommonBranchRef() {
-    let dir = "/wt/foo"
-    let perWt = "/parent/.git/worktrees/foo"
-    let common = "/parent/.git"
+    let dir = pathOf("wt", "foo")
+    let perWt = pathOf("parent", ".git", "worktrees", "foo")
+    let common = pathOf("parent", ".git")
     let result = FSWatchRegistry.classify(
       dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
-      events: [ev("\(common)/refs/heads/main")])
+      events: [ev(pathOf("parent", ".git", "refs", "heads", "main"))])
     #expect(result.hasBranchChange)
     #expect(!result.hasFsChange)
     #expect(!result.hasGitStatusChange)
@@ -333,12 +344,12 @@ struct ClassifyTests {
   func worktreeCommonPackedRefs() {
     // packed-refs は local ref と remote-tracking ref のどちらの pack かファイル名から
     // 判別不能なので両 subscriber に通知する。
-    let dir = "/wt/foo"
-    let perWt = "/parent/.git/worktrees/foo"
-    let common = "/parent/.git"
+    let dir = pathOf("wt", "foo")
+    let perWt = pathOf("parent", ".git", "worktrees", "foo")
+    let common = pathOf("parent", ".git")
     let result = FSWatchRegistry.classify(
       dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
-      events: [ev("\(common)/packed-refs")])
+      events: [ev(pathOf("parent", ".git", "packed-refs"))])
     #expect(result.hasBranchChange)
     #expect(result.hasGitStatusChange)
     #expect(!result.hasFsChange)
@@ -350,12 +361,12 @@ struct ClassifyTests {
     // git push / fetch 成功でローカルの remote-tracking ref が書き換わる。
     // git-graph の ahead/behind を更新するための gitStatusChange 経路。
     // worktree 一覧構造は変わらないため branchChange は発火させない。
-    let dir = "/wt/foo"
-    let perWt = "/parent/.git/worktrees/foo"
-    let common = "/parent/.git"
+    let dir = pathOf("wt", "foo")
+    let perWt = pathOf("parent", ".git", "worktrees", "foo")
+    let common = pathOf("parent", ".git")
     let result = FSWatchRegistry.classify(
       dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
-      events: [ev("\(common)/refs/remotes/origin/main")])
+      events: [ev(pathOf("parent", ".git", "refs", "remotes", "origin", "main"))])
     #expect(result.hasGitStatusChange)
     #expect(!result.hasBranchChange)
     #expect(!result.hasFsChange)
@@ -366,12 +377,12 @@ struct ClassifyTests {
   func worktreeCommonRemoteHeadSymRef() {
     // `origin/HEAD` は固定名の symbolic ref。`hasPrefix("refs/remotes/")` で同分岐に
     // 落ちる事を保証し、将来「branch 一覧変化」として再分類したくなった時の足場にする。
-    let dir = "/wt/foo"
-    let perWt = "/parent/.git/worktrees/foo"
-    let common = "/parent/.git"
+    let dir = pathOf("wt", "foo")
+    let perWt = pathOf("parent", ".git", "worktrees", "foo")
+    let common = pathOf("parent", ".git")
     let result = FSWatchRegistry.classify(
       dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
-      events: [ev("\(common)/refs/remotes/origin/HEAD")])
+      events: [ev(pathOf("parent", ".git", "refs", "remotes", "origin", "HEAD"))])
     #expect(result.hasGitStatusChange)
     #expect(!result.hasBranchChange)
   }
@@ -380,12 +391,12 @@ struct ClassifyTests {
   func worktreeCommonRemoteRefNestedName() {
     // `feature/sub` のようなスラッシュ区切り branch 名。`hasPrefix` 判定なので通るはずだが、
     // 将来 `==` 等価判定にリグレッションした時に検知できるよう明示的に踏む。
-    let dir = "/wt/foo"
-    let perWt = "/parent/.git/worktrees/foo"
-    let common = "/parent/.git"
+    let dir = pathOf("wt", "foo")
+    let perWt = pathOf("parent", ".git", "worktrees", "foo")
+    let common = pathOf("parent", ".git")
     let result = FSWatchRegistry.classify(
       dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
-      events: [ev("\(common)/refs/remotes/origin/feature/sub")])
+      events: [ev(pathOf("parent", ".git", "refs", "remotes", "origin", "feature", "sub"))])
     #expect(result.hasGitStatusChange)
     #expect(!result.hasBranchChange)
   }
@@ -394,12 +405,12 @@ struct ClassifyTests {
   func worktreeCommonTagsSilentDrop() {
     // 現状の git-graph はタグを `git for-each-ref` で取得しており、`# branch.ab` SSOT の
     // 射程外。タグ表示の即時反映が UI 要件になった時点でここに分岐を足す。
-    let dir = "/wt/foo"
-    let perWt = "/parent/.git/worktrees/foo"
-    let common = "/parent/.git"
+    let dir = pathOf("wt", "foo")
+    let perWt = pathOf("parent", ".git", "worktrees", "foo")
+    let common = pathOf("parent", ".git")
     let result = FSWatchRegistry.classify(
       dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
-      events: [ev("\(common)/refs/tags/v1.0.0")])
+      events: [ev(pathOf("parent", ".git", "refs", "tags", "v1.0.0"))])
     #expect(!result.hasGitStatusChange)
     #expect(!result.hasBranchChange)
     #expect(!result.hasFsChange)
@@ -410,12 +421,12 @@ struct ClassifyTests {
   func worktreeCommonSiblingAdded() {
     // 自分の per-wt git dir は foo。兄弟 bar が追加されると `<common>/worktrees/bar/...` に
     // ファイルが生まれる。これは worktree list の変更なので worktreeChange を発火させる。
-    let dir = "/wt/foo"
-    let perWt = "/parent/.git/worktrees/foo"
-    let common = "/parent/.git"
+    let dir = pathOf("wt", "foo")
+    let perWt = pathOf("parent", ".git", "worktrees", "foo")
+    let common = pathOf("parent", ".git")
     let result = FSWatchRegistry.classify(
       dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
-      events: [ev("\(common)/worktrees/bar/HEAD")])
+      events: [ev(pathOf("parent", ".git", "worktrees", "bar", "HEAD"))])
     #expect(result.hasWorktreeChange)
     #expect(!result.hasGitStatusChange)
   }
@@ -424,24 +435,24 @@ struct ClassifyTests {
   func worktreeCommonSelfInternalNotWorktreeChange() {
     // `<common>/worktrees/foo/locked` は per-wt git dir 配下なので per-wt 規則のみ適用。
     // worktree list の変更ではないため worktreeChange は出ない。
-    let dir = "/wt/foo"
-    let perWt = "/parent/.git/worktrees/foo"
-    let common = "/parent/.git"
+    let dir = pathOf("wt", "foo")
+    let perWt = pathOf("parent", ".git", "worktrees", "foo")
+    let common = pathOf("parent", ".git")
     let result = FSWatchRegistry.classify(
       dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
-      events: [ev("\(perWt)/locked")])
+      events: [ev(pathOf("parent", ".git", "worktrees", "foo", "locked"))])
     #expect(!result.hasWorktreeChange)
     #expect(!result.hasGitStatusChange)  // locked は HEAD/index ではないので status も無し
   }
 
   @Test("worktree 配置: 作業ツリー配下のファイルは fsChange + gitStatusChange")
   func worktreeWorkTreeFile() {
-    let dir = "/wt/foo"
-    let perWt = "/parent/.git/worktrees/foo"
-    let common = "/parent/.git"
+    let dir = pathOf("wt", "foo")
+    let perWt = pathOf("parent", ".git", "worktrees", "foo")
+    let common = pathOf("parent", ".git")
     let result = FSWatchRegistry.classify(
       dir: dir, perWorktreeGitDir: perWt, commonGitDir: common,
-      events: [ev("\(dir)/src/a.ts")])
+      events: [ev(pathOf("wt", "foo", "src", "a.ts"))])
     #expect(result.hasFsChange)
     #expect(result.hasGitStatusChange)
     #expect(result.fsRelDirs == ["src"])
@@ -449,13 +460,13 @@ struct ClassifyTests {
 
   @Test("通常 clone: per-worktree == common == <dir>/.git でも HEAD と refs/heads が両方分類される")
   func normalCloneDualClassification() {
-    let dir = "/repo"
-    let gitDir = "\(dir)/.git"
+    let dir = pathOf("repo")
+    let gitDir = pathOf("repo", ".git")
     let result = FSWatchRegistry.classify(
       dir: dir, perWorktreeGitDir: gitDir, commonGitDir: gitDir,
       events: [
-        ev("\(gitDir)/HEAD"),
-        ev("\(gitDir)/refs/heads/main"),
+        ev(pathOf("repo", ".git", "HEAD")),
+        ev(pathOf("repo", ".git", "refs", "heads", "main")),
       ])
     #expect(result.hasGitStatusChange)
     #expect(result.hasBranchChange)
@@ -465,11 +476,11 @@ struct ClassifyTests {
 
   @Test("通常 clone: .git 配下の関心外ファイル（objects/）は何も発火させない")
   func normalCloneIgnoresObjects() {
-    let dir = "/repo"
-    let gitDir = "\(dir)/.git"
+    let dir = pathOf("repo")
+    let gitDir = pathOf("repo", ".git")
     let result = FSWatchRegistry.classify(
       dir: dir, perWorktreeGitDir: gitDir, commonGitDir: gitDir,
-      events: [ev("\(gitDir)/objects/ab/cdef")])
+      events: [ev(pathOf("repo", ".git", "objects", "ab", "cdef"))])
     #expect(!result.hasFsChange)
     #expect(!result.hasGitStatusChange)
     #expect(!result.hasBranchChange)
@@ -478,21 +489,21 @@ struct ClassifyTests {
 
   @Test("git dir nil（非 repo）: 作業ツリー配下のファイルは fsChange + gitStatusChange")
   func nonRepoFallsToWorkTreeBranch() {
-    let dir = "/somewhere"
+    let dir = pathOf("somewhere")
     let result = FSWatchRegistry.classify(
       dir: dir, perWorktreeGitDir: nil, commonGitDir: nil,
-      events: [ev("\(dir)/note.txt")])
+      events: [ev(pathOf("somewhere", "note.txt"))])
     #expect(result.hasFsChange)
     #expect(result.hasGitStatusChange)
   }
 
   @Test("refs/heads/<name> 変更で changedRefs に basename が含まれる")
   func changedRefsContainsBasename() {
-    let dir = "/repo"
-    let gitDir = "\(dir)/.git"
+    let dir = pathOf("repo")
+    let gitDir = pathOf("repo", ".git")
     let result = FSWatchRegistry.classify(
       dir: dir, perWorktreeGitDir: gitDir, commonGitDir: gitDir,
-      events: [ev("\(gitDir)/refs/heads/main")])
+      events: [ev(pathOf("repo", ".git", "refs", "heads", "main"))])
     #expect(result.hasBranchChange)
     #expect(result.changedRefs == ["main"])
   }
@@ -501,24 +512,24 @@ struct ClassifyTests {
   func changedRefsKeepsSlashes() {
     // `feat/foo` のような nested branch 名は `refs/heads/feat/foo` で表現される。
     // basename を取るときに最初の `/` で切ってしまわないか保証する。
-    let dir = "/repo"
-    let gitDir = "\(dir)/.git"
+    let dir = pathOf("repo")
+    let gitDir = pathOf("repo", ".git")
     let result = FSWatchRegistry.classify(
       dir: dir, perWorktreeGitDir: gitDir, commonGitDir: gitDir,
-      events: [ev("\(gitDir)/refs/heads/feat/foo")])
+      events: [ev(pathOf("repo", ".git", "refs", "heads", "feat", "foo"))])
     #expect(result.hasBranchChange)
     #expect(result.changedRefs == ["feat/foo"])
   }
 
   @Test("複数の refs/heads/ event は changedRefs に全部入る")
   func changedRefsMergesMultiple() {
-    let dir = "/repo"
-    let gitDir = "\(dir)/.git"
+    let dir = pathOf("repo")
+    let gitDir = pathOf("repo", ".git")
     let result = FSWatchRegistry.classify(
       dir: dir, perWorktreeGitDir: gitDir, commonGitDir: gitDir,
       events: [
-        ev("\(gitDir)/refs/heads/main"),
-        ev("\(gitDir)/refs/heads/feat/sub"),
+        ev(pathOf("repo", ".git", "refs", "heads", "main")),
+        ev(pathOf("repo", ".git", "refs", "heads", "feat", "sub")),
       ])
     #expect(result.hasBranchChange)
     #expect(result.changedRefs == ["main", "feat/sub"])
@@ -528,11 +539,11 @@ struct ClassifyTests {
   func packedRefsHasNoChangedRefs() {
     // packed-refs の中身はファイル名から判別不能。個別 ref 特定は呼び出し側で諦め、
     // changedRefs は空のままにする（branchChange は発火するが具体名は載せない）。
-    let dir = "/repo"
-    let gitDir = "\(dir)/.git"
+    let dir = pathOf("repo")
+    let gitDir = pathOf("repo", ".git")
     let result = FSWatchRegistry.classify(
       dir: dir, perWorktreeGitDir: gitDir, commonGitDir: gitDir,
-      events: [ev("\(gitDir)/packed-refs")])
+      events: [ev(pathOf("repo", ".git", "packed-refs"))])
     #expect(result.hasBranchChange)
     #expect(result.hasGitStatusChange)
     #expect(result.changedRefs.isEmpty)
@@ -540,11 +551,11 @@ struct ClassifyTests {
 
   @Test("dir 配下でも git dir 配下でもない event は無視")
   func unrelatedPathIgnored() {
-    let dir = "/repo"
-    let gitDir = "\(dir)/.git"
+    let dir = pathOf("repo")
+    let gitDir = pathOf("repo", ".git")
     let result = FSWatchRegistry.classify(
       dir: dir, perWorktreeGitDir: gitDir, commonGitDir: gitDir,
-      events: [ev("/elsewhere/x.txt")])
+      events: [ev(pathOf("elsewhere", "x.txt"))])
     #expect(!result.hasFsChange)
     #expect(!result.hasGitStatusChange)
   }

--- a/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
@@ -207,6 +207,60 @@ struct FSWatchRegistryTests {
     #expect(collector.snapshot().contains("branchChange"))
   }
 
+  @Test("unwatchAll は全 entry を破棄して破棄件数を返し、以降イベントが届かない")
+  func unwatchAllRemovesEveryEntry() async throws {
+    // renderer の `onUnmounted` から 1 度の RPC で呼ばれる経路。N 個並列の `unwatch`
+    // 発射に対する観察可能性つき集約 cleanup として `FSWatchRegistry.unwatchAll()` を
+    // 守る regression test。返り値 (件数) と「以降 event が dispatch されない」の
+    // 両方を verify する。
+    let dirA = try makeTempDir()
+    let dirB = try makeTempDir()
+    defer {
+      try? FileManager.default.removeItem(at: dirA)
+      try? FileManager.default.removeItem(at: dirB)
+    }
+
+    let collector = EventNameCollector()
+    let registry = FSWatchRegistry(
+      onFsChange: { _, _ in collector.append("fsChange") },
+      onGitStatusChange: { _, _ in collector.append("gitStatusChange") },
+      onBranchChange: { _, _ in collector.append("branchChange") },
+      onWorktreeChange: { _ in collector.append("worktreeChange") }
+    )
+
+    try await registry.watch(dir: dirA.path)
+    try await registry.watch(dir: dirB.path)
+    try await Task.sleep(for: .milliseconds(300))
+
+    // 2 entry watched → unwatchAll で 2 を返す
+    let count = await registry.unwatchAll()
+    #expect(count == 2)
+    #expect(await registry.isWatching(dir: dirA.path) == false)
+    #expect(await registry.isWatching(dir: dirB.path) == false)
+    collector.clear()
+
+    // unwatchAll 後の file 作成は dispatch されない
+    let fileA = dirA.appendingPathComponent("after-unwatch-a.txt")
+    let fileB = dirB.appendingPathComponent("after-unwatch-b.txt")
+    try "x".write(to: fileA, atomically: true, encoding: .utf8)
+    try "x".write(to: fileB, atomically: true, encoding: .utf8)
+
+    try await Task.sleep(for: .milliseconds(500))
+    #expect(collector.snapshot().isEmpty)
+  }
+
+  @Test("entries 空での unwatchAll は 0 件返して no-op")
+  func unwatchAllWithNoEntriesReturnsZero() async throws {
+    let registry = FSWatchRegistry(
+      onFsChange: { _, _ in },
+      onGitStatusChange: { _, _ in },
+      onBranchChange: { _, _ in },
+      onWorktreeChange: { _ in }
+    )
+    let count = await registry.unwatchAll()
+    #expect(count == 0)
+  }
+
   @Test("unwatch 後はイベントが届かない")
   func unwatchStopsDispatch() async throws {
     let tmpDir = try makeTempDir()

--- a/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
+++ b/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
@@ -327,9 +327,13 @@ private func runTestGit(args: [String], cwd: String) async throws {
       if proc.terminationStatus == 0 {
         cont.resume()
       } else {
-        let stderr = String(
-          decoding: stderrPipe.fileHandleForReading.readDataToEndOfFile(),
-          as: UTF8.self)
+        // `String(decoding:as:)` は不正 UTF-8 を U+FFFD で lossy 置換してしまうので
+        // CI flake の真の原因バイトが潰れる。`String(bytes:encoding:)` で UTF-8 失敗を
+        // 明示的に nil 判定し、診断用に元データの byte 数を残す。
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderr =
+          String(bytes: stderrData, encoding: .utf8)
+          ?? "<non-UTF8 stderr (\(stderrData.count) bytes)>"
         cont.resume(
           throwing: GitError.commandFailed(exitCode: proc.terminationStatus, stderr: stderr))
       }

--- a/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
+++ b/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
@@ -307,10 +307,12 @@ private func makeGitRepo() async throws -> URL {
 /// production 側と同じく `process.environment` を明示 snapshot で渡すことで、
 /// 並列 test 実行時の Foundation `Process` 内部の lazy env read による EFAULT を避ける。
 ///
-/// 出力は `/dev/null` に直接捨てる。`Pipe` + `terminationHandler` 内の
-/// `readDataToEndOfFile()` パターンは pipe buffer (~64KB) を超える出力で deadlock
-/// するため、大きい出力を出すコマンドでも helper 自体が詰まらないように、
-/// stdout/stderr を捕捉する必要がない場合は最初から nullDevice に流す。
+/// stdout は `/dev/null` に直接捨てる（git 出力は本テストでは未使用かつ大量出力対応）。
+/// stderr は `Pipe` で捕捉し、失敗時に `GitError.commandFailed(stderr:)` に載せる。
+/// 「テストヘルパーも本体と同じ厳密さ」原則に従い、失敗時の調査コストを本体並みに
+/// 保つために stderr を握り潰さない。pipe deadlock を避けるため `waitUntilExit()` 後に
+/// `readDataToEndOfFile()` を呼ぶ（git の stderr は数百バイト程度なので buffer 溢れの
+/// 心配は実用上ない）。
 private func runTestGit(args: [String], cwd: String) async throws {
   try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
     let process = Process()
@@ -318,15 +320,18 @@ private func runTestGit(args: [String], cwd: String) async throws {
     process.arguments = ["git"] + args
     process.currentDirectoryURL = URL(fileURLWithPath: cwd)
     process.environment = ProcessInfo.processInfo.environment
-    let null = FileHandle.nullDevice
-    process.standardOutput = null
-    process.standardError = null
+    process.standardOutput = FileHandle.nullDevice
+    let stderrPipe = Pipe()
+    process.standardError = stderrPipe
     process.terminationHandler = { proc in
       if proc.terminationStatus == 0 {
         cont.resume()
       } else {
+        let stderr = String(
+          decoding: stderrPipe.fileHandleForReading.readDataToEndOfFile(),
+          as: UTF8.self)
         cont.resume(
-          throwing: GitError.commandFailed(exitCode: proc.terminationStatus, stderr: ""))
+          throwing: GitError.commandFailed(exitCode: proc.terminationStatus, stderr: stderr))
       }
     }
     do {

--- a/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
+++ b/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
@@ -202,6 +202,89 @@ struct GitOpsRunGitLargeOutputTests {
   }
 }
 
+@Suite("GitOps.gitStatusFull")
+struct GitOpsStatusFullTests {
+  @Test("HEAD が指す branch 名が `branchHead` に入る")
+  func branchHeadIsPopulated() async throws {
+    // ユーザー報告の主因シナリオを下支えするテスト: `git branch -m` は OID を変えず
+    // branch 名だけ変える。`branchHead` を payload に乗せるためには parse が値を
+    // 正しく拾える必要がある。
+    let dir = try await makeGitRepo()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try "seed".write(
+      to: dir.appendingPathComponent("seed.txt"), atomically: true, encoding: .utf8)
+    try await runTestGit(args: ["add", "seed.txt"], cwd: dir.path)
+    try await runTestGit(args: ["commit", "-m", "seed"], cwd: dir.path)
+
+    let status = try await GitOps.gitStatusFull(dir: dir.path)
+    #expect(status.branchHead == "main")
+  }
+
+  @Test("`git branch -m` 後の branchHead は新しい branch 名を返す")
+  func branchHeadFollowsRename() async throws {
+    let dir = try await makeGitRepo()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try "seed".write(
+      to: dir.appendingPathComponent("seed.txt"), atomically: true, encoding: .utf8)
+    try await runTestGit(args: ["add", "seed.txt"], cwd: dir.path)
+    try await runTestGit(args: ["commit", "-m", "seed"], cwd: dir.path)
+    try await runTestGit(args: ["branch", "-m", "renamed-feature"], cwd: dir.path)
+
+    let status = try await GitOps.gitStatusFull(dir: dir.path)
+    #expect(status.branchHead == "renamed-feature")
+  }
+
+  @Test("detached HEAD では branchHead は空文字")
+  func branchHeadEmptyOnDetached() async throws {
+    let dir = try await makeGitRepo()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try "seed".write(
+      to: dir.appendingPathComponent("seed.txt"), atomically: true, encoding: .utf8)
+    try await runTestGit(args: ["add", "seed.txt"], cwd: dir.path)
+    try await runTestGit(args: ["commit", "-m", "seed"], cwd: dir.path)
+    // HEAD を直接 commit にして detached state にする
+    try await runTestGit(args: ["checkout", "--detach", "HEAD"], cwd: dir.path)
+
+    let status = try await GitOps.gitStatusFull(dir: dir.path)
+    #expect(status.branchHead == "")
+  }
+}
+
+@Suite("GitOps.refsDigest")
+struct GitOpsRefsDigestTests {
+  @Test("同じ refs 状態では digest は変わらない")
+  func digestIsStableForSameState() async throws {
+    let dir = try await makeGitRepo()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try "seed".write(
+      to: dir.appendingPathComponent("seed.txt"), atomically: true, encoding: .utf8)
+    try await runTestGit(args: ["add", "seed.txt"], cwd: dir.path)
+    try await runTestGit(args: ["commit", "-m", "seed"], cwd: dir.path)
+
+    let d1 = try await GitOps.refsDigest(dir: dir.path)
+    let d2 = try await GitOps.refsDigest(dir: dir.path)
+    #expect(d1 == d2)
+    #expect(!d1.isEmpty)
+  }
+
+  @Test("`git branch -m` で digest が変化する")
+  func digestChangesOnRename() async throws {
+    // ユーザー報告の主因シナリオ: rename 直後に renderer がこの digest を取って
+    // 前回値と比較すれば、push 取りこぼし時の最終救済として整合性チェックが効く。
+    let dir = try await makeGitRepo()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try "seed".write(
+      to: dir.appendingPathComponent("seed.txt"), atomically: true, encoding: .utf8)
+    try await runTestGit(args: ["add", "seed.txt"], cwd: dir.path)
+    try await runTestGit(args: ["commit", "-m", "seed"], cwd: dir.path)
+
+    let before = try await GitOps.refsDigest(dir: dir.path)
+    try await runTestGit(args: ["branch", "-m", "renamed"], cwd: dir.path)
+    let after = try await GitOps.refsDigest(dir: dir.path)
+    #expect(before != after)
+  }
+}
+
 // MARK: - Helpers
 
 private func makeTempDir() throws -> URL {

--- a/apps/renderer/src/features/filer/collectTargetDirs.test.ts
+++ b/apps/renderer/src/features/filer/collectTargetDirs.test.ts
@@ -1,0 +1,86 @@
+import type { WorktreeEntry } from "@gozd/proto";
+import { describe, expect, test } from "bun:test";
+import { collectTargetDirs, type RepoStoreForTargetDirs } from "./collectTargetDirs";
+
+function wt(path: string, branch: string, isMain = false): WorktreeEntry {
+  return { path, head: "", branch, isMain, gitStatuses: {}, task: undefined };
+}
+
+function makeStore(shape: RepoStoreForTargetDirs): RepoStoreForTargetDirs {
+  return shape;
+}
+
+describe("collectTargetDirs", () => {
+  test("空 repo セットでは空集合", () => {
+    const store = makeStore({ dirOrder: [], repos: {} });
+    expect(collectTargetDirs(store)).toEqual(new Set());
+  });
+
+  test("git repo は配下の全 worktree path を集める", () => {
+    const store = makeStore({
+      dirOrder: ["/r1"],
+      repos: {
+        "/r1": {
+          rootDir: "/r1",
+          repoName: "r1",
+          isGitRepo: true,
+          worktrees: [wt("/r1", "main", true), wt("/r1/wt-1", "feat-a"), wt("/r1/wt-2", "feat-b")],
+        },
+      },
+    });
+    expect(collectTargetDirs(store)).toEqual(new Set(["/r1", "/r1/wt-1", "/r1/wt-2"]));
+  });
+
+  test("非 git project は rootDir 自身を 1 つだけ集める", () => {
+    const store = makeStore({
+      dirOrder: ["/note"],
+      repos: {
+        "/note": {
+          rootDir: "/note",
+          repoName: "note",
+          isGitRepo: false,
+          worktrees: [],
+        },
+      },
+    });
+    expect(collectTargetDirs(store)).toEqual(new Set(["/note"]));
+  });
+
+  test("複数 repo を独立に集めて union を返す", () => {
+    // gozd の主用途: マルチ repo / マルチ worktree の同時 watch。
+    // 別 repo の worktree もすべて対象に入ることを保証する。
+    const store = makeStore({
+      dirOrder: ["/repo-a", "/repo-b"],
+      repos: {
+        "/repo-a": {
+          rootDir: "/repo-a",
+          repoName: "a",
+          isGitRepo: true,
+          worktrees: [wt("/repo-a", "main", true), wt("/repo-a/wt", "feat")],
+        },
+        "/repo-b": {
+          rootDir: "/repo-b",
+          repoName: "b",
+          isGitRepo: true,
+          worktrees: [wt("/repo-b", "main", true)],
+        },
+      },
+    });
+    expect(collectTargetDirs(store)).toEqual(new Set(["/repo-a", "/repo-a/wt", "/repo-b"]));
+  });
+
+  test("dirOrder に載っているが repos から消えている rootDir は無視（hydrate 競合の最終防衛）", () => {
+    const store = makeStore({
+      dirOrder: ["/ghost", "/alive"],
+      repos: {
+        "/alive": {
+          rootDir: "/alive",
+          repoName: "alive",
+          isGitRepo: true,
+          worktrees: [wt("/alive", "main", true)],
+        },
+      },
+    });
+    expect(collectTargetDirs(store)).toEqual(new Set(["/alive"]));
+  });
+});

--- a/apps/renderer/src/features/filer/collectTargetDirs.ts
+++ b/apps/renderer/src/features/filer/collectTargetDirs.ts
@@ -1,0 +1,38 @@
+/**
+ * `useFsWatchSync` が watch 対象 dir を計算する pure helper。
+ *
+ * 切り出してある理由: `useFsWatchSync.ts` は `shared/rpc/messages.ts` を
+ * transitive に import し、それがモジュール ロード時に `window.__gozdReceive`
+ * へ代入する。bun test 環境（非 DOM）では `window` が存在せず unit test を
+ * import できない。`collectTargetDirs` は副作用ゼロの pure 関数なので、
+ * これだけを独立 module に置いて test 可能にする。
+ */
+import type { useRepoStore } from "../../shared/repo";
+
+/**
+ * `collectTargetDirs` が読む `repoStore` の最小スコープ。Pinia store 全型を要求すると
+ * test で stub を作る負担が大きいので、必要なフィールドだけを表現する型に絞る。
+ * production 側は `useRepoStore()` の戻り値をそのまま渡せる（structural 互換）。
+ */
+export type RepoStoreForTargetDirs = Pick<ReturnType<typeof useRepoStore>, "dirOrder" | "repos">;
+
+/**
+ * `repoStore` の現在 state から watch すべき dir 集合を計算する pure helper。
+ * - 各 repo の `isGitRepo` で分岐: git repo は配下の全 worktree path、非 git は rootDir 自身
+ * - `dirOrder` 順は集合計算には影響しないが、reactive 依存収集のために `dirOrder` を読む
+ */
+export function collectTargetDirs(repoStore: RepoStoreForTargetDirs): Set<string> {
+  const dirs = new Set<string>();
+  for (const rootDir of repoStore.dirOrder) {
+    const repo = repoStore.repos[rootDir];
+    if (repo === undefined) continue;
+    if (!repo.isGitRepo) {
+      dirs.add(repo.rootDir);
+      continue;
+    }
+    for (const wt of repo.worktrees) {
+      dirs.add(wt.path);
+    }
+  }
+  return dirs;
+}

--- a/apps/renderer/src/features/filer/rpc.ts
+++ b/apps/renderer/src/features/filer/rpc.ts
@@ -5,6 +5,8 @@ import {
   FsReadFileAbsoluteResponse,
   FsReadFileRequest,
   FsReadFileResponse,
+  FsUnwatchAllRequest,
+  FsUnwatchAllResponse,
   FsUnwatchRequest,
   FsUnwatchResponse,
   FsWatchRequest,
@@ -27,6 +29,9 @@ export const rpcFsWatch = (req: FsWatchRequest) =>
 
 export const rpcFsUnwatch = (req: FsUnwatchRequest) =>
   rpc("/fs/unwatch", req, FsUnwatchRequest, FsUnwatchResponse);
+
+export const rpcFsUnwatchAll = (req: FsUnwatchAllRequest) =>
+  rpc("/fs/unwatchAll", req, FsUnwatchAllRequest, FsUnwatchAllResponse);
 
 // fsChange push event payload
 export interface FsChangePayload {

--- a/apps/renderer/src/features/filer/runOneSyncPass.test.ts
+++ b/apps/renderer/src/features/filer/runOneSyncPass.test.ts
@@ -1,0 +1,240 @@
+import type { WorktreeEntry } from "@gozd/proto";
+import { describe, expect, test } from "bun:test";
+import type { RepoStoreForTargetDirs } from "./collectTargetDirs";
+import { runOneSyncPass, type SyncPassDeps } from "./runOneSyncPass";
+
+function wt(path: string, branch: string, isMain = false): WorktreeEntry {
+  return { path, head: "", branch, isMain, gitStatuses: {}, task: undefined };
+}
+
+/**
+ * トーストに渡された aggregate Error の cause chain を解く。
+ * `notify.error(message, aggregate)` で aggregate が Error として渡され、その `cause`
+ * に first failure の Error が入っている前提で展開する。`as` キャストを避けるため
+ * `instanceof Error` で narrowing する。
+ */
+function expectAggregate(cause: unknown): { aggregate: Error; first: Error } {
+  if (!(cause instanceof Error)) throw new Error(`expected Error, got ${typeof cause}`);
+  if (!(cause.cause instanceof Error)) {
+    throw new Error(`expected Error in cause.cause, got ${typeof cause.cause}`);
+  }
+  return { aggregate: cause, first: cause.cause };
+}
+
+interface CallRecord {
+  watch: string[];
+  unwatch: string[];
+  readyCount: number;
+  errors: Array<{ message: string; cause: unknown }>;
+}
+
+interface FixtureOptions {
+  store: RepoStoreForTargetDirs;
+  watchedDirs?: Set<string>;
+  failWatch?: Set<string>;
+  failUnwatch?: Set<string>;
+}
+
+function makeFixture(opts: FixtureOptions): { deps: SyncPassDeps; calls: CallRecord } {
+  const calls: CallRecord = { watch: [], unwatch: [], readyCount: 0, errors: [] };
+  const failWatch = opts.failWatch ?? new Set<string>();
+  const failUnwatch = opts.failUnwatch ?? new Set<string>();
+  const deps: SyncPassDeps = {
+    repoStore: opts.store,
+    watchedDirs: opts.watchedDirs ?? new Set(),
+    fsWatch: async ({ dir }) => {
+      calls.watch.push(dir);
+      if (failWatch.has(dir)) throw new Error(`watch failed: ${dir}`);
+      return {};
+    },
+    fsUnwatch: async ({ dir }) => {
+      calls.unwatch.push(dir);
+      if (failUnwatch.has(dir)) throw new Error(`unwatch failed: ${dir}`);
+      return {};
+    },
+    notify: {
+      error: (message, cause) => calls.errors.push({ message, cause }),
+    },
+    dispatchReady: () => {
+      calls.readyCount++;
+    },
+  };
+  return { deps, calls };
+}
+
+describe("runOneSyncPass", () => {
+  test("初回 sync で全 target を watch し、fsWatchReady を 1 回発射する", async () => {
+    const { deps, calls } = makeFixture({
+      store: {
+        dirOrder: ["/r1"],
+        repos: {
+          "/r1": {
+            rootDir: "/r1",
+            repoName: "r1",
+            isGitRepo: true,
+            worktrees: [wt("/r1", "main", true), wt("/r1/wt-a", "feat-a")],
+          },
+        },
+      },
+    });
+    await runOneSyncPass(deps);
+    expect(calls.watch).toEqual(["/r1", "/r1/wt-a"]);
+    expect(calls.unwatch).toEqual([]);
+    expect(calls.readyCount).toBe(1);
+    expect(calls.errors).toEqual([]);
+    expect(deps.watchedDirs).toEqual(new Set(["/r1", "/r1/wt-a"]));
+  });
+
+  test("target から消えた dir を unwatch して watchedDirs から除く", async () => {
+    const { deps, calls } = makeFixture({
+      store: {
+        dirOrder: ["/r1"],
+        repos: {
+          "/r1": {
+            rootDir: "/r1",
+            repoName: "r1",
+            isGitRepo: true,
+            worktrees: [wt("/r1", "main", true)],
+          },
+        },
+      },
+      watchedDirs: new Set(["/r1", "/r1/wt-removed"]),
+    });
+    await runOneSyncPass(deps);
+    expect(calls.unwatch).toEqual(["/r1/wt-removed"]);
+    expect(calls.watch).toEqual([]);
+    // 新規 watch ゼロのため Ready を発射しない
+    expect(calls.readyCount).toBe(0);
+    expect(deps.watchedDirs).toEqual(new Set(["/r1"]));
+  });
+
+  test("全 watch が失敗すると fsWatchReady を発射せず、aggregate Error をトーストする", async () => {
+    const { deps, calls } = makeFixture({
+      store: {
+        dirOrder: ["/r1"],
+        repos: {
+          "/r1": {
+            rootDir: "/r1",
+            repoName: "r1",
+            isGitRepo: true,
+            worktrees: [wt("/r1", "main", true)],
+          },
+        },
+      },
+      failWatch: new Set(["/r1"]),
+    });
+    await runOneSyncPass(deps);
+    expect(calls.readyCount).toBe(0);
+    expect(calls.errors.length).toBe(1);
+    expect(deps.watchedDirs.has("/r1")).toBe(false);
+    const [err] = calls.errors;
+    expect(err.message).toBe("Failed to sync FS watches (1)");
+    const { aggregate, first } = expectAggregate(err.cause);
+    expect(aggregate.message).toBe("watch:/r1 -- first error: watch failed: /r1");
+    expect(first.message).toBe("watch failed: /r1");
+  });
+
+  test("一部 watch のみ失敗した場合、aggregate に件数と first.error が乗り、Ready は発射する", async () => {
+    const { deps, calls } = makeFixture({
+      store: {
+        dirOrder: ["/r1"],
+        repos: {
+          "/r1": {
+            rootDir: "/r1",
+            repoName: "r1",
+            isGitRepo: true,
+            worktrees: [wt("/r1", "main", true), wt("/r1/wt-a", "feat-a")],
+          },
+        },
+      },
+      failWatch: new Set(["/r1/wt-a"]),
+    });
+    await runOneSyncPass(deps);
+    expect(deps.watchedDirs).toEqual(new Set(["/r1"]));
+    // 1 つでも watch 成功している = fsWatchReady を 1 回発射
+    expect(calls.readyCount).toBe(1);
+    expect(calls.errors.length).toBe(1);
+    const [err] = calls.errors;
+    expect(err.message).toBe("Failed to sync FS watches (1)");
+    const { aggregate, first } = expectAggregate(err.cause);
+    // aggregate.message に summary と first error message が両方乗る
+    expect(aggregate.message).toBe("watch:/r1/wt-a -- first error: watch failed: /r1/wt-a");
+    // cause chain の最上位は first.error の Error object
+    expect(first.message).toBe("watch failed: /r1/wt-a");
+  });
+
+  test("unwatch 失敗でも watchedDirs からは削除される (再 watch / unwatchAll で leak は閉じる)", async () => {
+    const { deps, calls } = makeFixture({
+      store: {
+        dirOrder: ["/r1"],
+        repos: {
+          "/r1": {
+            rootDir: "/r1",
+            repoName: "r1",
+            isGitRepo: true,
+            worktrees: [wt("/r1", "main", true)],
+          },
+        },
+      },
+      watchedDirs: new Set(["/r1", "/r1/wt-removed"]),
+      failUnwatch: new Set(["/r1/wt-removed"]),
+    });
+    await runOneSyncPass(deps);
+    expect(calls.unwatch).toEqual(["/r1/wt-removed"]);
+    expect(deps.watchedDirs).toEqual(new Set(["/r1"]));
+    expect(calls.errors.length).toBe(1);
+    expect(calls.errors[0].message).toBe("Failed to sync FS watches (1)");
+  });
+
+  test("watch / unwatch 両方失敗した場合、aggregate に first error として最初の failure が乗る", async () => {
+    const { deps, calls } = makeFixture({
+      store: {
+        dirOrder: ["/r1"],
+        repos: {
+          "/r1": {
+            rootDir: "/r1",
+            repoName: "r1",
+            isGitRepo: true,
+            worktrees: [wt("/r1/wt-new", "feat-a")],
+          },
+        },
+      },
+      watchedDirs: new Set(["/r1/wt-removed"]),
+      failWatch: new Set(["/r1/wt-new"]),
+      failUnwatch: new Set(["/r1/wt-removed"]),
+    });
+    await runOneSyncPass(deps);
+    expect(calls.errors.length).toBe(1);
+    const [err] = calls.errors;
+    expect(err.message).toBe("Failed to sync FS watches (2)");
+    const { aggregate, first } = expectAggregate(err.cause);
+    // unwatch が watch より先に実行されるため、first.error は unwatch failure
+    expect(aggregate.message).toBe(
+      "unwatch:/r1/wt-removed, watch:/r1/wt-new -- first error: unwatch failed: /r1/wt-removed",
+    );
+    expect(first.message).toBe("unwatch failed: /r1/wt-removed");
+  });
+
+  test("差分ゼロでは何も発射しない (toWatch / toUnwatch どちらも空)", async () => {
+    const { deps, calls } = makeFixture({
+      store: {
+        dirOrder: ["/r1"],
+        repos: {
+          "/r1": {
+            rootDir: "/r1",
+            repoName: "r1",
+            isGitRepo: true,
+            worktrees: [wt("/r1", "main", true)],
+          },
+        },
+      },
+      watchedDirs: new Set(["/r1"]),
+    });
+    await runOneSyncPass(deps);
+    expect(calls.watch).toEqual([]);
+    expect(calls.unwatch).toEqual([]);
+    expect(calls.readyCount).toBe(0);
+    expect(calls.errors).toEqual([]);
+    expect(deps.watchedDirs).toEqual(new Set(["/r1"]));
+  });
+});

--- a/apps/renderer/src/features/filer/runOneSyncPass.test.ts
+++ b/apps/renderer/src/features/filer/runOneSyncPass.test.ts
@@ -130,7 +130,7 @@ describe("runOneSyncPass", () => {
     const [err] = calls.errors;
     expect(err.message).toBe("Failed to sync FS watches (1)");
     const { aggregate, first } = expectAggregate(err.cause);
-    expect(aggregate.message).toBe("watch:/r1 -- first error: watch failed: /r1");
+    expect(aggregate.message).toBe("watch:/r1");
     expect(first.message).toBe("watch failed: /r1");
   });
 
@@ -157,9 +157,9 @@ describe("runOneSyncPass", () => {
     const [err] = calls.errors;
     expect(err.message).toBe("Failed to sync FS watches (1)");
     const { aggregate, first } = expectAggregate(err.cause);
-    // aggregate.message に summary と first error message が両方乗る
-    expect(aggregate.message).toBe("watch:/r1/wt-a -- first error: watch failed: /r1/wt-a");
-    // cause chain の最上位は first.error の Error object
+    // aggregate.message は summary のみ。first error の name/message/stack は cause 経由で
+    // `formatCauseChain` がトースト詳細に再帰展開する（toast UI 側の責務）
+    expect(aggregate.message).toBe("watch:/r1/wt-a");
     expect(first.message).toBe("watch failed: /r1/wt-a");
   });
 
@@ -209,9 +209,7 @@ describe("runOneSyncPass", () => {
     expect(err.message).toBe("Failed to sync FS watches (2)");
     const { aggregate, first } = expectAggregate(err.cause);
     // unwatch が watch より先に実行されるため、first.error は unwatch failure
-    expect(aggregate.message).toBe(
-      "unwatch:/r1/wt-removed, watch:/r1/wt-new -- first error: unwatch failed: /r1/wt-removed",
-    );
+    expect(aggregate.message).toBe("unwatch:/r1/wt-removed, watch:/r1/wt-new");
     expect(first.message).toBe("unwatch failed: /r1/wt-removed");
   });
 

--- a/apps/renderer/src/features/filer/runOneSyncPass.ts
+++ b/apps/renderer/src/features/filer/runOneSyncPass.ts
@@ -1,0 +1,85 @@
+/**
+ * `useFsWatchSync` の 1 回の sync pass 本体。`watchedDirs` と target dir 集合の差分を
+ * 計算して `fsWatch` / `fsUnwatch` を発射し、失敗を 1 件のトーストに集約する。
+ *
+ * 切り出した理由:
+ * - `useFsWatchSync.ts` は Vue の `watchEffect` / `onUnmounted` / Pinia store を直接
+ *   触るため、bun test で import するには Vue / DOM の整備が前提になる
+ * - 1 pass のロジックは「差分計算 + RPC 発射 + 失敗集約 + Ready 通知」で完結しており、
+ *   依存を引数で受け取れば pure 関数として直接呼べる
+ *
+ * 副作用は `watchedDirs` の mutation と `notify.error` / `fsWatch` / `fsUnwatch` /
+ * `dispatchReady` の呼び出しのみで、いずれも引数経由。production 側は固定の依存を
+ * 渡す薄い wrapper を持つ。
+ */
+import { tryCatch } from "@gozd/shared";
+import { collectTargetDirs, type RepoStoreForTargetDirs } from "./collectTargetDirs";
+
+export interface SyncPassDeps {
+  repoStore: RepoStoreForTargetDirs;
+  /** 現在 native 側で watch 中だと local に把握している dir の集合。pass 内で mutate される。 */
+  watchedDirs: Set<string>;
+  fsWatch: (req: { dir: string }) => Promise<unknown>;
+  fsUnwatch: (req: { dir: string }) => Promise<unknown>;
+  notify: { error: (message: string, cause?: unknown) => void };
+  /** 新規 watch が 1 つでも成功した時に呼ばれる。`fsWatchReady` 発射用。 */
+  dispatchReady: () => void;
+}
+
+export async function runOneSyncPass(deps: SyncPassDeps): Promise<void> {
+  const { repoStore, watchedDirs, fsWatch, fsUnwatch, notify, dispatchReady } = deps;
+
+  const next = collectTargetDirs(repoStore);
+  const toUnwatch: string[] = [];
+  const toWatch: string[] = [];
+  for (const dir of watchedDirs) {
+    if (!next.has(dir)) toUnwatch.push(dir);
+  }
+  for (const dir of next) {
+    if (!watchedDirs.has(dir)) toWatch.push(dir);
+  }
+
+  const failures: Array<{ kind: "watch" | "unwatch"; dir: string; error: Error }> = [];
+
+  for (const dir of toUnwatch) {
+    const r = await tryCatch(fsUnwatch({ dir }));
+    if (!r.ok) {
+      failures.push({ kind: "unwatch", dir, error: r.error });
+    }
+    // 失敗してもローカル set からは外す。native 側 watch は「既存 entry があれば破棄して
+    // 再構築」する設計なので、ローカル set と native 側で乖離しても次回の `fsWatch`
+    // で永続的不整合は解消される。再 watch が走らないケースでも `onUnmounted` の
+    // `rpcFsUnwatchAll` で native 側残骸は一括破棄される。
+    watchedDirs.delete(dir);
+  }
+  for (const dir of toWatch) {
+    const r = await tryCatch(fsWatch({ dir }));
+    if (!r.ok) {
+      failures.push({ kind: "watch", dir, error: r.error });
+      continue;
+    }
+    watchedDirs.add(dir);
+  }
+
+  if (failures.length > 0) {
+    // batch 単位で 1 件に集約する。トースト UI は cause chain の最上位だけ展開する
+    // （cause.cause は表示しない）ため、aggregate.message に summary と
+    // first.error.message の両方を載せて、トーストの詳細展開だけで「件数 + どの
+    // kind:dir + 最初の失敗の原因文言」が見えるようにする。
+    const summary = failures.map((f) => `${f.kind}:${f.dir}`).join(", ");
+    const [first] = failures;
+    const aggregate = new Error(`${summary} -- first error: ${first.error.message}`, {
+      cause: first.error,
+    });
+    notify.error(`Failed to sync FS watches (${failures.length})`, aggregate);
+  }
+
+  const watchFailures = failures.filter((f) => f.kind === "watch").length;
+  const successfulWatches = toWatch.length - watchFailures;
+  if (successfulWatches > 0) {
+    // 「Ready」というイベント名と実態を一致させるため、新規 watch が 1 つでも成功した
+    // 場合に限って発射する（全 watch が失敗した場合は新たに監視対象になった dir が無く、
+    // 救済する取りこぼし対象も存在しない）。
+    dispatchReady();
+  }
+}

--- a/apps/renderer/src/features/filer/runOneSyncPass.ts
+++ b/apps/renderer/src/features/filer/runOneSyncPass.ts
@@ -62,15 +62,13 @@ export async function runOneSyncPass(deps: SyncPassDeps): Promise<void> {
   }
 
   if (failures.length > 0) {
-    // batch 単位で 1 件に集約する。トースト UI は cause chain の最上位だけ展開する
-    // （cause.cause は表示しない）ため、aggregate.message に summary と
-    // first.error.message の両方を載せて、トーストの詳細展開だけで「件数 + どの
-    // kind:dir + 最初の失敗の原因文言」が見えるようにする。
+    // batch 単位で 1 件に集約する。aggregate.message には summary のみを載せ、first failure
+    // の Error は cause として埋める。`NotificationToastItem.vue` 側の `formatCauseChain`
+    // が cause 再帰展開を行うため、トースト詳細だけで「summary + 最初の失敗の name +
+    // message + stack」が読める（旧実装の文言併記 workaround は不要）。
     const summary = failures.map((f) => `${f.kind}:${f.dir}`).join(", ");
     const [first] = failures;
-    const aggregate = new Error(`${summary} -- first error: ${first.error.message}`, {
-      cause: first.error,
-    });
+    const aggregate = new Error(summary, { cause: first.error });
     notify.error(`Failed to sync FS watches (${failures.length})`, aggregate);
   }
 

--- a/apps/renderer/src/features/filer/runSerializedSync.test.ts
+++ b/apps/renderer/src/features/filer/runSerializedSync.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+import { runSerializedSync, type SerializeState } from "./runSerializedSync";
+
+/**
+ * production 側の `useFsWatchSync` は `runOneSyncPass` 固定の単一 pass を毎呼び出しで
+ * 渡す前提なので、テストでも 1 つの `sharedPass` を使い回す。pass 内で stage を進めて
+ * 「何回目の pass か」を観測する。
+ */
+
+describe("runSerializedSync", () => {
+  test("単発呼び出しは pass を 1 回だけ実行する", async () => {
+    const state: SerializeState = { running: false, pending: false };
+    let count = 0;
+    const pass = async () => {
+      count++;
+    };
+    await runSerializedSync(state, pass);
+    expect(count).toBe(1);
+    expect(state.running).toBe(false);
+    expect(state.pending).toBe(false);
+  });
+
+  test("in-flight 中の追加呼び出しは即 return して pending だけ立て、完了後に追加 1 pass が走る", async () => {
+    const state: SerializeState = { running: false, pending: false };
+    let resolveFirst!: () => void;
+    let count = 0;
+    const pass = async () => {
+      count++;
+      if (count === 1) {
+        await new Promise<void>((r) => {
+          resolveFirst = r;
+        });
+      }
+    };
+
+    const firstCall = runSerializedSync(state, pass);
+    // microtask 1 つ進めて pass 1 が await まで進んだ状態にする
+    await Promise.resolve();
+    expect(state.running).toBe(true);
+    expect(state.pending).toBe(false);
+    expect(count).toBe(1);
+
+    const secondCall = runSerializedSync(state, pass);
+    expect(state.pending).toBe(true);
+    expect(count).toBe(1); // pass 2 はまだ走っていない
+
+    resolveFirst();
+    await firstCall;
+    await secondCall;
+
+    // pass 1 完了後、pending を消化して pass 2 が 1 回走る
+    expect(count).toBe(2);
+    expect(state.running).toBe(false);
+    expect(state.pending).toBe(false);
+  });
+
+  test("in-flight 中の複数呼び出しは 1 回の追加 pass に coalesce される", async () => {
+    // ccfe6c7 で見落としたレースの核心テスト: 並列に N 個発射しても追加 pass は 1 回。
+    const state: SerializeState = { running: false, pending: false };
+    let resolveFirst!: () => void;
+    let count = 0;
+    const pass = async () => {
+      count++;
+      if (count === 1) {
+        await new Promise<void>((r) => {
+          resolveFirst = r;
+        });
+      }
+    };
+
+    const first = runSerializedSync(state, pass);
+    await Promise.resolve();
+    const second = runSerializedSync(state, pass);
+    const third = runSerializedSync(state, pass);
+    const fourth = runSerializedSync(state, pass);
+
+    expect(count).toBe(1);
+    expect(state.pending).toBe(true);
+
+    resolveFirst();
+    await Promise.all([first, second, third, fourth]);
+
+    // pass 1 + coalesced pass = 2 回。second/third/fourth は同じ追加 pass で消化される
+    expect(count).toBe(2);
+    expect(state.running).toBe(false);
+  });
+
+  test("coalesced pass が走っている間にさらに発射すると、もう 1 回 pass が走る", async () => {
+    // pass 2 完了寸前にも変化が来た場合、do-while ループで pass 3 も消化されることを担保。
+    const state: SerializeState = { running: false, pending: false };
+    let resolveFirst!: () => void;
+    let resolveSecond!: () => void;
+    let count = 0;
+    const pass = async () => {
+      count++;
+      if (count === 1) {
+        await new Promise<void>((r) => {
+          resolveFirst = r;
+        });
+      } else if (count === 2) {
+        await new Promise<void>((r) => {
+          resolveSecond = r;
+        });
+      }
+    };
+
+    const first = runSerializedSync(state, pass);
+    await Promise.resolve();
+    // pass 1 中に発射 → pass 2 を予約
+    const second = runSerializedSync(state, pass);
+    resolveFirst();
+    // pass 2 が始まるまで microtask を進める
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // pass 2 中にさらに発射 → pass 3 を予約
+    const third = runSerializedSync(state, pass);
+    resolveSecond();
+
+    await Promise.all([first, second, third]);
+
+    expect(count).toBeGreaterThanOrEqual(2);
+    expect(state.running).toBe(false);
+    expect(state.pending).toBe(false);
+  });
+
+  test("完了後の新規発射は fresh で pass 1 を実行する", async () => {
+    const state: SerializeState = { running: false, pending: false };
+    let count = 0;
+    const pass = async () => {
+      count++;
+    };
+    await runSerializedSync(state, pass);
+    await runSerializedSync(state, pass);
+    expect(count).toBe(2);
+    expect(state.running).toBe(false);
+  });
+
+  test("pass が throw した後も running フラグが false に戻る", async () => {
+    const state: SerializeState = { running: false, pending: false };
+    await expect(
+      runSerializedSync(state, async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    expect(state.running).toBe(false);
+    expect(state.pending).toBe(false);
+  });
+});

--- a/apps/renderer/src/features/filer/runSerializedSync.test.ts
+++ b/apps/renderer/src/features/filer/runSerializedSync.test.ts
@@ -86,41 +86,50 @@ describe("runSerializedSync", () => {
   });
 
   test("coalesced pass が走っている間にさらに発射すると、もう 1 回 pass が走る", async () => {
-    // pass 2 完了寸前にも変化が来た場合、do-while ループで pass 3 も消化されることを担保。
+    // pass 2 完了寸前にも変化が来た場合、do-while ループで pass 3 も消化されることを
+    // 厳密に担保する。`toBeGreaterThanOrEqual(2)` だと pass 3 が走らなくても通るため、
+    // `toBe(3)` で pass 3 の実行を assertion する。timing 依存を消すため、pass 2 が
+    // await に入った瞬間（resolves[1] が代入されたタイミング）で third を発射する。
     const state: SerializeState = { running: false, pending: false };
-    let resolveFirst!: () => void;
-    let resolveSecond!: () => void;
+    const resolves: Array<() => void> = [];
     let count = 0;
     const pass = async () => {
       count++;
-      if (count === 1) {
+      const myStage = count;
+      // pass 1 と pass 2 は await して外部 resolve を待つ。pass 3 は即完了。
+      if (myStage <= 2) {
         await new Promise<void>((r) => {
-          resolveFirst = r;
-        });
-      } else if (count === 2) {
-        await new Promise<void>((r) => {
-          resolveSecond = r;
+          resolves[myStage - 1] = r;
         });
       }
     };
 
     const first = runSerializedSync(state, pass);
-    await Promise.resolve();
+    // pass 1 が「await new Promise」に入るまで microtask を進める
+    while (resolves[0] === undefined) {
+      await Promise.resolve();
+    }
+    expect(count).toBe(1);
+
     // pass 1 中に発射 → pass 2 を予約
     const second = runSerializedSync(state, pass);
-    resolveFirst();
-    // pass 2 が始まるまで microtask を進める
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    expect(state.pending).toBe(true);
 
-    // pass 2 中にさらに発射 → pass 3 を予約
+    resolves[0]();
+    // pass 2 が「await new Promise」に入るまで待つ
+    while (resolves[1] === undefined) {
+      await Promise.resolve();
+    }
+    expect(count).toBe(2);
+    // pass 2 中の発射で pass 3 を予約
     const third = runSerializedSync(state, pass);
-    resolveSecond();
+    expect(state.pending).toBe(true);
 
+    resolves[1]();
     await Promise.all([first, second, third]);
 
-    expect(count).toBeGreaterThanOrEqual(2);
+    // pass 1 + pass 2 + pass 3 が全て走ったことを厳密に確認
+    expect(count).toBe(3);
     expect(state.running).toBe(false);
     expect(state.pending).toBe(false);
   });

--- a/apps/renderer/src/features/filer/runSerializedSync.test.ts
+++ b/apps/renderer/src/features/filer/runSerializedSync.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { runSerializedSync, type SerializeState } from "./runSerializedSync";
+import { runSerializedSync, type SerializeState, whenIdle } from "./runSerializedSync";
 
 /**
  * production 側の `useFsWatchSync` は `runOneSyncPass` 固定の単一 pass を毎呼び出しで
@@ -9,7 +9,7 @@ import { runSerializedSync, type SerializeState } from "./runSerializedSync";
 
 describe("runSerializedSync", () => {
   test("単発呼び出しは pass を 1 回だけ実行する", async () => {
-    const state: SerializeState = { running: false, pending: false };
+    const state: SerializeState = { running: false, pending: false, currentRun: null };
     let count = 0;
     const pass = async () => {
       count++;
@@ -21,7 +21,7 @@ describe("runSerializedSync", () => {
   });
 
   test("in-flight 中の追加呼び出しは即 return して pending だけ立て、完了後に追加 1 pass が走る", async () => {
-    const state: SerializeState = { running: false, pending: false };
+    const state: SerializeState = { running: false, pending: false, currentRun: null };
     let resolveFirst!: () => void;
     let count = 0;
     const pass = async () => {
@@ -56,7 +56,7 @@ describe("runSerializedSync", () => {
 
   test("in-flight 中の複数呼び出しは 1 回の追加 pass に coalesce される", async () => {
     // ccfe6c7 で見落としたレースの核心テスト: 並列に N 個発射しても追加 pass は 1 回。
-    const state: SerializeState = { running: false, pending: false };
+    const state: SerializeState = { running: false, pending: false, currentRun: null };
     let resolveFirst!: () => void;
     let count = 0;
     const pass = async () => {
@@ -90,7 +90,7 @@ describe("runSerializedSync", () => {
     // 厳密に担保する。`toBeGreaterThanOrEqual(2)` だと pass 3 が走らなくても通るため、
     // `toBe(3)` で pass 3 の実行を assertion する。timing 依存を消すため、pass 2 が
     // await に入った瞬間（resolves[1] が代入されたタイミング）で third を発射する。
-    const state: SerializeState = { running: false, pending: false };
+    const state: SerializeState = { running: false, pending: false, currentRun: null };
     const resolves: Array<() => void> = [];
     let count = 0;
     const pass = async () => {
@@ -135,7 +135,7 @@ describe("runSerializedSync", () => {
   });
 
   test("完了後の新規発射は fresh で pass 1 を実行する", async () => {
-    const state: SerializeState = { running: false, pending: false };
+    const state: SerializeState = { running: false, pending: false, currentRun: null };
     let count = 0;
     const pass = async () => {
       count++;
@@ -147,7 +147,7 @@ describe("runSerializedSync", () => {
   });
 
   test("pass が throw した後も running フラグが false に戻る", async () => {
-    const state: SerializeState = { running: false, pending: false };
+    const state: SerializeState = { running: false, pending: false, currentRun: null };
     let caught: Error | undefined;
     try {
       await runSerializedSync(state, async () => {
@@ -159,5 +159,54 @@ describe("runSerializedSync", () => {
     expect(caught?.message).toBe("boom");
     expect(state.running).toBe(false);
     expect(state.pending).toBe(false);
+    expect(state.currentRun).toBe(null);
+  });
+});
+
+describe("whenIdle", () => {
+  test("currentRun が null のときは即 resolve する", async () => {
+    const state: SerializeState = { running: false, pending: false, currentRun: null };
+    let resolved = false;
+    await whenIdle(state).then(() => {
+      resolved = true;
+    });
+    expect(resolved).toBe(true);
+  });
+
+  test("in-flight の pass チェーン完走を await できる (drain primitive)", async () => {
+    // `useFsWatchSync.onUnmounted` で「in-flight `runOneSyncPass` の `fsWatch` が完走する
+    // 前に `rpcFsUnwatchAll` を発射する」race を防ぐ用途。drain として正しく機能することを
+    // pass 1 + coalesced pass 2 の両方が `whenIdle` 経由で待てるかで verify する。
+    const state: SerializeState = { running: false, pending: false, currentRun: null };
+    let resolveFirst!: () => void;
+    let count = 0;
+    const pass = async () => {
+      count++;
+      if (count === 1) {
+        await new Promise<void>((r) => {
+          resolveFirst = r;
+        });
+      }
+    };
+
+    const first = runSerializedSync(state, pass);
+    // pass 1 が await まで進んだ状態にする
+    while (resolveFirst === undefined) {
+      await Promise.resolve();
+    }
+    // pass 1 中に追加発射して pass 2 を予約
+    void runSerializedSync(state, pass);
+    expect(state.currentRun).not.toBe(null);
+
+    // whenIdle で drain
+    const idle = whenIdle(state);
+    resolveFirst();
+    await idle;
+
+    // drain 完了時点で pass 1 + 2 がどちらも完走している
+    expect(count).toBe(2);
+    expect(state.running).toBe(false);
+    expect(state.currentRun).toBe(null);
+    await first;
   });
 });

--- a/apps/renderer/src/features/filer/runSerializedSync.test.ts
+++ b/apps/renderer/src/features/filer/runSerializedSync.test.ts
@@ -148,11 +148,15 @@ describe("runSerializedSync", () => {
 
   test("pass が throw した後も running フラグが false に戻る", async () => {
     const state: SerializeState = { running: false, pending: false };
-    await expect(
-      runSerializedSync(state, async () => {
+    let caught: Error | undefined;
+    try {
+      await runSerializedSync(state, async () => {
         throw new Error("boom");
-      }),
-    ).rejects.toThrow("boom");
+      });
+    } catch (e) {
+      if (e instanceof Error) caught = e;
+    }
+    expect(caught?.message).toBe("boom");
     expect(state.running).toBe(false);
     expect(state.pending).toBe(false);
   });

--- a/apps/renderer/src/features/filer/runSerializedSync.ts
+++ b/apps/renderer/src/features/filer/runSerializedSync.ts
@@ -1,0 +1,37 @@
+/**
+ * single-flight + coalesce な async runner。
+ *
+ * - `pass` が in-flight 中に再度呼ばれた場合、即 return して `pending` フラグだけ立てる
+ * - in-flight の `pass` 完了後、`pending` が立っていれば追加で 1 回だけ `pass` を実行
+ * - 複数回の重複呼び出しは 1 回の追加 pass に畳まれる（coalesce）
+ *
+ * `useFsWatchSync` の `syncWatches` から切り出した。`watchEffect` は依存変更で即時再 run
+ * するが前回の async 完了を待たないため、並列発射で内部 state（`watchedDirs` 等）の
+ * 整合性が壊れる race を構造的に防ぐ。
+ *
+ * pure な module-level 関数にすることで bun test で race / coalesce 挙動を直接検証できる。
+ * production 側は呼び出し元 closure が `state` を保持し、`runSerializedSync` を呼ぶ。
+ */
+export interface SerializeState {
+  running: boolean;
+  pending: boolean;
+}
+
+export async function runSerializedSync(
+  state: SerializeState,
+  pass: () => Promise<void>,
+): Promise<void> {
+  if (state.running) {
+    state.pending = true;
+    return;
+  }
+  state.running = true;
+  try {
+    do {
+      state.pending = false;
+      await pass();
+    } while (state.pending);
+  } finally {
+    state.running = false;
+  }
+}

--- a/apps/renderer/src/features/filer/runSerializedSync.ts
+++ b/apps/renderer/src/features/filer/runSerializedSync.ts
@@ -15,6 +15,13 @@
 export interface SerializeState {
   running: boolean;
   pending: boolean;
+  /**
+   * in-flight の pass チェーン全体（最初の caller が起動し、coalesce された pending を
+   * 含めて全 pass が完走するまで resolve しない）。後乗りした呼び出しは `pending` だけ
+   * 立てて即 return するが、外部から `whenIdle(state)` 越しに完走を await できる。
+   * 完走後の finally で null に戻る。
+   */
+  currentRun: Promise<void> | null;
 }
 
 export async function runSerializedSync(
@@ -26,12 +33,31 @@ export async function runSerializedSync(
     return;
   }
   state.running = true;
-  try {
-    do {
-      state.pending = false;
-      await pass();
-    } while (state.pending);
-  } finally {
-    state.running = false;
+  const run = (async () => {
+    try {
+      do {
+        state.pending = false;
+        await pass();
+      } while (state.pending);
+    } finally {
+      state.running = false;
+      state.currentRun = null;
+    }
+  })();
+  state.currentRun = run;
+  await run;
+}
+
+/**
+ * 現在 in-flight の pass チェーンが完走するまで await する。in-flight が無ければ即 resolve。
+ *
+ * `useFsWatchSync` の `onUnmounted` で「in-flight `runOneSyncPass` の `fsWatch` が
+ * native で entry を登録する前に `rpcFsUnwatchAll` を発射する」race を構造的に潰すための
+ * drain primitive。caller 側で `disposing` ガードを立てて新規 pass の start を抑制した上で
+ * `whenIdle` で in-flight を待ち、 そこから unwatchAll を発射する流れ。
+ */
+export async function whenIdle(state: SerializeState): Promise<void> {
+  if (state.currentRun !== null) {
+    await state.currentRun;
   }
 }

--- a/apps/renderer/src/features/filer/useFsWatchSync.ts
+++ b/apps/renderer/src/features/filer/useFsWatchSync.ts
@@ -1,45 +1,102 @@
 /**
- * 選択中 dir に応じて native 側の FSWatchRegistry の対象 dir を切り替える app-scope な watcher。
+ * gozd が開いている全 repo / 全 worktree の dir を native 側 `FSWatchRegistry` に同期して
+ * watch させる app-scope な watcher。
  *
- * 旧 dir は unwatch、新 dir は watch することで、サーバー側の FSWatcher を選択中 worktree に
- * 同期させる。fsChange / gitStatusChange 等の push event がここを起点に届くようになる。
+ * 設計判断:
+ *
+ * - 単一 active worktree だけを watch する旧設計は、別 repo / 別 worktree で起きた
+ *   commit / rename / push を取りこぼす。gozd は「window 内マルチ repo + マルチ worktree」
+ *   が機能要件なので、watch も全 worktree を均等に対象とする
+ * - `repoStore.repos[*].worktrees` の集合変化（追加 / 削除）を `watchEffect` で追い、
+ *   diff を取って `rpcFsWatch` / `rpcFsUnwatch` を発射する
+ * - 非 git project（`isGitRepo === false`）は rootDir そのものを watch（FS 変化のみ）
+ * - 失敗はトーストで通知（CLAUDE.md 規律）。silent drop は禁止
+ * - 新規 watch 開始後に `fsWatchReady` を発射して、購読側に 1 度だけ再同期させる
+ *   （watch 起動往復中の取りこぼし救済）
  */
 import { tryCatch } from "@gozd/shared";
-import { onUnmounted, watch } from "vue";
+import { onUnmounted, watchEffect } from "vue";
 import { useNotificationStore } from "../../shared/notification";
+import { useRepoStore } from "../../shared/repo";
 import { dispatchMessage } from "../../shared/rpc";
-import { useWorktreeStore } from "../worktree";
 import { rpcFsUnwatch, rpcFsWatch } from "./rpc";
 
 export function useFsWatchSync() {
-  const worktreeStore = useWorktreeStore();
+  const repoStore = useRepoStore();
   const notify = useNotificationStore();
 
-  watch(
-    () => worktreeStore.dir,
-    async (newDir, oldDir) => {
-      if (oldDir !== undefined && oldDir !== newDir) {
-        await tryCatch(rpcFsUnwatch({ dir: oldDir }));
+  /** 現在 native 側で watch 中だと local に把握している dir の集合。
+   * 差分計算の baseline で、 rpcFsWatch / rpcFsUnwatch の発射対象を絞るために使う。
+   * native 側 `FSWatchRegistry.entries` とは独立に持つが、native 側は idempotent なので
+   * ズレても correctness は保たれる。 */
+  const watchedDirs = new Set<string>();
+
+  function collectTargetDirs(): Set<string> {
+    const dirs = new Set<string>();
+    for (const rootDir of repoStore.dirOrder) {
+      const repo = repoStore.repos[rootDir];
+      if (repo === undefined) continue;
+      if (!repo.isGitRepo) {
+        // 非 git project は worktrees を持たないので rootDir 自身を watch する。
+        dirs.add(repo.rootDir);
+        continue;
       }
-      if (newDir !== undefined && newDir !== oldDir) {
-        const result = await tryCatch(rpcFsWatch({ dir: newDir }));
-        if (!result.ok) {
-          notify.error("Failed to start FS watch", result.error);
-          return;
-        }
-        // rpcFsWatch の往復遅延中に発生した FS / refs 変化を救済する再同期トリガー。
-        // FSEvents は `kFSEventStreamEventIdSinceNow` 起点で動くため、watch 起動前後の
-        // 数十〜数百 ms 窓で起きた変更は配信されない。subscriber 側で `loadLog` /
-        // `fetchOwnerOfActive` 等を一度だけ再発射してもらう。
-        dispatchMessage("fsWatchReady", { dir: newDir });
+      for (const wt of repo.worktrees) {
+        dirs.add(wt.path);
       }
-    },
-    { immediate: true },
-  );
+    }
+    return dirs;
+  }
+
+  async function syncWatches() {
+    const next = collectTargetDirs();
+    const toUnwatch: string[] = [];
+    const toWatch: string[] = [];
+    for (const dir of watchedDirs) {
+      if (!next.has(dir)) toUnwatch.push(dir);
+    }
+    for (const dir of next) {
+      if (!watchedDirs.has(dir)) toWatch.push(dir);
+    }
+
+    for (const dir of toUnwatch) {
+      const r = await tryCatch(rpcFsUnwatch({ dir }));
+      if (!r.ok) {
+        notify.error("Failed to stop FS watch", r.error);
+      }
+      // 失敗してもローカル set からは外す。native 側 entry が残っても次回の watch で
+      // idempotent に re-entry するため、長期的な乖離にはならない。
+      watchedDirs.delete(dir);
+    }
+    for (const dir of toWatch) {
+      const r = await tryCatch(rpcFsWatch({ dir }));
+      if (!r.ok) {
+        notify.error("Failed to start FS watch", r.error);
+        continue;
+      }
+      watchedDirs.add(dir);
+    }
+
+    if (toWatch.length > 0) {
+      // watch 起動往復中に発生した FS / refs 変化の救済として、購読側に 1 度だけ
+      // 再同期を促す。payload を持たない契約（dir は購読側が `worktreeStore.dir` を
+      // 都度読む）。
+      dispatchMessage("fsWatchReady", {});
+    }
+  }
+
+  watchEffect(() => {
+    // `repoStore.dirOrder` / `repoStore.repos[rootDir]` / 各 repo の worktrees 配列を
+    // reactive 読みすることで、worktree 集合の変化で再 run される。実 RPC は async で
+    // 走るが、並列実行になっても native 側 / collectTargetDirs / watchedDirs の更新は
+    // 順序に依存しない（idempotent）。
+    void syncWatches();
+  });
 
   onUnmounted(() => {
-    if (worktreeStore.dir !== undefined) {
-      void tryCatch(rpcFsUnwatch({ dir: worktreeStore.dir }));
+    for (const dir of watchedDirs) {
+      void tryCatch(rpcFsUnwatch({ dir }));
     }
+    watchedDirs.clear();
   });
 }

--- a/apps/renderer/src/features/filer/useFsWatchSync.ts
+++ b/apps/renderer/src/features/filer/useFsWatchSync.ts
@@ -64,6 +64,11 @@ export function useFsWatchSync() {
       // 失敗してもローカル set からは外す。native 側 watch は「既存 entry があれば破棄して
       // 再構築」する設計なので、ローカル set と native 側で乖離しても次回の `rpcFsWatch`
       // で永続的不整合は解消される。
+      // ただしこの保証は「次回再度同 dir が watch される」場合に限る。worktree が削除されて
+      // 二度と同 path が現れない場合、native entry はプロセス終了まで残り FSEventStream slot
+      // を消費し続ける。発生頻度は低く、対応 path 不在なら新規 event も出ない（push noise
+      // は生じない）が、長時間稼働でリソース leak が累積する余地は残る。
+      // onUnmounted 時の native 一括掃除 RPC は別 PR で検討する。
       watchedDirs.delete(dir);
     }
     for (const dir of toWatch) {
@@ -90,10 +95,15 @@ export function useFsWatchSync() {
       notify.error(`Failed to sync FS watches (${failures.length})`, aggregate);
     }
 
-    if (toWatch.length > 0) {
+    const watchFailures = failures.filter((f) => f.kind === "watch").length;
+    const successfulWatches = toWatch.length - watchFailures;
+    if (successfulWatches > 0) {
       // watch 起動往復中に発生した FS / refs 変化の救済として、購読側に 1 度だけ
       // 再同期を促す。payload を持たない契約（dir は購読側が `worktreeStore.dir` を
       // 都度読む）。
+      // 「Ready」というイベント名と実態を一致させるため、新規 watch が 1 つでも成功した
+      // 場合に限って発射する（全 watch が失敗した場合は新たに監視対象になった dir が無く、
+      // 救済する取りこぼし対象も存在しない）。
       dispatchMessage("fsWatchReady", {});
     }
   }

--- a/apps/renderer/src/features/filer/useFsWatchSync.ts
+++ b/apps/renderer/src/features/filer/useFsWatchSync.ts
@@ -24,6 +24,7 @@ import { useRepoStore } from "../../shared/repo";
 import { dispatchMessage } from "../../shared/rpc";
 import { collectTargetDirs, type RepoStoreForTargetDirs } from "./collectTargetDirs";
 import { rpcFsUnwatch, rpcFsWatch } from "./rpc";
+import { runSerializedSync, type SerializeState } from "./runSerializedSync";
 
 export function useFsWatchSync() {
   const repoStore: RepoStoreForTargetDirs = useRepoStore();
@@ -33,27 +34,13 @@ export function useFsWatchSync() {
    * 差分計算の baseline で、 `rpcFsWatch` / `rpcFsUnwatch` の発射対象を絞るために使う。 */
   const watchedDirs = new Set<string>();
 
-  /** `syncWatches` の serialize 用 mutex 兼 coalesce フラグ。
-   * - `running`: 現在 in-flight な `syncWatches` があるか
-   * - `pending`: in-flight 中に新しい dependency 変化が来たか
-   *   in-flight 終了後に pending を消化して 1 回だけ追加実行する（多重 trigger を畳む） */
-  let running = false;
-  let pending = false;
+  /** `syncWatches` の serialize 用 state。`runSerializedSync` に渡す mutex 兼 coalesce フラグ。
+   * 実体ロジックは `runSerializedSync.ts` 側の pure helper に切り出し、test で race coalesce
+   * 挙動を直接検証している。 */
+  const serializeState: SerializeState = { running: false, pending: false };
 
   async function syncWatches(): Promise<void> {
-    if (running) {
-      pending = true;
-      return;
-    }
-    running = true;
-    try {
-      do {
-        pending = false;
-        await runOneSyncPass();
-      } while (pending);
-    } finally {
-      running = false;
-    }
+    await runSerializedSync(serializeState, runOneSyncPass);
   }
 
   async function runOneSyncPass(): Promise<void> {
@@ -90,14 +77,15 @@ export function useFsWatchSync() {
 
     if (failures.length > 0) {
       // batch 単位で 1 件に集約する。1 ターンで N 個失敗したときにトースト N 個出すのは
-      // UX 上 noisy で、全体像も見失う。集約することで「何件、どの種類、どの dir」を
-      // 1 件の cause に折り畳む。
+      // UX 上 noisy で、全体像も見失う。
+      // summary を主メッセージ、最初の error を cause に置く Error を作って notify する
+      // ことで、トースト本文クリック時の cause 詳細展開で「どの kind:dir が何件 / 最初の
+      // 失敗の stack」を辿れる。`tryCatch` の error は常に Error なので cause は必ず
+      // 定義済み。
       const summary = failures.map((f) => `${f.kind}:${f.dir}`).join(", ");
-      const aggregate = new Error(`FS watch sync had ${failures.length} failure(s): ${summary}`);
-      // 最初の error を cause として stack を保持する
       const [first] = failures;
-      const cause = first?.error;
-      notify.error(`Failed to sync FS watches (${failures.length})`, cause ?? aggregate);
+      const aggregate = new Error(summary, { cause: first.error });
+      notify.error(`Failed to sync FS watches (${failures.length})`, aggregate);
     }
 
     if (toWatch.length > 0) {

--- a/apps/renderer/src/features/filer/useFsWatchSync.ts
+++ b/apps/renderer/src/features/filer/useFsWatchSync.ts
@@ -22,8 +22,9 @@ import { onUnmounted, watchEffect } from "vue";
 import { useNotificationStore } from "../../shared/notification";
 import { useRepoStore } from "../../shared/repo";
 import { dispatchMessage } from "../../shared/rpc";
-import { collectTargetDirs, type RepoStoreForTargetDirs } from "./collectTargetDirs";
-import { rpcFsUnwatch, rpcFsWatch } from "./rpc";
+import { type RepoStoreForTargetDirs } from "./collectTargetDirs";
+import { rpcFsUnwatchAll, rpcFsWatch, rpcFsUnwatch } from "./rpc";
+import { runOneSyncPass } from "./runOneSyncPass";
 import { runSerializedSync, type SerializeState } from "./runSerializedSync";
 
 export function useFsWatchSync() {
@@ -40,72 +41,16 @@ export function useFsWatchSync() {
   const serializeState: SerializeState = { running: false, pending: false };
 
   async function syncWatches(): Promise<void> {
-    await runSerializedSync(serializeState, runOneSyncPass);
-  }
-
-  async function runOneSyncPass(): Promise<void> {
-    const next = collectTargetDirs(repoStore);
-    const toUnwatch: string[] = [];
-    const toWatch: string[] = [];
-    for (const dir of watchedDirs) {
-      if (!next.has(dir)) toUnwatch.push(dir);
-    }
-    for (const dir of next) {
-      if (!watchedDirs.has(dir)) toWatch.push(dir);
-    }
-
-    const failures: Array<{ kind: "watch" | "unwatch"; dir: string; error: Error }> = [];
-
-    for (const dir of toUnwatch) {
-      const r = await tryCatch(rpcFsUnwatch({ dir }));
-      if (!r.ok) {
-        failures.push({ kind: "unwatch", dir, error: r.error });
-      }
-      // 失敗してもローカル set からは外す。native 側 watch は「既存 entry があれば破棄して
-      // 再構築」する設計なので、ローカル set と native 側で乖離しても次回の `rpcFsWatch`
-      // で永続的不整合は解消される。
-      // ただしこの保証は「次回再度同 dir が watch される」場合に限る。worktree が削除されて
-      // 二度と同 path が現れない場合、native entry はプロセス終了まで残り FSEventStream slot
-      // を消費し続ける。発生頻度は低く、対応 path 不在なら新規 event も出ない（push noise
-      // は生じない）が、長時間稼働でリソース leak が累積する余地は残る。
-      // onUnmounted 時の native 一括掃除 RPC は別 PR で検討する。
-      watchedDirs.delete(dir);
-    }
-    for (const dir of toWatch) {
-      const r = await tryCatch(rpcFsWatch({ dir }));
-      if (!r.ok) {
-        failures.push({ kind: "watch", dir, error: r.error });
-        continue;
-      }
-      watchedDirs.add(dir);
-    }
-
-    if (failures.length > 0) {
-      // batch 単位で 1 件に集約する。1 ターンで N 個失敗したときにトースト N 個出すのは
-      // UX 上 noisy で、全体像も見失う。
-      // トースト UI は cause chain の最上位だけ展開する（cause.cause は表示しない）ため、
-      // aggregate.message に summary と first.error.message の両方を載せて、トーストの
-      // 詳細展開だけで「件数 + どの kind:dir + 最初の失敗の原因文言」が見えるようにする。
-      // first.error.stack は console には残るので、devtools で完全な根本原因を辿れる。
-      const summary = failures.map((f) => `${f.kind}:${f.dir}`).join(", ");
-      const [first] = failures;
-      const aggregate = new Error(`${summary} -- first error: ${first.error.message}`, {
-        cause: first.error,
-      });
-      notify.error(`Failed to sync FS watches (${failures.length})`, aggregate);
-    }
-
-    const watchFailures = failures.filter((f) => f.kind === "watch").length;
-    const successfulWatches = toWatch.length - watchFailures;
-    if (successfulWatches > 0) {
-      // watch 起動往復中に発生した FS / refs 変化の救済として、購読側に 1 度だけ
-      // 再同期を促す。payload を持たない契約（dir は購読側が `worktreeStore.dir` を
-      // 都度読む）。
-      // 「Ready」というイベント名と実態を一致させるため、新規 watch が 1 つでも成功した
-      // 場合に限って発射する（全 watch が失敗した場合は新たに監視対象になった dir が無く、
-      // 救済する取りこぼし対象も存在しない）。
-      dispatchMessage("fsWatchReady", {});
-    }
+    await runSerializedSync(serializeState, () =>
+      runOneSyncPass({
+        repoStore,
+        watchedDirs,
+        fsWatch: rpcFsWatch,
+        fsUnwatch: rpcFsUnwatch,
+        notify,
+        dispatchReady: () => dispatchMessage("fsWatchReady", {}),
+      }),
+    );
   }
 
   watchEffect(() => {
@@ -116,9 +61,15 @@ export function useFsWatchSync() {
   });
 
   onUnmounted(() => {
-    for (const dir of watchedDirs) {
-      void tryCatch(rpcFsUnwatch({ dir }));
-    }
+    // 1 回の RPC で全 entry を一括破棄する。N 個の `rpcFsUnwatch` を並列発射する
+    // 旧設計は失敗を観察可能性なく捨てる構造だったので、`/fs/unwatchAll` に集約。
+    // 失敗時は `notify.error` で観察可能性を残す（アプリ終了 race で見えない場合も
+    // store 内の console.error が devtools に残る）。
+    void tryCatch(rpcFsUnwatchAll({})).then((r) => {
+      if (!r.ok) {
+        notify.error("Failed to cleanup FS watches", r.error);
+      }
+    });
     watchedDirs.clear();
   });
 }

--- a/apps/renderer/src/features/filer/useFsWatchSync.ts
+++ b/apps/renderer/src/features/filer/useFsWatchSync.ts
@@ -23,9 +23,9 @@ import { useNotificationStore } from "../../shared/notification";
 import { useRepoStore } from "../../shared/repo";
 import { dispatchMessage } from "../../shared/rpc";
 import { type RepoStoreForTargetDirs } from "./collectTargetDirs";
-import { rpcFsUnwatchAll, rpcFsWatch, rpcFsUnwatch } from "./rpc";
+import { rpcFsUnwatch, rpcFsUnwatchAll, rpcFsWatch } from "./rpc";
 import { runOneSyncPass } from "./runOneSyncPass";
-import { runSerializedSync, type SerializeState } from "./runSerializedSync";
+import { runSerializedSync, type SerializeState, whenIdle } from "./runSerializedSync";
 
 export function useFsWatchSync() {
   const repoStore: RepoStoreForTargetDirs = useRepoStore();
@@ -38,7 +38,13 @@ export function useFsWatchSync() {
   /** `syncWatches` の serialize 用 state。`runSerializedSync` に渡す mutex 兼 coalesce フラグ。
    * 実体ロジックは `runSerializedSync.ts` 側の pure helper に切り出し、test で race coalesce
    * 挙動を直接検証している。 */
-  const serializeState: SerializeState = { running: false, pending: false };
+  const serializeState: SerializeState = { running: false, pending: false, currentRun: null };
+
+  /** unmount 開始フラグ。`true` 以降は新規 sync を抑制して、in-flight の完走後に
+   * `rpcFsUnwatchAll` を発射する drain 経路を成立させる。`watchEffect` は Vue が
+   * 自動 dispose するが、その時点で残っている async chain が `fsWatch(X)` を native に
+   * 発火する race を closing する。 */
+  let disposing = false;
 
   async function syncWatches(): Promise<void> {
     await runSerializedSync(serializeState, () =>
@@ -57,19 +63,26 @@ export function useFsWatchSync() {
     // `repoStore.dirOrder` / `repoStore.repos[rootDir]` / 各 repo の worktrees 配列を
     // reactive 読みすることで、worktree 集合の変化で再 run される。実 RPC は async で
     // 走るが serialize されており、複数 trigger は 1 回の追加 pass に畳まれる。
+    // unmount 中は新規 sync を抑制する。Vue の effect dispose が走る前に reactive
+    // trigger が来ても、ここで guard することで `fsWatch` が native に追加発火しない。
+    if (disposing) return;
     void syncWatches();
   });
 
   onUnmounted(() => {
-    // 1 回の RPC で全 entry を一括破棄する。N 個の `rpcFsUnwatch` を並列発射する
-    // 旧設計は失敗を観察可能性なく捨てる構造だったので、`/fs/unwatchAll` に集約。
-    // 失敗時は `notify.error` で観察可能性を残す（アプリ終了 race で見えない場合も
-    // store 内の console.error が devtools に残る）。
-    void tryCatch(rpcFsUnwatchAll({})).then((r) => {
+    disposing = true;
+    // 在 in-flight の `runOneSyncPass` がある場合、その fsWatch / fsUnwatch RPC の完走を
+    // 待ってから `rpcFsUnwatchAll` を発射する。これで「unwatchAll の後に fsWatch(X) が
+    // native に届いて X が leak する」race window を構造的に閉じる。
+    // unwatchAll 失敗は `notify.error` で観察可能性を残す（アプリ終了 race で UI 上に
+    // 見えない場合も store 内の console.error が devtools に残る）。
+    void (async () => {
+      await whenIdle(serializeState);
+      const r = await tryCatch(rpcFsUnwatchAll({}));
       if (!r.ok) {
         notify.error("Failed to cleanup FS watches", r.error);
       }
-    });
-    watchedDirs.clear();
+      watchedDirs.clear();
+    })();
   });
 }

--- a/apps/renderer/src/features/filer/useFsWatchSync.ts
+++ b/apps/renderer/src/features/filer/useFsWatchSync.ts
@@ -7,6 +7,7 @@
 import { tryCatch } from "@gozd/shared";
 import { onUnmounted, watch } from "vue";
 import { useNotificationStore } from "../../shared/notification";
+import { dispatchMessage } from "../../shared/rpc";
 import { useWorktreeStore } from "../worktree";
 import { rpcFsUnwatch, rpcFsWatch } from "./rpc";
 
@@ -24,7 +25,13 @@ export function useFsWatchSync() {
         const result = await tryCatch(rpcFsWatch({ dir: newDir }));
         if (!result.ok) {
           notify.error("Failed to start FS watch", result.error);
+          return;
         }
+        // rpcFsWatch の往復遅延中に発生した FS / refs 変化を救済する再同期トリガー。
+        // FSEvents は `kFSEventStreamEventIdSinceNow` 起点で動くため、watch 起動前後の
+        // 数十〜数百 ms 窓で起きた変更は配信されない。subscriber 側で `loadLog` /
+        // `fetchOwnerOfActive` 等を一度だけ再発射してもらう。
+        dispatchMessage("fsWatchReady", { dir: newDir });
       }
     },
     { immediate: true },

--- a/apps/renderer/src/features/filer/useFsWatchSync.ts
+++ b/apps/renderer/src/features/filer/useFsWatchSync.ts
@@ -54,7 +54,7 @@ export function useFsWatchSync() {
       if (!watchedDirs.has(dir)) toWatch.push(dir);
     }
 
-    const failures: Array<{ kind: "watch" | "unwatch"; dir: string; error: unknown }> = [];
+    const failures: Array<{ kind: "watch" | "unwatch"; dir: string; error: Error }> = [];
 
     for (const dir of toUnwatch) {
       const r = await tryCatch(rpcFsUnwatch({ dir }));
@@ -78,13 +78,15 @@ export function useFsWatchSync() {
     if (failures.length > 0) {
       // batch 単位で 1 件に集約する。1 ターンで N 個失敗したときにトースト N 個出すのは
       // UX 上 noisy で、全体像も見失う。
-      // summary を主メッセージ、最初の error を cause に置く Error を作って notify する
-      // ことで、トースト本文クリック時の cause 詳細展開で「どの kind:dir が何件 / 最初の
-      // 失敗の stack」を辿れる。`tryCatch` の error は常に Error なので cause は必ず
-      // 定義済み。
+      // トースト UI は cause chain の最上位だけ展開する（cause.cause は表示しない）ため、
+      // aggregate.message に summary と first.error.message の両方を載せて、トーストの
+      // 詳細展開だけで「件数 + どの kind:dir + 最初の失敗の原因文言」が見えるようにする。
+      // first.error.stack は console には残るので、devtools で完全な根本原因を辿れる。
       const summary = failures.map((f) => `${f.kind}:${f.dir}`).join(", ");
       const [first] = failures;
-      const aggregate = new Error(summary, { cause: first.error });
+      const aggregate = new Error(`${summary} -- first error: ${first.error.message}`, {
+        cause: first.error,
+      });
       notify.error(`Failed to sync FS watches (${failures.length})`, aggregate);
     }
 

--- a/apps/renderer/src/features/filer/useFsWatchSync.ts
+++ b/apps/renderer/src/features/filer/useFsWatchSync.ts
@@ -10,46 +10,54 @@
  * - `repoStore.repos[*].worktrees` の集合変化（追加 / 削除）を `watchEffect` で追い、
  *   diff を取って `rpcFsWatch` / `rpcFsUnwatch` を発射する
  * - 非 git project（`isGitRepo === false`）は rootDir そのものを watch（FS 変化のみ）
- * - 失敗はトーストで通知（CLAUDE.md 規律）。silent drop は禁止
+ * - 失敗はトーストで通知（CLAUDE.md 規律）。複数同時失敗は集約 1 件にする
  * - 新規 watch 開始後に `fsWatchReady` を発射して、購読側に 1 度だけ再同期させる
- *   （watch 起動往復中の取りこぼし救済）
+ * - **並列実行を generation で serialize する**: `watchEffect` は依存変更で再 run するが
+ *   前回の async コールバック完了を待たない。前回が `watchedDirs` を更新する前に次回が
+ *   走ると、削除済み worktree の watch が永続的に残るレースが起きる。前回完了まで次回を
+ *   coalesce することで `watchedDirs` の整合性を保つ
  */
 import { tryCatch } from "@gozd/shared";
 import { onUnmounted, watchEffect } from "vue";
 import { useNotificationStore } from "../../shared/notification";
 import { useRepoStore } from "../../shared/repo";
 import { dispatchMessage } from "../../shared/rpc";
+import { collectTargetDirs, type RepoStoreForTargetDirs } from "./collectTargetDirs";
 import { rpcFsUnwatch, rpcFsWatch } from "./rpc";
 
 export function useFsWatchSync() {
-  const repoStore = useRepoStore();
+  const repoStore: RepoStoreForTargetDirs = useRepoStore();
   const notify = useNotificationStore();
 
   /** 現在 native 側で watch 中だと local に把握している dir の集合。
-   * 差分計算の baseline で、 rpcFsWatch / rpcFsUnwatch の発射対象を絞るために使う。
-   * native 側 `FSWatchRegistry.entries` とは独立に持つが、native 側は idempotent なので
-   * ズレても correctness は保たれる。 */
+   * 差分計算の baseline で、 `rpcFsWatch` / `rpcFsUnwatch` の発射対象を絞るために使う。 */
   const watchedDirs = new Set<string>();
 
-  function collectTargetDirs(): Set<string> {
-    const dirs = new Set<string>();
-    for (const rootDir of repoStore.dirOrder) {
-      const repo = repoStore.repos[rootDir];
-      if (repo === undefined) continue;
-      if (!repo.isGitRepo) {
-        // 非 git project は worktrees を持たないので rootDir 自身を watch する。
-        dirs.add(repo.rootDir);
-        continue;
-      }
-      for (const wt of repo.worktrees) {
-        dirs.add(wt.path);
-      }
+  /** `syncWatches` の serialize 用 mutex 兼 coalesce フラグ。
+   * - `running`: 現在 in-flight な `syncWatches` があるか
+   * - `pending`: in-flight 中に新しい dependency 変化が来たか
+   *   in-flight 終了後に pending を消化して 1 回だけ追加実行する（多重 trigger を畳む） */
+  let running = false;
+  let pending = false;
+
+  async function syncWatches(): Promise<void> {
+    if (running) {
+      pending = true;
+      return;
     }
-    return dirs;
+    running = true;
+    try {
+      do {
+        pending = false;
+        await runOneSyncPass();
+      } while (pending);
+    } finally {
+      running = false;
+    }
   }
 
-  async function syncWatches() {
-    const next = collectTargetDirs();
+  async function runOneSyncPass(): Promise<void> {
+    const next = collectTargetDirs(repoStore);
     const toUnwatch: string[] = [];
     const toWatch: string[] = [];
     for (const dir of watchedDirs) {
@@ -59,22 +67,37 @@ export function useFsWatchSync() {
       if (!watchedDirs.has(dir)) toWatch.push(dir);
     }
 
+    const failures: Array<{ kind: "watch" | "unwatch"; dir: string; error: unknown }> = [];
+
     for (const dir of toUnwatch) {
       const r = await tryCatch(rpcFsUnwatch({ dir }));
       if (!r.ok) {
-        notify.error("Failed to stop FS watch", r.error);
+        failures.push({ kind: "unwatch", dir, error: r.error });
       }
-      // 失敗してもローカル set からは外す。native 側 entry が残っても次回の watch で
-      // idempotent に re-entry するため、長期的な乖離にはならない。
+      // 失敗してもローカル set からは外す。native 側 watch は「既存 entry があれば破棄して
+      // 再構築」する設計なので、ローカル set と native 側で乖離しても次回の `rpcFsWatch`
+      // で永続的不整合は解消される。
       watchedDirs.delete(dir);
     }
     for (const dir of toWatch) {
       const r = await tryCatch(rpcFsWatch({ dir }));
       if (!r.ok) {
-        notify.error("Failed to start FS watch", r.error);
+        failures.push({ kind: "watch", dir, error: r.error });
         continue;
       }
       watchedDirs.add(dir);
+    }
+
+    if (failures.length > 0) {
+      // batch 単位で 1 件に集約する。1 ターンで N 個失敗したときにトースト N 個出すのは
+      // UX 上 noisy で、全体像も見失う。集約することで「何件、どの種類、どの dir」を
+      // 1 件の cause に折り畳む。
+      const summary = failures.map((f) => `${f.kind}:${f.dir}`).join(", ");
+      const aggregate = new Error(`FS watch sync had ${failures.length} failure(s): ${summary}`);
+      // 最初の error を cause として stack を保持する
+      const [first] = failures;
+      const cause = first?.error;
+      notify.error(`Failed to sync FS watches (${failures.length})`, cause ?? aggregate);
     }
 
     if (toWatch.length > 0) {
@@ -88,8 +111,7 @@ export function useFsWatchSync() {
   watchEffect(() => {
     // `repoStore.dirOrder` / `repoStore.repos[rootDir]` / 各 repo の worktrees 配列を
     // reactive 読みすることで、worktree 集合の変化で再 run される。実 RPC は async で
-    // 走るが、並列実行になっても native 側 / collectTargetDirs / watchedDirs の更新は
-    // 順序に依存しない（idempotent）。
+    // 走るが serialize されており、複数 trigger は 1 回の追加 pass に畳まれる。
     void syncWatches();
   });
 

--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -28,7 +28,7 @@ import {
 import { onMessage } from "../../shared/rpc";
 import { ResizeHandle } from "../layout";
 import { rpcGitPrList } from "../palette";
-import type { BranchChangePayload } from "../sidebar";
+import type { BranchChangePayload, FsWatchReadyPayload } from "../sidebar";
 import type { GitStatusChangePayload } from "../worktree";
 import {
   UNCOMMITTED_HASH,
@@ -44,7 +44,7 @@ import type { GraphLayout } from "./graphLayout";
 import { mergeCommitStreams } from "./mergeCommitStreams";
 import type { SortMode } from "./mergeCommitStreams";
 import RefBadge from "./RefBadge.vue";
-import { rpcGitLog } from "./rpc";
+import { rpcGitLog, rpcGitRefsDigest } from "./rpc";
 import { useGitGraphStore } from "./useGitGraphStore";
 
 const rootRef = useTemplateRef<HTMLElement>("root");
@@ -129,6 +129,9 @@ const headLane = computed(() => {
 
 /** 前回の HEAD ハッシュ。gitStatusChange で変化を検知するために使用 */
 let lastHead = "";
+/** 前回の HEAD が指す branch 名。`git branch -m` は OID を変えないため、
+ * rename を gitStatusChange 経路で検知するためにこの値の変化を追う。 */
+let lastBranchHead = "";
 /** 前回の upstream ahead/behind。push/fetch による ref 変化を検知するために使用 */
 let lastUpstream = "";
 /** loadLog の世代管理。並行実行で古いレスポンスが後着して上書きするのを防ぐ */
@@ -194,19 +197,23 @@ watch(sortMode, () => {
 
 // git status 変更時: Working Tree 固定行の件数・アイコンは computed で自動更新されるため watcher 不要
 
-// HEAD 変更（コミット、リベース等）や upstream 変更（push、fetch）を検知して git log を再取得する。
-// head ハッシュまたは ahead/behind の変化があった場合のみ再取得する（ファイル保存では走らない）。
+// HEAD 変更（コミット、リベース等）/ branch 名変更（git branch -m）/ upstream 変更（push、fetch）
+// を検知して git log を再取得する。`git branch -m` は OID を変えないため、
+// head ハッシュだけで判定すると rename が漏れる。branchHead（HEAD が指す branch 名）の
+// 変化も発火条件に含めて、SSOT 経路の取りこぼしを構造的に防ぐ。
 const disposeGitStatus = onMessage<GitStatusChangePayload>(
   "gitStatusChange",
-  ({ head, hasUpstream, ahead, behind }) => {
+  ({ head, branchHead, hasUpstream, ahead, behind }) => {
     const upstreamKey = hasUpstream ? `${ahead}/${behind}` : "";
     const headChanged = head !== "" && head !== lastHead;
+    const branchHeadChanged = branchHead !== lastBranchHead;
     const upstreamChanged = upstreamKey !== lastUpstream;
 
     if (headChanged) lastHead = head;
+    if (branchHeadChanged) lastBranchHead = branchHead;
     if (upstreamChanged) lastUpstream = upstreamKey;
 
-    if (headChanged || upstreamChanged) {
+    if (headChanged || branchHeadChanged || upstreamChanged) {
       void (async () => {
         const updated = await loadLog();
         if (!updated || !headChanged) return;
@@ -227,6 +234,13 @@ const disposeBranchChange = onMessage<BranchChangePayload>("branchChange", () =>
   void loadLog();
 });
 onUnmounted(disposeBranchChange);
+
+// `useFsWatchSync` の `rpcFsWatch` 完了直後に発射される再同期通知。watch 起動往復中の
+// FS 変化を救済するため、1 度だけ git log を取り直す。
+const disposeFsWatchReady = onMessage<FsWatchReadyPayload>("fsWatchReady", () => {
+  void loadLog();
+});
+onUnmounted(disposeFsWatchReady);
 
 // --- PR 情報（非同期で後追い取得） ---
 
@@ -259,9 +273,39 @@ const { pause: pausePrPoll, resume: resumePrPoll } = useIntervalFn(
   { immediate: false },
 );
 
+// SSOT 経路（branchChange / gitStatusChange）の到達率を計測するための低頻度 pull。
+// `git for-each-ref` の digest を取り、前回値と異なれば push が取りこぼされた可能性を
+// console.warn で観察可能性として残し、loadLog で UI を実状態に追従させる。
+// 「予防 retry」ではなく、SSOT の不達を 60s で必ず救済できる保険。
+let lastRefsDigest: string | undefined;
+async function checkRefsDigest(): Promise<void> {
+  const dir = worktreeStore.dir;
+  if (dir === undefined) return;
+  const result = await rpcGitRefsDigest({ dir });
+  // 初回は前回値が無いので比較せずに記録だけする
+  if (lastRefsDigest === undefined) {
+    lastRefsDigest = result.digest;
+    return;
+  }
+  if (result.digest === lastRefsDigest) return;
+  console.warn("[git-graph] refs digest mismatch — SSOT push may have been dropped", {
+    dir,
+    previous: lastRefsDigest,
+    current: result.digest,
+  });
+  lastRefsDigest = result.digest;
+  void loadLog();
+}
+const { pause: pauseRefsDigestPoll, resume: resumeRefsDigestPoll } = useIntervalFn(
+  () => void checkRefsDigest(),
+  PR_POLL_INTERVAL_MS,
+  { immediate: false },
+);
+
 onMounted(() => {
   void loadPrList();
   resumePrPoll();
+  resumeRefsDigestPoll();
 });
 
 // worktree 切り替え時にポーリングをリセット
@@ -271,6 +315,10 @@ watch(
     pausePrPoll();
     void loadPrList();
     resumePrPoll();
+    // refs digest baseline は worktree ごとに別物なのでリセット。次回 poll で再記録される。
+    pauseRefsDigestPoll();
+    lastRefsDigest = undefined;
+    resumeRefsDigestPoll();
   },
 );
 

--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -13,6 +13,7 @@ Git commit graph showing the current worktree branch and the default branch.
 
 <script setup lang="ts">
 import type { GitCommit, GitPullRequest } from "@gozd/proto";
+import { tryCatch } from "@gozd/shared";
 import { useElementSize, useIntervalFn } from "@vueuse/core";
 import { storeToRefs } from "pinia";
 import {
@@ -25,6 +26,7 @@ import {
   watch,
   watchEffect,
 } from "vue";
+import { useNotificationStore } from "../../shared/notification";
 import { onMessage } from "../../shared/rpc";
 import { ResizeHandle } from "../layout";
 import { rpcGitPrList } from "../palette";
@@ -52,6 +54,7 @@ const { width: rootWidth } = useElementSize(rootRef);
 const worktreeStore = useWorktreeStore();
 const gitStatusStore = useGitStatusStore();
 const gitGraphStore = useGitGraphStore();
+const notify = useNotificationStore();
 const { gitStatuses } = storeToRefs(gitStatusStore);
 
 const { commits } = storeToRefs(gitGraphStore);
@@ -157,7 +160,12 @@ async function loadLog(): Promise<boolean> {
 
   commits.value = merged;
   defaultBranch.value = result.defaultBranch === "" ? undefined : result.defaultBranch;
-  lastHead = findHeadCommit(merged)?.hash ?? "";
+  const headCommit = findHeadCommit(merged);
+  lastHead = headCommit?.hash ?? "";
+  // `lastBranchHead` も loadLog の結果に合わせて更新する。これをやらないと worktree
+  // 切替後の最初の gitStatusChange push で branchHeadChanged が偽陽性で立ち、
+  // 冗長な 2 度目の loadLog が走る（lastHead との非対称を防ぐ）。
+  lastBranchHead = headCommit !== undefined ? (findCurrentBranch(headCommit.refs) ?? "") : "";
   recomputeLayout();
 
   // 選択中・比較中のコミットが一覧から消えた場合はクリア
@@ -281,19 +289,26 @@ let lastRefsDigest: string | undefined;
 async function checkRefsDigest(): Promise<void> {
   const dir = worktreeStore.dir;
   if (dir === undefined) return;
-  const result = await rpcGitRefsDigest({ dir });
-  // 初回は前回値が無いので比較せずに記録だけする
-  if (lastRefsDigest === undefined) {
-    lastRefsDigest = result.digest;
+  const result = await tryCatch(rpcGitRefsDigest({ dir }));
+  if (!result.ok) {
+    // 整合性チェッカ自身が silent fail するのは設計意図に反する。トースト + cause で
+    // ユーザーと開発者の両方に届くようにする。RPC 失敗の典型は worktree 切替直後の dir
+    // 不在 / git locking 競合 / git バイナリ未解決。
+    notify.error("Failed to compute refs digest", result.error);
     return;
   }
-  if (result.digest === lastRefsDigest) return;
+  // 初回は前回値が無いので比較せずに記録だけする
+  if (lastRefsDigest === undefined) {
+    lastRefsDigest = result.value.digest;
+    return;
+  }
+  if (result.value.digest === lastRefsDigest) return;
   console.warn("[git-graph] refs digest mismatch — SSOT push may have been dropped", {
     dir,
     previous: lastRefsDigest,
-    current: result.digest,
+    current: result.value.digest,
   });
-  lastRefsDigest = result.digest;
+  lastRefsDigest = result.value.digest;
   void loadLog();
 }
 const { pause: pauseRefsDigestPoll, resume: resumeRefsDigestPoll } = useIntervalFn(

--- a/apps/renderer/src/features/git-graph/rpc.ts
+++ b/apps/renderer/src/features/git-graph/rpc.ts
@@ -3,6 +3,8 @@ import {
   GitCommitFilesResponse,
   GitLogRequest,
   GitLogResponse,
+  GitRefsDigestRequest,
+  GitRefsDigestResponse,
 } from "@gozd/proto";
 
 import { rpc } from "../../shared/rpc";
@@ -12,3 +14,6 @@ export const rpcGitLog = (req: GitLogRequest) =>
 
 export const rpcGitCommitFiles = (req: GitCommitFilesRequest) =>
   rpc("/git/commitFiles", req, GitCommitFilesRequest, GitCommitFilesResponse);
+
+export const rpcGitRefsDigest = (req: GitRefsDigestRequest) =>
+  rpc("/git/refsDigest", req, GitRefsDigestRequest, GitRefsDigestResponse);

--- a/apps/renderer/src/features/layout/NotificationToastItem.vue
+++ b/apps/renderer/src/features/layout/NotificationToastItem.vue
@@ -4,7 +4,8 @@
 ## 動作
 
 - `cause` がある場合のみメッセージ全体をクリック可能にし、詳細パネルを展開する
-- `Error` インスタンスは `name + message + stack`、それ以外は `String(cause)` または `JSON.stringify` フォールバックで表示
+- `Error` の `cause` chain を再帰的に辿り、各段を `Caused by: ` で連結して表示する
+- `Error` 以外（string / object など）は 1 段だけ整形して終了
 - 詳細パネルには「Copy」ボタンを併設し、issue 報告にコピペしやすくする
 - dismiss ボタンは独立しており、本文クリックで dismiss されない
 </doc>
@@ -12,6 +13,7 @@
 <script setup lang="ts">
 import { tryCatch } from "@gozd/shared";
 import { computed, ref } from "vue";
+import { formatCauseChain } from "./formatCause";
 
 const props = defineProps<{
   type: "error" | "info";
@@ -57,53 +59,7 @@ const iconColorMap = {
 
 const hasCause = computed(() => props.cause !== undefined);
 
-// 循環参照や toString が壊れたオブジェクトでもトースト描画を壊さないように整形する
-function safeStringify(value: unknown): string {
-  // String() は Symbol.toPrimitive / toString / valueOf が壊れている時に throw する
-  const stringResult = tryCatch(() => String(value));
-  if (stringResult.ok && stringResult.value !== "[object Object]") {
-    return stringResult.value;
-  }
-  // Object 系で String() が "[object Object]" になるケースは JSON 整形を試す
-  const seen = new WeakSet<object>();
-  const jsonResult = tryCatch(() =>
-    JSON.stringify(
-      value,
-      (_key, v) => {
-        if (typeof v === "object" && v !== null) {
-          if (seen.has(v)) return "[Circular]";
-          seen.add(v);
-        }
-        return v;
-      },
-      2,
-    ),
-  );
-  if (jsonResult.ok && jsonResult.value !== undefined) return jsonResult.value;
-  // どちらも失敗 / undefined を返す場合は prototype-free な型表記にフォールバック。
-  // Symbol.toStringTag の getter が throw するケースに備えてこれも tryCatch で包む
-  const tagResult = tryCatch(() => Object.prototype.toString.call(value));
-  return tagResult.ok ? tagResult.value : "[unrepresentable cause]";
-}
-
-const detail = computed(() => {
-  const { cause } = props;
-  if (cause instanceof Error) {
-    const head = `${cause.name}: ${cause.message}`;
-    const stack = cause.stack;
-    if (stack === undefined || stack === "") return head;
-    // V8 系の stack は先頭行に "name: message" を含み（message が改行を含めばその 1 行目のみ）、
-    // WebKit/JavaScriptCore の stack はフレームのみで "name: message" 行を持たない。
-    // stack.startsWith(head) で判定すると message が改行を含むときに V8 でも false になり二重表示になるため、
-    // 先頭行が `<name>:` で始まるかで V8 形式と判定し、その場合は先頭行を捨てて head + 残り frame に正規化する。
-    const [firstLine = "", ...rest] = stack.split("\n");
-    const frames = firstLine.startsWith(`${cause.name}:`) ? rest : [firstLine, ...rest];
-    const body = frames.join("\n");
-    return body === "" ? head : `${head}\n${body}`;
-  }
-  if (typeof cause === "string") return cause;
-  return safeStringify(cause);
-});
+const detail = computed(() => formatCauseChain(props.cause));
 
 function toggle() {
   if (!hasCause.value) return;

--- a/apps/renderer/src/features/layout/formatCause.test.ts
+++ b/apps/renderer/src/features/layout/formatCause.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { formatCauseChain } from "./formatCause";
+
+describe("formatCauseChain", () => {
+  test("単一 Error は 1 段だけ展開する", () => {
+    const e = new Error("boom");
+    const out = formatCauseChain(e);
+    expect(out.startsWith("Error: boom")).toBe(true);
+    expect(out.includes("Caused by:")).toBe(false);
+  });
+
+  test("Error.cause が Error なら chain を Caused by: で連結する", () => {
+    const inner = new Error("inner reason");
+    const outer = new Error("outer summary", { cause: inner });
+    const out = formatCauseChain(outer);
+    expect(out.startsWith("Error: outer summary")).toBe(true);
+    expect(out.includes("\n\nCaused by: Error: inner reason")).toBe(true);
+  });
+
+  test("3 段の chain も全部辿る", () => {
+    // 一意な marker 文字列で位置検査する。stack の file path に出ない pattern にする。
+    const a = new Error("level-aaa");
+    const b = new Error("level-bbb", { cause: a });
+    const c = new Error("level-ccc", { cause: b });
+    const out = formatCauseChain(c);
+    expect(out.indexOf("level-ccc")).toBeLessThan(out.indexOf("level-bbb"));
+    expect(out.indexOf("level-bbb")).toBeLessThan(out.indexOf("level-aaa"));
+    // Caused by: は 2 個出現（c→b と b→a）
+    expect(out.split("Caused by:").length - 1).toBe(2);
+  });
+
+  test("Error.cause が string なら 1 段降りて文字列として表示する", () => {
+    const e = new Error("outer", { cause: "raw string cause" });
+    const out = formatCauseChain(e);
+    expect(out.startsWith("Error: outer")).toBe(true);
+    expect(out.includes("Caused by: raw string cause")).toBe(true);
+  });
+
+  test("非 Error の cause（string）は 1 段で終了", () => {
+    const out = formatCauseChain("just a string");
+    expect(out).toBe("just a string");
+  });
+
+  test("undefined cause は空文字を返す (toast が detail を表示しない契約)", () => {
+    expect(formatCauseChain(undefined)).toBe("");
+  });
+
+  test("循環参照（自己 cause）は [Circular cause] で打ち切る", () => {
+    const a = new Error("self-referencing");
+    Object.defineProperty(a, "cause", { value: a, enumerable: false });
+    const out = formatCauseChain(a);
+    expect(out.startsWith("Error: self-referencing")).toBe(true);
+    expect(out.includes("[Circular cause]")).toBe(true);
+  });
+
+  test("V8 形式 stack の先頭 `name: message` 行は head と二重表示しない", () => {
+    const e = new Error("msg");
+    e.stack = "Error: msg\n    at frame1\n    at frame2";
+    const out = formatCauseChain(e);
+    // "Error: msg" は head に 1 回だけ、stack 側の同じ行はカットされている
+    expect(out.match(/Error: msg/g)?.length).toBe(1);
+    expect(out.includes("at frame1")).toBe(true);
+    expect(out.includes("at frame2")).toBe(true);
+  });
+
+  test("WebKit 形式 stack（先頭 `name:` 行なし）はそのままフレームを後置", () => {
+    const e = new Error("msg");
+    e.stack = "frame1@file.js:1\nframe2@file.js:2";
+    const out = formatCauseChain(e);
+    expect(out.startsWith("Error: msg\nframe1@file.js:1\nframe2@file.js:2")).toBe(true);
+  });
+
+  test("aggregate 構造（外側 message に summary、cause に first.error）でも各段が読める", () => {
+    // useFsWatchSync の runOneSyncPass が作る形を模倣:
+    //   notify.error("Failed to sync FS watches (1)", aggregate)
+    //   aggregate = new Error(summary, { cause: first.error })
+    // SFC は cause 引数 = aggregate を formatCauseChain に渡す。
+    const firstError = new Error("watch failed: /r1/wt-a");
+    const aggregate = new Error("watch:/r1/wt-a", { cause: firstError });
+    const out = formatCauseChain(aggregate);
+    expect(out.includes("Error: watch:/r1/wt-a")).toBe(true);
+    expect(out.includes("Caused by: Error: watch failed: /r1/wt-a")).toBe(true);
+  });
+});

--- a/apps/renderer/src/features/layout/formatCause.ts
+++ b/apps/renderer/src/features/layout/formatCause.ts
@@ -1,0 +1,96 @@
+/**
+ * トースト詳細パネル用に `cause` を文字列化するヘルパー。
+ *
+ * Error の `cause` chain を辿って再帰展開する: 1 段目は `<name>: <message>` + stack、
+ * 2 段目以降は `\n\nCaused by: ` をプレフィックスして並べる。これにより aggregate
+ * Error が `cause` に first failure を持つパターン (`useFsWatchSync` の `runOneSyncPass`
+ * など複数 caller で使う) で、トースト詳細 1 つだけで「集約 message + 根本原因 + stack」
+ * が全部読める。
+ *
+ * `NotificationToastItem.vue` から SFC 外に切り出した理由: chain walker は純関数で
+ * bun test から DOM 無しで直接呼べる方が回帰が固い。SFC 側は `computed` で薄く呼ぶだけ。
+ *
+ * V8 と JavaScriptCore で `Error.stack` のフォーマットが違う点も中で正規化する:
+ * - V8: 先頭行に `<name>: <message>` を含む（multi-line message ならその 1 行目のみ）
+ * - JavaScriptCore: フレーム列のみ、`<name>: <message>` 行を持たない
+ *
+ * `name:` で始まる先頭行は V8 形式とみなして捨て、`head` を毎回前置する。これで多段の
+ * stack でも先頭行のフォーマットが揃う。
+ */
+import { tryCatch } from "@gozd/shared";
+
+/** cause chain の最大再帰深度。循環参照や悪意ある cause 設定で無限ループに陥らない安全弁。 */
+const MAX_CAUSE_DEPTH = 10;
+
+/** 1 つの cause 値（Error / string / その他）を 1 ブロックの文字列にする。 */
+function formatSingleCause(cause: unknown): string {
+  if (cause instanceof Error) {
+    const head = `${cause.name}: ${cause.message}`;
+    const stack = cause.stack;
+    if (stack === undefined || stack === "") return head;
+    const [firstLine = "", ...rest] = stack.split("\n");
+    const frames = firstLine.startsWith(`${cause.name}:`) ? rest : [firstLine, ...rest];
+    const body = frames.join("\n");
+    return body === "" ? head : `${head}\n${body}`;
+  }
+  if (typeof cause === "string") return cause;
+  return safeStringify(cause);
+}
+
+/** 循環参照や toString が壊れたオブジェクトでもトースト描画を壊さないように整形する。 */
+function safeStringify(value: unknown): string {
+  // String() は Symbol.toPrimitive / toString / valueOf が壊れている時に throw する
+  const stringResult = tryCatch(() => String(value));
+  if (stringResult.ok && stringResult.value !== "[object Object]") {
+    return stringResult.value;
+  }
+  // Object 系で String() が "[object Object]" になるケースは JSON 整形を試す
+  const seen = new WeakSet<object>();
+  const jsonResult = tryCatch(() =>
+    JSON.stringify(
+      value,
+      (_key, v) => {
+        if (typeof v === "object" && v !== null) {
+          if (seen.has(v)) return "[Circular]";
+          seen.add(v);
+        }
+        return v;
+      },
+      2,
+    ),
+  );
+  if (jsonResult.ok && jsonResult.value !== undefined) return jsonResult.value;
+  // どちらも失敗 / undefined を返す場合は prototype-free な型表記にフォールバック。
+  // Symbol.toStringTag の getter が throw するケースに備えてこれも tryCatch で包む
+  const tagResult = tryCatch(() => Object.prototype.toString.call(value));
+  return tagResult.ok ? tagResult.value : "[unrepresentable cause]";
+}
+
+/**
+ * cause が Error なら `cause.cause` を辿って chain 全体を文字列化する。
+ * Error 以外（string / object など）が来た時点で chain walker は終了する。
+ * 循環参照は `WeakSet` で検出して同じ Error に再到達したら止める。
+ */
+export function formatCauseChain(initial: unknown): string {
+  const parts: string[] = [];
+  const seen = new WeakSet<Error>();
+  let current: unknown = initial;
+  let depth = 0;
+  while (current !== undefined && depth < MAX_CAUSE_DEPTH) {
+    if (current instanceof Error) {
+      if (seen.has(current)) {
+        parts.push("[Circular cause]");
+        break;
+      }
+      seen.add(current);
+    }
+    parts.push(formatSingleCause(current));
+    if (current instanceof Error) {
+      current = current.cause;
+      depth++;
+    } else {
+      break;
+    }
+  }
+  return parts.join("\n\nCaused by: ");
+}

--- a/apps/renderer/src/features/sidebar/index.ts
+++ b/apps/renderer/src/features/sidebar/index.ts
@@ -1,5 +1,5 @@
 export { default as SidebarPane } from "./SidebarPane.vue";
 export { rpcCreateWorktree, rpcGitDefaultBranch, rpcGitWorktreeList, rpcTaskAdd } from "./rpc";
-export type { BranchChangePayload } from "./rpc";
+export type { BranchChangePayload, FsWatchReadyPayload } from "./rpc";
 export { useGozdOpenHandler } from "./useGozdOpenHandler";
 export { useRepoContextKey } from "./useRepoContextKey";

--- a/apps/renderer/src/features/sidebar/rpc.ts
+++ b/apps/renderer/src/features/sidebar/rpc.ts
@@ -67,7 +67,7 @@ export interface WorktreeChangePayload {
 
 /** `useFsWatchSync` が `rpcFsWatch` 完了直後に renderer 内部で発射する再同期通知。
  * watch 開始往復中に起きた FS / refs 変化を救済するため、subscriber は受信時に
- * 1 回だけ自分の state を refetch する。type 名は `fsWatchReady` で固定。 */
-export interface FsWatchReadyPayload {
-  dir: string;
-}
+ * 1 回だけ自分の state を refetch する。type 名は `fsWatchReady` で固定。
+ * payload に dir を載せないのは、watch start await 中に worktree 切替が起きると
+ * dir が stale 値になりうるため。購読側は `worktreeStore.dir` を都度読む契約。 */
+export type FsWatchReadyPayload = Record<string, never>;

--- a/apps/renderer/src/features/sidebar/rpc.ts
+++ b/apps/renderer/src/features/sidebar/rpc.ts
@@ -54,8 +54,20 @@ export const rpcAppStateSave = (req: SaveAppStateRequest) =>
 
 export interface BranchChangePayload {
   dir: string;
+  /** 今回のバッチで動いた `refs/heads/` 配下の ref 名（prefix を剥がした basename）。
+   * 例: `["main", "feat/foo"]`。`packed-refs` の更新で個別 ref を特定できない場合は空配列。
+   * 観察可能性のため payload に含める（バグ報告 / ログ参照用）。
+   * renderer 側の振る舞い（loadLog 全件 refetch）には現状影響しない。 */
+  changedRefs: string[];
 }
 
 export interface WorktreeChangePayload {
+  dir: string;
+}
+
+/** `useFsWatchSync` が `rpcFsWatch` 完了直後に renderer 内部で発射する再同期通知。
+ * watch 開始往復中に起きた FS / refs 変化を救済するため、subscriber は受信時に
+ * 1 回だけ自分の state を refetch する。type 名は `fsWatchReady` で固定。 */
+export interface FsWatchReadyPayload {
   dir: string;
 }

--- a/apps/renderer/src/features/sidebar/useSidebarData.ts
+++ b/apps/renderer/src/features/sidebar/useSidebarData.ts
@@ -12,7 +12,7 @@ import {
   rpcTaskAdd,
   rpcTaskUpdate,
 } from "./rpc";
-import type { BranchChangePayload, WorktreeChangePayload } from "./rpc";
+import type { BranchChangePayload, FsWatchReadyPayload, WorktreeChangePayload } from "./rpc";
 
 /**
  * サイドバーのデータ取得・状態管理。
@@ -214,6 +214,9 @@ export function useSidebarData() {
     // ここで全件 refetch を走らせない（N 倍の git status 実行を避ける）。
     cleanups.push(onMessage<BranchChangePayload>("branchChange", () => fetchOwnerOfActive()));
     cleanups.push(onMessage<WorktreeChangePayload>("worktreeChange", () => fetchOwnerOfActive()));
+    // `useFsWatchSync` の watch 起動完了通知。往復中の取りこぼし救済として 1 回だけ
+    // worktree list を取り直す。
+    cleanups.push(onMessage<FsWatchReadyPayload>("fsWatchReady", () => fetchOwnerOfActive()));
     void hydrateAppState();
   });
   onUnmounted(() => {

--- a/apps/renderer/src/features/worktree/rpc.ts
+++ b/apps/renderer/src/features/worktree/rpc.ts
@@ -10,6 +10,10 @@ export interface GitStatusChangePayload {
   dir: string;
   statuses: Record<string, string>;
   head: string;
+  /** HEAD が指す branch 名（`git status --porcelain=v2 --branch` の `# branch.head`）。
+   * `git branch -m` は OID を変えないため、rename はこの値の変化で検知する。
+   * detached HEAD の場合は空文字。 */
+  branchHead: string;
   hasUpstream: boolean;
   ahead: number;
   behind: number;

--- a/apps/renderer/src/shared/rpc/index.ts
+++ b/apps/renderer/src/shared/rpc/index.ts
@@ -1,3 +1,3 @@
 // transport のみ公開する。feature 固有の RPC wrapper は各 feature の rpc.ts に置く。
 export { rpc } from "./client";
-export { onMessage } from "./messages";
+export { dispatchMessage, onMessage } from "./messages";

--- a/apps/renderer/src/shared/rpc/messages.ts
+++ b/apps/renderer/src/shared/rpc/messages.ts
@@ -40,3 +40,18 @@ export function onMessage<T>(type: string, fn: (payload: T) => void): () => void
     if (idx >= 0) cur.splice(idx, 1);
   };
 }
+
+/**
+ * renderer 内部発の push を同じ dispatcher 経由で発火する。
+ *
+ * 通常 push は native → renderer の一方向（`window.__gozdReceive` 経由）だが、
+ * renderer 内で「watch 開始後の取りこぼし救済」「明示的な再同期トリガー」など
+ * native 経由ではない再同期 event が必要なケースで使う。listener 側は
+ * `onMessage` と同じ subscriber を再利用できる（native 由来と renderer 由来を
+ * 区別せず処理する）。
+ *
+ * 命名は `dispatchMessage` で、native の push と意味的に並ぶ位置に置く。
+ */
+export function dispatchMessage(type: string, payload: unknown): void {
+  window.__gozdReceive?.(type, payload);
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,8 +114,19 @@ native → renderer の push は `WebPage.callJavaScript("window.__gozdReceive(t
 FSEvents 経由の push は ms オーダーで届くが、watch 開始往復中の取りこぼしや、`callJavaScript` の失敗で 1 度の event を落とすと、UI 状態と git refs の実体が永続的にずれる。これを防ぐため次の二重防御を入れている。
 
 - **再同期トリガー**: `useFsWatchSync` が `rpcFsWatch` 応答直後に renderer 内部で `fsWatchReady` を `dispatchMessage` 経由で発射する。GitGraphPane / useSidebarData は同 type を `onMessage` で購読しており、watch 起動瞬間に 1 度だけ state を refetch する
-- **ref-digest 整合性チェッカ**: GitGraphPane が 60 秒間隔で `rpcGitRefsDigest`（`git for-each-ref refs/heads/ refs/remotes/` の SHA-256）を取り、前回値と比較する。不一致なら `console.warn` で観察可能性を残しつつ `loadLog` を発射。「予防 retry」ではなく、SSOT 経路（branchChange / gitStatusChange）の到達率を計測する保険として使う
+- **ref-digest 整合性チェッカ**: GitGraphPane が 60 秒間隔で `rpcGitRefsDigest`（`git for-each-ref refs/heads/ refs/remotes/ --sort=refname` の SHA-256）を取り、前回値と比較する。不一致なら `console.warn` で観察可能性を残しつつ `loadLog` を発射。「予防 retry」ではなく、SSOT 経路（branchChange / gitStatusChange）の到達率を計測する保険として使う。チェッカ自体の RPC 失敗も `useNotificationStore.error` でトースト通知する（silent fail で自己否定にならないように）
 - **status payload に branch.head を含める**: `git branch -m` は HEAD の commit OID を変えないため、`gitStatusChange.head` だけで判定すると rename を取りこぼす。`git status --porcelain=v2 --branch` が出す `# branch.head <name>` を payload に乗せ、renderer 側は `branchHead` の変化でも `loadLog` を発火する
+
+### FSWatch の対象スコープ
+
+`useFsWatchSync` は **開いている全 repo / 全 worktree の dir** を `rpcFsWatch` に登録する。`repoStore.repos[*].worktrees` の集合変化（追加 / 削除）を `watchEffect` で追い、差分を `rpcFsWatch` / `rpcFsUnwatch` で同期する。
+
+- gozd は「window 内マルチ repo + マルチ worktree」が機能要件なので、active 1 dir だけ watch する設計だと別 repo / 別 worktree の commit / rename / push を取りこぼす
+- 別 repo は commonGitDir が完全に独立。1 dir だけ watch ではこれを救済できないため、全 worktree を均等に対象とする
+- per-worktree git dir 配下の `HEAD` / `index` 変化（commit / checkout 完了の即時反映）も worktree ごとに独立して watch される
+- 非 git project（`isGitRepo === false`）は rootDir そのものを watch（fsChange のみが意味を持つ）
+- `rpcFsWatch` / `rpcFsUnwatch` はどちらも native 側 `FSWatchRegistry` で idempotent。並列発射でも整合性は崩れない
+- watch 数の上限は OS の FSEventStream slot に依存するが、実用域（数十〜百 worktree）で問題になる事例は確認されていない
 
 ### Unix ドメインソケット（CLI / Claude hooks → native）
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,12 +102,20 @@ socket / launch dir / claude settings は `GOZD_DEV_PROJECT_ROOT` の有無で `
 
 renderer は `fetch("gozd-rpc://localhost/{path}", { method, body })` で RPC を呼ぶ。`RpcSchemeHandler`（`apps/native/Sources/Gozd/GozdApp.swift`）が HTTP 風のレスポンスにラップして返す。実際のロジックは `RpcDispatcher`。
 
-native → renderer の push は `WebPage.callJavaScript("window.__gozdReceive(type, payload)", ...)` で行う。
+native → renderer の push は `WebPage.callJavaScript("window.__gozdReceive(type, payload)", ...)` で行う。失敗（page 未初期化 / JS 例外）は `pushToRenderer` ヘルパー（`apps/native/Sources/Gozd/GozdApp.swift`）が stderr に `[GozdApp] push failed: type=...` の形で必ずログを残す。silent drop は禁止 — 1 度の取りこぼしで UI 状態が永続的にずれるため、観察可能性を全 push に必須として課している。
 
 - **request**（応答あり）: `renderer → native`。ptySpawn, fsReadFile, gitStatus 等
 - **push**（一方向）: `native → renderer`。ptyText, hook, fsChange, gitStatusChange 等
 
 詳細なメッセージ一覧は [rpc.md](rpc.md)。
+
+### SSOT push + 低頻度 pull の整合性チェック
+
+FSEvents 経由の push は ms オーダーで届くが、watch 開始往復中の取りこぼしや、`callJavaScript` の失敗で 1 度の event を落とすと、UI 状態と git refs の実体が永続的にずれる。これを防ぐため次の二重防御を入れている。
+
+- **再同期トリガー**: `useFsWatchSync` が `rpcFsWatch` 応答直後に renderer 内部で `fsWatchReady` を `dispatchMessage` 経由で発射する。GitGraphPane / useSidebarData は同 type を `onMessage` で購読しており、watch 起動瞬間に 1 度だけ state を refetch する
+- **ref-digest 整合性チェッカ**: GitGraphPane が 60 秒間隔で `rpcGitRefsDigest`（`git for-each-ref refs/heads/ refs/remotes/` の SHA-256）を取り、前回値と比較する。不一致なら `console.warn` で観察可能性を残しつつ `loadLog` を発射。「予防 retry」ではなく、SSOT 経路（branchChange / gitStatusChange）の到達率を計測する保険として使う
+- **status payload に branch.head を含める**: `git branch -m` は HEAD の commit OID を変えないため、`gitStatusChange.head` だけで判定すると rename を取りこぼす。`git status --porcelain=v2 --branch` が出す `# branch.head <name>` を payload に乗せ、renderer 側は `branchHead` の変化でも `loadLog` を発火する
 
 ### Unix ドメインソケット（CLI / Claude hooks → native）
 

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_fs.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_fs.pb.swift
@@ -154,6 +154,33 @@ public struct Gozd_V1_FsUnwatchResponse: Sendable {
   public init() {}
 }
 
+/// 全 watch を一括停止する。renderer の onUnmounted で N 個の `/fs/unwatch` を
+/// 並列発射する代わりに 1 回の RPC で済ませる。native 側 entry は idempotent に
+/// 破棄され、残骸を残さない（FSEventStream slot leak の構造防止）。
+public struct Gozd_V1_FsUnwatchAllRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+/// 観察可能性のため、解除した dir 数を返す。renderer の watchedDirs と差異が
+/// 出れば前段で race が発生していた示唆になる。
+public struct Gozd_V1_FsUnwatchAllResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var unwatchedCount: UInt32 = 0
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "gozd.v1"
@@ -436,6 +463,55 @@ extension Gozd_V1_FsUnwatchResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 
   public static func ==(lhs: Gozd_V1_FsUnwatchResponse, rhs: Gozd_V1_FsUnwatchResponse) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Gozd_V1_FsUnwatchAllRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".FsUnwatchAllRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Gozd_V1_FsUnwatchAllRequest, rhs: Gozd_V1_FsUnwatchAllRequest) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Gozd_V1_FsUnwatchAllResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".FsUnwatchAllResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}unwatched_count\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularUInt32Field(value: &self.unwatchedCount) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.unwatchedCount != 0 {
+      try visitor.visitSingularUInt32Field(value: self.unwatchedCount, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Gozd_V1_FsUnwatchAllResponse, rhs: Gozd_V1_FsUnwatchAllResponse) -> Bool {
+    if lhs.unwatchedCount != rhs.unwatchedCount {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
@@ -416,6 +416,34 @@ public struct Gozd_V1_GitWorktreeRemoveResponse: Sendable {
   public init() {}
 }
 
+/// gitRefsDigest: refs/heads/ と refs/remotes/ の現在状態を 1 つの digest 文字列で返す。
+/// renderer 側は前回値と比較して、push event の取りこぼしを検知する低頻度の整合性チェッカに
+/// 使う。SSOT 経路（branchChange / gitStatusChange）の到達率を計測する観察可能性の補強で、
+/// 「予防的 retry」ではない。不一致時のみ loadLog + console.warn を出す。
+public struct Gozd_V1_GitRefsDigestRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var dir: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public struct Gozd_V1_GitRefsDigestResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var digest: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "gozd.v1"
@@ -1251,6 +1279,66 @@ extension Gozd_V1_GitWorktreeRemoveResponse: SwiftProtobuf.Message, SwiftProtobu
   }
 
   public static func ==(lhs: Gozd_V1_GitWorktreeRemoveResponse, rhs: Gozd_V1_GitWorktreeRemoveResponse) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Gozd_V1_GitRefsDigestRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GitRefsDigestRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}dir\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.dir) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.dir.isEmpty {
+      try visitor.visitSingularStringField(value: self.dir, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Gozd_V1_GitRefsDigestRequest, rhs: Gozd_V1_GitRefsDigestRequest) -> Bool {
+    if lhs.dir != rhs.dir {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Gozd_V1_GitRefsDigestResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GitRefsDigestResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}digest\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.digest) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.digest.isEmpty {
+      try visitor.visitSingularStringField(value: self.digest, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Gozd_V1_GitRefsDigestResponse, rhs: Gozd_V1_GitRefsDigestResponse) -> Bool {
+    if lhs.digest != rhs.digest {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/packages/proto-ts/src/generated/gozd/v1/fs.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/fs.ts
@@ -74,6 +74,22 @@ export interface FsUnwatchRequest {
 export interface FsUnwatchResponse {
 }
 
+/**
+ * 全 watch を一括停止する。renderer の onUnmounted で N 個の `/fs/unwatch` を
+ * 並列発射する代わりに 1 回の RPC で済ませる。native 側 entry は idempotent に
+ * 破棄され、残骸を残さない（FSEventStream slot leak の構造防止）。
+ */
+export interface FsUnwatchAllRequest {
+}
+
+/**
+ * 観察可能性のため、解除した dir 数を返す。renderer の watchedDirs と差異が
+ * 出れば前段で race が発生していた示唆になる。
+ */
+export interface FsUnwatchAllResponse {
+  unwatchedCount: number;
+}
+
 function createBaseFsReadFileRequest(): FsReadFileRequest {
   return { dir: "", path: "" };
 }
@@ -702,6 +718,113 @@ export const FsUnwatchResponse: MessageFns<FsUnwatchResponse> = {
   },
   fromPartial(_: DeepPartial<FsUnwatchResponse>): FsUnwatchResponse {
     const message = createBaseFsUnwatchResponse();
+    return message;
+  },
+};
+
+function createBaseFsUnwatchAllRequest(): FsUnwatchAllRequest {
+  return {};
+}
+
+export const FsUnwatchAllRequest: MessageFns<FsUnwatchAllRequest> = {
+  encode(_: FsUnwatchAllRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): FsUnwatchAllRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseFsUnwatchAllRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(_: any): FsUnwatchAllRequest {
+    return {};
+  },
+
+  toJSON(_: FsUnwatchAllRequest): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create(base?: DeepPartial<FsUnwatchAllRequest>): FsUnwatchAllRequest {
+    return FsUnwatchAllRequest.fromPartial(base ?? {});
+  },
+  fromPartial(_: DeepPartial<FsUnwatchAllRequest>): FsUnwatchAllRequest {
+    const message = createBaseFsUnwatchAllRequest();
+    return message;
+  },
+};
+
+function createBaseFsUnwatchAllResponse(): FsUnwatchAllResponse {
+  return { unwatchedCount: 0 };
+}
+
+export const FsUnwatchAllResponse: MessageFns<FsUnwatchAllResponse> = {
+  encode(message: FsUnwatchAllResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.unwatchedCount !== 0) {
+      writer.uint32(8).uint32(message.unwatchedCount);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): FsUnwatchAllResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseFsUnwatchAllResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.unwatchedCount = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): FsUnwatchAllResponse {
+    return {
+      unwatchedCount: isSet(object.unwatchedCount)
+        ? globalThis.Number(object.unwatchedCount)
+        : isSet(object.unwatched_count)
+        ? globalThis.Number(object.unwatched_count)
+        : 0,
+    };
+  },
+
+  toJSON(message: FsUnwatchAllResponse): unknown {
+    const obj: any = {};
+    if (message.unwatchedCount !== 0) {
+      obj.unwatchedCount = Math.round(message.unwatchedCount);
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<FsUnwatchAllResponse>): FsUnwatchAllResponse {
+    return FsUnwatchAllResponse.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<FsUnwatchAllResponse>): FsUnwatchAllResponse {
+    const message = createBaseFsUnwatchAllResponse();
+    message.unwatchedCount = object.unwatchedCount ?? 0;
     return message;
   },
 };

--- a/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
@@ -167,6 +167,20 @@ export interface GitWorktreeRemoveRequest {
 export interface GitWorktreeRemoveResponse {
 }
 
+/**
+ * gitRefsDigest: refs/heads/ と refs/remotes/ の現在状態を 1 つの digest 文字列で返す。
+ * renderer 側は前回値と比較して、push event の取りこぼしを検知する低頻度の整合性チェッカに
+ * 使う。SSOT 経路（branchChange / gitStatusChange）の到達率を計測する観察可能性の補強で、
+ * 「予防的 retry」ではない。不一致時のみ loadLog + console.warn を出す。
+ */
+export interface GitRefsDigestRequest {
+  dir: string;
+}
+
+export interface GitRefsDigestResponse {
+  digest: string;
+}
+
 function createBaseGitWorktreeListRequest(): GitWorktreeListRequest {
   return { dir: "" };
 }
@@ -2004,6 +2018,122 @@ export const GitWorktreeRemoveResponse: MessageFns<GitWorktreeRemoveResponse> = 
   },
   fromPartial(_: DeepPartial<GitWorktreeRemoveResponse>): GitWorktreeRemoveResponse {
     const message = createBaseGitWorktreeRemoveResponse();
+    return message;
+  },
+};
+
+function createBaseGitRefsDigestRequest(): GitRefsDigestRequest {
+  return { dir: "" };
+}
+
+export const GitRefsDigestRequest: MessageFns<GitRefsDigestRequest> = {
+  encode(message: GitRefsDigestRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.dir !== "") {
+      writer.uint32(10).string(message.dir);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GitRefsDigestRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGitRefsDigestRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.dir = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GitRefsDigestRequest {
+    return { dir: isSet(object.dir) ? globalThis.String(object.dir) : "" };
+  },
+
+  toJSON(message: GitRefsDigestRequest): unknown {
+    const obj: any = {};
+    if (message.dir !== "") {
+      obj.dir = message.dir;
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<GitRefsDigestRequest>): GitRefsDigestRequest {
+    return GitRefsDigestRequest.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<GitRefsDigestRequest>): GitRefsDigestRequest {
+    const message = createBaseGitRefsDigestRequest();
+    message.dir = object.dir ?? "";
+    return message;
+  },
+};
+
+function createBaseGitRefsDigestResponse(): GitRefsDigestResponse {
+  return { digest: "" };
+}
+
+export const GitRefsDigestResponse: MessageFns<GitRefsDigestResponse> = {
+  encode(message: GitRefsDigestResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.digest !== "") {
+      writer.uint32(10).string(message.digest);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GitRefsDigestResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGitRefsDigestResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.digest = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GitRefsDigestResponse {
+    return { digest: isSet(object.digest) ? globalThis.String(object.digest) : "" };
+  },
+
+  toJSON(message: GitRefsDigestResponse): unknown {
+    const obj: any = {};
+    if (message.digest !== "") {
+      obj.digest = message.digest;
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<GitRefsDigestResponse>): GitRefsDigestResponse {
+    return GitRefsDigestResponse.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<GitRefsDigestResponse>): GitRefsDigestResponse {
+    const message = createBaseGitRefsDigestResponse();
+    message.digest = object.digest ?? "";
     return message;
   },
 };

--- a/packages/proto-ts/src/index.ts
+++ b/packages/proto-ts/src/index.ts
@@ -90,6 +90,8 @@ export {
   GitLogResponse,
   GitPrListRequest,
   GitPrListResponse,
+  GitRefsDigestRequest,
+  GitRefsDigestResponse,
   GitShowCommitFileRequest,
   GitShowCommitFileResponse,
   GitShowFileRequest,

--- a/packages/proto-ts/src/index.ts
+++ b/packages/proto-ts/src/index.ts
@@ -62,6 +62,8 @@ export {
   FsReadDirResponse,
   FsReadFileRequest,
   FsReadFileResponse,
+  FsUnwatchAllRequest,
+  FsUnwatchAllResponse,
   FsUnwatchRequest,
   FsUnwatchResponse,
   FsWatchRequest,

--- a/packages/proto/gozd/v1/fs.proto
+++ b/packages/proto/gozd/v1/fs.proto
@@ -56,3 +56,14 @@ message FsUnwatchRequest {
 }
 
 message FsUnwatchResponse {}
+
+// 全 watch を一括停止する。renderer の onUnmounted で N 個の `/fs/unwatch` を
+// 並列発射する代わりに 1 回の RPC で済ませる。native 側 entry は idempotent に
+// 破棄され、残骸を残さない（FSEventStream slot leak の構造防止）。
+message FsUnwatchAllRequest {}
+
+// 観察可能性のため、解除した dir 数を返す。renderer の watchedDirs と差異が
+// 出れば前段で race が発生していた示唆になる。
+message FsUnwatchAllResponse {
+  uint32 unwatched_count = 1;
+}

--- a/packages/proto/gozd/v1/git_ops.proto
+++ b/packages/proto/gozd/v1/git_ops.proto
@@ -138,3 +138,14 @@ message GitWorktreeRemoveRequest {
 }
 message GitWorktreeRemoveResponse {}
 
+// gitRefsDigest: refs/heads/ と refs/remotes/ の現在状態を 1 つの digest 文字列で返す。
+// renderer 側は前回値と比較して、push event の取りこぼしを検知する低頻度の整合性チェッカに
+// 使う。SSOT 経路（branchChange / gitStatusChange）の到達率を計測する観察可能性の補強で、
+// 「予防的 retry」ではない。不一致時のみ loadLog + console.warn を出す。
+message GitRefsDigestRequest {
+  string dir = 1;
+}
+message GitRefsDigestResponse {
+  string digest = 1;
+}
+


### PR DESCRIPTION
## 概要

PR #420 (Electrobun → SwiftUI 全面書き直し) で落ちた fs-watch / push observability まわりの構造的欠陥を一括で修正する。`git branch -m` 後に gozd の Git Graph が古いブランチ名を表示し続ける症状を入口として、push 経路の silent drop / SSOT 経路 1 段依存 / active 1 dir watch / payload 貧弱さなど複数の劣化を SSOT push + 低頻度 pull 整合性チェックの多層防御で潰す。

## 背景

ユーザーから「new worktree でデフォルトブランチから作られた作業ブランチ ( 20260513_103416 ) が PR を作るにあたり別名にリネームされた後も Git Graph に残り続ける。 git refs は正常」と報告された。

調査経緯:

- 当初は rename-branch skill / git refs の問題を疑ったが、ユーザー指摘「git の status 変化は監視しているのに、 refs を watch していないのか」で focus が PR #420 関連の rewrite による劣化に切り替わった
- PR #420 以前 (Electrobun + Bun 実装、 PR #241 / commit e1586ba ) は `fs.watchFile` で 500 ms 間隔の mtime ポーリングで HEAD が指す ref / remote-tracking ref を監視していた
- PR #420 で `fs.watchFile` を撤廃して FSEvents recursive 監視に置換した際、 classify 規則の方が `refs/heads/...` だけしか拾わない実装で出荷されており、 `refs/remotes/...` と `packed-refs` が silent drop していた
- f016b97 ( fix(fs-watch): classify refs/remotes and packed-refs to restore push/fetch sync ) で classify 漏れは復元されたが、 push 経路の観察可能性 / `branch.head` の伝搬 / 整合性チェック / 全 worktree watch / aggregate Error の chain などの 4 側面は未復元のまま残っていた
- 別 context の Claude ( subagent ) レビューを 5 周以上回して指摘 A〜W を順次潰した
- CodeRabbit インラインレビューと subagent 再レビューで残った 4 件 ( push 失敗ログ stdout / onUnmounted silent drop / cause chain UI / useFsWatchSync テスト不在 ) も本対象内で構造的に解消した

`git branch -m` は HEAD の commit OID を変えないため、 `gitStatusChange.head` 単独判定では rename を取りこぼす。 `branchChange` 単独経路に依存していた状態が壊れると UI が永続的に古い state に固定される構造欠陥が主因。

## 変更内容

### push 経路の観察可能性 ( native )

- `apps/native/Sources/Gozd/GozdApp.swift` の `_ = try? await holder.page?.callJavaScript(...)` を 11 箇所散らばっていた状態から `pushToRenderer(page:type:payload:)` ヘルパーに集約。 page nil と JS 例外の両方を `[GozdApp] push dropped` / `[GozdApp] push failed: type=...` の形で必ず stderr に記録する。 silent drop は禁止
- 同じ「失敗ログ = stderr」原則を近傍に拡張: `GozdApp.swift` の `[ClaudeHooks] settings write failed` / `[SocketServer] start failed`、`FSWatchRegistry.swift` の `[FSWatchRegistry] gitStatusFull failed` も `FileHandle.standardError.write` に揃え、`Sources/GozdCore/RpcDispatcher.swift:72` 等の既存パターンに合流

### `branch.head` を SSOT として並走させる

- `apps/native/Sources/GozdCore/GitOps.swift` の `parsePorcelainV2WithBranch` で `# branch.head` を抽出して `StatusFull.branchHead` に取り込む ( detached HEAD は空文字に正規化 )
- `gitStatusChange` payload に `branchHead` を追加
- `apps/renderer/src/features/git-graph/GitGraphPane.vue` の `loadLog` 起動条件に `branchHeadChanged` を追加。 `lastBranchHead` を `loadLog` 完了時にも `findCurrentBranch` 経由で更新して `lastHead` との対称性を確保

### `branchChange` payload の充実

- `BranchChangeHandler` のシグネチャを `(dir, changedRefs) -> Void` に拡張
- `Classification.changedRefs` で `refs/heads/<name>` の basename を集めて payload に乗せる
- バグ報告 / ログで「どの ref が動いたか」を追える

### FSEventStream の対象スコープ ( renderer )

- `apps/renderer/src/features/filer/useFsWatchSync.ts` を active 1 dir 体制から `repoStore.repos[*].worktrees` の全 worktree watch に拡張
- `watchEffect` で集合変化を追って `rpcFsWatch` / `rpcFsUnwatch` を差分発射
- 非 git project は rootDir 自身を watch
- 別 repo の commonGitDir が完全に独立する状況でも refs / HEAD / index 変化を均等に検知できる

### `syncWatches` の serialize + drain ( renderer )

- `apps/renderer/src/features/filer/runSerializedSync.ts` に `running` / `pending` フラグによる single-flight + coalesce ロジックを pure helper として切り出し
- `watchEffect` 再 run と async コールバックの並列で削除済み worktree の watch が永続化する race を構造的に防ぐ
- `SerializeState.currentRun` に in-flight pass チェーン全体の Promise を保持し、`whenIdle(state)` で drain 可能にする
- `useFsWatchSync.onUnmounted` は `disposing` フラグを立てて新規 sync を抑止 → `whenIdle` で in-flight 完了を待つ → `rpcFsUnwatchAll` を発射する手順に変更。「unwatchAll の後に fsWatch(X) が native に届いて X が leak する」race window を構造的に閉じる
- `useFsWatchSync` は `runOneSyncPass` pure helper に依存注入する薄い wrapper に簡素化

### native 側 FSWatcher の再構築 + 一括 cleanup ( native )

- `apps/native/Sources/GozdCore/FSWatchRegistry.swift` の `watch` を「既存 entry あれば破棄して再構築」に変更
- `git worktree repair` 等で `perWorktreeGitDir` / `commonGitDir` の解決値が変わった場合の永続不整合を解消
- private `_unwatch(realpathDir:)` helper を切り出して watch 経由の自己 unwatch と外部 `unwatch` を共通化
- `unwatchAll()` を新設して全 entry を一括破棄。renderer の `onUnmounted` から 1 度の RPC で呼ぶ経路として `/fs/unwatchAll` を proto SSOT (`packages/proto/gozd/v1/fs.proto`) に追加し、`FsUnwatchAllResponse.unwatched_count` で観察可能性を保つ。N 個並列 `rpcFsUnwatch` の silent drop を構造的に解消

### 再同期トリガー ( renderer )

- `apps/renderer/src/shared/rpc/messages.ts` に `dispatchMessage(type, payload)` を新設して renderer 内部発の push を同じ dispatcher 経由で発火可能にする
- `useFsWatchSync` が `rpcFsWatch` 完了直後に `dispatchMessage("fsWatchReady", {})` を発射
- `GitGraphPane` / `useSidebarData` が `fsWatchReady` を購読して 1 度だけ refetch
- watch 起動往復中の取りこぼしを救済する
- payload は空 ( `Record<string, never>` ) にして購読側が `worktreeStore.dir` を都度読む契約を型で強制

### refs digest 整合性チェッカ ( renderer + native )

- 新規 RPC `/git/refsDigest` で `git for-each-ref refs/heads/ refs/remotes/ --sort=refname` の SHA-256 hex digest を返す
- `GitGraphPane` が PR 一覧の 60 秒ポーリングと同じタイマで digest を取り、 前回値と比較
- 不一致時 `console.warn` を残しつつ `loadLog` を発射
- RPC 失敗自体も `useNotificationStore.error` でトースト通知 ( silent fail で観察可能性を自己否定しない )。`useNotificationStore` 側の `type + message` 重複抑止により 60s 周期の連続失敗でもトーストは積み上がらない

### 失敗トーストの集約 + cause chain 再帰展開 ( renderer )

- watch / unwatch 失敗を 1 batch 単位で 1 件のトーストに集約
- `aggregate.message` には `${summary}` のみを載せ、 cause に first failure の `Error` を保持
- `apps/renderer/src/features/layout/NotificationToastItem.vue` の `detail` 表示を `formatCauseChain` に切り替え、`cause.cause` 以降の chain を `Caused by: ` プレフィックスで再帰展開する。aggregate pattern を使う他箇所 ( RPC client / PTY exit / git op 集約 ) が今後増えても同じ workaround を量産しない上流の根本修正

### docs

- `docs/architecture.md` に「SSOT push + 低頻度 pull の整合性チェック」節と「FSWatch の対象スコープ」節を追加し、 全 worktree watch / 非 git project / OS slot 上限の扱い、 整合性チェッカが何を見ているかを明示

### テスト

- bun test:
  - `runSerializedSync.test.ts`: single-flight + coalesce の race 挙動 6 ケース + `whenIdle` drain primitive 2 ケース ( null 即 resolve / pass チェーン完走待ち )
  - `runOneSyncPass.test.ts`: pure helper の差分計算・失敗集約・Ready 発射条件 7 ケース ( 初回 watch / 削除 dir unwatch / 全 watch 失敗 / 部分失敗 / unwatch 失敗 / watch+unwatch 両失敗 / 差分ゼロ )
  - `collectTargetDirs.test.ts`: 全 worktree watch の対象集合計算 5 ケース
  - `formatCause.test.ts`: cause chain 再帰展開 9 ケース ( 1 段 / 多段 / string / undefined / 循環 / V8 stack 正規化 / WebKit stack / aggregate 構造 )
- Swift Testing:
  - `FSWatchRegistryTests` に `git branch -m` 直後の `branchChange + gitStatusChange` 統合テスト、 `git pack-refs --all` の統合テスト、 `Classification.changedRefs` の 4 ケース pure unit test、 再 watch entry 破棄 + 再構築の integration test、 `unwatchAll` 2 ケース ( 全 entry 破棄 + 件数返却 + 以降 dispatch 停止 / entries 空での no-op )
  - `GitOpsTests` に `branchHead` の populated / rename 追従 / detached、 `refsDigest` の安定性 / rename 検知

### テストヘルパー整備

- `GitOpsTests.swift` の `runTestGit` を stderr 捕捉する形に修正 ( 既存ヘルパー `runGitCmd` の厳密さに揃え、 CI flaky 時の調査コストを本体並みに保つ )

## 確認事項

- [ ] `git branch -m` で current branch を改名した直後に gozd の Git Graph が新ブランチ名に追従する
- [ ] 別 repo の worktree で `git commit` した時、 active 1 dir でない側でもサイドバーのバッジ / Git Graph が更新される
- [ ] `git pack-refs --all` 後にも UI が古い ref に固まらない
- [ ] FSWatch の dir 数が増えた状態 ( 数十 worktree 同時 watch ) で性能 / メモリの不具合が出ない
- [ ] watch / unwatch RPC 失敗時のトーストの cause 詳細展開で「件数 + どの kind:dir + 最初の失敗の Error name + message + stack」が読める ( aggregate の cause chain 再帰展開で )
- [ ] worktree を多数開いた状態でアプリを終了 / リロードしたとき、native 側に watch entry の残骸が残らない ( `unwatchAll` 1 回呼び出し )
