### PR TITLE
refactor(reactivity): forbid reactive() and migrate remaining usages to ref()

### DIFF
--- a/apps/renderer/eslint.config.ts
+++ b/apps/renderer/eslint.config.ts
@@ -39,6 +39,20 @@ export default defineConfigWithVueTs(
         },
       ],
 
+      // vue: reactive() を禁止。ref() のみ使用する（issue #501）
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "vue",
+              importNames: ["reactive"],
+              message: "Use ref() instead. See issue #501.",
+            },
+          ],
+        },
+      ],
+
       // import-x
       "import-x/no-duplicates": "error",
       // 保存時の自動 lint で並び替えが発生すると編集中に邪魔なので off

--- a/apps/renderer/src/features/settings/SettingsModal.vue
+++ b/apps/renderer/src/features/settings/SettingsModal.vue
@@ -10,7 +10,7 @@
 
 <script setup lang="ts">
 import { tryCatch } from "@gozd/shared";
-import { reactive, watch } from "vue";
+import { ref, watch } from "vue";
 import { useDialog } from "../palette";
 import { previewFontFamily, previewFontSize } from "../preview";
 import { applyTerminalTheme, terminalFontFamily, terminalFontSize } from "../terminal";
@@ -41,28 +41,26 @@ const { isOpen: modalIsOpen } = useSettingsModal();
 const voicevoxStore = useVoicevoxStore();
 const worktreeStore = useWorktreeStore();
 
-const state = reactive({
-  activeTab: "global" as TabId,
-  loading: true,
-  globalValues: {} as Record<string, unknown>,
-  projectValues: {} as Record<string, unknown>,
-});
+const activeTab = ref<TabId>("global");
+const loading = ref(true);
+const globalValues = ref<Record<string, unknown>>({});
+const projectValues = ref<Record<string, unknown>>({});
 
 /** モーダルを開くときに設定を読み込む。load 完了後に dialog を表示する */
 async function openWithSettings() {
-  state.loading = true;
+  loading.value = true;
   const dir = worktreeStore.dir;
   const [globalResult, projectResult] = await Promise.all([
     tryCatch(rpcLoadAppConfig()),
     dir !== undefined ? tryCatch(rpcProjectConfigLoad({ dir })) : Promise.resolve(undefined),
   ]);
   if (globalResult.ok) {
-    state.globalValues = flattenAppConfig(globalResult.value.config);
+    globalValues.value = flattenAppConfig(globalResult.value.config);
   }
   if (projectResult !== undefined && projectResult.ok) {
-    state.projectValues = flattenProjectConfig(projectResult.value.config);
+    projectValues.value = flattenProjectConfig(projectResult.value.config);
   }
-  state.loading = false;
+  loading.value = false;
   show();
 }
 
@@ -87,7 +85,7 @@ const REACTIVE_SYNC: Record<string, (value: unknown) => void> = {
 
 /** グローバル設定の値変更ハンドラー */
 function handleGlobalChange(key: string, value: unknown) {
-  state.globalValues[key] = value;
+  globalValues.value[key] = value;
 
   // VOICEVOX store との同期（store の watch が configSave を発火）
   if (key === "voicevox.enabled") {
@@ -95,7 +93,7 @@ function handleGlobalChange(key: string, value: unknown) {
       void voicevoxStore.activate().then((errorMessage) => {
         if (errorMessage !== undefined) {
           // activate 失敗時はトグルを戻す
-          state.globalValues[key] = false;
+          globalValues.value[key] = false;
         }
       });
     } else {
@@ -121,7 +119,7 @@ function handleGlobalChange(key: string, value: unknown) {
 
 /** プロジェクト設定の値変更ハンドラー */
 function handleProjectChange(key: string, value: unknown) {
-  state.projectValues[key] = value;
+  projectValues.value[key] = value;
   const dir = worktreeStore.dir;
   if (dir === undefined) return;
   void tryCatch(patchProjectConfig(dir, { [key]: value }));
@@ -172,11 +170,11 @@ watch(isOpen, (open) => {
             type="button"
             class="px-4 py-1.5 text-left text-sm"
             :class="
-              state.activeTab === tab.id
+              activeTab === tab.id
                 ? 'bg-zinc-700/50 text-zinc-200'
                 : 'text-zinc-500 hover:text-zinc-300'
             "
-            @click="state.activeTab = tab.id"
+            @click="activeTab = tab.id"
           >
             {{ tab.label }}
           </button>
@@ -184,12 +182,12 @@ watch(isOpen, (open) => {
 
         <!-- 右コンテンツ -->
         <div class="flex-1 overflow-y-auto p-4">
-          <template v-if="state.activeTab === 'global'">
+          <template v-if="activeTab === 'global'">
             <SettingSection
               v-for="section in globalSettingsSections"
               :key="section.title"
               :section="section"
-              :values="state.globalValues"
+              :values="globalValues"
               @change="handleGlobalChange"
             />
           </template>
@@ -198,7 +196,7 @@ watch(isOpen, (open) => {
               v-for="section in projectSettingsSections"
               :key="section.title"
               :section="section"
-              :values="state.projectValues"
+              :values="projectValues"
               @change="handleProjectChange"
             />
           </template>

--- a/apps/renderer/src/shared/command/useContextKeys.ts
+++ b/apps/renderer/src/shared/command/useContextKeys.ts
@@ -2,7 +2,7 @@
  * Context Key の管理。module singleton パターン。
  * keybinding の when 条件評価に使用する。
  */
-import { reactive } from "vue";
+import { ref } from "vue";
 import type { ContextKey, ContextMap, When } from "./types";
 
 const INITIAL_STATE: ContextMap = {
@@ -16,14 +16,14 @@ const INITIAL_STATE: ContextMap = {
   isGitRepo: false,
 };
 
-const state = reactive<ContextMap>({ ...INITIAL_STATE });
+const state = ref<ContextMap>({ ...INITIAL_STATE });
 
 function get<K extends ContextKey>(key: K): ContextMap[K] {
-  return state[key];
+  return state.value[key];
 }
 
 function set<K extends ContextKey>(key: K, value: ContextMap[K]): void {
-  state[key] = value;
+  state.value[key] = value;
 }
 
 /** When 条件を現在の context key 状態で評価する。undefined は常に true */
@@ -32,7 +32,7 @@ function evaluate(when: When | undefined): boolean {
 
   switch (when.type) {
     case "key":
-      return state[when.key] === true;
+      return state.value[when.key] === true;
     case "not":
       return !evaluate(when.value);
     case "and":
@@ -44,7 +44,7 @@ function evaluate(when: When | undefined): boolean {
 
 /** HMR / テスト用。全 context key を初期値にリセットする */
 function reset(): void {
-  Object.assign(state, INITIAL_STATE);
+  state.value = { ...INITIAL_STATE };
 }
 
 export function useContextKeys() {


### PR DESCRIPTION
## 概要

renderer のリアクティブ状態を `ref()` ベースに統一するための足固め。残存していた 2 箇所の `reactive()` 使用を `ref()` に書き換え、ESLint で `vue` からの `reactive` named import を禁止する。

## 背景

`reactive()` には Vue を使い込むほど踏みやすい落とし穴がいくつもある ( #501 ) 。

- destructure / 関数引数渡しで reactivity が切れる
- 全体差し替えで reactivity が切れる（同一 reference の保持が必須）
- primitive を扱えない
- `.value` という明示シグナルが無く、プレーンオブジェクトと区別がつかない
- Map / Set など collection 型での auto-unwrap の挙動が不整合 ( vuejs/core issue9314 )

renderer のコードベースはすでに大半が `ref()` 主体で、`reactive()` の残存は `SettingsModal.vue` と `useContextKeys.ts` の 2 箇所のみ。この機会に「迷ったら ref」の方針を機械的に強制できる lint ルールを入れる。

## 変更内容

### `useContextKeys.ts` を ref ベースに書き換え

- `reactive<ContextMap>` を `ref<ContextMap>` に変更
- `state[key]` → `state.value[key]` に置換
- `reset()` は `state.value = { ...INITIAL_STATE }` で全体差し替え（`ref` 経由なので参照入れ替えでも追跡は切れない）

### `SettingsModal.vue` を ref ベースに書き換え

- 単一の `reactive({ activeTab, loading, globalValues, projectValues })` を 4 つの個別 `ref` に分解
- template 内は auto-unwrap が効くので `state.globalValues` → `globalValues` のみで済む（`.value` 不要）

### ESLint で `reactive` import を禁止

- `no-restricted-imports` で `vue` の `reactive` named import のみを弾く設定を追加
- `ref` / `watch` などは通常通り import できる最小侵襲な構成
- eslint-plugin-vue に `reactive` 自体を禁止するルールは存在しないため、ビルトインルールで対応

## 確認事項

- [ ] Cmd+, で設定モーダルを開き、Global / Project タブ切り替え、各設定値の編集・保存が機能する
- [ ] キーバインドの when 条件（`terminalFocus` / `previewVisible` 等の context key 評価）が正常に動く
- [ ] `pnpm lint` / `pnpm typecheck` が通る
