### PR TITLE
fix(sidebar): isolate worktree creating state per rootDir

### DIFF
--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -56,9 +56,10 @@ useSidebarData();
 
 const { confirmRef, confirmMessage, showConfirm, closeConfirm, executeConfirm } = useDialogs();
 
-const { isCreating, handleWorktreeSelect, addWorktree, handleWorktreeRemove } = useWorktreeActions({
-  showConfirm,
-});
+const { isCreatingFor, handleWorktreeSelect, addWorktree, handleWorktreeRemove } =
+  useWorktreeActions({
+    showConfirm,
+  });
 
 // --- 経過時間表示用の現在時刻 ---
 
@@ -232,7 +233,7 @@ const activeRootWorktree = computed(() => {
           :index="i"
           :edit-mode="editMode"
           :active-dir="worktreeStore.dir"
-          :is-creating="isCreating"
+          :is-creating="isCreatingFor(rootDir)"
           :now="now"
           :get-resumeable-session-count="terminalStore.getResumeableSessionCount"
           :get-terminal-count="getTerminalCount"

--- a/apps/renderer/src/features/sidebar/features/worktree/useWorktreeActions.ts
+++ b/apps/renderer/src/features/sidebar/features/worktree/useWorktreeActions.ts
@@ -24,7 +24,7 @@ export function useWorktreeActions({ showConfirm }: UseWorktreeActionsOptions) {
   const terminalStore = useTerminalStore();
   const repoStore = useRepoStore();
 
-  const isCreating = ref(false);
+  const creatingRootDirs = ref(new Set<string>());
 
   function handleWorktreeSelect(wt: WorktreeEntry) {
     terminalStore.viewMode = "wt";
@@ -47,37 +47,43 @@ export function useWorktreeActions({ showConfirm }: UseWorktreeActionsOptions) {
 
   /** タイムスタンプで即座に新規 worktree を作成する（Task なし） */
   async function addWorktree(rootDir: string) {
-    if (isCreating.value) return;
-    isCreating.value = true;
-    // default branch を起点にする。Swift 側で `origin/HEAD` を優先し、未設定
-    // （remote 無し / push 前 repo）の場合は main repo root 自身の current branch に
-    // fallback した ref を受け取り、`startPoint` に渡す。
-    const branchResult = await tryCatch(rpcGitDefaultBranch({ dir: rootDir }));
-    if (!branchResult.ok || branchResult.value.branch === "") {
-      notify.error(
-        "Failed to resolve default branch",
-        branchResult.ok ? undefined : branchResult.error,
+    if (creatingRootDirs.value.has(rootDir)) return;
+    creatingRootDirs.value.add(rootDir);
+    try {
+      // default branch を起点にする。Swift 側で `origin/HEAD` を優先し、未設定
+      // （remote 無し / push 前 repo）の場合は main repo root 自身の current branch に
+      // fallback した ref を受け取り、`startPoint` に渡す。
+      const branchResult = await tryCatch(rpcGitDefaultBranch({ dir: rootDir }));
+      if (!branchResult.ok || branchResult.value.branch === "") {
+        notify.error(
+          "Failed to resolve default branch",
+          branchResult.ok ? undefined : branchResult.error,
+        );
+        return;
+      }
+      const timestamp = generateTimestamp();
+      const result = await tryCatch(
+        rpcCreateWorktree({
+          dir: rootDir,
+          worktreeDir: timestamp,
+          branch: timestamp,
+          startPoint: branchResult.value.branch,
+        }),
       );
-      isCreating.value = false;
-      return;
+      if (result.ok && result.value.worktree !== undefined) {
+        repoStore.appendWorktree(rootDir, result.value.worktree);
+        terminalStore.viewMode = "wt";
+        worktreeStore.setOpen(result.value.dir);
+      } else {
+        notify.error("Failed to add worktree", result.ok ? undefined : result.error);
+      }
+    } finally {
+      creatingRootDirs.value.delete(rootDir);
     }
-    const timestamp = generateTimestamp();
-    const result = await tryCatch(
-      rpcCreateWorktree({
-        dir: rootDir,
-        worktreeDir: timestamp,
-        branch: timestamp,
-        startPoint: branchResult.value.branch,
-      }),
-    );
-    if (result.ok && result.value.worktree !== undefined) {
-      repoStore.appendWorktree(rootDir, result.value.worktree);
-      terminalStore.viewMode = "wt";
-      worktreeStore.setOpen(result.value.dir);
-    } else {
-      notify.error("Failed to add worktree", result.ok ? undefined : result.error);
-    }
-    isCreating.value = false;
+  }
+
+  function isCreatingFor(rootDir: string): boolean {
+    return creatingRootDirs.value.has(rootDir);
   }
 
   /** worktree 解除: 通常削除 → 失敗時に確認の上 --force */
@@ -105,7 +111,7 @@ export function useWorktreeActions({ showConfirm }: UseWorktreeActionsOptions) {
   }
 
   return {
-    isCreating,
+    isCreatingFor,
     handleWorktreeSelect,
     addWorktree,
     handleWorktreeRemove,


### PR DESCRIPTION
## 概要

サイドバーで 1 つの repo の「new worktree」ボタンを押すと、開いている全 repo のボタンが同時にローディング状態になっていたのを修正する。進行中状態を rootDir 単位に分離した。

## 背景

`useWorktreeActions` 内の `isCreating` が単一の `ref<boolean>` で、`SidebarPane` がそれを全 `RepoSection` に同じ prop として配っていた。`addWorktree` は `rootDir` を引数で受け取って per-repo に動作するのに、進行中フラグだけは rootDir で分離されておらず、どの repo で押しても同じスカラが true になる構造。複数 repo をサイドバーに並列表示する gozd の前提と矛盾していた。

「per-entity の状態を global scalar で持っている」というモデリングミスで、entity 単位の状態は entity id を含む集合への所属判定で表現するのが正しい。

## 変更内容

### sidebar / worktree actions

- `useWorktreeActions` の `isCreating: Ref<boolean>` を `creatingRootDirs: Ref<Set<string>>` に置き換え
- `addWorktree(rootDir)` の進行中マーク・解除を rootDir 単位の `add` / `delete` に変更
- 早期 return 経路が複数あるため try/finally でラップし、全分岐で確実に `delete` する。消し忘れによる永久ローディングを防ぐ
- 公開 API を `isCreatingFor(rootDir): boolean` に変更
- `SidebarPane` の `RepoSection` への prop を `:is-creating="isCreatingFor(rootDir)"` に変更し、ループ内で各 repo が独立して評価されるようにする

## 確認事項

- [ ] 複数 repo を開いた状態で、1 つの repo の「new worktree」を押したときに、その repo のボタンだけがローディング表示になり、他 repo のボタンは押下可能なままであること
- [ ] worktree 作成が失敗した（default branch 解決失敗 / 作成 RPC エラー）ときも、押した repo のローディング状態が解除されること
- [ ] 同じ repo の「new worktree」連打が `creatingRootDirs.has(rootDir)` のガードで弾かれること
