### PR TITLE
refactor(sidebar): レイアウト刷新と親子ハイライト

### DIFF
--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -209,7 +209,7 @@ const activeRootWorktree = computed(() => {
       </button>
     </div>
 
-    <div class="flex flex-1 flex-col overflow-y-auto py-4">
+    <div class="_sidebar-scroll flex flex-1 scrollbar-none flex-col overflow-y-auto py-4">
       <DragDropProvider @drag-end="onDragEnd">
         <RepoSection
           v-for="(rootDir, i) in repoStore.dirOrder"
@@ -277,3 +277,10 @@ const activeRootWorktree = computed(() => {
     <VoicevoxPanel @error="notify.error" />
   </div>
 </template>
+
+<style scoped>
+/* scrollbar 自体を非表示 (macOS の overlay も hover で content に被るため使わない)。スクロール操作はトラックパッド / ホイールのみ */
+._sidebar-scroll::-webkit-scrollbar {
+  display: none;
+}
+</style>

--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -34,7 +34,7 @@ import { computed, ref } from "vue";
 import { useNotificationStore } from "../../shared/notification";
 import { useRepoStore } from "../../shared/repo";
 import { rpcPickAndOpen } from "../layout";
-import { collectLeafIds, useTerminalStore } from "../terminal";
+import { useTerminalStore } from "../terminal";
 import { useWorktreeStore } from "../worktree";
 import { RepoSection } from "./features/repo";
 import { useWorktreeActions } from "./features/worktree";
@@ -94,13 +94,6 @@ function getFocusedPtyId(dir: string): number | undefined {
   const focusedLeafId = terminalStore.layoutsByDir[dir]?.focusedLeafId;
   if (focusedLeafId === undefined) return undefined;
   return terminalStore.getPtyId(focusedLeafId);
-}
-
-/** 指定 wt 内の terminal 数 (= leaf 数)。terminal count バッジ表示判定に使う */
-function getTerminalCount(dir: string): number {
-  const root = terminalStore.layoutsByDir[dir]?.root;
-  if (root === undefined) return 0;
-  return collectLeafIds(root).length;
 }
 
 function onRemoveRepo(rootDir: string) {
@@ -216,7 +209,7 @@ const activeRootWorktree = computed(() => {
       </button>
     </div>
 
-    <div class="flex-1 overflow-y-auto px-3 py-4">
+    <div class="flex flex-1 flex-col overflow-y-auto py-4">
       <DragDropProvider @drag-end="onDragEnd">
         <RepoSection
           v-for="(rootDir, i) in repoStore.dirOrder"
@@ -227,7 +220,6 @@ const activeRootWorktree = computed(() => {
           :active-dir="worktreeStore.dir"
           :is-creating="isCreatingFor(rootDir)"
           :get-resumeable-session-count="terminalStore.getResumeableSessionCount"
-          :get-terminal-count="getTerminalCount"
           :get-focused-pty-id="getFocusedPtyId"
           @remove-repo="onRemoveRepo"
           @select-wt="onSelectWt"
@@ -243,7 +235,7 @@ const activeRootWorktree = computed(() => {
       <button
         v-if="editMode"
         type="button"
-        class="mt-2 flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+        class="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
         title="Add directory"
         @click="onAddDir"
       >
@@ -258,10 +250,10 @@ const activeRootWorktree = computed(() => {
     <!-- 確認ダイアログ -->
     <dialog
       ref="confirmRef"
-      class="fixed inset-0 m-auto size-fit rounded-lg border border-zinc-700 bg-zinc-900 p-4 text-white backdrop:bg-black/50"
+      class="fixed inset-0 m-auto flex size-fit flex-col gap-4 rounded-lg border border-zinc-700 bg-zinc-900 p-4 text-white backdrop:bg-black/50"
       @click="$event.target === confirmRef && closeConfirm()"
     >
-      <p class="mb-4 text-sm">{{ confirmMessage }}</p>
+      <p class="text-sm">{{ confirmMessage }}</p>
       <div class="flex justify-end gap-2">
         <button
           class="rounded-sm px-3 py-1.5 text-sm text-zinc-400 hover:bg-zinc-800"

--- a/apps/renderer/src/features/sidebar/features/repo/RepoSection.vue
+++ b/apps/renderer/src/features/sidebar/features/repo/RepoSection.vue
@@ -65,12 +65,6 @@ const orderedWorktrees = computed(() => {
   return main !== undefined ? [main, ...others] : others;
 });
 
-const isOwningActive = computed(() => {
-  if (props.activeDir === undefined) return false;
-  if (props.activeDir === props.rootDir) return true;
-  return worktrees.value.some((wt) => wt.path === props.activeDir);
-});
-
 const sectionEl = useTemplateRef<HTMLElement>("section");
 const dragHandleEl = useTemplateRef<HTMLElement>("dragHandle");
 
@@ -93,11 +87,8 @@ function onHeaderClick() {
 <template>
   <section ref="section" class="flex flex-col gap-2 rounded-lg p-2">
     <header
-      class="group/repo flex items-center gap-2 rounded-lg"
-      :class="[
-        isOwningActive ? 'text-blue-300' : 'text-zinc-200',
-        editMode ? '' : 'cursor-pointer hover:bg-white/5',
-      ]"
+      class="group/repo flex items-center gap-2 rounded-lg text-zinc-200"
+      :class="editMode ? '' : 'cursor-pointer hover:bg-white/5'"
       :role="editMode ? undefined : 'button'"
       :aria-label="editMode ? undefined : visiblyCollapsed ? 'Expand' : 'Collapse'"
       :aria-expanded="editMode ? undefined : !visiblyCollapsed"
@@ -129,7 +120,7 @@ function onHeaderClick() {
       </button>
     </header>
 
-    <div v-if="isGitRepo && !visiblyCollapsed" class="flex flex-col gap-1">
+    <div v-if="isGitRepo && !visiblyCollapsed" class="flex flex-col">
       <WtCard
         v-for="wt in orderedWorktrees"
         :key="wt.path"

--- a/apps/renderer/src/features/sidebar/features/repo/RepoSection.vue
+++ b/apps/renderer/src/features/sidebar/features/repo/RepoSection.vue
@@ -34,7 +34,6 @@ const props = defineProps<{
   activeDir: string | undefined;
   isCreating: boolean;
   getResumeableSessionCount: (dir: string) => number;
-  getTerminalCount: (dir: string) => number;
   getFocusedPtyId: (dir: string) => number | undefined;
 }>();
 
@@ -92,13 +91,9 @@ function onHeaderClick() {
 </script>
 
 <template>
-  <section
-    ref="section"
-    :data-has-active="isOwningActive"
-    class="rounded-lg p-1 data-[has-active=true]:bg-blue-500/8"
-  >
+  <section ref="section" class="flex flex-col gap-2 rounded-lg p-2">
     <header
-      class="group/repo flex items-center gap-1 rounded-lg px-2 py-1.5"
+      class="group/repo flex items-center gap-2 rounded-lg"
       :class="[
         isOwningActive ? 'text-blue-300' : 'text-zinc-200',
         editMode ? '' : 'cursor-pointer hover:bg-white/5',
@@ -115,10 +110,10 @@ function onHeaderClick() {
         :title="rootDir"
       >
         <span
-          class="size-4 shrink-0"
-          :class="isGitRepo ? 'icon-[lucide--folder-git-2]' : 'icon-[lucide--folder]'"
+          class="size-5 shrink-0"
+          :class="visiblyCollapsed ? 'icon-[lucide--folder]' : 'icon-[lucide--folder-open]'"
         />
-        <span class="min-w-0 flex-1 truncate text-xs font-semibold tracking-wide uppercase">
+        <span class="min-w-0 flex-1 truncate text-sm font-semibold">
           {{ repoName }}
         </span>
       </div>
@@ -134,7 +129,7 @@ function onHeaderClick() {
       </button>
     </header>
 
-    <div v-if="isGitRepo && !visiblyCollapsed" class="mt-1 flex flex-col gap-1">
+    <div v-if="isGitRepo && !visiblyCollapsed" class="flex flex-col gap-1">
       <WtCard
         v-for="wt in orderedWorktrees"
         :key="wt.path"
@@ -142,7 +137,6 @@ function onHeaderClick() {
         :root-dir="rootDir"
         :active="activeDir === wt.path"
         :focused-pty-id="getFocusedPtyId(wt.path)"
-        :terminal-count="getTerminalCount(wt.path)"
         :resumeable-session-count="getResumeableSessionCount(wt.path)"
         @select-wt="emit('selectWt', $event)"
         @select-task="(w, t) => emit('selectTask', w, t)"
@@ -150,12 +144,12 @@ function onHeaderClick() {
       />
       <button
         type="button"
-        class="grid w-full grid-cols-[auto_1fr] items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-zinc-500 hover:bg-white/5 disabled:opacity-50"
+        class="flex w-full items-center justify-center gap-1.5 rounded-md border border-dashed border-zinc-700 px-2 py-1.5 text-xs text-zinc-500 transition-colors hover:border-zinc-600 hover:bg-white/5 hover:text-zinc-300 disabled:opacity-50"
         :disabled="isCreating"
         @click="emit('addWorktree', rootDir)"
       >
         <span
-          class="size-5"
+          class="size-3.5"
           :class="isCreating ? 'icon-[lucide--loader-circle] animate-spin' : 'icon-[lucide--plus]'"
         />
         <span>New worktree</span>

--- a/apps/renderer/src/features/sidebar/features/worktree/TaskRow.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/TaskRow.vue
@@ -96,7 +96,7 @@ const bubbleColorClass = computed(() => {
   <button
     type="button"
     :data-active="active"
-    class="flex w-full items-center gap-2 rounded-lg p-2 text-left transition-colors hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none focus-visible:ring-inset data-[active=true]:bg-blue-500 data-[active=true]:text-white"
+    class="flex w-full items-center gap-2 rounded-lg p-2 text-left transition-colors hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none focus-visible:ring-inset data-[active=true]:bg-blue-500/30"
     @click="emit('select', task)"
   >
     <span

--- a/apps/renderer/src/features/sidebar/features/worktree/TaskRow.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/TaskRow.vue
@@ -96,7 +96,7 @@ const bubbleColorClass = computed(() => {
   <button
     type="button"
     :data-active="active"
-    class="grid w-full grid-cols-[auto_1fr_auto] items-center gap-2 rounded-lg px-3 py-2 text-left transition-colors hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none focus-visible:ring-inset data-[active=true]:bg-blue-500 data-[active=true]:text-white"
+    class="flex w-full items-center gap-2 rounded-lg p-2 text-left transition-colors hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none focus-visible:ring-inset data-[active=true]:bg-blue-500 data-[active=true]:text-white"
     @click="emit('select', task)"
   >
     <span
@@ -105,12 +105,12 @@ const bubbleColorClass = computed(() => {
       role="img"
       :aria-label="visual.ariaLabel"
     />
-    <span class="truncate text-sm">{{ title }}</span>
-    <span class="text-xs tabular-nums opacity-70">{{ relativeTime }}</span>
+    <span class="line-clamp-2 flex-1 text-sm break-all" :title="title">{{ title }}</span>
+    <span class="text-[10px] tabular-nums opacity-70">{{ relativeTime }}</span>
   </button>
   <p
     v-if="bubbleText"
-    class="line-clamp-1 pr-3 pl-9 text-xs italic"
+    class="line-clamp-1 text-xs italic"
     :class="bubbleColorClass"
     :title="bubbleText"
   >

--- a/apps/renderer/src/features/sidebar/features/worktree/TaskRow.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/TaskRow.vue
@@ -96,7 +96,7 @@ const bubbleColorClass = computed(() => {
   <button
     type="button"
     :data-active="active"
-    class="flex w-full items-center gap-2 rounded-lg p-2 text-left transition-colors hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none focus-visible:ring-inset data-[active=true]:bg-blue-500/30"
+    class="flex w-full items-center gap-2 rounded-lg p-2 text-left transition-colors hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-hidden focus-visible:ring-inset data-[active=true]:bg-blue-500/30"
     @click="emit('select', task)"
   >
     <span

--- a/apps/renderer/src/features/sidebar/features/worktree/WtCard.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/WtCard.vue
@@ -1,19 +1,20 @@
 <doc lang="md">
-1 worktree のカード。ヘッダ (branch icon / branch / git status / terminal count / ⋮) と、
+1 worktree のカード。ヘッダ (branch icon / branch / git status / resumable count / ⋮) と、
 session 由来の Task 行 (TaskRow) を縦に並べる。task が無い wt はヘッダのみ。
 
-## ハイライトの二者択一
+## ハイライト
 
-ヘッダと task 行のうち capsule fill が当たるのはどちらか一方:
-
-- focused PTY が task (= session) なら → 該当 task 行に capsule
-- focused PTY が shell なら → wt ヘッダに capsule
-
-両方同時には付かない。
+active wt の場合、wt ヘッダには常に capsule fill。さらに focused PTY が task
+(= session) なら該当 task 行にも capsule。wt と task の両方が同時にハイライト
+されることで「どの wt のどの task に focus があるか」が一目で識別できる。
 
 ## 並び順
 
-task 内: state 優先順 (asking > working > done > idle > resumable)、同 state 内は時刻新しい順。
+task は `task.createdAt` 昇順 (append 順) で固定。新しい task は末尾に追加され、
+既存 task の位置は動かない。state や lastActivityAt は動的なためソートキーに
+混ぜない。位置の安定性を優先し、状態は行頭アイコンと相対時刻表示で示す責務
+分担。wt の並び (`RepoSection.orderedWorktrees` の `git worktree list` append 順)
+と同じ方針。
 </doc>
 
 <script setup lang="ts">
@@ -22,25 +23,14 @@ import { computed } from "vue";
 import type { ClaudeStatus } from "../../../terminal";
 import { useTerminalStore } from "../../../terminal";
 import { computeStatusIcons, StatusIcons } from "../../../worktree";
-import { resolveTaskBaseTime } from "../../taskBaseTime";
 import { branchLabel as resolveBranchLabel, hasChanges } from "../../utils";
 import TaskRow from "./TaskRow.vue";
-
-type StateKey = "asking" | "working" | "done" | "idle" | "resumable";
-const STATE_PRIORITY: Record<StateKey, number> = {
-  asking: 4,
-  working: 3,
-  done: 2,
-  idle: 1,
-  resumable: 0,
-};
 
 const props = defineProps<{
   wt: WorktreeEntry;
   rootDir: string;
   active: boolean;
   focusedPtyId: number | undefined;
-  terminalCount: number;
   resumeableSessionCount: number;
 }>();
 
@@ -66,41 +56,21 @@ interface TaskWithStatus {
   task: Task;
   status: ClaudeStatus | undefined;
   ptyId: number | undefined;
-  stateKey: StateKey;
-  baseTime: number;
 }
 
 /**
- * status が undefined になるケースは 2 つあり、ptyId の有無で区別する。
- * - ptyId が紐付いている: live PTY はあるが session-start hook の status 反映が
- *   間に合っていない一瞬の窓 → idle 相当として扱う (resumable に倒すと UI 上で
- *   起動中 session が灰色アイコンに化けて UX が崩れる)
- * - ptyId が無い: 永続化された session のみで live PTY 不在 → 真の resumable
+ * ソートは `task.createdAt` (静的) のみ。state や lastActivityAt のような
+ * 動的値をキーに混ぜると Claude の活動ごとに行位置が入れ替わり、ユーザーが
+ * 「どこに何の task があるか」を空間記憶で辿れなくなる。位置は固定、状態は
+ * 行頭アイコンと相対時刻で表現する責務分担。
  */
-function resolveStateKey(status: ClaudeStatus | undefined, ptyId: number | undefined): StateKey {
-  if (status !== undefined) return status.state;
-  if (ptyId === undefined) return "resumable";
-  return "idle";
-}
-
 const tasksWithStatus = computed<TaskWithStatus[]>(() => {
-  const list = props.wt.tasks.map<TaskWithStatus>((task) => {
-    const status = terminalStore.getClaudeStatusBySessionId(task.id);
-    const ptyId = terminalStore.getPtyIdBySessionId(task.id);
-    return {
-      task,
-      status,
-      ptyId,
-      stateKey: resolveStateKey(status, ptyId),
-      // sort 用なので createdAt パース失敗時 (proto 契約違反) は 0 に倒す
-      baseTime: resolveTaskBaseTime(status, task) ?? 0,
-    };
-  });
-  return list.sort((a, b) => {
-    const diff = STATE_PRIORITY[b.stateKey] - STATE_PRIORITY[a.stateKey];
-    if (diff !== 0) return diff;
-    return b.baseTime - a.baseTime;
-  });
+  const list = props.wt.tasks.map<TaskWithStatus>((task) => ({
+    task,
+    status: terminalStore.getClaudeStatusBySessionId(task.id),
+    ptyId: terminalStore.getPtyIdBySessionId(task.id),
+  }));
+  return list.sort((a, b) => Date.parse(a.task.createdAt) - Date.parse(b.task.createdAt));
 });
 
 /**
@@ -117,8 +87,8 @@ const focusedTaskId = computed(() => {
   return found?.task.id;
 });
 
-/** focus が wt 内にあり、かつ task でない (= shell) なら header に capsule */
-const headerActive = computed(() => props.active && focusedTaskId.value === undefined);
+/** focus が wt 内にあるなら header に capsule (task focus 時も同時にハイライト) */
+const headerActive = computed(() => props.active);
 
 function onMenuClick(event: MouseEvent) {
   event.stopPropagation();
@@ -133,49 +103,46 @@ function onHeaderClick() {
 
 <template>
   <article class="rounded-lg">
-    <div
-      role="button"
-      tabindex="0"
-      :data-active="headerActive"
-      class="group/wt grid w-full cursor-pointer grid-cols-[auto_1fr_auto_auto_auto] items-center gap-2 rounded-lg px-3 py-2 transition-colors hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none focus-visible:ring-inset data-[active=true]:bg-blue-500 data-[active=true]:text-white"
-      @click="onHeaderClick"
-      @keydown.enter.prevent="onHeaderClick"
-      @keydown.space.prevent="onHeaderClick"
-    >
-      <span class="size-5 shrink-0" :class="branchIcon" aria-hidden="true" />
-      <span class="truncate text-left text-sm font-medium">{{ branchLabel }}</span>
-      <span
-        v-if="wt.gitStatuses && hasChanges(wt.gitStatuses)"
-        class="flex items-center gap-1 text-xs"
+    <div class="group/wt relative">
+      <div
+        role="button"
+        tabindex="0"
+        :data-active="headerActive"
+        class="flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 text-zinc-400 transition-colors hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none focus-visible:ring-inset data-[active=true]:bg-blue-500 data-[active=true]:text-white"
+        @click="onHeaderClick"
+        @keydown.enter.prevent="onHeaderClick"
+        @keydown.space.prevent="onHeaderClick"
       >
-        <StatusIcons :entries="statusIcons" />
-      </span>
-      <span
-        v-if="terminalCount >= 2"
-        class="grid size-4 min-w-4 place-items-center rounded-full bg-zinc-700 px-1 text-[10px] font-medium text-zinc-200 tabular-nums"
-        :title="`${terminalCount} terminals`"
-      >
-        {{ terminalCount }}
-      </span>
-      <span
-        v-else-if="resumeableSessionCount > 0"
-        class="flex items-center gap-1 text-[10px] text-zinc-400"
-        :title="`${resumeableSessionCount} resumable session${resumeableSessionCount === 1 ? '' : 's'}`"
-      >
-        <span class="icon-[lucide--rotate-cw] size-3" />
-        <span class="tabular-nums">{{ resumeableSessionCount }}</span>
-      </span>
+        <span class="grid size-5 shrink-0 place-items-center" aria-hidden="true">
+          <span class="size-3.5" :class="branchIcon" />
+        </span>
+        <span class="flex-1 truncate text-left text-xs font-medium">{{ branchLabel }}</span>
+        <span
+          v-if="wt.gitStatuses && hasChanges(wt.gitStatuses)"
+          class="flex items-center justify-end gap-1 text-xs"
+        >
+          <StatusIcons :entries="statusIcons" />
+        </span>
+        <span
+          v-if="resumeableSessionCount > 0"
+          class="flex items-center gap-1 text-[10px] text-zinc-400"
+          :title="`${resumeableSessionCount} resumable session${resumeableSessionCount === 1 ? '' : 's'}`"
+        >
+          <span class="icon-[lucide--rotate-cw] size-3" />
+          <span class="tabular-nums">{{ resumeableSessionCount }}</span>
+        </span>
+      </div>
       <button
         type="button"
         aria-label="Open menu"
-        class="grid size-6 place-items-center rounded-sm text-zinc-400 opacity-0 transition-opacity duration-100 group-focus-within/wt:opacity-100 group-hover/wt:opacity-100 hover:bg-white/10 hover:text-zinc-100"
+        class="absolute top-1/2 right-1 grid size-5 -translate-y-1/2 place-items-center rounded-sm bg-zinc-800 text-zinc-300 opacity-0 shadow-md ring-1 ring-zinc-700 transition-opacity duration-100 group-focus-within/wt:opacity-100 group-hover/wt:opacity-100 hover:bg-zinc-700 hover:text-zinc-100"
         @click="onMenuClick"
       >
-        <span class="icon-[lucide--ellipsis-vertical] text-sm" />
+        <span class="icon-[lucide--ellipsis-vertical] text-xs" />
       </button>
     </div>
 
-    <div v-if="tasksWithStatus.length > 0" class="p-1">
+    <div v-if="tasksWithStatus.length > 0">
       <TaskRow
         v-for="entry in tasksWithStatus"
         :key="entry.task.id"

--- a/apps/renderer/src/features/sidebar/features/worktree/WtCard.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/WtCard.vue
@@ -102,13 +102,16 @@ function onHeaderClick() {
 </script>
 
 <template>
-  <article class="rounded-lg">
+  <article
+    :data-active="active"
+    class="rounded-lg transition-colors data-[active=true]:bg-blue-500/10"
+  >
     <div class="group/wt relative">
       <div
         role="button"
         tabindex="0"
         :data-active="headerActive"
-        class="flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 text-zinc-400 transition-colors hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none focus-visible:ring-inset data-[active=true]:bg-blue-500 data-[active=true]:text-white"
+        class="flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 py-1 text-zinc-400 transition-colors hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none focus-visible:ring-inset"
         @click="onHeaderClick"
         @keydown.enter.prevent="onHeaderClick"
         @keydown.space.prevent="onHeaderClick"

--- a/apps/renderer/src/features/sidebar/features/worktree/WtCard.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/WtCard.vue
@@ -111,7 +111,7 @@ function onHeaderClick() {
         role="button"
         tabindex="0"
         :data-active="headerActive"
-        class="flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 py-1 text-zinc-400 transition-colors hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none focus-visible:ring-inset"
+        class="flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 py-1 text-zinc-400 transition-colors hover:bg-white/5 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-hidden focus-visible:ring-inset"
         @click="onHeaderClick"
         @keydown.enter.prevent="onHeaderClick"
         @keydown.space.prevent="onHeaderClick"

--- a/apps/renderer/src/features/terminal/index.ts
+++ b/apps/renderer/src/features/terminal/index.ts
@@ -4,4 +4,3 @@ export { applyTerminalTheme, registerThemeCommand } from "./registerThemeCommand
 export { terminalFontFamily, terminalFontSize } from "./terminalConfig";
 export type { ClaudeStatus } from "./claudeStatus";
 export type { HookPayload } from "./rpc";
-export { collectLeafIds } from "./splitTree";


### PR DESCRIPTION
## 概要

サイドバーのレイアウトを刷新し、repo / wt / task の視覚階層を整理しました。task の並び順を静的化、scrollbar によるレイアウト変動を撤去、wt と task の親子関係をブロック塗りで表現します。

## 背景

サイドバーには次の問題がありました。

- 階層が逆転していた: repo header が `py-1.5 text-xs` に対し wt header が `py-2 text-sm` で、子要素のほうが視覚的に強い
- task ソートが動的: state 優先順 + `lastActivityAt` を sort key にしていたため、Claude が動くたびに行位置が入れ替わり、空間記憶が壊れる (wt や repo は append 順固定なのに task だけ動的、という非対称設計)
- scrollbar が content 上に被る: 右端の git diff バッジが macOS overlay scrollbar や `scrollbar-gutter:stable` のガター幅と干渉
- highlight が二者択一だった: focus が task にあるとき wt header の active 表示が落ち、「どの wt のどの task に focus か」が一目で分からない
- terminal count バッジが phantom gap の原因: `grid-cols-[auto_1fr_auto_auto]` で 4 列目が空でも track gap が予約され、status badge の右端が TaskRow の経過時刻と 8px ズレる

## 変更内容

### 視覚階層の反転

- repo header: `py-2.5 text-sm` / icon `size-5` / `lucide--folder-open` (展開時) / `lucide--folder` (折り畳み時) — `folder-git-2` 差分はやめ、collapse 状態を icon で示す
- wt header: `py-1 text-xs` / icon `size-3.5` (列幅は `size-5` wrapper で統一) — repo よりコンパクト
- task: `p-2 line-clamp-2 break-all` — 2 行表示対応。経過時刻は `text-[10px]`

### task ソートの静的化

- `task.createdAt` 昇順 (append 順) のみ
- `STATE_PRIORITY` / `resolveStateKey` / `stateKey` / `baseTime` フィールドを削除
- `lastActivityAt` は `TaskRow` の相対時刻表示用にのみ残す (動的キーをソートで使うのを廃止し、表示用と分離)
- `<doc>` ブロックに「append 順 / 状態は icon + 相対時刻で表現」の責務分担を明記

### 親領域ハイライト

- `<article>` (wt ブロック全体) に `data-[active=true]:bg-blue-500/10` の薄塗り
- `TaskRow` active に `bg-blue-500/30` の中濃 capsule
- 同色相の濃度差 (10% / 30%) で親子の階層を表現
- wt header / repo header の active 時文字色変更 (`text-blue-300`) を撤去 — 面塗りの濃度で active を表現済みなので文字色との二重表現は冗長
- `headerActive` は `props.active` 単体評価に変更 (旧: `props.active && focusedTaskId === undefined` の排他)

### レイアウト精度の改善

- grid 4 列構成を flex + `flex-1` に変更 (phantom gap 解消で右端コンテンツ x 座標が統一)
- メニュー ⋮ ボタンを wt 行の relative wrapper 内に `absolute right-1 top-1/2` で配置 — task 行を含む article 全体を基準にすると task 追加で縦中央が下方にずれる
- terminal count バッジを削除 (関連 prop チェーン `getTerminalCount` も剥がす)
- 経過時刻バッジを content-fit 化 (固定 `size-4` 廃止) で右端を `21m` と揃える

### scrollbar 撤去

- `scrollbar-width: none` + `::-webkit-scrollbar { display: none }` で完全非表示
- macOS native の trackpad / wheel / keyboard でスクロール可能なため scrollbar UI 自体が不要、content がフル幅を保てる
- `scrollbar-gutter: stable` および classic 強制 (`::-webkit-scrollbar { width: 10px }`) は「scrollbar 列を常時予約」する点で content 幅を犠牲にするため不採用

### padding / gap の SSOT 化

- サイドバー横余白の責務を `RepoSection` の `p-2` に集約
- repo 間: `SidebarPane` 外枠 `flex flex-col` (gap なし)
- wt 間: `RepoSection` 内 `flex flex-col` (gap なし、wt ヘッダの `py-1` で行高制御)
- header / wt list 間: `gap-2` (8px)
- ラベル左端 x 座標を repo / wt / task で統一 (icon 列 20px + gap 8px = 28px)

### その他

- `+ New worktree` ボタンを破線ボーダーのゴーストボタン化 + 中央寄せ
- `<dialog>` 確認ダイアログ内の `mt-2` / `mb-4` を `flex flex-col gap-4` に置換 (margin → gap)
- `useTerminalStore` の `collectLeafIds` export を削除 (knip 自動修正)

## 確認事項

- [ ] サイドバーで repo / wt / task の階層が視覚的に repo > wt > task の順で識別できる
- [ ] task 行の並びが Claude の活動で動かない (createdAt 昇順固定)
- [ ] active wt のブロック全体が薄い青、focus task に中濃の capsule が同時に出る
- [ ] scrollbar が出現しても content 幅がジャンプしない
- [ ] git diff バッジと task の経過時刻が右端で揃っている
- [ ] folder icon が collapse 状態と連動 (折り畳み時 `folder` / 展開時 `folder-open`)
- [ ] `+ New worktree` の hover で border / bg / text が変化
- [ ] メニュー ⋮ ボタンが wt 行の縦中央に固定 (task が増えても下にズレない)
