### PR TITLE
fix(sidebar): 確認ダイアログが起動時から常時表示される問題を修正

### DIFF
--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -250,23 +250,25 @@ const activeRootWorktree = computed(() => {
     <!-- 確認ダイアログ -->
     <dialog
       ref="confirmRef"
-      class="fixed inset-0 m-auto flex size-fit flex-col gap-4 rounded-lg border border-zinc-700 bg-zinc-900 p-4 text-white backdrop:bg-black/50"
+      class="backdrop:bg-black/50"
       @click="$event.target === confirmRef && closeConfirm()"
     >
-      <p class="text-sm">{{ confirmMessage }}</p>
-      <div class="flex justify-end gap-2">
-        <button
-          class="rounded-sm px-3 py-1.5 text-sm text-zinc-400 hover:bg-zinc-800"
-          @click="closeConfirm"
-        >
-          Cancel
-        </button>
-        <button
-          class="rounded-sm bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-500"
-          @click="executeConfirm"
-        >
-          OK
-        </button>
+      <div class="space-y-4 rounded-lg border border-zinc-700 bg-zinc-900 p-4 text-white">
+        <p class="text-sm">{{ confirmMessage }}</p>
+        <div class="flex justify-end gap-2">
+          <button
+            class="rounded-sm px-3 py-1.5 text-sm text-zinc-400 hover:bg-zinc-800"
+            @click="closeConfirm"
+          >
+            Cancel
+          </button>
+          <button
+            class="rounded-sm bg-red-600 px-3 py-1.5 text-sm text-white hover:bg-red-500"
+            @click="executeConfirm"
+          >
+            OK
+          </button>
+        </div>
       </div>
     </dialog>
 


### PR DESCRIPTION
## 概要

サイドバーの確認ダイアログ ( `<dialog>` ) が、close 状態でも画面中央に常時表示されてしまう不具合を修正します。

## 背景

直近の `c1aef0c refactor(sidebar): レイアウト刷新と task ソート静的化` で `SidebarPane.vue` の `<dialog>` 要素に `flex flex-col gap-4` が追加されました。これによりダイアログが open 属性に関係なく常に表示される状態になり、本文が空の Cancel / OK ダイアログが起動直後から画面中央に出続けていました。

`<dialog>` はブラウザが `display` の出し分けで open / close を制御する特殊要素で、`display` 系ユーティリティ ( `flex` / `block` / `grid` 等 ) を素のセレクタで当てるとこの制御が壊れます。レイアウト整形のために flex を当てたつもりが、close 状態でも `display: flex` が効いてしまうリグレッションでした。

## 変更内容

### sidebar

- `<dialog>` 本体には `::backdrop` 装飾 ( `backdrop:bg-black/50` ) のみを残し、枠・背景・余白・レイアウトは内側 wrapper `<div>` に集約
- `flex flex-col gap-4` を廃止し、wrapper 側で `space-y-4` による block 縦積みに変更
- dialog の中央配置はブラウザの modal 既定挙動に任せ、`fixed inset-0 m-auto size-fit` も削除

## 確認事項

- [ ] アプリ起動直後にサイドバーの確認ダイアログが表示されないこと
- [ ] サイドバー編集モードから repo を `✕` で削除する際の確認ダイアログが正しく中央モーダルで開くこと
- [ ] worktree remove が失敗した時の `--force` 確認ダイアログが正しく開くこと
- [ ] バックドロップが半透明黒で表示され、バックドロップクリックで閉じられること
