### PR TITLE
fix(sidebar): main worktree の ⋮ メニューを非表示にする

### DIFF
--- a/apps/renderer/src/features/sidebar/features/worktree/WtCard.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/WtCard.vue
@@ -90,6 +90,9 @@ const focusedTaskId = computed(() => {
 /** focus が wt 内にあるなら header に capsule (task focus 時も同時にハイライト) */
 const headerActive = computed(() => props.active);
 
+/** main worktree (= リポジトリ root) は git worktree remove 不可。現状メニュー項目は Remove のみ。 */
+const canRemove = computed(() => !props.wt.isMain);
+
 function onMenuClick(event: MouseEvent) {
   event.stopPropagation();
   const target = event.currentTarget;
@@ -136,6 +139,7 @@ function onHeaderClick() {
         </span>
       </div>
       <button
+        v-if="canRemove"
         type="button"
         aria-label="Open menu"
         class="absolute top-1/2 right-1 grid size-5 -translate-y-1/2 place-items-center rounded-sm bg-zinc-800 text-zinc-300 opacity-0 shadow-md ring-1 ring-zinc-700 transition-opacity duration-100 group-focus-within/wt:opacity-100 group-hover/wt:opacity-100 hover:bg-zinc-700 hover:text-zinc-100"


### PR DESCRIPTION
## 概要

サイドバー worktree カードで、main worktree (リポジトリ root) のヘッダに表示される `⋮` メニューボタンを非表示にする。

## 背景

現状サイドバーの `⋮` メニュー (`SidebarMenu.vue`) には worktree に対するアクションとして `Remove worktree` 1 項目しか存在しない。一方 git の仕様上 main worktree (`git worktree list` の primary) は `git worktree remove` で削除できないため、main wt でメニューを開いても実質できることが何もない。

`docs/task.md` には既に `ROOT: メニューなし` と記載されており、ドキュメント上の仕様には沿っていなかった実装側を仕様に揃える形となる。

## 変更内容

### sidebar

- `WtCard.vue` に `canRemove` computed (`!props.wt.isMain`) を追加し、`⋮` ボタンに `v-if="canRemove"` を付与。main wt ではボタンごと描画しない
- 条件式を inline で書かず named computed に切り出し、将来メニュー項目が増えた際に `canShowMenu` 等へ意味を更新できる余地を残す

## 確認事項

- [ ] main worktree のヘッダに `⋮` が出ない (hover / focus でも出現しない) こと
- [ ] 非 main worktree のヘッダでは従来通り `⋮` が hover / focus で表示され、`Remove worktree` を実行できること
