### PR TITLE
fix(fs-watch): primary watcher を main worktree に固定する

### DIFF
--- a/apps/native/Sources/GozdCore/FSWatchRegistry.swift
+++ b/apps/native/Sources/GozdCore/FSWatchRegistry.swift
@@ -260,15 +260,21 @@ public actor FSWatchRegistry {
 
   /// `primaryByCommonGitDir` を該当 commonGitDir のグループに対して再計算する。
   /// entry の追加 / 削除時に呼ぶ。グループに entry が残っていなければ map から消す。
+  /// 選出基準: main worktree (`perWorktreeGitDir == commonGitDir`) を primary にする。
+  /// 旧実装の「resolved dir の lex 最小」は、gozd 配置 wt path (`.local/share/...`) が
+  /// main repo path (`ghq/...`) より lex 小になるため wt が primary を奪う。worktree clone
+  /// の wt watcher は classify で `applyCommonRule` が false となり `hasWorktreeChange` を
+  /// 立てない一方、main watcher は `perWtSameAsCommon=true` なので立てる。primary が wt の
+  /// 状態で `.git/worktrees/<name>/` 単独削除が起きると、worktreeChange を立てる側 (root)
+  /// は primary 抑止で suppress、立てない側 (wt) が primary で何も発火しない経路に陥る。
+  /// main worktree は `git worktree remove` で消せない invariant も併せ持つため、発火元と
+  /// して常に生存する。
   private func recomputePrimary(forCommonGitDir commonGitDir: String) {
-    var minDir: String?
     for (key, entry) in entries where entry.commonGitDir == commonGitDir {
-      // 現在値と新候補の min を取る。Optional 対応で if-else を避ける。
-      minDir = minDir.map { Swift.min($0, key) } ?? key
-    }
-    if let minDir {
-      primaryByCommonGitDir[commonGitDir] = minDir
-      return
+      if entry.perWorktreeGitDir == commonGitDir {
+        primaryByCommonGitDir[commonGitDir] = key
+        return
+      }
     }
     primaryByCommonGitDir.removeValue(forKey: commonGitDir)
   }

--- a/apps/native/Sources/GozdCore/FSWatchRegistry.swift
+++ b/apps/native/Sources/GozdCore/FSWatchRegistry.swift
@@ -316,15 +316,20 @@ public actor FSWatchRegistry {
     // 陥る。renderer (useFsWatchSync) は repo を開いた時点で main worktree も登録するため
     // 通常運用では発生しないが、`watch()` の `await GitOps.gitDirs` 中に non-main wt の event
     // が先に届く startup race / bare repo / 単体テストでの部分登録で起こり得る。観察可能化
-    // のため stderr にログする。dispatch 自体は contract どおり主走らない。
-    if (result.hasBranchChange || result.hasWorktreeChange)
-      && !isPrimaryForCommonDir
-      && entry.commonGitDir != nil
-      && primaryByCommonGitDir[entry.commonGitDir ?? ""] == nil
+    // のため stderr にログする。dispatch 自体は contract どおり走らない。
+    // entries の dir 一覧と各 entry が main worktree (`perWorktreeGitDir == commonGitDir`)
+    // かどうかを併記して、startup race か bare repo か永続未確立かを log から切り分け可能にする。
+    if (result.hasBranchChange || result.hasWorktreeChange) && !isPrimaryForCommonDir,
+      let commonGitDir = entry.commonGitDir,
+      primaryByCommonGitDir[commonGitDir] == nil
     {
+      let siblings = entries
+        .filter { _, e in e.commonGitDir == commonGitDir }
+        .map { key, e in "\(key)(main=\(e.perWorktreeGitDir == commonGitDir))" }
+        .sorted()
       FileHandle.standardError.write(
         Data(
-          "[FSWatchRegistry] primary missing for commonGitDir=\(entry.commonGitDir ?? "<nil>"); dropping branchChange=\(result.hasBranchChange) worktreeChange=\(result.hasWorktreeChange) from dir=\(dir)\n"
+          "[FSWatchRegistry] primary missing for commonGitDir=\(commonGitDir); dropping branchChange=\(result.hasBranchChange) worktreeChange=\(result.hasWorktreeChange) from dir=\(dir); entries=\(siblings)\n"
             .utf8))
     }
     if result.hasBranchChange && isPrimaryForCommonDir {

--- a/apps/native/Sources/GozdCore/FSWatchRegistry.swift
+++ b/apps/native/Sources/GozdCore/FSWatchRegistry.swift
@@ -86,9 +86,10 @@ public actor FSWatchRegistry {
   /// この逆引きを使えば「watch 時に解決した resolved key」で確実に削除できる。
   private var resolvedKeyByOriginalDir: [String: String] = [:]
   /// commonGitDir → primary watcher の resolved dir。`branchChange` / `worktreeChange`
-  /// dispatch 時の dedup に使う。primary 判定は resolved dir の lexical 最小で決定論的に
-  /// 選ぶ。entries の add / remove 時に該当 commonGitDir のグループだけ再計算する
-  /// (handleEvents での O(N) 走査を O(1) lookup に置き換える)。
+  /// dispatch 時の dedup に使う。primary 判定は main worktree (`perWorktreeGitDir ==
+  /// commonGitDir`) を選ぶ。entries の add / remove 時に該当 commonGitDir のグループだけ
+  /// 再計算する (handleEvents での O(N) 走査を O(1) lookup に置き換える)。
+  /// 選出理由は `recomputePrimary` の docstring を参照。
   private var primaryByCommonGitDir: [String: String] = [:]
   /// watch ごとに増える世代番号。unwatch 後に積まれていた stale event の dispatch を
   /// 抑止するため、event 配送前後に entries[dir]?.generation と一致するか check する。
@@ -308,8 +309,24 @@ public actor FSWatchRegistry {
     // `branchChange` / `worktreeChange` は common git dir 配下の event から派生し、
     // repo を共有する全 worktree の watcher が同じ event で同時発火する。
     // ここで commonGitDir 単位の primary watcher 1 つに collapse し、N 個の watcher 由来の
-    // N 連射を 1 push にまとめる。primary 判定は resolved dir の lexical 最小（決定的）。
+    // N 連射を 1 push にまとめる。primary は main worktree
+    // (`perWorktreeGitDir == commonGitDir`) を選ぶ (`recomputePrimary` 参照)。
     let isPrimaryForCommonDir = isPrimaryWatcher(forCommonGitDir: entry.commonGitDir, dir: dir)
+    // primary watcher が未確立で `worktreeChange` / `branchChange` を立てた場合は silent drop に
+    // 陥る。renderer (useFsWatchSync) は repo を開いた時点で main worktree も登録するため
+    // 通常運用では発生しないが、`watch()` の `await GitOps.gitDirs` 中に non-main wt の event
+    // が先に届く startup race / bare repo / 単体テストでの部分登録で起こり得る。観察可能化
+    // のため stderr にログする。dispatch 自体は contract どおり主走らない。
+    if (result.hasBranchChange || result.hasWorktreeChange)
+      && !isPrimaryForCommonDir
+      && entry.commonGitDir != nil
+      && primaryByCommonGitDir[entry.commonGitDir ?? ""] == nil
+    {
+      FileHandle.standardError.write(
+        Data(
+          "[FSWatchRegistry] primary missing for commonGitDir=\(entry.commonGitDir ?? "<nil>"); dropping branchChange=\(result.hasBranchChange) worktreeChange=\(result.hasWorktreeChange) from dir=\(dir)\n"
+            .utf8))
+    }
     if result.hasBranchChange && isPrimaryForCommonDir {
       onBranchChange(originalDir)
     }

--- a/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
@@ -173,7 +173,7 @@ struct FSWatchRegistryTests {
     #expect(events.contains("gitStatusChange"))
   }
 
-  @Test("main repo + worktree clone を並列 watch 中、`.git/worktrees/<name>/` 単独削除で worktreeChange が 1 回 fire する")
+  @Test("main repo + worktree clone を並列 watch 中、`.git/worktrees/<name>/` 単独削除で worktreeChange が fire し branchChange は伴走しない")
   func dispatchesWorktreeChangeFromMainOnWorktreeDirRemoval() async throws {
     // primary 選出が「lex 最小」だと wt watcher (gozd 配置の `.local/...`) が main
     // (`ghq/...` 相当) より lex 小で primary を奪う。worktree clone の wt watcher は
@@ -181,6 +181,12 @@ struct FSWatchRegistryTests {
     // `hasWorktreeChange` に分類できず、main 側が立てるが non-primary で suppress
     // されて誰も発火しない死角があった。primary を main worktree に固定した修正の
     // regression guard。
+    //
+    // bug を実際に踏ませるには wt path が main path より lex 小である必要がある。
+    // makeTempDir() の prefix は `gozd-fswatchregistry-` (lex 上 `g...` で始まる) のため、
+    // wt root は `a-wt-<uuid>` という prefix で main と同じ親 dir 直下に置き、必ず
+    // `a-...` < `gozd-...` (lex) を成立させる。これで「wt が lex 小なのに primary は main」
+    // という新規則の本質が test で固定される。
     let mainRepo = try makeTempDir()
     defer { try? FileManager.default.removeItem(at: mainRepo) }
     try await initGitRepo(at: mainRepo)
@@ -191,17 +197,22 @@ struct FSWatchRegistryTests {
     try await runGitCmd(["commit", "-m", "seed"], cwd: mainRepo)
 
     let worktreeRoot = mainRepo.deletingLastPathComponent()
-      .appendingPathComponent("wt-\(UUID().uuidString)")
+      .appendingPathComponent("a-wt-\(UUID().uuidString)")
     defer { try? FileManager.default.removeItem(at: worktreeRoot) }
     try await runGitCmd(
       ["worktree", "add", "-b", "feature", worktreeRoot.path], cwd: mainRepo)
     let worktreeRootResolved = URL(fileURLWithPath: worktreeRoot.path).resolvingSymlinksInPath()
+    let mainRepoResolved = URL(fileURLWithPath: mainRepo.path).resolvingSymlinksInPath()
+    // assertion 前提条件: wt path が main path より lex 小であること。
+    // 旧 lex-min ルールでこの test が pass しないこと（= bug 再現）の根拠になる。
+    #expect(worktreeRootResolved.path < mainRepoResolved.path)
 
-    let worktreeChangeCount = WorktreeChangeCounter()
+    let worktreeChangeCount = EventCounter()
+    let branchChangeCount = EventCounter()
     let registry = FSWatchRegistry(
       onFsChange: { _, _ in },
       onGitStatusChange: { _, _ in },
-      onBranchChange: { _ in },
+      onBranchChange: { _ in branchChangeCount.increment() },
       onWorktreeChange: { _ in worktreeChangeCount.increment() }
     )
 
@@ -219,6 +230,10 @@ struct FSWatchRegistryTests {
 
     try await waitForCount(worktreeChangeCount, atLeast: 1)
     #expect(worktreeChangeCount.value >= 1)
+    // branchChange は伴走しない (本シナリオは worktreeChange 単独経路) こと。
+    // 仮に伴走したら、本 test は「branchChange の伴走 fetch で隠蔽されていた死角」を
+    // 再現できておらず、worktreeChange 単独経路の regression を捕まえられない。
+    #expect(branchChangeCount.value == 0)
   }
 
   @Test("同一 dir を再 watch すると古い entry を破棄して再構築する（idempotent re-entry 契約）")
@@ -638,7 +653,7 @@ private func waitForEvent(
 }
 
 private func waitForCount(
-  _ counter: WorktreeChangeCounter,
+  _ counter: EventCounter,
   atLeast target: Int,
   timeout: Duration = .seconds(2)
 ) async throws {
@@ -647,10 +662,10 @@ private func waitForCount(
     if counter.value >= target { return }
     try await Task.sleep(for: .milliseconds(50))
   }
-  throw EventTimeout(timeout: timeout, observed: ["worktreeChange<\(counter.value)>"])
+  throw EventTimeout(timeout: timeout, observed: ["count<\(counter.value)>"])
 }
 
-private final class WorktreeChangeCounter: @unchecked Sendable {
+private final class EventCounter: @unchecked Sendable {
   private let lock = NSLock()
   private var count: Int = 0
 

--- a/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
@@ -173,6 +173,54 @@ struct FSWatchRegistryTests {
     #expect(events.contains("gitStatusChange"))
   }
 
+  @Test("main repo + worktree clone を並列 watch 中、`.git/worktrees/<name>/` 単独削除で worktreeChange が 1 回 fire する")
+  func dispatchesWorktreeChangeFromMainOnWorktreeDirRemoval() async throws {
+    // primary 選出が「lex 最小」だと wt watcher (gozd 配置の `.local/...`) が main
+    // (`ghq/...` 相当) より lex 小で primary を奪う。worktree clone の wt watcher は
+    // classify で `applyCommonRule=false` のため `worktrees/<name>/` 削除を
+    // `hasWorktreeChange` に分類できず、main 側が立てるが non-primary で suppress
+    // されて誰も発火しない死角があった。primary を main worktree に固定した修正の
+    // regression guard。
+    let mainRepo = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: mainRepo) }
+    try await initGitRepo(at: mainRepo)
+
+    let seed = mainRepo.appendingPathComponent("seed.txt")
+    try "seed".write(to: seed, atomically: true, encoding: .utf8)
+    try await runGitCmd(["add", "seed.txt"], cwd: mainRepo)
+    try await runGitCmd(["commit", "-m", "seed"], cwd: mainRepo)
+
+    let worktreeRoot = mainRepo.deletingLastPathComponent()
+      .appendingPathComponent("wt-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: worktreeRoot) }
+    try await runGitCmd(
+      ["worktree", "add", "-b", "feature", worktreeRoot.path], cwd: mainRepo)
+    let worktreeRootResolved = URL(fileURLWithPath: worktreeRoot.path).resolvingSymlinksInPath()
+
+    let worktreeChangeCount = WorktreeChangeCounter()
+    let registry = FSWatchRegistry(
+      onFsChange: { _, _ in },
+      onGitStatusChange: { _, _ in },
+      onBranchChange: { _ in },
+      onWorktreeChange: { _ in worktreeChangeCount.increment() }
+    )
+
+    // main + wt の両方を watch。primary は main worktree に固定されることを期待する。
+    try await registry.watch(dir: mainRepo.path)
+    try await registry.watch(dir: worktreeRootResolved.path)
+    try await Task.sleep(for: .milliseconds(300))
+
+    // ブランチには触らず `.git/worktrees/<name>/` だけを単独削除して
+    // `worktreeChange` 単独経路を踏ませる（`bdc` 経由の `branchChange` 伴走 fetch で
+    // 隠蔽されていた死角の再現条件）。
+    let perWtGitDir = mainRepo.appendingPathComponent(".git/worktrees")
+      .appendingPathComponent(worktreeRoot.lastPathComponent)
+    try FileManager.default.removeItem(at: perWtGitDir)
+
+    try await waitForCount(worktreeChangeCount, atLeast: 1)
+    #expect(worktreeChangeCount.value >= 1)
+  }
+
   @Test("同一 dir を再 watch すると古い entry を破棄して再構築する（idempotent re-entry 契約）")
   func watchRebuildsExistingEntry() async throws {
     // P 指摘の根本対応テスト: 旧 entry no-op 返しでは perWorktreeGitDir / commonGitDir の
@@ -587,6 +635,36 @@ private func waitForEvent(
   // タイムアウトを silent return せず throw する。「期待イベントが届かなかった」のか
   // 「タイムアウトで打ち切った」のかを呼び出し側が区別できるようにする。
   throw EventTimeout(timeout: timeout, observed: collector.snapshot())
+}
+
+private func waitForCount(
+  _ counter: WorktreeChangeCounter,
+  atLeast target: Int,
+  timeout: Duration = .seconds(2)
+) async throws {
+  let deadline = ContinuousClock.now.advanced(by: timeout)
+  while ContinuousClock.now < deadline {
+    if counter.value >= target { return }
+    try await Task.sleep(for: .milliseconds(50))
+  }
+  throw EventTimeout(timeout: timeout, observed: ["worktreeChange<\(counter.value)>"])
+}
+
+private final class WorktreeChangeCounter: @unchecked Sendable {
+  private let lock = NSLock()
+  private var count: Int = 0
+
+  func increment() {
+    lock.lock()
+    defer { lock.unlock() }
+    count += 1
+  }
+
+  var value: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return count
+  }
 }
 
 private final class EventNameCollector: @unchecked Sendable {


### PR DESCRIPTION
## 概要

FSWatchRegistry の primary watcher 選出基準を「`commonGitDir` を共有する watcher 群の `resolved dir` の lex 最小」から「main worktree (`perWorktreeGitDir == commonGitDir`)」に変更する。これにより、外部で worktree を削除したあとサイドバーから消えない問題を解消する。

## 背景

PR #509 で `branchChange` / `worktreeChange` の fan-out を抑えるため、`commonGitDir` を共有する watcher 群の中から 1 つに collapse する dedup が入った ( c0a9297 )。選出基準は resolved dir の lex 最小。

これにより以下の経路で `worktreeChange` push が誰からも発火しない死角が生まれていた:

- gozd 配置の worktree path (`/Users/<user>/.local/share/gozd/worktrees/...`) は main repo path (`/Users/<user>/ghq/...`) より lex 小 (`.` = 0x2E < `g` = 0x67) のため、wt の watcher が `entries` に入った瞬間に wt が primary を奪う
- worktree clone の wt watcher は `classify` で `applyCommonRule = perWtSameAsCommon || underPerWt == nil` が両方 false になり、`commonGitDir` 配下の `worktrees/<name>/` 削除 event を `hasWorktreeChange` に分類できない (per-wt 規則が `matchedGitDir` を立てて common 規則を skip する)
- 一方で main repo watcher は `perWtSameAsCommon=true` なので `hasWorktreeChange` を立てる。だが primary でないため抑止される
- 結果: primary (wt) は worktreeChange を立てない / sibling (main) は立てるが抑止、で誰も発火しない

実際にデバッグログを仕込んで観察した dispatch:

```
dir=ghq/.../dotfiles    isPrimary=false hasWorktreeChange=true  → SUPPRESSED
dir=.local/.../wt       isPrimary=true  hasWorktreeChange=false → branchChange のみ fire
dir=ghq/.../dotfiles    isPrimary=false hasWorktreeChange=true  → SUPPRESSED
```

`git worktree remove` + `git branch -D` を伴う通常の削除経路では `branchChange` が伴走 fetch を発火させるので症状が隠蔽されていた。`rm -rf .git/worktrees/<name>/` 単独 / `git worktree prune` 単独だと `branchChange` が立たず、`worktreeChange` 単独経路でこの穴が剥き出しになる。

## 変更内容

### `FSWatchRegistry.recomputePrimary`

選出基準を「`entry.perWorktreeGitDir == entry.commonGitDir` を満たす entry」に変更。main worktree は同一 commonGitDir につき必ず 1 つで、`git worktree remove` で削除できない invariant を持つため発火元として常に生存する。

## 確認事項

- [ ] `git worktree add` で wt を作る → サイドバー表示確認 → `rm -rf <commonGitDir>/worktrees/<name>` で `.git/worktrees/<name>/` 単独削除 → サイドバーから wt が消える
- [ ] `git worktree remove <path>` で通常削除 → サイドバーから wt が消える (regression check)
- [ ] `git branch -m` でブランチ rename → Git Graph と Sidebar が追従する (branchChange の primary 通過確認)
