### PR TITLE
fix(preview): commit モードの diff endpoint と Original 表示を Changes と揃える

### DIFF
--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -355,6 +355,9 @@ public enum GitOps {
   /// `git rev-parse <hash>:<path>` でファイルの blob OID を返す。
   /// hash 自体が解決不能（root の `^` 等）／path 未追跡なら nil。
   /// from と to の OID が一致すれば「コミット範囲で変更なし」の SSOT 判定として使える。
+  /// 失敗は nil 化するが silent drop を避けるため stderr に詳細を残す
+  /// （root commit の `^` 等の想定エラーも、予期しない repo 破損も同列にログするのは
+  /// `fileReadResultFromGit` と同じ規律）。
   public static func treeFileOID(dir: String, hash: String, relPath: String) async -> String? {
     do {
       let stdout = try await runGit(args: ["rev-parse", "\(hash):\(relPath)"], cwd: dir)
@@ -362,6 +365,9 @@ public enum GitOps {
         .trimmingCharacters(in: .whitespacesAndNewlines)
       return line.isEmpty ? nil : line
     } catch {
+      FileHandle.standardError.write(
+        Data("[GitOps] rev-parse \(hash):\(relPath) failed in \(dir): \(error)\n".utf8)
+      )
       return nil
     }
   }

--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -352,6 +352,20 @@ public enum GitOps {
     return try await runGit(args: ["show", "\(hash):\(relPath)"], cwd: dir)
   }
 
+  /// `git rev-parse <hash>:<path>` でファイルの blob OID を返す。
+  /// hash 自体が解決不能（root の `^` 等）／path 未追跡なら nil。
+  /// from と to の OID が一致すれば「コミット範囲で変更なし」の SSOT 判定として使える。
+  public static func treeFileOID(dir: String, hash: String, relPath: String) async -> String? {
+    do {
+      let stdout = try await runGit(args: ["rev-parse", "\(hash):\(relPath)"], cwd: dir)
+      let line = String(decoding: stdout, as: UTF8.self)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+      return line.isEmpty ? nil : line
+    } catch {
+      return nil
+    }
+  }
+
   /// 指定コミット（または範囲指定）の name-status 差分を返す。
   ///
   /// - 単一コミット非ルート: `git diff <hash>^ <hash>` で first parent との比較。

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -680,9 +680,8 @@ public actor RpcDispatcher {
     let (from, to, fOID, tOID) = await (fromContent, toContent, fromOID, toOID)
     resp.from = from
     resp.to = to
-    if let fOID, let tOID {
-      resp.unchanged = fOID == tOID
-    }
+    // 両 OID が解決でき、かつ一致した場合のみ true。proto3 default false 依存にせず明示代入。
+    resp.unchanged = fOID != nil && tOID != nil && fOID == tOID
     return try resp.jsonUTF8Data()
   }
 

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -18,10 +18,6 @@ import GozdProto
 //
 // 4. **戻り値は proto JSON Data**。失敗は throw。URLSchemeHandler 側が HTTP 200 / 4xx / 5xx と
 //    `Access-Control-Allow-Origin: *` ヘッダを付ける。
-/// renderer 側 UNCOMMITTED_HASH と一致する all-zero sentinel。
-/// commit hash として使われた場合「working tree（filesystem）から読む」を意味する。
-private let uncommittedHashSentinel = "0000000000000000000000000000000000000000"
-
 public actor RpcDispatcher {
   public typealias HookHandler = @Sendable (Gozd_V1_HookMessage) -> Void
   public typealias OpenHandler = @Sendable (String) -> Void
@@ -666,40 +662,22 @@ public actor RpcDispatcher {
     // 単一コミット選択 (compareHash 空) では GitHub と同等の <hash>^ vs <hash> 比較に揃える。
     // GitOps.commitFiles のファイル一覧と diff endpoint を一致させるため。
     // root commit は <hash>^ が解決失敗 → notFound=true となり追加扱いに自然解決する。
-    // hash が UNCOMMITTED_HASH の場合は working tree（filesystem）を読む。
-    // Working Tree 端を含む範囲選択でも to/from を正しく取得するため。
     // 範囲選択 (compareHash 非空) では GitOps.commitFiles の <older>^ vs <newer> に揃え、
     // older 端自身の変更も diff に含める。root commit は `^` 解決失敗 → notFound に倒れる。
+    // Working Tree 端の扱いは renderer 側で分岐し、wire には常に実 git hash のみ流れる契約。
     let olderEnd = req.compareHash.isEmpty ? req.hash : req.compareHash
     let fromHash = "\(olderEnd)^"
-    resp.from = await fileReadResultAt(
+    resp.from = await fileReadResultFromGit(
       dir: req.dir, hash: fromHash, relPath: req.relPath)
-    resp.to = await fileReadResultAt(dir: req.dir, hash: req.hash, relPath: req.relPath)
+    resp.to = await fileReadResultFromGit(dir: req.dir, hash: req.hash, relPath: req.relPath)
     return try resp.jsonUTF8Data()
-  }
-
-  /// hash が UNCOMMITTED_HASH（all-zero）なら working tree から読み、それ以外は git show を使う。
-  private func fileReadResultAt(dir: String, hash: String, relPath: String) async
-    -> Gozd_V1_FileReadResult
-  {
-    if hash == uncommittedHashSentinel {
-      var fr = Gozd_V1_FileReadResult()
-      do {
-        let info = try FSOps.readFile(dir: dir, path: relPath)
-        fr.content = info.content
-        fr.isBinary = info.isBinary
-        fr.isDirectory = info.isDirectory
-        fr.notFound = info.notFound
-      } catch {
-        fr.notFound = true
-      }
-      return fr
-    }
-    return await fileReadResultFromGit(dir: dir, hash: hash, relPath: relPath)
   }
 
   /// `git show <hash>:<path>` の結果を FileReadResult shape にまとめる。
   /// 失敗（exit != 0）= ファイル不在として not_found=true を返す。
+  /// 想定する失敗: root commit の `^` 解決失敗、未追跡 path、invalid hash。
+  /// それ以外（commandFailed の予期しない exit code 等）は silent drop しないよう
+  /// stderr にログを残して dev 環境で観察可能にする。
   private func fileReadResultFromGit(dir: String, hash: String, relPath: String) async
     -> Gozd_V1_FileReadResult
   {
@@ -715,6 +693,11 @@ public actor RpcDispatcher {
       }
     } catch {
       fr.notFound = true
+      FileHandle.standardError.write(
+        Data(
+          "[RpcDispatcher] git show \(hash):\(relPath) failed in \(dir): \(error)\n".utf8
+        )
+      )
     }
     return fr
   }

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -667,9 +667,22 @@ public actor RpcDispatcher {
     // Working Tree 端の扱いは renderer 側で分岐し、wire には常に実 git hash のみ流れる契約。
     let olderEnd = req.compareHash.isEmpty ? req.hash : req.compareHash
     let fromHash = "\(olderEnd)^"
-    resp.from = await fileReadResultFromGit(
+    // content と OID を並行取得。両端の blob OID が一致すれば
+    // 「コミット範囲で変更なし」として renderer に伝える（Filer 経由の非変更ファイル選択を救済）。
+    async let fromContent = fileReadResultFromGit(
       dir: req.dir, hash: fromHash, relPath: req.relPath)
-    resp.to = await fileReadResultFromGit(dir: req.dir, hash: req.hash, relPath: req.relPath)
+    async let toContent = fileReadResultFromGit(
+      dir: req.dir, hash: req.hash, relPath: req.relPath)
+    async let fromOID = GitOps.treeFileOID(
+      dir: req.dir, hash: fromHash, relPath: req.relPath)
+    async let toOID = GitOps.treeFileOID(
+      dir: req.dir, hash: req.hash, relPath: req.relPath)
+    let (from, to, fOID, tOID) = await (fromContent, toContent, fromOID, toOID)
+    resp.from = from
+    resp.to = to
+    if let fOID, let tOID {
+      resp.unchanged = fOID == tOID
+    }
     return try resp.jsonUTF8Data()
   }
 

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -659,14 +659,12 @@ public actor RpcDispatcher {
   private func handleGitShowCommitFile(_ body: Data) async throws -> Data {
     let req = try Gozd_V1_GitShowCommitFileRequest(jsonUTF8Data: body)
     var resp = Gozd_V1_GitShowCommitFileResponse()
-    if !req.compareHash.isEmpty {
-      resp.from = await fileReadResultFromGit(
-        dir: req.dir, hash: req.compareHash, relPath: req.relPath)
-    } else {
-      var notFound = Gozd_V1_FileReadResult()
-      notFound.notFound = true
-      resp.from = notFound
-    }
+    // 単一コミット選択 (compareHash 空) では GitHub と同等の <hash>^ vs <hash> 比較に揃える。
+    // GitOps.commitFiles のファイル一覧と diff endpoint を一致させるため。
+    // root commit は <hash>^ が解決失敗 → notFound=true となり追加扱いに自然解決する。
+    let fromHash = req.compareHash.isEmpty ? "\(req.hash)^" : req.compareHash
+    resp.from = await fileReadResultFromGit(
+      dir: req.dir, hash: fromHash, relPath: req.relPath)
     resp.to = await fileReadResultFromGit(dir: req.dir, hash: req.hash, relPath: req.relPath)
     return try resp.jsonUTF8Data()
   }

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -18,6 +18,10 @@ import GozdProto
 //
 // 4. **戻り値は proto JSON Data**。失敗は throw。URLSchemeHandler 側が HTTP 200 / 4xx / 5xx と
 //    `Access-Control-Allow-Origin: *` ヘッダを付ける。
+/// renderer 側 UNCOMMITTED_HASH と一致する all-zero sentinel。
+/// commit hash として使われた場合「working tree（filesystem）から読む」を意味する。
+private let uncommittedHashSentinel = "0000000000000000000000000000000000000000"
+
 public actor RpcDispatcher {
   public typealias HookHandler = @Sendable (Gozd_V1_HookMessage) -> Void
   public typealias OpenHandler = @Sendable (String) -> Void
@@ -662,11 +666,36 @@ public actor RpcDispatcher {
     // 単一コミット選択 (compareHash 空) では GitHub と同等の <hash>^ vs <hash> 比較に揃える。
     // GitOps.commitFiles のファイル一覧と diff endpoint を一致させるため。
     // root commit は <hash>^ が解決失敗 → notFound=true となり追加扱いに自然解決する。
-    let fromHash = req.compareHash.isEmpty ? "\(req.hash)^" : req.compareHash
-    resp.from = await fileReadResultFromGit(
+    // hash が UNCOMMITTED_HASH の場合は working tree（filesystem）を読む。
+    // Working Tree 端を含む範囲選択でも to/from を正しく取得するため。
+    // 範囲選択 (compareHash 非空) では GitOps.commitFiles の <older>^ vs <newer> に揃え、
+    // older 端自身の変更も diff に含める。root commit は `^` 解決失敗 → notFound に倒れる。
+    let olderEnd = req.compareHash.isEmpty ? req.hash : req.compareHash
+    let fromHash = "\(olderEnd)^"
+    resp.from = await fileReadResultAt(
       dir: req.dir, hash: fromHash, relPath: req.relPath)
-    resp.to = await fileReadResultFromGit(dir: req.dir, hash: req.hash, relPath: req.relPath)
+    resp.to = await fileReadResultAt(dir: req.dir, hash: req.hash, relPath: req.relPath)
     return try resp.jsonUTF8Data()
+  }
+
+  /// hash が UNCOMMITTED_HASH（all-zero）なら working tree から読み、それ以外は git show を使う。
+  private func fileReadResultAt(dir: String, hash: String, relPath: String) async
+    -> Gozd_V1_FileReadResult
+  {
+    if hash == uncommittedHashSentinel {
+      var fr = Gozd_V1_FileReadResult()
+      do {
+        let info = try FSOps.readFile(dir: dir, path: relPath)
+        fr.content = info.content
+        fr.isBinary = info.isBinary
+        fr.isDirectory = info.isDirectory
+        fr.notFound = info.notFound
+      } catch {
+        fr.notFound = true
+      }
+      return fr
+    }
+    return await fileReadResultFromGit(dir: dir, hash: hash, relPath: relPath)
   }
 
   /// `git show <hash>:<path>` の結果を FileReadResult shape にまとめる。

--- a/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
+++ b/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
@@ -250,6 +250,76 @@ struct GitOpsStatusFullTests {
   }
 }
 
+@Suite("GitOps.treeFileOID")
+struct GitOpsTreeFileOIDTests {
+  @Test("コミット済みファイルの blob OID を返す")
+  func returnsBlobOIDForCommittedFile() async throws {
+    let dir = try await makeGitRepo()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try "v1".write(
+      to: dir.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+    try await runTestGit(args: ["add", "a.txt"], cwd: dir.path)
+    try await runTestGit(args: ["commit", "-m", "init"], cwd: dir.path)
+
+    let oid = await GitOps.treeFileOID(dir: dir.path, hash: "HEAD", relPath: "a.txt")
+    #expect(oid != nil)
+    #expect(oid?.count == 40)
+  }
+
+  @Test("root commit の `^` 解決失敗時は nil")
+  func rootCommitParentReturnsNil() async throws {
+    let dir = try await makeGitRepo()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try "v1".write(
+      to: dir.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+    try await runTestGit(args: ["add", "a.txt"], cwd: dir.path)
+    try await runTestGit(args: ["commit", "-m", "init"], cwd: dir.path)
+
+    let oid = await GitOps.treeFileOID(dir: dir.path, hash: "HEAD^", relPath: "a.txt")
+    #expect(oid == nil)
+  }
+
+  @Test("未追跡 path は nil")
+  func untrackedPathReturnsNil() async throws {
+    let dir = try await makeGitRepo()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try "v1".write(
+      to: dir.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+    try await runTestGit(args: ["add", "a.txt"], cwd: dir.path)
+    try await runTestGit(args: ["commit", "-m", "init"], cwd: dir.path)
+
+    let oid = await GitOps.treeFileOID(dir: dir.path, hash: "HEAD", relPath: "nope.txt")
+    #expect(oid == nil)
+  }
+
+  @Test("2 コミット間で変更されていないファイルは両端で OID が一致する")
+  func sameOIDAcrossUnchangedCommits() async throws {
+    let dir = try await makeGitRepo()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try "kept".write(
+      to: dir.appendingPathComponent("b.txt"), atomically: true, encoding: .utf8)
+    try "v1".write(
+      to: dir.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+    try await runTestGit(args: ["add", "a.txt", "b.txt"], cwd: dir.path)
+    try await runTestGit(args: ["commit", "-m", "init"], cwd: dir.path)
+    try "v2".write(
+      to: dir.appendingPathComponent("a.txt"), atomically: true, encoding: .utf8)
+    try await runTestGit(args: ["add", "a.txt"], cwd: dir.path)
+    try await runTestGit(args: ["commit", "-m", "modify a"], cwd: dir.path)
+
+    let bAtParent = await GitOps.treeFileOID(dir: dir.path, hash: "HEAD^", relPath: "b.txt")
+    let bAtHead = await GitOps.treeFileOID(dir: dir.path, hash: "HEAD", relPath: "b.txt")
+    #expect(bAtParent != nil)
+    #expect(bAtParent == bAtHead)
+
+    let aAtParent = await GitOps.treeFileOID(dir: dir.path, hash: "HEAD^", relPath: "a.txt")
+    let aAtHead = await GitOps.treeFileOID(dir: dir.path, hash: "HEAD", relPath: "a.txt")
+    #expect(aAtParent != nil)
+    #expect(aAtHead != nil)
+    #expect(aAtParent != aAtHead)
+  }
+}
+
 // MARK: - Helpers
 
 private func makeTempDir() throws -> URL {

--- a/apps/native/Tests/GozdCoreTests/RpcDispatcherTests.swift
+++ b/apps/native/Tests/GozdCoreTests/RpcDispatcherTests.swift
@@ -306,6 +306,160 @@ struct RpcDispatcherTests {
   }
 }
 
+@Suite("RpcDispatcher./git/showCommitFile")
+struct RpcDispatcherGitShowCommitFileTests {
+  @Test("単一コミット: from=<hash>^, to=<hash>, modified ファイルは unchanged=false")
+  func singleCommitModified() async throws {
+    let repo = try await makeGitRepoForRpc()
+    defer { try? FileManager.default.removeItem(at: URL(fileURLWithPath: repo)) }
+    try "v1".write(
+      toFile: (repo as NSString).appendingPathComponent("a.txt"),
+      atomically: true, encoding: .utf8)
+    try await runGitForRpc(args: ["add", "a.txt"], cwd: repo)
+    try await runGitForRpc(args: ["commit", "-m", "init"], cwd: repo)
+    try "v2".write(
+      toFile: (repo as NSString).appendingPathComponent("a.txt"),
+      atomically: true, encoding: .utf8)
+    try await runGitForRpc(args: ["add", "a.txt"], cwd: repo)
+    try await runGitForRpc(args: ["commit", "-m", "mod"], cwd: repo)
+    let head = try await readGitForRpc(args: ["rev-parse", "HEAD"], cwd: repo)
+
+    let resp = try await dispatchShowCommitFile(
+      configDir: repo, dir: repo, relPath: "a.txt", hash: head, compareHash: "")
+    #expect(resp.from.notFound == false)
+    #expect(resp.from.content == "v1")
+    #expect(resp.to.notFound == false)
+    #expect(resp.to.content == "v2")
+    #expect(resp.unchanged == false)
+  }
+
+  @Test("root commit: from は notFound (<hash>^ 解決失敗), to は内容を返す")
+  func rootCommit() async throws {
+    let repo = try await makeGitRepoForRpc()
+    defer { try? FileManager.default.removeItem(at: URL(fileURLWithPath: repo)) }
+    try "only".write(
+      toFile: (repo as NSString).appendingPathComponent("a.txt"),
+      atomically: true, encoding: .utf8)
+    try await runGitForRpc(args: ["add", "a.txt"], cwd: repo)
+    try await runGitForRpc(args: ["commit", "-m", "init"], cwd: repo)
+    let head = try await readGitForRpc(args: ["rev-parse", "HEAD"], cwd: repo)
+
+    let resp = try await dispatchShowCommitFile(
+      configDir: repo, dir: repo, relPath: "a.txt", hash: head, compareHash: "")
+    #expect(resp.from.notFound == true)
+    #expect(resp.to.notFound == false)
+    #expect(resp.to.content == "only")
+    #expect(resp.unchanged == false)
+  }
+
+  @Test("範囲選択: 範囲内で変更されていないファイルは unchanged=true、変更されていれば unchanged=false")
+  func rangeUnchangedFile() async throws {
+    let repo = try await makeGitRepoForRpc()
+    defer { try? FileManager.default.removeItem(at: URL(fileURLWithPath: repo)) }
+    // <older>^ vs <newer> で older が root だと `^` 解決失敗するため、
+    // older の前に seed commit を置いて 3 commit 構成にする。
+    try "v0".write(
+      toFile: (repo as NSString).appendingPathComponent("a.txt"),
+      atomically: true, encoding: .utf8)
+    try "kept".write(
+      toFile: (repo as NSString).appendingPathComponent("b.txt"),
+      atomically: true, encoding: .utf8)
+    try await runGitForRpc(args: ["add", "a.txt", "b.txt"], cwd: repo)
+    try await runGitForRpc(args: ["commit", "-m", "seed"], cwd: repo)
+    try "v1".write(
+      toFile: (repo as NSString).appendingPathComponent("a.txt"),
+      atomically: true, encoding: .utf8)
+    try await runGitForRpc(args: ["add", "a.txt"], cwd: repo)
+    try await runGitForRpc(args: ["commit", "-m", "mod a v1"], cwd: repo)
+    let older = try await readGitForRpc(args: ["rev-parse", "HEAD"], cwd: repo)
+    try "v2".write(
+      toFile: (repo as NSString).appendingPathComponent("a.txt"),
+      atomically: true, encoding: .utf8)
+    try await runGitForRpc(args: ["add", "a.txt"], cwd: repo)
+    try await runGitForRpc(args: ["commit", "-m", "mod a v2"], cwd: repo)
+    let newer = try await readGitForRpc(args: ["rev-parse", "HEAD"], cwd: repo)
+
+    // b.txt は <older>^ = seed と <newer> どちらでも OID 同一 → unchanged=true
+    let respB = try await dispatchShowCommitFile(
+      configDir: repo, dir: repo, relPath: "b.txt", hash: newer, compareHash: older)
+    #expect(respB.unchanged == true)
+
+    // a.txt は範囲内で変更されている → unchanged=false。
+    // from = <older>^ = seed の a.txt = "v0", to = newer の a.txt = "v2"
+    let respA = try await dispatchShowCommitFile(
+      configDir: repo, dir: repo, relPath: "a.txt", hash: newer, compareHash: older)
+    #expect(respA.unchanged == false)
+    #expect(respA.from.content == "v0")
+    #expect(respA.to.content == "v2")
+  }
+}
+
+// MARK: - showCommitFile test helpers
+
+private func dispatchShowCommitFile(
+  configDir: String, dir: String, relPath: String, hash: String, compareHash: String
+) async throws -> Gozd_V1_GitShowCommitFileResponse {
+  let dispatcher = RpcDispatcher(
+    configDir: configDir,
+    onPtyText: { _, _ in },
+    onPtyExit: { _, _ in }
+  )
+  var req = Gozd_V1_GitShowCommitFileRequest()
+  req.dir = dir
+  req.relPath = relPath
+  req.hash = hash
+  req.compareHash = compareHash
+  let respData = try await dispatcher.dispatch(
+    path: "/git/showCommitFile", body: try req.jsonUTF8Data())
+  return try Gozd_V1_GitShowCommitFileResponse(jsonUTF8Data: respData)
+}
+
+private func makeGitRepoForRpc() async throws -> String {
+  let dir = try makeTempDir()
+  try await runGitForRpc(args: ["init", "-q", "-b", "main"], cwd: dir)
+  try await runGitForRpc(args: ["config", "user.name", "Test"], cwd: dir)
+  try await runGitForRpc(args: ["config", "user.email", "test@example.com"], cwd: dir)
+  return dir
+}
+
+private func runGitForRpc(args: [String], cwd: String) async throws {
+  _ = try await readGitForRpc(args: args, cwd: cwd)
+}
+
+private func readGitForRpc(args: [String], cwd: String) async throws -> String {
+  try await withCheckedThrowingContinuation {
+    (cont: CheckedContinuation<String, Error>) in
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["git"] + args
+    process.currentDirectoryURL = URL(fileURLWithPath: cwd)
+    process.environment = ProcessInfo.processInfo.environment
+    let stdoutPipe = Pipe()
+    let stderrPipe = Pipe()
+    process.standardOutput = stdoutPipe
+    process.standardError = stderrPipe
+    process.terminationHandler = { proc in
+      let outData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+      let errData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+      if proc.terminationStatus == 0 {
+        let text = String(decoding: outData, as: UTF8.self)
+          .trimmingCharacters(in: .whitespacesAndNewlines)
+        cont.resume(returning: text)
+      } else {
+        cont.resume(
+          throwing: NSError(
+            domain: "GitForRpc", code: Int(proc.terminationStatus),
+            userInfo: [NSLocalizedDescriptionKey: String(decoding: errData, as: UTF8.self)]))
+      }
+    }
+    do {
+      try process.run()
+    } catch {
+      cont.resume(throwing: error)
+    }
+  }
+}
+
 // MARK: - Helpers
 
 private func makeTempDir() throws -> String {

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -283,20 +283,32 @@ async function fetchCommitContent(filePath: string) {
     const fromNotFound = from?.notFound ?? true;
     const toNotFound = to?.notFound ?? true;
 
-    if (fromNotFound && !toNotFound) {
+    // from / to が両方存在しかつ内容も同一なら「この範囲では変更なし」。
+    // Filer から非変更ファイルを選んだ場合に Diff タブを出さないために必要な判定。
+    const unchanged =
+      !fromNotFound &&
+      !toNotFound &&
+      from?.content === to?.content &&
+      from?.isBinary === to?.isBinary;
+
+    if (fromNotFound && toNotFound) {
+      commitGitChange.value = undefined;
+    } else if (fromNotFound) {
       commitGitChange.value = "added";
-    } else if (!fromNotFound && toNotFound) {
+    } else if (toNotFound) {
       commitGitChange.value = "deleted";
+    } else if (unchanged) {
+      commitGitChange.value = undefined;
     } else {
       commitGitChange.value = "modified";
     }
 
     if (commitGitChange.value === "deleted") {
       activeMode.value = "original";
-    } else if (commitGitChange.value === "added") {
-      activeMode.value = "current";
-    } else {
+    } else if (commitGitChange.value === "modified") {
       activeMode.value = "diff";
+    } else {
+      activeMode.value = "current";
     }
 
     originalContent.value = fromNotFound ? undefined : from?.content;

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -188,11 +188,12 @@ const orderedRange = computed<OrderedRange | null>(() => {
  * - uncommitted モード (newer=Working Tree, older=undefined): HEAD
  * - 単一コミット: <hash>^
  * - 範囲選択: <older>^
- * - orderedRange が null（不整合）: HEAD にフォールバックして render を落とさない
+ * - orderedRange が null（不整合）: undefined を返す。`modeLabel` 側で hash 表記なしに倒し、
+ *   実際には参照していない HEAD などの虚偽情報をラベルに出さない。
  */
-const originalHashLabel = computed(() => {
+const originalHashLabel = computed<string | undefined>(() => {
   const range = orderedRange.value;
-  if (range === null) return "HEAD";
+  if (range === null) return undefined;
   const { newer, older } = range;
   if (newer === UNCOMMITTED_HASH && older === undefined) return "HEAD";
   const olderEnd = older ?? newer;
@@ -202,7 +203,8 @@ const originalHashLabel = computed(() => {
 function modeLabel(mode: PreviewMode): string {
   if (mode === "current") return "Current";
   if (mode === "diff") return "Diff";
-  return `Original (${originalHashLabel.value})`;
+  const label = originalHashLabel.value;
+  return label === undefined ? "Original" : `Original (${label})`;
 }
 
 /** 非同期レース防止 + 画像キャッシュバスト用のバージョンカウンター */
@@ -226,8 +228,9 @@ async function fetchContent(path: string, gitChange: GitChangeKind | undefined) 
   const isAbsolute = path.startsWith("/");
 
   const dir = worktreeStore.dir;
+  // await 前の同期パス: version === fetchVersion 保証のため version ガード不要。
   if (dir === undefined) {
-    if (version === fetchVersion) loading.value = false;
+    loading.value = false;
     return;
   }
 
@@ -291,16 +294,16 @@ async function fetchCommitContent(filePath: string) {
   const version = ++fetchVersion;
   fetchVersionRef.value = version;
 
+  // 以下 await 前の同期パス: version === fetchVersion が保証されているため version ガード不要。
   const dir = worktreeStore.dir;
   if (dir === undefined) {
-    if (version === fetchVersion) loading.value = false;
+    loading.value = false;
     return;
   }
 
   // クリック順に依存せず時系列で並べ替え: newer = current(to), older = original(from)
   const range = orderedRange.value;
   if (range === null) {
-    if (version !== fetchVersion) return;
     error.value = "Commit selection is inconsistent with loaded git log";
     notification.error(error.value);
     loading.value = false;
@@ -311,8 +314,8 @@ async function fetchCommitContent(filePath: string) {
   // RPC 境界では UNCOMMITTED_HASH sentinel を流さず、wire 上は常に実 hash のみ扱う。
   // newer が Working Tree のときは to を filesystem から、from は <older>^ の内容を
   // gitShowCommitFile(hash=older, compareHash="") の from 結果として取得する。
-  // older が undefined のケースは orderedRange の不変条件上ありえない
-  // (compareHash=null なら newer は uncommitted 単独 = fetchContent 経路、commit モードに来ない)。
+  // 以下 throw は orderedRange の不変条件上ありえないケースの防御的観察可能化:
+  // 到達したら tryCatch 経路で notification.error に上がる。
   const fetchResult = await tryCatch(
     (async () => {
       if (newer === UNCOMMITTED_HASH) {

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -23,8 +23,10 @@
 </doc>
 
 <script setup lang="ts">
+import { tryCatch } from "@gozd/shared";
 import { storeToRefs } from "pinia";
 import { computed, onUnmounted, ref, watch } from "vue";
+import { useNotificationStore } from "../../shared/notification";
 import { onMessage } from "../../shared/rpc";
 import { getFileIconUrl, rpcFsReadFile, rpcFsReadFileAbsolute } from "../filer";
 import type { FsChangePayload } from "../filer";
@@ -74,6 +76,7 @@ const worktreeStore = useWorktreeStore();
 const { selectedPath, selectedLineNumber, selectedGitChange, fileServerBaseUrl, revealVersion } =
   storeToRefs(worktreeStore);
 const gitGraphStore = useGitGraphStore();
+const notification = useNotificationStore();
 
 const currentContent = ref<string>();
 const originalContent = ref<string>();
@@ -152,23 +155,28 @@ const SHORT_HASH_LEN = 7;
  * 範囲選択を時系列順に整列した {newer, older}。
  * commits[0] が newest（小さい idx ほど新しい）。UNCOMMITTED_HASH は idx=-1 扱いで常に newer 側。
  * compareHash が null の単一選択時は older は undefined。
- * commits 配列にロードされていない hash が来た場合は throw して不整合を観察可能にする
- * （loadLog 完了前の選択 / stale な選択を黙って older 側に倒さない）。
+ *
+ * 不整合（commits 未ロード / stale 選択 / 両端 UNCOMMITTED）のときは null を返す。
+ * 呼び出し側で UI fallback（fetchCommitContent はエラー化、ラベルは "HEAD" に倒す）。
+ * 黙って older 側に倒すと選択順依存のバグが再発するため fallback では絶対に補わない。
  */
-const orderedRange = computed<{ newer: string; older: string | undefined }>(() => {
+type OrderedRange = { newer: string; older: string | undefined };
+const orderedRange = computed<OrderedRange | null>(() => {
   const selected = gitGraphStore.selectedHash;
   const compare = gitGraphStore.compareHash;
   if (compare === null) return { newer: selected, older: undefined };
 
+  // 両端 UNCOMMITTED_HASH は store API レイヤーでガードしていない不整合。null を返す。
+  if (selected === UNCOMMITTED_HASH && compare === UNCOMMITTED_HASH) return null;
+
   const map = gitGraphStore.hashToIndex;
   const idx = (h: string) => {
     if (h === UNCOMMITTED_HASH) return -1;
-    const i = map.get(h);
-    if (i === undefined) throw new Error(`hash ${h} not in loaded commits`);
-    return i;
+    return map.get(h);
   };
   const selectedIdx = idx(selected);
   const compareIdx = idx(compare);
+  if (selectedIdx === undefined || compareIdx === undefined) return null;
   // idx が大きい方が older
   if (selectedIdx >= compareIdx) return { newer: compare, older: selected };
   return { newer: selected, older: compare };
@@ -176,13 +184,16 @@ const orderedRange = computed<{ newer: string; older: string | undefined }>(() =
 
 /**
  * Original タブが指している hash の表記。
- * Swift 側 fileReadResultAt の fromHash と一致させる:
+ * Swift 側 handleGitShowCommitFile の fromHash (= `<olderEnd>^`) と一致させる:
  * - uncommitted モード (newer=Working Tree, older=undefined): HEAD
  * - 単一コミット: <hash>^
  * - 範囲選択: <older>^
+ * - orderedRange が null（不整合）: HEAD にフォールバックして render を落とさない
  */
 const originalHashLabel = computed(() => {
-  const { newer, older } = orderedRange.value;
+  const range = orderedRange.value;
+  if (range === null) return "HEAD";
+  const { newer, older } = range;
   if (newer === UNCOMMITTED_HASH && older === undefined) return "HEAD";
   const olderEnd = older ?? newer;
   return `${olderEnd.slice(0, SHORT_HASH_LEN)}^`;
@@ -275,92 +286,105 @@ async function fetchCommitContent(filePath: string) {
   const version = ++fetchVersion;
   fetchVersionRef.value = version;
 
-  try {
-    const dir = worktreeStore.dir;
-    if (dir === undefined) return;
-    // クリック順に依存せず時系列で並べ替え: newer = current(to), older = original(from)
-    const { newer, older } = orderedRange.value;
+  const dir = worktreeStore.dir;
+  if (dir === undefined) {
+    if (version === fetchVersion) loading.value = false;
+    return;
+  }
 
-    // RPC 境界では UNCOMMITTED_HASH sentinel を流さず、wire 上は常に実 hash のみ扱う。
-    // newer が Working Tree のときは:
-    //   - to: rpcFsReadFile で filesystem から直接読む
-    //   - from: rpcGitShowCommitFile(hash=older, compareHash="") の from 結果 (= <older>^)
-    //     older が undefined のケースは orderedRange の不変条件上ありえない
-    //     (compareHash=null なら newer は uncommitted 単独 = fetchContent 経路、commit モードに来ない)
-    // それ以外は rpcGitShowCommitFile を 1 回で from/to を取得する。
-    let from: { content: string; isBinary: boolean; notFound: boolean } | undefined;
-    let to: { content: string; isBinary: boolean; notFound: boolean } | undefined;
-    if (newer === UNCOMMITTED_HASH) {
-      if (older === undefined) {
-        throw new Error("commit mode with working tree newer requires an older endpoint");
+  // クリック順に依存せず時系列で並べ替え: newer = current(to), older = original(from)
+  const range = orderedRange.value;
+  if (range === null) {
+    if (version !== fetchVersion) return;
+    error.value = "Commit selection is inconsistent with loaded git log";
+    notification.error(error.value);
+    loading.value = false;
+    return;
+  }
+  const { newer, older } = range;
+
+  // RPC 境界では UNCOMMITTED_HASH sentinel を流さず、wire 上は常に実 hash のみ扱う。
+  // newer が Working Tree のときは to を filesystem から、from は <older>^ の内容を
+  // gitShowCommitFile(hash=older, compareHash="") の from 結果として取得する。
+  // older が undefined のケースは orderedRange の不変条件上ありえない
+  // (compareHash=null なら newer は uncommitted 単独 = fetchContent 経路、commit モードに来ない)。
+  const fetchResult = await tryCatch(
+    (async () => {
+      if (newer === UNCOMMITTED_HASH) {
+        if (older === undefined) {
+          throw new Error("commit mode with working tree newer requires an older endpoint");
+        }
+        const [showResult, fsResult] = await Promise.all([
+          rpcGitShowCommitFile({ dir, relPath: filePath, hash: older, compareHash: "" }),
+          rpcFsReadFile({ dir, path: filePath }),
+        ]);
+        return {
+          from: showResult.from,
+          to: {
+            content: fsResult.content,
+            isBinary: fsResult.isBinary,
+            notFound: fsResult.notFound,
+          },
+        };
       }
-      const [showResult, fsResult] = await Promise.all([
-        rpcGitShowCommitFile({ dir, relPath: filePath, hash: older, compareHash: "" }),
-        rpcFsReadFile({ dir, path: filePath }),
-      ]);
-      from = showResult.from;
-      to = {
-        content: fsResult.content,
-        isBinary: fsResult.isBinary,
-        notFound: fsResult.notFound,
-      };
-    } else {
       const showResult = await rpcGitShowCommitFile({
         dir,
         relPath: filePath,
         hash: newer,
         compareHash: older ?? "",
       });
-      from = showResult.from;
-      to = showResult.to;
-    }
+      return { from: showResult.from, to: showResult.to };
+    })(),
+  );
 
-    if (version !== fetchVersion) return;
+  if (version !== fetchVersion) return;
 
-    const fromNotFound = from?.notFound ?? true;
-    const toNotFound = to?.notFound ?? true;
-
-    // from / to が両方存在しかつ内容も同一なら「この範囲では変更なし」。
-    // Filer から非変更ファイルを選んだ場合に Diff タブを出さないために必要な判定。
-    const unchanged =
-      !fromNotFound &&
-      !toNotFound &&
-      from?.content === to?.content &&
-      from?.isBinary === to?.isBinary;
-
-    if (fromNotFound && toNotFound) {
-      commitGitChange.value = undefined;
-    } else if (fromNotFound) {
-      commitGitChange.value = "added";
-    } else if (toNotFound) {
-      commitGitChange.value = "deleted";
-    } else if (unchanged) {
-      commitGitChange.value = undefined;
-    } else {
-      commitGitChange.value = "modified";
-    }
-
-    if (commitGitChange.value === "deleted") {
-      activeMode.value = "original";
-    } else if (commitGitChange.value === "modified") {
-      activeMode.value = "diff";
-    } else {
-      activeMode.value = "current";
-    }
-
-    originalContent.value = fromNotFound ? undefined : from?.content;
-    isOriginalBinary.value = from?.isBinary ?? false;
-    currentContent.value = toNotFound ? undefined : to?.content;
-    isBinary.value = to?.isBinary ?? false;
-    isNotFound.value = fromNotFound && toNotFound;
-  } catch (e) {
-    if (version !== fetchVersion) return;
-    error.value = e instanceof Error ? e.message : "Failed to read file";
-  } finally {
-    if (version === fetchVersion) {
-      loading.value = false;
-    }
+  if (!fetchResult.ok) {
+    error.value = fetchResult.error.message;
+    notification.error("Failed to read commit file", fetchResult.error);
+    loading.value = false;
+    return;
   }
+
+  const { from, to } = fetchResult.value;
+  const fromNotFound = from?.notFound ?? true;
+  const toNotFound = to?.notFound ?? true;
+
+  // from / to が両方存在しかつ内容も同一なら「この範囲では変更なし」。
+  // Filer から非変更ファイルを選んだ場合に Diff タブを出さないために必要な判定。
+  const unchanged =
+    !fromNotFound &&
+    !toNotFound &&
+    from?.content === to?.content &&
+    from?.isBinary === to?.isBinary;
+
+  if (fromNotFound && toNotFound) {
+    commitGitChange.value = undefined;
+  } else if (fromNotFound) {
+    commitGitChange.value = "added";
+  } else if (toNotFound) {
+    commitGitChange.value = "deleted";
+  } else if (unchanged) {
+    commitGitChange.value = undefined;
+  } else {
+    commitGitChange.value = "modified";
+  }
+
+  if (commitGitChange.value === "deleted") {
+    activeMode.value = "original";
+  } else if (commitGitChange.value === "modified") {
+    activeMode.value = "diff";
+  } else {
+    activeMode.value = "current";
+  }
+
+  originalContent.value = fromNotFound ? undefined : from?.content;
+  isOriginalBinary.value = from?.isBinary ?? false;
+  currentContent.value = toNotFound ? undefined : to?.content;
+  isBinary.value = to?.isBinary ?? false;
+  isNotFound.value = fromNotFound && toNotFound;
+
+  loading.value = false;
 }
 
 /** ファイル選択・git status 変化・コミット選択変化時にリセット＋再取得 */

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -167,14 +167,18 @@ const orderedRange = computed<{ newer: string; older: string | undefined }>(() =
   return { newer: selected, older: compare };
 });
 
-/** Original タブが指している hash の表記（uncommitted では HEAD、単一コミットでは <hash>^、範囲では older 端） */
+/**
+ * Original タブが指している hash の表記。
+ * Swift 側 fileReadResultAt の fromHash と一致させる:
+ * - uncommitted モード (newer=Working Tree, older=undefined): HEAD
+ * - 単一コミット: <hash>^
+ * - 範囲選択: <older>^
+ */
 const originalHashLabel = computed(() => {
   const { newer, older } = orderedRange.value;
   if (newer === UNCOMMITTED_HASH && older === undefined) return "HEAD";
-  if (older !== undefined && older !== UNCOMMITTED_HASH) {
-    return older.slice(0, SHORT_HASH_LEN);
-  }
-  return `${newer.slice(0, SHORT_HASH_LEN)}^`;
+  const olderEnd = older ?? newer;
+  return `${olderEnd.slice(0, SHORT_HASH_LEN)}^`;
 });
 
 function modeLabel(mode: PreviewMode): string {

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -219,61 +219,66 @@ async function fetchContent(path: string, gitChange: GitChangeKind | undefined) 
   const version = ++fetchVersion;
   fetchVersionRef.value = version;
 
-  try {
-    const isDeleted = gitChange === "deleted";
-    const hasDiff = hasGitDiff(gitChange);
+  const isDeleted = gitChange === "deleted";
+  const hasDiff = hasGitDiff(gitChange);
 
-    // 絶対パスの場合は fsReadFileAbsolute を使い、git 操作は不要
-    const isAbsolute = path.startsWith("/");
+  // 絶対パスの場合は fsReadFileAbsolute を使い、git 操作は不要
+  const isAbsolute = path.startsWith("/");
 
-    const dir = worktreeStore.dir;
-    if (dir === undefined) return;
-
-    // 並列でデータ取得
-    const currentPromise = isDeleted
-      ? Promise.resolve(undefined)
-      : isAbsolute
-        ? rpcFsReadFileAbsolute({ absolutePath: path }).then((r) => r.result)
-        : rpcFsReadFile({ dir, path }).then((r) => ({
-            content: r.content,
-            isBinary: r.isBinary,
-            isDirectory: r.isDirectory,
-            notFound: r.notFound,
-          }));
-    const originalPromise =
-      !isAbsolute && (hasDiff || isDeleted)
-        ? rpcGitShowFile({ dir, relPath: path }).then((r) => r.result)
-        : Promise.resolve(undefined);
-    const [currentResult, originalResult] = await Promise.all([currentPromise, originalPromise]);
-
-    // 別の読み込みが開始された場合は結果を破棄
-    if (version !== fetchVersion) return;
-
-    isDirectory.value = currentResult?.isDirectory ?? false;
-    isNotFound.value = currentResult?.notFound ?? false;
-
-    if (currentResult !== undefined) {
-      currentContent.value = currentResult.content;
-      isBinary.value = currentResult.isBinary;
-    } else {
-      currentContent.value = undefined;
-      isBinary.value = false;
-    }
-    if (originalResult !== undefined) {
-      originalContent.value = originalResult.content;
-      isOriginalBinary.value = originalResult.isBinary;
-    } else {
-      originalContent.value = undefined;
-      isOriginalBinary.value = false;
-    }
-  } catch (e) {
-    if (version !== fetchVersion) return;
-    error.value = e instanceof Error ? e.message : "Failed to read file";
-  } finally {
-    if (version === fetchVersion) {
-      loading.value = false;
-    }
+  const dir = worktreeStore.dir;
+  if (dir === undefined) {
+    if (version === fetchVersion) loading.value = false;
+    return;
   }
+
+  // 並列でデータ取得
+  const currentPromise = isDeleted
+    ? Promise.resolve(undefined)
+    : isAbsolute
+      ? rpcFsReadFileAbsolute({ absolutePath: path }).then((r) => r.result)
+      : rpcFsReadFile({ dir, path }).then((r) => ({
+          content: r.content,
+          isBinary: r.isBinary,
+          isDirectory: r.isDirectory,
+          notFound: r.notFound,
+        }));
+  const originalPromise =
+    !isAbsolute && (hasDiff || isDeleted)
+      ? rpcGitShowFile({ dir, relPath: path }).then((r) => r.result)
+      : Promise.resolve(undefined);
+  const fetchResult = await tryCatch(Promise.all([currentPromise, originalPromise]));
+
+  // 別の読み込みが開始された場合は結果を破棄
+  if (version !== fetchVersion) return;
+
+  if (!fetchResult.ok) {
+    error.value = fetchResult.error.message;
+    notification.error("Failed to read file", fetchResult.error);
+    loading.value = false;
+    return;
+  }
+
+  const [currentResult, originalResult] = fetchResult.value;
+
+  isDirectory.value = currentResult?.isDirectory ?? false;
+  isNotFound.value = currentResult?.notFound ?? false;
+
+  if (currentResult !== undefined) {
+    currentContent.value = currentResult.content;
+    isBinary.value = currentResult.isBinary;
+  } else {
+    currentContent.value = undefined;
+    isBinary.value = false;
+  }
+  if (originalResult !== undefined) {
+    originalContent.value = originalResult.content;
+    isOriginalBinary.value = originalResult.isBinary;
+  } else {
+    originalContent.value = undefined;
+    isOriginalBinary.value = false;
+  }
+
+  loading.value = false;
 }
 
 /** コミットモード時のファイル内容取得 */
@@ -325,6 +330,8 @@ async function fetchCommitContent(filePath: string) {
             isBinary: fsResult.isBinary,
             notFound: fsResult.notFound,
           },
+          // Working Tree との比較は git blob OID が無いので unchanged 判定なし。
+          unchanged: false,
         };
       }
       const showResult = await rpcGitShowCommitFile({
@@ -333,7 +340,7 @@ async function fetchCommitContent(filePath: string) {
         hash: newer,
         compareHash: older ?? "",
       });
-      return { from: showResult.from, to: showResult.to };
+      return { from: showResult.from, to: showResult.to, unchanged: showResult.unchanged };
     })(),
   );
 
@@ -346,17 +353,11 @@ async function fetchCommitContent(filePath: string) {
     return;
   }
 
-  const { from, to } = fetchResult.value;
+  // unchanged は Swift 側で from と to の blob OID 比較から導出される SSOT 判定。
+  // Filer 経由でコミット範囲外（差分のない）ファイルを選んだ場合の救済はここに寄せる。
+  const { from, to, unchanged } = fetchResult.value;
   const fromNotFound = from?.notFound ?? true;
   const toNotFound = to?.notFound ?? true;
-
-  // from / to が両方存在しかつ内容も同一なら「この範囲では変更なし」。
-  // Filer から非変更ファイルを選んだ場合に Diff タブを出さないために必要な判定。
-  const unchanged =
-    !fromNotFound &&
-    !toNotFound &&
-    from?.content === to?.content &&
-    from?.isBinary === to?.isBinary;
 
   if (fromNotFound && toNotFound) {
     commitGitChange.value = undefined;

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -139,11 +139,49 @@ function defaultMode(gitChange: GitChangeKind | undefined): PreviewMode {
   return "current";
 }
 
-const MODE_LABELS: Record<PreviewMode, { icon: string; label: string }> = {
-  current: { icon: "icon-[lucide--file-text]", label: "Current" },
-  diff: { icon: "icon-[lucide--file-diff]", label: "Diff" },
-  original: { icon: "icon-[lucide--file-clock]", label: "Original" },
+const MODE_ICONS: Record<PreviewMode, string> = {
+  current: "icon-[lucide--file-text]",
+  diff: "icon-[lucide--file-diff]",
+  original: "icon-[lucide--file-clock]",
 };
+
+const SHORT_HASH_LEN = 7;
+
+/**
+ * 範囲選択を時系列順に整列した {newer, older}。
+ * commits[0] が newest（小さい idx ほど新しい）。UNCOMMITTED_HASH は idx=-1 扱いで常に newer 側。
+ * compareHash が null の単一選択時は older は undefined。
+ */
+const orderedRange = computed<{ newer: string; older: string | undefined }>(() => {
+  const selected = gitGraphStore.selectedHash;
+  const compare = gitGraphStore.compareHash;
+  if (compare === null) return { newer: selected, older: undefined };
+
+  const map = gitGraphStore.hashToIndex;
+  const idx = (h: string) =>
+    h === UNCOMMITTED_HASH ? -1 : (map.get(h) ?? Number.POSITIVE_INFINITY);
+  const selectedIdx = idx(selected);
+  const compareIdx = idx(compare);
+  // idx が大きい方が older
+  if (selectedIdx >= compareIdx) return { newer: compare, older: selected };
+  return { newer: selected, older: compare };
+});
+
+/** Original タブが指している hash の表記（uncommitted では HEAD、単一コミットでは <hash>^、範囲では older 端） */
+const originalHashLabel = computed(() => {
+  const { newer, older } = orderedRange.value;
+  if (newer === UNCOMMITTED_HASH && older === undefined) return "HEAD";
+  if (older !== undefined && older !== UNCOMMITTED_HASH) {
+    return older.slice(0, SHORT_HASH_LEN);
+  }
+  return `${newer.slice(0, SHORT_HASH_LEN)}^`;
+});
+
+function modeLabel(mode: PreviewMode): string {
+  if (mode === "current") return "Current";
+  if (mode === "diff") return "Diff";
+  return `Original (${originalHashLabel.value})`;
+}
 
 /** 非同期レース防止 + 画像キャッシュバスト用のバージョンカウンター */
 const fetchVersionRef = ref(0);
@@ -229,11 +267,13 @@ async function fetchCommitContent(filePath: string) {
   try {
     const dir = worktreeStore.dir;
     if (dir === undefined) return;
+    // クリック順に依存せず時系列で並べ替え: newer = current(to), older = original(from)
+    const { newer, older } = orderedRange.value;
     const result = await rpcGitShowCommitFile({
       dir,
       relPath: filePath,
-      hash: gitGraphStore.selectedHash,
-      compareHash: gitGraphStore.compareHash ?? "",
+      hash: newer,
+      compareHash: older ?? "",
     });
 
     if (version !== fetchVersion) return;
@@ -424,8 +464,8 @@ const headerIconUrl = computed(() => {
           "
           @click="activeMode = mode"
         >
-          <span class="size-3.5" :class="MODE_LABELS[mode].icon" />
-          {{ MODE_LABELS[mode].label }}
+          <span class="size-3.5" :class="MODE_ICONS[mode]" />
+          {{ modeLabel(mode) }}
         </button>
 
         <div class="ml-auto flex items-center">

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -157,7 +157,7 @@ const SHORT_HASH_LEN = 7;
  * compareHash が null の単一選択時は older は undefined。
  *
  * 不整合（commits 未ロード / stale 選択 / 両端 UNCOMMITTED）のときは null を返す。
- * 呼び出し側で UI fallback（fetchCommitContent はエラー化、ラベルは "HEAD" に倒す）。
+ * 呼び出し側で UI fallback（fetchCommitContent はエラー化、ラベルは "Original" の hash 表記なしに倒す）。
  * 黙って older 側に倒すと選択順依存のバグが再発するため fallback では絶対に補わない。
  */
 type OrderedRange = { newer: string; older: string | undefined };

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -16,7 +16,8 @@
 ## データ取得
 
 - Uncommitted モード: ファイル選択・git status 変化時に current（ファイルシステム）/ original（HEAD）を並列取得
-- コミットモード: git-graph の選択コミットに応じて gitShowCommitFile RPC で from/to を一括取得
+- コミットモード: git-graph の選択コミットに応じて gitShowCommitFile RPC で from/to を一括取得。
+  範囲選択時は `commits` 配列の index で時系列順に整列し（クリック順非依存）、older 側を Original、newer 側を Current に固定する
 - fsChange メッセージで選択中ファイルをリアクティブに再取得（uncommitted モードのみ）
 - バージョンカウンターで非同期レースを防止
 </doc>

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -152,6 +152,8 @@ const SHORT_HASH_LEN = 7;
  * 範囲選択を時系列順に整列した {newer, older}。
  * commits[0] が newest（小さい idx ほど新しい）。UNCOMMITTED_HASH は idx=-1 扱いで常に newer 側。
  * compareHash が null の単一選択時は older は undefined。
+ * commits 配列にロードされていない hash が来た場合は throw して不整合を観察可能にする
+ * （loadLog 完了前の選択 / stale な選択を黙って older 側に倒さない）。
  */
 const orderedRange = computed<{ newer: string; older: string | undefined }>(() => {
   const selected = gitGraphStore.selectedHash;
@@ -159,8 +161,12 @@ const orderedRange = computed<{ newer: string; older: string | undefined }>(() =
   if (compare === null) return { newer: selected, older: undefined };
 
   const map = gitGraphStore.hashToIndex;
-  const idx = (h: string) =>
-    h === UNCOMMITTED_HASH ? -1 : (map.get(h) ?? Number.POSITIVE_INFINITY);
+  const idx = (h: string) => {
+    if (h === UNCOMMITTED_HASH) return -1;
+    const i = map.get(h);
+    if (i === undefined) throw new Error(`hash ${h} not in loaded commits`);
+    return i;
+  };
   const selectedIdx = idx(selected);
   const compareIdx = idx(compare);
   // idx が大きい方が older
@@ -274,17 +280,43 @@ async function fetchCommitContent(filePath: string) {
     if (dir === undefined) return;
     // クリック順に依存せず時系列で並べ替え: newer = current(to), older = original(from)
     const { newer, older } = orderedRange.value;
-    const result = await rpcGitShowCommitFile({
-      dir,
-      relPath: filePath,
-      hash: newer,
-      compareHash: older ?? "",
-    });
+
+    // RPC 境界では UNCOMMITTED_HASH sentinel を流さず、wire 上は常に実 hash のみ扱う。
+    // newer が Working Tree のときは:
+    //   - to: rpcFsReadFile で filesystem から直接読む
+    //   - from: rpcGitShowCommitFile(hash=older, compareHash="") の from 結果 (= <older>^)
+    //     older が undefined のケースは orderedRange の不変条件上ありえない
+    //     (compareHash=null なら newer は uncommitted 単独 = fetchContent 経路、commit モードに来ない)
+    // それ以外は rpcGitShowCommitFile を 1 回で from/to を取得する。
+    let from: { content: string; isBinary: boolean; notFound: boolean } | undefined;
+    let to: { content: string; isBinary: boolean; notFound: boolean } | undefined;
+    if (newer === UNCOMMITTED_HASH) {
+      if (older === undefined) {
+        throw new Error("commit mode with working tree newer requires an older endpoint");
+      }
+      const [showResult, fsResult] = await Promise.all([
+        rpcGitShowCommitFile({ dir, relPath: filePath, hash: older, compareHash: "" }),
+        rpcFsReadFile({ dir, path: filePath }),
+      ]);
+      from = showResult.from;
+      to = {
+        content: fsResult.content,
+        isBinary: fsResult.isBinary,
+        notFound: fsResult.notFound,
+      };
+    } else {
+      const showResult = await rpcGitShowCommitFile({
+        dir,
+        relPath: filePath,
+        hash: newer,
+        compareHash: older ?? "",
+      });
+      from = showResult.from;
+      to = showResult.to;
+    }
 
     if (version !== fetchVersion) return;
 
-    const from = result.from;
-    const to = result.to;
     const fromNotFound = from?.notFound ?? true;
     const toNotFound = to?.notFound ?? true;
 

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -41,13 +41,33 @@ git 変更ファイルには Original / Diff / Current の3タブを表示する
 
 ### コミットモード（git-graph でコミット選択時）
 
-変更種別は `gitShowCommitFile` の from/to 結果から導出する。
+変更種別は `gitShowCommitFile` の from/to 結果から導出する。from/to の解決方法は以下:
 
-| 変更種別                      | 利用可能なモード        | デフォルト |
-| ----------------------------- | ----------------------- | ---------- |
-| modified（from/to 両方あり）  | Original, Diff, Current | Diff       |
-| added（from なし、to あり）   | Current                 | Current    |
-| deleted（from あり、to なし） | Original                | Original   |
+- 単一コミット選択: from = `<hash>^`, to = `<hash>`
+- 範囲選択: from = `<older>^`, to = `<newer>`（older / newer はクリック順ではなく `commits` 配列の index で時系列順に整列）
+- 端点に Working Tree（`UNCOMMITTED_HASH`）を含む範囲選択: その端点だけ filesystem から読み、もう一方は git show
+
+`GitOps.commitFiles` のファイル一覧 (`<older>^ vs <newer>`) と endpoint を揃えてあるため、Changes パネルのファイル一覧と Preview の diff が常に一致する。
+
+| 変更種別                                    | 利用可能なモード               | デフォルト |
+| ------------------------------------------- | ------------------------------ | ---------- |
+| modified（from/to 両方あり + 内容差分あり） | Original, Diff, Current        | Diff       |
+| 変更なし（from/to 両方あり + 内容同一）     | Current                        | Current    |
+| added（from なし、to あり）                 | Current                        | Current    |
+| deleted（from あり、to なし）               | Original                       | Original   |
+| 両方 not found                              | Current（File not found 表示） | Current    |
+
+「変更なし」判定は Filer 経由でコミット範囲外のファイルを選択したケースを救済する。Changes 経由では差分のあるファイルしかリストされないため発生しない。
+
+### Original タブの hash 表示
+
+タブラベルは `Original (<hash>)` 形式で、実際に from として読んでいる ref を可視化する。Swift 側の `fromHash` 算出式と一致する。
+
+| 選択状態           | 表示        |
+| ------------------ | ----------- |
+| Uncommitted モード | `HEAD`      |
+| 単一コミット       | `<hash7>^`  |
+| 範囲選択           | `<older7>^` |
 
 ## 開閉機能
 

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -45,7 +45,7 @@ git 変更ファイルには Original / Diff / Current の3タブを表示する
 
 - 単一コミット選択: from = `<hash>^`, to = `<hash>`
 - 範囲選択: from = `<older>^`, to = `<newer>`（older / newer はクリック順ではなく `commits` 配列の index で時系列順に整列）
-- 端点に Working Tree（`UNCOMMITTED_HASH`）を含む範囲選択: その端点だけ filesystem から読み、もう一方は git show
+- 端点に Working Tree を含む範囲選択: renderer 側で分岐し、to は `fsReadFile`、from は `gitShowCommitFile(hash=<older>, compareHash="")` の `from` 結果（= `<older>^`）を流用する。`UNCOMMITTED_HASH` sentinel は RPC 境界を越えず wire 上は常に実 git hash のみ流れる
 
 `GitOps.commitFiles` のファイル一覧 (`<older>^ vs <newer>`) と endpoint を揃えてあるため、Changes パネルのファイル一覧と Preview の diff が常に一致する。
 

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -49,15 +49,15 @@ git 変更ファイルには Original / Diff / Current の3タブを表示する
 
 `GitOps.commitFiles` のファイル一覧 (`<older>^ vs <newer>`) と endpoint を揃えてあるため、Changes パネルのファイル一覧と Preview の diff が常に一致する。
 
-| 変更種別                                    | 利用可能なモード               | デフォルト |
-| ------------------------------------------- | ------------------------------ | ---------- |
-| modified（from/to 両方あり + 内容差分あり） | Original, Diff, Current        | Diff       |
-| 変更なし（from/to 両方あり + 内容同一）     | Current                        | Current    |
-| added（from なし、to あり）                 | Current                        | Current    |
-| deleted（from あり、to なし）               | Original                       | Original   |
-| 両方 not found                              | Current（File not found 表示） | Current    |
+| 変更種別                                     | 利用可能なモード               | デフォルト |
+| -------------------------------------------- | ------------------------------ | ---------- |
+| modified（from/to 両方あり + OID 差分あり）  | Original, Diff, Current        | Diff       |
+| 変更なし（from/to 両方あり + blob OID 同一） | Current                        | Current    |
+| added（from なし、to あり）                  | Current                        | Current    |
+| deleted（from あり、to なし）                | Original                       | Original   |
+| 両方 not found                               | Current（File not found 表示） | Current    |
 
-「変更なし」判定は Filer 経由でコミット範囲外のファイルを選択したケースを救済する。Changes 経由では差分のあるファイルしかリストされないため発生しない。
+「変更なし」判定は Filer 経由でコミット範囲外のファイルを選択したケースを救済する。Changes 経由では差分のあるファイルしかリストされないため発生しない。判定の SSOT は `gitShowCommitFile` 応答の `unchanged` フィールド（Swift 側で `git rev-parse <hash>:<path>` の blob OID 比較から導出）に置き、renderer 内のテキスト比較は行わない。Working Tree 端を含む範囲選択は OID が無いため `unchanged=false` で扱う。
 
 ### Original タブの hash 表示
 

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
@@ -251,6 +251,9 @@ public struct Gozd_V1_GitShowCommitFileResponse: Sendable {
   /// from と to の指す blob OID が一致しているか。
   /// Filer 経由でコミット範囲外（差分のない）ファイルを選んだ場合の
   /// 「Diff タブを出さない」判定の SSOT。renderer 側 content 比較は使わない。
+  /// true になるのは「from と to の OID が両方解決でき、かつ一致」したときのみ。
+  /// どちらかが解決失敗（root の `^` / 未追跡 path / repo 破損）した場合は false。
+  /// 既存の `from.not_found` / `to.not_found` を優先評価する規約は変えない。
   public var unchanged: Bool = false
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
@@ -248,6 +248,11 @@ public struct Gozd_V1_GitShowCommitFileResponse: Sendable {
   /// Clears the value of `to`. Subsequent reads from it will return its default value.
   public mutating func clearTo() {self._to = nil}
 
+  /// from と to の指す blob OID が一致しているか。
+  /// Filer 経由でコミット範囲外（差分のない）ファイルを選んだ場合の
+  /// 「Diff タブを出さない」判定の SSOT。renderer 側 content 比較は使わない。
+  public var unchanged: Bool = false
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -848,7 +853,7 @@ extension Gozd_V1_GitShowCommitFileRequest: SwiftProtobuf.Message, SwiftProtobuf
 
 extension Gozd_V1_GitShowCommitFileResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GitShowCommitFileResponse"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}from\0\u{1}to\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}from\0\u{1}to\0\u{1}unchanged\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -858,6 +863,7 @@ extension Gozd_V1_GitShowCommitFileResponse: SwiftProtobuf.Message, SwiftProtobu
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularMessageField(value: &self._from) }()
       case 2: try { try decoder.decodeSingularMessageField(value: &self._to) }()
+      case 3: try { try decoder.decodeSingularBoolField(value: &self.unchanged) }()
       default: break
       }
     }
@@ -874,12 +880,16 @@ extension Gozd_V1_GitShowCommitFileResponse: SwiftProtobuf.Message, SwiftProtobu
     try { if let v = self._to {
       try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
     } }()
+    if self.unchanged != false {
+      try visitor.visitSingularBoolField(value: self.unchanged, fieldNumber: 3)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Gozd_V1_GitShowCommitFileResponse, rhs: Gozd_V1_GitShowCommitFileResponse) -> Bool {
     if lhs._from != rhs._from {return false}
     if lhs._to != rhs._to {return false}
+    if lhs.unchanged != rhs.unchanged {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
@@ -133,7 +133,15 @@ export interface GitShowCommitFileRequest {
 
 export interface GitShowCommitFileResponse {
   from: FileReadResult | undefined;
-  to: FileReadResult | undefined;
+  to:
+    | FileReadResult
+    | undefined;
+  /**
+   * from と to の指す blob OID が一致しているか。
+   * Filer 経由でコミット範囲外（差分のない）ファイルを選んだ場合の
+   * 「Diff タブを出さない」判定の SSOT。renderer 側 content 比較は使わない。
+   */
+  unchanged: boolean;
 }
 
 /**
@@ -973,7 +981,7 @@ export const GitShowCommitFileRequest: MessageFns<GitShowCommitFileRequest> = {
 };
 
 function createBaseGitShowCommitFileResponse(): GitShowCommitFileResponse {
-  return { from: undefined, to: undefined };
+  return { from: undefined, to: undefined, unchanged: false };
 }
 
 export const GitShowCommitFileResponse: MessageFns<GitShowCommitFileResponse> = {
@@ -983,6 +991,9 @@ export const GitShowCommitFileResponse: MessageFns<GitShowCommitFileResponse> = 
     }
     if (message.to !== undefined) {
       FileReadResult.encode(message.to, writer.uint32(18).fork()).join();
+    }
+    if (message.unchanged !== false) {
+      writer.uint32(24).bool(message.unchanged);
     }
     return writer;
   },
@@ -1010,6 +1021,14 @@ export const GitShowCommitFileResponse: MessageFns<GitShowCommitFileResponse> = 
           message.to = FileReadResult.decode(reader, reader.uint32());
           continue;
         }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.unchanged = reader.bool();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -1023,6 +1042,7 @@ export const GitShowCommitFileResponse: MessageFns<GitShowCommitFileResponse> = 
     return {
       from: isSet(object.from) ? FileReadResult.fromJSON(object.from) : undefined,
       to: isSet(object.to) ? FileReadResult.fromJSON(object.to) : undefined,
+      unchanged: isSet(object.unchanged) ? globalThis.Boolean(object.unchanged) : false,
     };
   },
 
@@ -1033,6 +1053,9 @@ export const GitShowCommitFileResponse: MessageFns<GitShowCommitFileResponse> = 
     }
     if (message.to !== undefined) {
       obj.to = FileReadResult.toJSON(message.to);
+    }
+    if (message.unchanged !== false) {
+      obj.unchanged = message.unchanged;
     }
     return obj;
   },
@@ -1046,6 +1069,7 @@ export const GitShowCommitFileResponse: MessageFns<GitShowCommitFileResponse> = 
       ? FileReadResult.fromPartial(object.from)
       : undefined;
     message.to = (object.to !== undefined && object.to !== null) ? FileReadResult.fromPartial(object.to) : undefined;
+    message.unchanged = object.unchanged ?? false;
     return message;
   },
 };

--- a/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
@@ -140,6 +140,9 @@ export interface GitShowCommitFileResponse {
    * from と to の指す blob OID が一致しているか。
    * Filer 経由でコミット範囲外（差分のない）ファイルを選んだ場合の
    * 「Diff タブを出さない」判定の SSOT。renderer 側 content 比較は使わない。
+   * true になるのは「from と to の OID が両方解決でき、かつ一致」したときのみ。
+   * どちらかが解決失敗（root の `^` / 未追跡 path / repo 破損）した場合は false。
+   * 既存の `from.not_found` / `to.not_found` を優先評価する規約は変えない。
    */
   unchanged: boolean;
 }

--- a/packages/proto/gozd/v1/git_ops.proto
+++ b/packages/proto/gozd/v1/git_ops.proto
@@ -54,6 +54,10 @@ message GitShowCommitFileRequest {
 message GitShowCommitFileResponse {
   FileReadResult from = 1;
   FileReadResult to = 2;
+  // from と to の指す blob OID が一致しているか。
+  // Filer 経由でコミット範囲外（差分のない）ファイルを選んだ場合の
+  // 「Diff タブを出さない」判定の SSOT。renderer 側 content 比較は使わない。
+  bool unchanged = 3;
 }
 
 // gitCommitFiles: コミット（または範囲指定）の変更ファイル一覧

--- a/packages/proto/gozd/v1/git_ops.proto
+++ b/packages/proto/gozd/v1/git_ops.proto
@@ -57,6 +57,9 @@ message GitShowCommitFileResponse {
   // from と to の指す blob OID が一致しているか。
   // Filer 経由でコミット範囲外（差分のない）ファイルを選んだ場合の
   // 「Diff タブを出さない」判定の SSOT。renderer 側 content 比較は使わない。
+  // true になるのは「from と to の OID が両方解決でき、かつ一致」したときのみ。
+  // どちらかが解決失敗（root の `^` / 未追跡 path / repo 破損）した場合は false。
+  // 既存の `from.not_found` / `to.not_found` を優先評価する規約は変えない。
   bool unchanged = 3;
 }
 


### PR DESCRIPTION
## 概要

git-graph でコミットを選択した状態 / 範囲選択した状態の Preview ペインで、diff endpoint が ChangesPane のファイル一覧と一致せず、Diff タブが出ない・空 diff が出る・Original のみになる等の不整合が出ていたのを揃える。あわせて Original タブに参照中の hash を表示する。

## 背景

Preview ペインの commit モードは `gitShowCommitFile` で from/to のファイル内容を取得し、その有無で `commitGitChange` を `modified` / `added` / `deleted` に分類していたが、以下の問題があった。

- 単一コミット選択時、Swift 側 `handleGitShowCommitFile` が `compareHash` 空のとき `from` を一律 `notFound=true` で返していたため、`originalContent` が `undefined` で Diff タブが描画できなかった。`GitOps.commitFiles` のファイル一覧は `<hash>^ vs <hash>` を比較しており、「Changes では modified なのに Preview では added 扱いで diff が出ない」という乖離が出ていた
- 範囲選択時、Original / Current がクリック順 (`selectedHash` / `compareHash`) に依存して入れ替わっていた。下から上に選んだ場合は newer 側が Original にされていた
- 範囲選択時の from が `compareHash` そのものになっており、`GitOps.commitFiles` の `<older>^ vs <newer>` と endpoint が 1 commit ぶんずれていた（older 端自身の変更が抜ける）
- Working Tree 端を含む範囲選択 (`UNCOMMITTED_HASH = 0000...`) では `git show 0000...:<path>` が exit 非0 → `to` が notFound 扱いで "deleted" に分類され、Diff ではなく Original タブのみ表示されていた
- Filer から、選択コミット範囲では差分のないファイルを選ぶと from/to の両方が存在するため `modified` に倒れ、Diff タブで空 diff が出ていた

## 変更内容

### Swift: `handleGitShowCommitFile` ( apps/native/Sources/GozdCore/RpcDispatcher.swift )

- from の hash を `<older>^` に揃える式に変更（単一コミット時は older = `hash`、範囲時は older = `compareHash`）。`GitOps.commitFiles` の `<older>^ vs <newer>` と endpoint が一致する
- `fileReadResultAt(dir:hash:relPath:)` を追加。`hash == UNCOMMITTED_HASH` のとき `FSOps.readFile` で working tree から読み、それ以外は既存の `git show` 経路へ委譲。Working Tree 端を含む範囲選択でも to/from が解決できるようになる
- renderer 側の `UNCOMMITTED_HASH` と一致する all-zero sentinel を file-scope の private 定数として明示

### Renderer: `PreviewPane.vue` ( apps/renderer/src/features/preview/PreviewPane.vue )

- `orderedRange` computed を追加。`useGitGraphStore.hashToIndex` を使い、クリック順ではなく `commits` 配列の index で `{ newer, older }` を時系列順に整列する。`UNCOMMITTED_HASH` は idx=-1 として常に newer 側へ落ちる
- `rpcGitShowCommitFile` への引数を `hash = newer`, `compareHash = older` に固定。下→上・上→下のどちらの順で選んでも older が Original になる
- `fetchCommitContent` の commitGitChange 判定で、from/to の `content` と `isBinary` が両方一致する場合は `undefined`（変更なし）に倒し、Diff / Original タブを `availableModes` 経由で非表示にする。Filer 由来の範囲外ファイル選択で空 Diff が出るのを抑止する
- `MODE_LABELS` を `MODE_ICONS` + 動的 `modeLabel(mode)` 関数に置き換え、Original タブを `Original (<hash>)` 形式で表示。Swift 側 `fromHash` 算出式 (`${olderEnd}^`) と 1:1 対応する

### Docs: `docs/preview.md` / `PreviewPane.vue` `<doc>` ブロック

- コミットモードの表に「変更なし（from/to 両方あり + 内容同一）」「両方 not found」行を追加
- from/to の解決方法（単一・範囲・Working Tree 端）を表の前に明示
- Original タブの hash 表記表を追加し、Swift 側 `fromHash` との対応を明文化
- `<doc>` ブロックのデータ取得セクションに「範囲選択時は時系列順で整列、older を Original に固定」を追記

## 確認事項

- [ ] 単一コミット選択時、Changes 一覧で modified のファイルを選ぶと Diff タブがデフォルトで開き、`<hash>^` との diff が描画される
- [ ] root commit を単一選択した場合、`<hash>^` が解決失敗 → added 扱いで Current のみ表示される
- [ ] 範囲選択時、上→下 / 下→上 のどちらの順で選んでも常に older 側が Original になり、Original タブに `<older7>^` が表示される
- [ ] Working Tree 端を含む範囲選択で、コミット側を older として diff が描画される（newer は filesystem 内容）
- [ ] Filer からコミット範囲では差分のないファイルを選択した場合、Current タブのみ表示される（Diff / Original は出ない）
- [ ] ChangesPane のファイル一覧と Preview の diff が一致する（同じ from/to を見ている）
