### PR TITLE
fix(worktree-list): 壊れた永続データや prunable worktree で sidebar が止まる問題を解消

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,15 @@ import { useTerminalStore } from "../terminal/useTerminalStore";
 
 - import の整理（未使用 import の削除、並び替え）は commit 時に lint が自動実行する。手動で整理しない
 
+## リリースステージとデータポリシー
+
+gozd は現在 **ベータ版**。安定版リリース前であり、永続データ（`~/.config/gozd/` 配下 / `.proto` schema）に **後方互換性は作らない**。
+
+- proto schema 進化（フィールド削除・rename・型変更）で旧 JSON が parse 失敗した場合、**新規初期化が期待挙動**。マイグレーションコード（旧フィールド読み替え・退避コピー・shallow merge による未知フィールド保持等）は書かない
+- 破壊的変更を許容する。古い設定 / 永続データを「いつまでも動かす」ためのコードを足さない
+- 永続化ストアの load 経路で proto JSON parse 失敗を検知したら空オブジェクトで上書き save する（`TaskStore` / `ClaudeSessionStore` 参照）。stderr に reinit ログを残し観察可能性は保つ
+- 安定版に切り替わる時点で本セクションを書き換える
+
 ## 現在のフォーカス
 
 シングルウィンドウ + マルチ repo + マルチ worktree の運用環境（[workspace.md](docs/workspace.md)）。

--- a/apps/native/Sources/GozdCore/ClaudeSessionStore.swift
+++ b/apps/native/Sources/GozdCore/ClaudeSessionStore.swift
@@ -86,12 +86,17 @@ public actor ClaudeSessionStore {
   /// 起動時に 1 回呼ぶ reconcile。`~/.config/gozd/projects/*/claude-sessions.json` を
   /// 走査して、transcript ファイルが消滅したエントリを落とす。落とした件数を stderr に
   /// ログ出力する(観察可能性確保)。read 時 silent save の代替経路。
-  public func reconcileAll() throws {
+  ///
+  /// 戻り値: projectKey → 生存 session id 集合の map。TaskStore.reconcileAll が
+  /// dead session 判定の根拠として受け取り、同一 claude-sessions.json を二重 read する
+  /// SSOT 違反を避ける。reconcile 時点で reinit された projectKey は空集合をマップする。
+  public func reconcileAll() throws -> [String: Set<String>] {
     let projectsURL = URL(fileURLWithPath: configDir).appendingPathComponent("projects")
     let fm = FileManager.default
-    guard fm.fileExists(atPath: projectsURL.path) else { return }
+    guard fm.fileExists(atPath: projectsURL.path) else { return [:] }
     let projectKeys = try fm.contentsOfDirectory(atPath: projectsURL.path)
     var totalDropped = 0
+    var liveSessionsByProject: [String: Set<String>] = [:]
     for projectKey in projectKeys {
       let fileURL = projectsURL
         .appendingPathComponent(projectKey)
@@ -111,6 +116,7 @@ public actor ClaudeSessionStore {
           Data(
             "[ClaudeSessionStore] reconcile: corrupted claude-sessions.json reinitialized for \(projectKey)\n"
               .utf8))
+        liveSessionsByProject[projectKey] = []
         continue
       }
       let before = list.sessions.count
@@ -127,11 +133,13 @@ public actor ClaudeSessionStore {
             "[ClaudeSessionStore] reconcile: dropped \(dropped) dead entries from \(projectKey)\n"
               .utf8))
       }
+      liveSessionsByProject[projectKey] = Set(list.sessions.map { $0.sessionID })
     }
     if totalDropped > 0 {
       FileHandle.standardError.write(
         Data("[ClaudeSessionStore] reconcile: total \(totalDropped) dead entries cleaned\n".utf8))
     }
+    return liveSessionsByProject
   }
 
   /// worktree 削除時に該当 worktreePath のエントリを全削除。

--- a/apps/native/Sources/GozdCore/ClaudeSessionStore.swift
+++ b/apps/native/Sources/GozdCore/ClaudeSessionStore.swift
@@ -98,8 +98,21 @@ public actor ClaudeSessionStore {
         .appendingPathComponent("claude-sessions.json")
       guard fm.fileExists(atPath: fileURL.path) else { continue }
       let data = try Data(contentsOf: fileURL)
-      let json = String(decoding: data, as: UTF8.self)
-      var list = try Gozd_V1_ClaudeSessionList(jsonString: json)
+      var list: Gozd_V1_ClaudeSessionList
+      if let json = String(bytes: data, encoding: .utf8),
+        let parsed = try? Gozd_V1_ClaudeSessionList(jsonString: json)
+      {
+        list = parsed
+      } else {
+        let empty = Gozd_V1_ClaudeSessionList()
+        let emptyJson = try empty.jsonString()
+        try emptyJson.write(to: fileURL, atomically: true, encoding: .utf8)
+        FileHandle.standardError.write(
+          Data(
+            "[ClaudeSessionStore] reconcile: corrupted claude-sessions.json reinitialized for \(projectKey)\n"
+              .utf8))
+        continue
+      }
       let before = list.sessions.count
       list.sessions.removeAll { entry in
         !FileManager.default.fileExists(atPath: entry.transcriptPath)
@@ -153,9 +166,18 @@ public actor ClaudeSessionStore {
       return Gozd_V1_ClaudeSessionList()
     }
     let data = try Data(contentsOf: url)
-    let json = String(decoding: data, as: UTF8.self)
-    // parse 失敗は壊れたファイルの兆候。fallback で空 list を返すと原因が見えなくなるため throw する。
-    return try Gozd_V1_ClaudeSessionList(jsonString: json)
+    if let json = String(bytes: data, encoding: .utf8),
+      let list = try? Gozd_V1_ClaudeSessionList(jsonString: json)
+    {
+      return list
+    }
+    let empty = Gozd_V1_ClaudeSessionList()
+    try saveFile(empty, for: dir)
+    FileHandle.standardError.write(
+      Data(
+        "[ClaudeSessionStore] loadFile: corrupted claude-sessions.json reinitialized at \(url.path)\n"
+          .utf8))
+    return empty
   }
 
   private func saveFile(_ list: Gozd_V1_ClaudeSessionList, for dir: String) throws {

--- a/apps/native/Sources/GozdCore/ClaudeSessionStore.swift
+++ b/apps/native/Sources/GozdCore/ClaudeSessionStore.swift
@@ -104,9 +104,25 @@ public actor ClaudeSessionStore {
       guard fm.fileExists(atPath: fileURL.path) else { continue }
       let data = try Data(contentsOf: fileURL)
       var list: Gozd_V1_ClaudeSessionList
-      if let json = String(bytes: data, encoding: .utf8),
-        let parsed = try? Gozd_V1_ClaudeSessionList(jsonString: json)
-      {
+      let parsedSessions: Gozd_V1_ClaudeSessionList?
+      if let json = String(bytes: data, encoding: .utf8) {
+        do {
+          parsedSessions = try Gozd_V1_ClaudeSessionList(jsonString: json)
+        } catch {
+          FileHandle.standardError.write(
+            Data(
+              "[ClaudeSessionStore] reconcile: parse failed for claude-sessions.json in \(projectKey): \(error)\n"
+                .utf8))
+          parsedSessions = nil
+        }
+      } else {
+        FileHandle.standardError.write(
+          Data(
+            "[ClaudeSessionStore] reconcile: invalid UTF-8 in claude-sessions.json for \(projectKey)\n"
+              .utf8))
+        parsedSessions = nil
+      }
+      if let parsed = parsedSessions {
         list = parsed
       } else {
         let empty = Gozd_V1_ClaudeSessionList()
@@ -174,10 +190,18 @@ public actor ClaudeSessionStore {
       return Gozd_V1_ClaudeSessionList()
     }
     let data = try Data(contentsOf: url)
-    if let json = String(bytes: data, encoding: .utf8),
-      let list = try? Gozd_V1_ClaudeSessionList(jsonString: json)
-    {
-      return list
+    if let json = String(bytes: data, encoding: .utf8) {
+      do {
+        return try Gozd_V1_ClaudeSessionList(jsonString: json)
+      } catch {
+        FileHandle.standardError.write(
+          Data(
+            "[ClaudeSessionStore] loadFile: parse failed at \(url.path): \(error)\n"
+              .utf8))
+      }
+    } else {
+      FileHandle.standardError.write(
+        Data("[ClaudeSessionStore] loadFile: invalid UTF-8 at \(url.path)\n".utf8))
     }
     let empty = Gozd_V1_ClaudeSessionList()
     try saveFile(empty, for: dir)

--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -575,6 +575,10 @@ private func runGitOnce(gitPath: String, args: [String], cwd: String) async thro
 }
 
 /// `git worktree list --porcelain` の出力をパースする。
+///
+/// `prunable` 注釈付きのエントリは git にとっても解決不能な孤児（gitdir file が
+/// 指す先が消滅している等）なので listing から除外する。`git status` 等の後段操作は
+/// 必ず失敗するため、SSOT 段階で落とす。
 private func parseWorktreePorcelain(_ data: Data) -> [WorktreeInfo] {
   let text = String(decoding: data, as: UTF8.self)
   var result: [WorktreeInfo] = []
@@ -582,9 +586,11 @@ private func parseWorktreePorcelain(_ data: Data) -> [WorktreeInfo] {
   var head: String = ""
   var branch: String?
   var isDetached = false
+  var isPrunable = false
 
   func flush() {
     guard let p = path, !p.isEmpty else { return }
+    if isPrunable { return }
     let isMain = result.isEmpty  // 最初のエントリが main worktree
     let resolvedBranch = isDetached ? nil : branch
     result.append(WorktreeInfo(path: p, head: head, branch: resolvedBranch, isMain: isMain))
@@ -598,6 +604,7 @@ private func parseWorktreePorcelain(_ data: Data) -> [WorktreeInfo] {
       head = ""
       branch = nil
       isDetached = false
+      isPrunable = false
       continue
     }
     if s.hasPrefix("worktree ") {
@@ -610,6 +617,8 @@ private func parseWorktreePorcelain(_ data: Data) -> [WorktreeInfo] {
         ref.hasPrefix("refs/heads/") ? String(ref.dropFirst("refs/heads/".count)) : ref
     } else if s == "detached" {
       isDetached = true
+    } else if s == "prunable" || s.hasPrefix("prunable ") {
+      isPrunable = true
     }
   }
   flush()

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -90,21 +90,7 @@ public actor RpcDispatcher {
         String(describing: error), "")
     }
     do {
-      let parseFailureProjects = try await tasks.reconcileAll()
-      if !parseFailureProjects.isEmpty {
-        // claude-sessions.json の parse 失敗で skip した projectKey がある場合、
-        // renderer にトースト通知して復旧操作（手動修復 / 削除）を促す。
-        // skip 自体は安全側の挙動だが、放置すると孤児 Task が永続化に残るため
-        // ユーザーに気付かせる必要がある。reconcile は起動時 1 回かつ全 projectKey
-        // 横断なので dir 紐付けは無く、空文字を渡す (renderer 側は全 repo refetch)。
-        onNotify(
-          "error",
-          "task-store",
-          "Failed to parse claude-sessions.json; orphan task cleanup skipped",
-          "projectKeys: \(parseFailureProjects.joined(separator: ", "))",
-          ""
-        )
-      }
+      try await tasks.reconcileAll()
     } catch {
       FileHandle.standardError.write(
         Data("[TaskStore] reconcileAll failed: \(error)\n".utf8))
@@ -548,69 +534,32 @@ public actor RpcDispatcher {
   private func handleGitWorktreeList(_ body: Data) async throws -> Data {
     let req = try Gozd_V1_GitWorktreeListRequest(jsonUTF8Data: body)
     let worktrees = try await GitOps.worktreeList(dir: req.dir)
-    // 同一 projectKey の登録 session 集合 (transcript 存在チェックなし) を真とし、
-    // TaskStore の孤児を read-only で弾く。session-start hook 直後は Claude が
-    // transcript ファイルをまだ作っていないため、transcript 存在で filter すると
-    // 「session-start で楽観追加 → fetchRepo で消える」race が起きる
-    // (`allRegisteredSessions` の docstring 参照)。
-    // アプリ稼働中の死亡判定 (session-end / removeByPty が来なかった残骸) は
-    // session-start hook の upsert と削除経路の対称性で担保されるため、ここでは
-    // claude-sessions.json への登録有無だけを基準にする。永続化のクラッシュ復旧は
-    // 起動時 reconcileAll が transcript 存在チェックで担当する。
-    //
-    // 1 ファイル破損で sidebar 全体が描けなくなるのを避けるため、registered の取得が
-    // throw した場合は filter をスキップして tasks をそのまま返す。破損ファイルの
-    // 復旧は起動時 reconcileAll / upsert 経路の上書きに任せる。
-    let registeredSessionIds: Set<String>?
-    do {
-      let registered = try await claudeSessions.allRegisteredSessions(forProject: req.dir)
-      registeredSessionIds = Set(registered.map { $0.sessionID })
-    } catch {
-      FileHandle.standardError.write(
-        Data(
-          "[RpcDispatcher] handleGitWorktreeList: allRegisteredSessions failed (\(error)) — falling back to no-filter\n"
-            .utf8))
-      registeredSessionIds = nil
-      // source=`claude-sessions-read` は専用カテゴリで、useSidebarData の
-      // `ROLLBACK_SOURCES` には含めない。rollback (= 該当 repo の refetch) の
-      // トリガとして同じ source を共有すると、handleGitWorktreeList → notify →
-      // refetch → 同 path → notify の無限ループになる。read 失敗時の単発通知だけが
-      // 必要なので別 source とする。toast 表示は `useNotifySubscription` が全 source を
-      // 受けるため別途登録不要。
-      onNotify(
-        "error",
-        "claude-sessions-read",
-        "Failed to read claude-sessions index; sidebar may show orphan tasks",
-        String(describing: error),
-        req.dir
-      )
-    }
+    let registered = try await claudeSessions.allRegisteredSessions(forProject: req.dir)
+    let registeredSessionIds = Set(registered.map { $0.sessionID })
     let listedTasks = try await tasks.list(dir: req.dir)
     // task ≠ session 設計: 身元 (body / gh_ref) があれば session が dead でも表示する。
     // session 単独で生きていた task (Claude 直接起動 + 即終了の残骸) のみ filter で落とす。
-    let allTasks: [Gozd_V1_Task]
-    if let ids = registeredSessionIds {
-      allTasks = listedTasks.filter { task in
-        if task.hasNonSessionIdentity { return true }
-        return !task.sessionID.isEmpty && ids.contains(task.sessionID)
-      }
-    } else {
-      allTasks = listedTasks
+    let allTasks = listedTasks.filter { task in
+      if task.hasNonSessionIdentity { return true }
+      return !task.sessionID.isEmpty && registeredSessionIds.contains(task.sessionID)
     }
-    // サイドバーで各 worktree に変更ファイル数を出すため、worktree ごとに git status を並列取得する。
-    // 1 worktree でも失敗したら集約段階で throw して上位（renderer 側 tryCatch → notify.error）に伝える。
-    let statusesByPath: [String: [String: String]] = try await withThrowingTaskGroup(
+    // 各 wt の git status は補助データ。1 wt の失敗で worktree list 全体を捨てない
+    // ため、per-wt で握って空 statuses で続行する。prunable wt は listing から除外
+    // 済みなので、ここで失敗するのは worktree 実 path 不整合などの稀ケース。
+    let statusesByPath: [String: [String: String]] = await withTaskGroup(
       of: (String, [String: String]).self
     ) { group in
       for wt in worktrees {
         let path = wt.path
         group.addTask {
-          let statuses = try await GitOps.gitStatus(dir: path)
+          guard let statuses = try? await GitOps.gitStatus(dir: path) else {
+            return (path, [:])
+          }
           return (path, statuses)
         }
       }
       var result: [String: [String: String]] = [:]
-      for try await (path, statuses) in group { result[path] = statuses }
+      for await (path, statuses) in group { result[path] = statuses }
       return result
     }
     var resp = Gozd_V1_GitWorktreeListResponse()

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -545,17 +545,24 @@ public actor RpcDispatcher {
     }
     // 各 wt の git status は補助データ。1 wt の失敗で worktree list 全体を捨てない
     // ため、per-wt で握って空 statuses で続行する。prunable wt は listing から除外
-    // 済みなので、ここで失敗するのは worktree 実 path 不整合などの稀ケース。
+    // 済みなので、ここで失敗するのは worktree 実 path 不整合などの稀ケース。失敗は
+    // stderr に残して silent 握り潰しを避ける (主経路に throw は伝播させない)。
     let statusesByPath: [String: [String: String]] = await withTaskGroup(
       of: (String, [String: String]).self
     ) { group in
       for wt in worktrees {
         let path = wt.path
         group.addTask {
-          guard let statuses = try? await GitOps.gitStatus(dir: path) else {
+          do {
+            let statuses = try await GitOps.gitStatus(dir: path)
+            return (path, statuses)
+          } catch {
+            FileHandle.standardError.write(
+              Data(
+                "[handleGitWorktreeList] gitStatus failed for \(path): \(error)\n"
+                  .utf8))
             return (path, [:])
           }
-          return (path, statuses)
         }
       }
       var result: [String: [String: String]] = [:]

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -80,17 +80,23 @@ public actor RpcDispatcher {
   /// 孤児 Task を掃除するため、claudeSessions の reconcile を先に通して
   /// 「session が消えていれば task も消える」を成立させる。
   public func reconcileClaudeSessions() async {
+    let liveSessionsByProject: [String: Set<String>]
     do {
-      try await claudeSessions.reconcileAll()
+      liveSessionsByProject = try await claudeSessions.reconcileAll()
     } catch {
       FileHandle.standardError.write(
         Data("[ClaudeSessionStore] reconcileAll failed: \(error)\n".utf8))
       onNotify(
         "error", "claude-sessions", "Claude session store reconcile failed",
         String(describing: error), "")
+      // claudeSessions.reconcileAll の throw は projects/ ディレクトリ列挙失敗等の
+      // 致命環境。live session 集合が全 projectKey 規模で不明な状態で TaskStore の
+      // dead 判定 (sid クリア + orphan 削除) を回すと、全生存 task を巻き添え削除する
+      // 危険があるため tasks.reconcileAll は skip する。
+      return
     }
     do {
-      try await tasks.reconcileAll()
+      try await tasks.reconcileAll(liveSessionsByProject: liveSessionsByProject)
     } catch {
       FileHandle.standardError.write(
         Data("[TaskStore] reconcileAll failed: \(error)\n".utf8))

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -89,10 +89,15 @@ public actor RpcDispatcher {
       onNotify(
         "error", "claude-sessions", "Claude session store reconcile failed",
         String(describing: error), "")
-      // claudeSessions.reconcileAll の throw は projects/ ディレクトリ列挙失敗等の
-      // 致命環境。live session 集合が全 projectKey 規模で不明な状態で TaskStore の
-      // dead 判定 (sid クリア + orphan 削除) を回すと、全生存 task を巻き添え削除する
-      // 危険があるため tasks.reconcileAll は skip する。
+      // claudeSessions.reconcileAll の throw 源は次のいずれか:
+      //   - projects/ ディレクトリ列挙失敗 (致命環境)
+      //   - 個別 projectKey の claude-sessions.json read 失敗 (FS I/O エラー)
+      //   - reinit / save 時の proto JSON encode / write 失敗
+      // 後 2 つは特定 projectKey の I/O 失敗で、他 projectKey の live session 集合は
+      // 取得できている可能性がある。partial 集合で続行する設計は本経路では採らず、
+      // 安全側で tasks.reconcileAll を全 skip する。live session 集合が一部欠落した
+      // 状態で dead 判定 (sid クリア + orphan 削除) を回すと、欠落側の生存 task を
+      // 巻き添え削除する破壊が起きうるため、partial 続行よりも全 skip を選ぶ。
       return
     }
     do {

--- a/apps/native/Sources/GozdCore/TaskStore.swift
+++ b/apps/native/Sources/GozdCore/TaskStore.swift
@@ -125,20 +125,12 @@ public actor TaskStore {
   }
 
   /// 起動時の reconcile。dead session を attach したまま放置された task の sessionID を
-  /// クリアし、加えて「body / gh_ref いずれも空」かつ「sessionID も dead」の
-  /// task は孤児として削除する (AND 条件)。
+  /// クリアし、加えて「body / gh_ref いずれも空」かつ「sessionID も dead」の task は
+  /// 孤児として削除する (AND 条件)。
   ///
-  /// task.sessionID は SessionEnd でも保持する設計なので、resume が永久に効かなくなった
-  /// dead session id をクリアして次回クリック時に「素の claude」を起動できる状態に戻す。
-  /// body / gh_ref が残っていれば task 本体は維持する。
-  /// この経路が無いと、アプリクラッシュ / kill -9 / transcript 削除で session-end hook も
-  /// removeByPty も来なかった残骸が永続化に居座り続け、サイドバーに `New session` の
-  /// ゾンビ行として現れる。
-  ///
-  /// parse 失敗 (UTF-8 不正 / JSON 不整合 / 未知フィールド) の tasks.json / claude-sessions.json
-  /// は空オブジェクトで上書き save する。「壊れているデータに価値はない、削除か初期化」方針。
-  /// throw + 起動時 notify では window.__gozdReceive 未初期化中に silent drop されて
-  /// ユーザーが破損を観測できないため、stderr ログだけで観察可能性を確保する。
+  /// parse 失敗 (UTF-8 不正 / JSON syntax 不正 / proto schema 進化) の永続化ファイルは
+  /// 空オブジェクトで上書き save する。本アプリはベータ版で永続データに後方互換を作らない
+  /// (CLAUDE.md 規約)。schema 進化で旧 JSON が parse 失敗した時は新規初期化が期待挙動。
   public func reconcileAll() throws {
     let projectsURL = URL(fileURLWithPath: configDir).appendingPathComponent("projects")
     let fm = FileManager.default
@@ -171,6 +163,9 @@ public actor TaskStore {
       }
       if taskList.tasks.isEmpty { continue }
 
+      // dead session 判定の根拠は claude-sessions.json。破損していれば「空」と
+      // 取り違えて全 task を orphan 化する事故になるため、parse 失敗時は当該 projectKey
+      // の dead session 判定をスキップして次に進む (`continue`)。
       var liveSessionIds: Set<String> = []
       let sessionsURL = projectDir.appendingPathComponent("claude-sessions.json")
       if fm.fileExists(atPath: sessionsURL.path) {
@@ -189,6 +184,7 @@ public actor TaskStore {
             Data(
               "[TaskStore] reconcile: corrupted claude-sessions.json reinitialized for \(projectKey)\n"
                 .utf8))
+          continue
         }
       }
 
@@ -243,10 +239,6 @@ public actor TaskStore {
       return Gozd_V1_TaskList()
     }
     let data = try Data(contentsOf: url)
-    // parse 失敗 (UTF-8 不正 / JSON 不整合 / 未知フィールド) は壊れた tasks.json として
-    // 扱い、空 list で上書き save する。throw + 起動時 notify では window.__gozdReceive
-    // 未初期化中に silent drop されて観測経路が消えるため、stderr ログだけ残して観察可能性を
-    // 確保する。「壊れているデータに価値はない、削除か初期化」方針。
     if let json = String(bytes: data, encoding: .utf8),
       let list = try? Gozd_V1_TaskList(jsonString: json)
     {

--- a/apps/native/Sources/GozdCore/TaskStore.swift
+++ b/apps/native/Sources/GozdCore/TaskStore.swift
@@ -128,10 +128,14 @@ public actor TaskStore {
   /// クリアし、加えて「body / gh_ref いずれも空」かつ「sessionID も dead」の task は
   /// 孤児として削除する (AND 条件)。
   ///
-  /// parse 失敗 (UTF-8 不正 / JSON syntax 不正 / proto schema 進化) の永続化ファイルは
-  /// 空オブジェクトで上書き save する。本アプリはベータ版で永続データに後方互換を作らない
-  /// (CLAUDE.md 規約)。schema 進化で旧 JSON が parse 失敗した時は新規初期化が期待挙動。
-  public func reconcileAll() throws {
+  /// 引数 `liveSessionsByProject` は `ClaudeSessionStore.reconcileAll` の戻り値を直接
+  /// 受け取る。claude-sessions.json の read / reinit は ClaudeSessionStore に集約され、
+  /// 同ファイルを TaskStore 側でも parse する SSOT 違反を避ける。
+  ///
+  /// parse 失敗 (UTF-8 不正 / JSON syntax 不正 / proto schema 進化) の tasks.json は
+  /// 空オブジェクトで上書き save する。永続データに後方互換を作らない (CLAUDE.md 規約)
+  /// ため、schema 進化で旧 JSON が parse 失敗した時は新規初期化が期待挙動。
+  public func reconcileAll(liveSessionsByProject: [String: Set<String>]) throws {
     let projectsURL = URL(fileURLWithPath: configDir).appendingPathComponent("projects")
     let fm = FileManager.default
     guard fm.fileExists(atPath: projectsURL.path) else { return }
@@ -163,30 +167,7 @@ public actor TaskStore {
       }
       if taskList.tasks.isEmpty { continue }
 
-      // dead session 判定の根拠は claude-sessions.json。破損していれば「空」と
-      // 取り違えて全 task を orphan 化する事故になるため、parse 失敗時は当該 projectKey
-      // の dead session 判定をスキップして次に進む (`continue`)。
-      var liveSessionIds: Set<String> = []
-      let sessionsURL = projectDir.appendingPathComponent("claude-sessions.json")
-      if fm.fileExists(atPath: sessionsURL.path) {
-        let sessionsData = try Data(contentsOf: sessionsURL)
-        if let sessionsJson = String(bytes: sessionsData, encoding: .utf8),
-          let sessionList = try? Gozd_V1_ClaudeSessionList(jsonString: sessionsJson)
-        {
-          for session in sessionList.sessions {
-            liveSessionIds.insert(session.sessionID)
-          }
-        } else {
-          let empty = Gozd_V1_ClaudeSessionList()
-          let emptyJson = try empty.jsonString()
-          try emptyJson.write(to: sessionsURL, atomically: true, encoding: .utf8)
-          FileHandle.standardError.write(
-            Data(
-              "[TaskStore] reconcile: corrupted claude-sessions.json reinitialized for \(projectKey)\n"
-                .utf8))
-          continue
-        }
-      }
+      let liveSessionIds = liveSessionsByProject[projectKey] ?? []
 
       let before = taskList.tasks.count
       var mutated = false

--- a/apps/native/Sources/GozdCore/TaskStore.swift
+++ b/apps/native/Sources/GozdCore/TaskStore.swift
@@ -134,85 +134,61 @@ public actor TaskStore {
   /// この経路が無いと、アプリクラッシュ / kill -9 / transcript 削除で session-end hook も
   /// removeByPty も来なかった残骸が永続化に居座り続け、サイドバーに `New session` の
   /// ゾンビ行として現れる。
-  /// 戻り値: tasks.json / claude-sessions.json のいずれかが「読めない or parse できない」
-  /// 理由で skip した projectKey 一覧 (UTF-8 デコード失敗・proto JSON parse 失敗を含む)。
-  /// 呼び出し元はこれを renderer に notify push して、ユーザーに復旧操作を促す。
-  public func reconcileAll() throws -> [String] {
+  ///
+  /// parse 失敗 (UTF-8 不正 / JSON 不整合 / 未知フィールド) の tasks.json / claude-sessions.json
+  /// は空オブジェクトで上書き save する。「壊れているデータに価値はない、削除か初期化」方針。
+  /// throw + 起動時 notify では window.__gozdReceive 未初期化中に silent drop されて
+  /// ユーザーが破損を観測できないため、stderr ログだけで観察可能性を確保する。
+  public func reconcileAll() throws {
     let projectsURL = URL(fileURLWithPath: configDir).appendingPathComponent("projects")
     let fm = FileManager.default
-    guard fm.fileExists(atPath: projectsURL.path) else { return [] }
-    // macOS では .DS_Store などの hidden entry が projects/ 直下に紛れ込みうるため、
-    // URL ベース API + .skipsHiddenFiles で除外する。tasks.json 不在の continue でも
-    // 動作上は問題ないが、無駄な iteration / 誤った projectKey 出現を未然に防ぐ。
+    guard fm.fileExists(atPath: projectsURL.path) else { return }
     let projectDirs = try fm.contentsOfDirectory(
       at: projectsURL,
       includingPropertiesForKeys: nil,
       options: [.skipsHiddenFiles]
     )
     var totalDropped = 0
-    // tasks.json / claude-sessions.json の read or parse 失敗を統合して集計する。
-    // 上位 (RpcDispatcher.reconcileClaudeSessions) は notify メッセージで
-    // 「Failed to parse claude-sessions.json」と書いていたが、tasks.json 側 / UTF-8 側
-    // の失敗も同じ復旧操作 (該当 projectKey の手動修復) を要するので 1 つにまとめる。
-    var decodeFailureProjects: [String] = []
     for projectDir in projectDirs {
       let projectKey = projectDir.lastPathComponent
       let tasksURL = projectDir.appendingPathComponent("tasks.json")
       guard fm.fileExists(atPath: tasksURL.path) else { continue }
       let tasksData = try Data(contentsOf: tasksURL)
-      // 不正な UTF-8 を U+FFFD で黙置換する `String(decoding:as:)` は使わない
-      // (silent corruption の温床)。デコード失敗時は projectKey ごと skip + notify 対象。
-      guard let tasksJson = String(bytes: tasksData, encoding: .utf8) else {
+      var taskList: Gozd_V1_TaskList
+      if let tasksJson = String(bytes: tasksData, encoding: .utf8),
+        let parsed = try? Gozd_V1_TaskList(jsonString: tasksJson)
+      {
+        taskList = parsed
+      } else {
+        let empty = Gozd_V1_TaskList()
+        let emptyJson = try empty.jsonString()
+        try emptyJson.write(to: tasksURL, atomically: true, encoding: .utf8)
         FileHandle.standardError.write(
           Data(
-            "[TaskStore] reconcile: tasks.json is not valid UTF-8 for \(projectKey), skipping\n"
+            "[TaskStore] reconcile: corrupted tasks.json reinitialized for \(projectKey)\n"
               .utf8))
-        decodeFailureProjects.append(projectKey)
         continue
       }
-      // proto JSON parse 失敗も skip + notify 対象 (silent に空 list として進めると
-      // 後段の orphan 削除で生きている Task まで巻き添えになる)。
-      guard let parsedTaskList = try? Gozd_V1_TaskList(jsonString: tasksJson) else {
-        FileHandle.standardError.write(
-          Data(
-            "[TaskStore] reconcile: failed to parse tasks.json for \(projectKey), skipping\n"
-              .utf8))
-        decodeFailureProjects.append(projectKey)
-        continue
-      }
-      var taskList = parsedTaskList
       if taskList.tasks.isEmpty { continue }
 
-      // 同 projectKey の生存 sessionId を計算する。
-      // claude-sessions.json が存在しない / 空なら、その projectKey の Task は
-      // 全件孤児扱い。reconcileAll の順序として ClaudeSessionStore → TaskStore
-      // で動かす前提なので、claude-sessions.json は既に reconcile 済み。
       var liveSessionIds: Set<String> = []
       let sessionsURL = projectDir.appendingPathComponent("claude-sessions.json")
       if fm.fileExists(atPath: sessionsURL.path) {
         let sessionsData = try Data(contentsOf: sessionsURL)
-        // UTF-8 デコード失敗は parse 失敗と同じ扱い (生存判定根拠が欠落) で skip。
-        guard let sessionsJson = String(bytes: sessionsData, encoding: .utf8) else {
+        if let sessionsJson = String(bytes: sessionsData, encoding: .utf8),
+          let sessionList = try? Gozd_V1_ClaudeSessionList(jsonString: sessionsJson)
+        {
+          for session in sessionList.sessions {
+            liveSessionIds.insert(session.sessionID)
+          }
+        } else {
+          let empty = Gozd_V1_ClaudeSessionList()
+          let emptyJson = try empty.jsonString()
+          try emptyJson.write(to: sessionsURL, atomically: true, encoding: .utf8)
           FileHandle.standardError.write(
             Data(
-              "[TaskStore] reconcile: claude-sessions.json is not valid UTF-8 for \(projectKey), skipping\n"
+              "[TaskStore] reconcile: corrupted claude-sessions.json reinitialized for \(projectKey)\n"
                 .utf8))
-          decodeFailureProjects.append(projectKey)
-          continue
-        }
-        guard let sessionList = try? Gozd_V1_ClaudeSessionList(jsonString: sessionsJson)
-        else {
-          // parse 失敗時は「session 全滅」と判定する根拠が無いため projectKey ごと skip。
-          // 一時的なディスク破損 / 中断書き込みで生きている Task まで巻き添えに削除されないようにする。
-          FileHandle.standardError.write(
-            Data(
-              "[TaskStore] reconcile: failed to parse claude-sessions.json for \(projectKey), skipping\n"
-                .utf8))
-          decodeFailureProjects.append(projectKey)
-          continue
-        }
-        for session in sessionList.sessions {
-          liveSessionIds.insert(session.sessionID)
         }
       }
 
@@ -246,7 +222,6 @@ public actor TaskStore {
       FileHandle.standardError.write(
         Data("[TaskStore] reconcile: total \(totalDropped) orphan tasks cleaned\n".utf8))
     }
-    return decodeFailureProjects
   }
 
   // MARK: - paths
@@ -268,14 +243,20 @@ public actor TaskStore {
       return Gozd_V1_TaskList()
     }
     let data = try Data(contentsOf: url)
-    // 不正な UTF-8 / proto JSON parse 失敗を silent に「空 list」として扱うと、
-    // 直後の save で空 list を書き戻し、ユーザーの全 task が消える破壊的副作用がある
-    // (一時的なディスク破損 / 中断書き込みでも発動)。throw に倒して上位 (RpcDispatcher)
-    // で notify + UI に伝え、ユーザーが復旧操作 (手動修復 / 削除) を選べるようにする。
-    guard let json = String(bytes: data, encoding: .utf8) else {
-      throw TaskStoreError.fileDecodeFailed(url.path)
+    // parse 失敗 (UTF-8 不正 / JSON 不整合 / 未知フィールド) は壊れた tasks.json として
+    // 扱い、空 list で上書き save する。throw + 起動時 notify では window.__gozdReceive
+    // 未初期化中に silent drop されて観測経路が消えるため、stderr ログだけ残して観察可能性を
+    // 確保する。「壊れているデータに価値はない、削除か初期化」方針。
+    if let json = String(bytes: data, encoding: .utf8),
+      let list = try? Gozd_V1_TaskList(jsonString: json)
+    {
+      return list
     }
-    return try Gozd_V1_TaskList(jsonString: json)
+    let empty = Gozd_V1_TaskList()
+    try saveFile(empty, for: dir)
+    FileHandle.standardError.write(
+      Data("[TaskStore] loadFile: corrupted tasks.json reinitialized at \(url.path)\n".utf8))
+    return empty
   }
 
   private func saveFile(_ list: Gozd_V1_TaskList, for dir: String) throws {
@@ -290,7 +271,6 @@ public actor TaskStore {
 
 public enum TaskStoreError: Error, Equatable {
   case notFound(String)
-  case fileDecodeFailed(String)
 }
 
 extension Gozd_V1_Task {

--- a/apps/native/Sources/GozdCore/TaskStore.swift
+++ b/apps/native/Sources/GozdCore/TaskStore.swift
@@ -157,9 +157,25 @@ public actor TaskStore {
       guard fm.fileExists(atPath: tasksURL.path) else { continue }
       let tasksData = try Data(contentsOf: tasksURL)
       var taskList: Gozd_V1_TaskList
-      if let tasksJson = String(bytes: tasksData, encoding: .utf8),
-        let parsed = try? Gozd_V1_TaskList(jsonString: tasksJson)
-      {
+      let parsedTasks: Gozd_V1_TaskList?
+      if let tasksJson = String(bytes: tasksData, encoding: .utf8) {
+        do {
+          parsedTasks = try Gozd_V1_TaskList(jsonString: tasksJson)
+        } catch {
+          FileHandle.standardError.write(
+            Data(
+              "[TaskStore] reconcile: parse failed for tasks.json in \(projectKey): \(error)\n"
+                .utf8))
+          parsedTasks = nil
+        }
+      } else {
+        FileHandle.standardError.write(
+          Data(
+            "[TaskStore] reconcile: invalid UTF-8 in tasks.json for \(projectKey)\n"
+              .utf8))
+        parsedTasks = nil
+      }
+      if let parsed = parsedTasks {
         taskList = parsed
       } else {
         let empty = Gozd_V1_TaskList()
@@ -226,10 +242,18 @@ public actor TaskStore {
       return Gozd_V1_TaskList()
     }
     let data = try Data(contentsOf: url)
-    if let json = String(bytes: data, encoding: .utf8),
-      let list = try? Gozd_V1_TaskList(jsonString: json)
-    {
-      return list
+    if let json = String(bytes: data, encoding: .utf8) {
+      do {
+        return try Gozd_V1_TaskList(jsonString: json)
+      } catch {
+        FileHandle.standardError.write(
+          Data(
+            "[TaskStore] loadFile: parse failed at \(url.path): \(error)\n"
+              .utf8))
+      }
+    } else {
+      FileHandle.standardError.write(
+        Data("[TaskStore] loadFile: invalid UTF-8 at \(url.path)\n".utf8))
     }
     let empty = Gozd_V1_TaskList()
     try saveFile(empty, for: dir)

--- a/apps/native/Sources/GozdCore/TaskStore.swift
+++ b/apps/native/Sources/GozdCore/TaskStore.swift
@@ -132,6 +132,12 @@ public actor TaskStore {
   /// 受け取る。claude-sessions.json の read / reinit は ClaudeSessionStore に集約され、
   /// 同ファイルを TaskStore 側でも parse する SSOT 違反を避ける。
   ///
+  /// 引数の map に projectKey のキーが無い場合は空集合扱いとし、当該 projectKey の全 task
+  /// が dead 判定対象 (sessionID クリア + identity 空なら orphan 削除) になる。これは
+  /// 「claude-sessions.json が存在しない projectKey」「reinit で空になった projectKey」
+  /// のいずれも「生存 sid が存在しない」というセマンティクスで揃えるため。明示的に空集合を
+  /// マップしたケースと map 不在ケースは同義に扱う。
+  ///
   /// parse 失敗 (UTF-8 不正 / JSON syntax 不正 / proto schema 進化) の tasks.json は
   /// 空オブジェクトで上書き save する。永続データに後方互換を作らない (CLAUDE.md 規約)
   /// ため、schema 進化で旧 JSON が parse 失敗した時は新規初期化が期待挙動。

--- a/apps/native/Tests/GozdCoreTests/TaskStoreTests.swift
+++ b/apps/native/Tests/GozdCoreTests/TaskStoreTests.swift
@@ -198,9 +198,10 @@ struct TaskStoreTests {
     )
     try await store.attachSession(
       dir: env.worktreeA, sessionId: "dead", worktreeDir: env.worktreeA)
-    // 当該 projectKey の claude-sessions.json は作らない (= dead 扱い)
 
-    try await store.reconcileAll()
+    // 当該 projectKey の生存 sid は空 (= dead 扱い) を渡す。
+    let projectKey = ProjectKey.resolveAndCompute(for: env.worktreeA)
+    try await store.reconcileAll(liveSessionsByProject: [projectKey: []])
 
     let list = try await store.list(dir: env.worktreeA)
     let kept = try #require(list.first)
@@ -218,7 +219,8 @@ struct TaskStoreTests {
     try await store.attachSession(
       dir: env.worktreeA, sessionId: "ghost", worktreeDir: env.worktreeA)
 
-    try await store.reconcileAll()
+    let projectKey = ProjectKey.resolveAndCompute(for: env.worktreeA)
+    try await store.reconcileAll(liveSessionsByProject: [projectKey: []])
 
     let list = try await store.list(dir: env.worktreeA)
     #expect(list.isEmpty) // dead session クリア → identity 完全消失 → 削除
@@ -237,16 +239,8 @@ struct TaskStoreTests {
     try await store.attachSession(
       dir: env.worktreeA, sessionId: "live", worktreeDir: env.worktreeA)
 
-    // 生存 sessionId として claude-sessions.json を用意する。transcript パスは
-    // reconcileAll の判定で読まれないが、CLAUDE.md の規約に従い /tmp ハードコードを避ける。
-    let dummyTranscript = FileManager.default.temporaryDirectory
-      .appendingPathComponent("dummy-transcript.jsonl").path
-    try writeClaudeSessions(
-      configDir: env.configDir, dir: env.worktreeA,
-      entries: [("live", env.worktreeA, dummyTranscript)]
-    )
-
-    try await store.reconcileAll()
+    let projectKey = ProjectKey.resolveAndCompute(for: env.worktreeA)
+    try await store.reconcileAll(liveSessionsByProject: [projectKey: ["live"]])
 
     let list = try await store.list(dir: env.worktreeA)
     #expect(list.count == 1)
@@ -327,26 +321,3 @@ private func runTestGit(args: [String], cwd: String) async throws {
   }
 }
 
-// projectKey の解決方式に合わせて claude-sessions.json を tasks.json と同じ projectDir に
-// 書き込む。reconcileAll は projects/<projectKey>/claude-sessions.json を参照する。
-private func writeClaudeSessions(
-  configDir: String, dir: String, entries: [(sessionId: String, worktreePath: String, transcript: String)]
-) throws {
-  let projectKey = ProjectKey.resolveAndCompute(for: dir)
-  let projectDir = URL(fileURLWithPath: configDir)
-    .appendingPathComponent("projects")
-    .appendingPathComponent(projectKey)
-  try FileManager.default.createDirectory(at: projectDir, withIntermediateDirectories: true)
-
-  var list = Gozd_V1_ClaudeSessionList()
-  for entry in entries {
-    var session = Gozd_V1_ClaudeSession()
-    session.sessionID = entry.sessionId
-    session.worktreePath = entry.worktreePath
-    session.transcriptPath = entry.transcript
-    list.sessions.append(session)
-  }
-  let json = try list.jsonString()
-  let path = projectDir.appendingPathComponent("claude-sessions.json")
-  try json.write(to: path, atomically: true, encoding: .utf8)
-}

--- a/apps/native/Tests/GozdCoreTests/TaskStoreTests.swift
+++ b/apps/native/Tests/GozdCoreTests/TaskStoreTests.swift
@@ -200,8 +200,7 @@ struct TaskStoreTests {
       dir: env.worktreeA, sessionId: "dead", worktreeDir: env.worktreeA)
     // 当該 projectKey の claude-sessions.json は作らない (= dead 扱い)
 
-    let failed = try await store.reconcileAll()
-    #expect(failed.isEmpty)
+    try await store.reconcileAll()
 
     let list = try await store.list(dir: env.worktreeA)
     let kept = try #require(list.first)
@@ -219,8 +218,7 @@ struct TaskStoreTests {
     try await store.attachSession(
       dir: env.worktreeA, sessionId: "ghost", worktreeDir: env.worktreeA)
 
-    let failed = try await store.reconcileAll()
-    #expect(failed.isEmpty)
+    try await store.reconcileAll()
 
     let list = try await store.list(dir: env.worktreeA)
     #expect(list.isEmpty) // dead session クリア → identity 完全消失 → 削除
@@ -248,8 +246,7 @@ struct TaskStoreTests {
       entries: [("live", env.worktreeA, dummyTranscript)]
     )
 
-    let failed = try await store.reconcileAll()
-    #expect(failed.isEmpty)
+    try await store.reconcileAll()
 
     let list = try await store.list(dir: env.worktreeA)
     #expect(list.count == 1)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -214,7 +214,7 @@ zsh 起動
 
 `AppStateStore` / `AppConfigStore` / `ProjectConfigStore` の load は `JSONDecodingOptions.ignoreUnknownFields = true` を有効にして forward/backward compat を確保する。save は raw dict と shallow merge して未知の top-level キーを落とさない。
 
-`TaskStore` (`tasks.json`) と `ClaudeSessionStore` (`claude-sessions.json`) の load は parse 失敗時に **空オブジェクトで上書き save** する。本アプリはベータ版で永続データに後方互換を作らない (CLAUDE.md 規約) ため、proto schema 進化で旧 JSON が parse 失敗した場合は新規初期化が期待挙動。これらは補助データ (Task / Claude session) であり、主データ (worktree list 等) の取得経路への throw 伝播を避けるためにも load 経路では throw しない。stderr に reinitialized ログを残して観察可能性を確保する。
+`TaskStore` (`tasks.json`) と `ClaudeSessionStore` (`claude-sessions.json`) の load は parse 失敗時に **空オブジェクトで上書き save** する。永続データに後方互換を作らない (CLAUDE.md 規約) ため、proto schema 進化で旧 JSON が parse 失敗した場合は新規初期化が期待挙動。加えて取得経路上、これらは主データ (例: `git worktree list`) を JOIN する立場にあり、load 経路から throw が伝播すると主データ取得経路を巻き込むため、空オブジェクトに倒す。stderr に reinitialized ログを残して観察可能性を確保する。
 
 ### スコープの使い分け
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -214,7 +214,7 @@ zsh 起動
 
 `AppStateStore` / `AppConfigStore` / `ProjectConfigStore` の load は `JSONDecodingOptions.ignoreUnknownFields = true` を有効にして forward/backward compat を確保する。save は raw dict と shallow merge して未知の top-level キーを落とさない。
 
-`TaskStore` (`tasks.json`) と `ClaudeSessionStore` (`claude-sessions.json`) の load は parse 失敗時に **空オブジェクトで上書き save** する。壊れたデータは保護しても価値がなく、throw に倒すと上位 (`handleGitWorktreeList`) で worktree list 全体が renderer に届かない（補助データ 1 件の破損で UI 全体が止まる）副作用がある。stderr に reinitialized ログを残し、観察可能性は確保する。
+`TaskStore` (`tasks.json`) と `ClaudeSessionStore` (`claude-sessions.json`) の load は parse 失敗時に **空オブジェクトで上書き save** する。本アプリはベータ版で永続データに後方互換を作らない (CLAUDE.md 規約) ため、proto schema 進化で旧 JSON が parse 失敗した場合は新規初期化が期待挙動。これらは補助データ (Task / Claude session) であり、主データ (worktree list 等) の取得経路への throw 伝播を避けるためにも load 経路では throw しない。stderr に reinitialized ログを残して観察可能性を確保する。
 
 ### スコープの使い分け
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -214,6 +214,8 @@ zsh 起動
 
 `AppStateStore` / `AppConfigStore` / `ProjectConfigStore` の load は `JSONDecodingOptions.ignoreUnknownFields = true` を有効にして forward/backward compat を確保する。save は raw dict と shallow merge して未知の top-level キーを落とさない。
 
+`TaskStore` (`tasks.json`) と `ClaudeSessionStore` (`claude-sessions.json`) の load は parse 失敗時に **空オブジェクトで上書き save** する。壊れたデータは保護しても価値がなく、throw に倒すと上位 (`handleGitWorktreeList`) で worktree list 全体が renderer に届かない（補助データ 1 件の破損で UI 全体が止まる）副作用がある。stderr に reinitialized ログを残し、観察可能性は確保する。
+
 ### スコープの使い分け
 
 | スコープ       | 保存先                                  | 例                                            |


### PR DESCRIPTION
## 概要

壊れた永続データや prunable な git worktree が 1 個でも存在すると、その repo の sidebar から root worktree を含む全 worktree が消える問題を直す。

- `TaskStore` / `ClaudeSessionStore` の load 経路で proto3 JSON parse に失敗した場合、空オブジェクトで上書き save する
- `handleGitWorktreeList` の per-wt `git status` 集約を `withThrowingTaskGroup` から `withTaskGroup` に変更し、個別 wt の失敗を空 statuses で隔離する
- `git worktree list --porcelain` の `prunable` 注釈付きエントリを listing 段階で除外する

## 経緯 (再発理由)

本 PR は 5/15 時点で main にマージする想定だったが open のまま停滞している間に、#528 (task / session decouple) と #532 (`pr_number`/`issue_number` → `GhRef` 統合) が先に main にマージされた。結果、現在の main には:

- `TaskStore.loadFile` / `reconcileAll` が **parse 失敗時に throw** する状態 (本 PR で消すはずだったロジックが #528 のリファクタで復活)
- `Task` proto から `issue_number` フィールドが削除された状態 (#532)

の 2 条件が揃っている。既存ユーザーの `~/.config/gozd/projects/<projectKey>/tasks.json` に残る `issueNumber` フィールドが proto JSON parser に `unknownField("issueNumber")` で throw されると、`handleGitWorktreeList` 全体が 500 を返し、worktree list が renderer に届かず sidebar の root worktree が表示できなくなる:

```text
Failed to fetch repo data: gozd
Error: RPC /git/worktreeList failed: 500 unknownField("issueNumber")
```

#532 の本文では「proto JSON parser の unknown field silent drop に任せる」前提だったが、TaskStore は `ignoreUnknownFields` を渡しておらず、本 PR のリカバリ機構 (parse 失敗 → 空 list reinit) が未マージだったため silent drop も reinit も成立せず throw に倒れていた。

## 背景

sidebar で studio-front / studio-preview の repo セクションが「New worktree」ボタンだけになり、root を含む worktree がまったく描画されない症状が出ていた。原因は 2 系統あった。

`studio-preview` 側: `~/.config/gozd/projects/<projectKey>/tasks.json` が proto3 JSON 形式 (`{"tasks": [...]}`) ではなく素の配列 `[...]` で保存されており、`Gozd_V1_TaskList(jsonString:)` が `JSONDecodingError.failure` を throw。`handleGitWorktreeList` 全体が 500 を返し、worktree list そのものは取得済みだったにもかかわらず renderer に届かない。

`studio-front` 側: 削除済みの worktree が `prunable gitdir file points to non-existent location` の状態で `git worktree list --porcelain` に残存。それに対する `git status` が exit 128 で失敗し、`withThrowingTaskGroup` が他の全 wt (root を含む) を SIGTERM (exit 15) で道連れ cancel して全体 throw。同じく RPC 500。

つまり「主データ (worktree list) はすでに手中にあるのに、補助データ (tasks / per-wt gitStatuses) の 1 個の失敗で全体を捨てる」設計が共通の根本原因だった。さらに起動時 `reconcileClaudeSessions` が出す parse 失敗 notify は renderer の `window.__gozdReceive` 未初期化中に撃たれて silent drop されており、ユーザーが破損を観測する経路もなかった。

「壊れているデータに価値はない、削除か初期化しろ」という方針で、parse 失敗時は空で書き直し、補助データ取得の失敗は per-wt で隔離するように書き換える。

## 変更内容

### 永続化ストアの parse 失敗復旧

- `TaskStore.loadFile` / `TaskStore.reconcileAll`: parse 失敗時に `Gozd_V1_TaskList()` を save 上書きし、stderr に reinitialized ログを残す
- `ClaudeSessionStore.loadFile` / `ClaudeSessionStore.reconcileAll`: 同様に `Gozd_V1_ClaudeSessionList()` を上書き
- `TaskStore.reconcileAll` の戻り値 `[String]` (parse 失敗 projectKey 一覧) と `TaskStoreError.fileDecodeFailed` を撤去。`RpcDispatcher.reconcileClaudeSessions` 内の関連 notify 経路も削除
- これにより `issueNumber` のような **未知フィールド** で parse が失敗するケースも、reinit 経路で自動復旧する (#532 が想定していた挙動が本 PR で初めて成立する)

### handleGitWorktreeList の例外伝播粒度

- per-wt `git status` を `withThrowingTaskGroup` → `withTaskGroup` に変更し、失敗した wt は `[:]` で続行
- `allRegisteredSessions` の catch + fallback notify 経路を撤去 (loadFile が空初期化に倒すので throw しない)
- これにより主データ (worktree list) の renderer 到達が補助データの失敗から独立する

### prunable worktree の listing 除外

- `parseWorktreePorcelain` で `prunable` 行および `prunable <reason>` 形式の reason 付きを検知し、該当エントリを result に append しない
- git 自身が解決不能と注釈している孤児に対する後段 `git status` が必ず失敗することへの SSOT 段階の対応

### rebase 適用差分 (#528 / #532 後コードベースへの追従)

元 PR は `prNumber / issueNumber` 時代のコードで書かれていたため main への rebase 時に conflict。以下の方針で解決:

- `RpcDispatcher.handleGitWorktreeList` の task filter は **`task.hasNonSessionIdentity` ベース** (`GhRef` 統合後の正しい述語) を維持しつつ、`withTaskGroup` への切替と Optional fallback 撤去は本 PR の方針を採用
- `TaskStore.loadFile` の URL ベース API (`url.path` / `appendingPathComponent`) は #532 後の状態を維持
- `TaskStoreTests.swift` の `let failed = try await store.reconcileAll(); #expect(failed.isEmpty)` を `try await store.reconcileAll()` に書き換え (戻り値 `[String]` 撤去に伴う)

### ドキュメント

- `docs/architecture.md` の永続化セクションに、`TaskStore` / `ClaudeSessionStore` の load 経路における parse 失敗時の空初期化挙動と、その設計判断の根拠を追記

## 確認事項

- [ ] 既存の sidebar / worktree 表示に regression がないこと
- [ ] 壊れた `tasks.json` を持つ project を起動した時、空ファイルで書き直されて worktree list が正常表示されること
- [ ] **`issueNumber` を含む既存 `tasks.json`** で起動した時、reinit 経路で自動復旧して `unknownField` 由来の sidebar 停止が起きないこと
- [ ] prunable な worktree を含む repo で root を含む他の worktree が正常表示されること
- [x] `swift build` が通ること
- [x] `swift test` が通ること (155 tests pass)