### PR TITLE
refactor(task,proto): unify pr/issue number into GhRef discriminator

### DIFF
--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -181,7 +181,7 @@ public actor RpcDispatcher {
           try await claudeSessions.removeBySessionId(
             worktreePath: worktreePath, sessionId: previous)
           // 旧 session を持っていた Task から sessionID を切り離す。task 本体は
-          // 残し (body/pr/issue があれば永続)、新 session 開始経路 (attachSession)
+          // 残し (body / gh_ref があれば永続)、新 session 開始経路 (attachSession)
           // と矛盾しないよう「sessionID 空 + 同 worktree」候補を増やす。
           do {
             try await tasks.detachSession(dir: worktreePath, sessionId: previous)
@@ -225,7 +225,7 @@ public actor RpcDispatcher {
         try await claudeSessions.removeBySessionId(
           worktreePath: worktreePath, sessionId: hook.sessionID)
         // SessionEnd: task.sessionID は保持して `claude --resume` の起点に使う。
-        // body/pr/issue がすべて空の task のみ削除する (Claude 直接起動 + 即終了の残骸)。
+        // body / gh_ref がすべて空の task のみ削除する (Claude 直接起動 + 即終了の残骸)。
         do {
           try await tasks.detachSession(dir: worktreePath, sessionId: hook.sessionID)
         } catch {
@@ -951,7 +951,7 @@ public actor RpcDispatcher {
         removeError = error
       }
       // ターミナル close は session-end hook を発火させないため、ここで明示的に
-      // task.sessionID を切り離す。body/pr/issue が空なら同時に task も削除される
+      // task.sessionID を切り離す。body / gh_ref が空なら同時に task も削除される
       // (detachSession 内部で判定)。claudeSessions 側のエラーを優先するため tasks 側は
       // throw しないが、失敗を放置すると stale な sessionID が残るので notify する。
       do {

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -586,7 +586,7 @@ public actor RpcDispatcher {
       )
     }
     let listedTasks = try await tasks.list(dir: req.dir)
-    // task ≠ session 設計: 身元 (body / pr / issue) があれば session が dead でも表示する。
+    // task ≠ session 設計: 身元 (body / gh_ref) があれば session が dead でも表示する。
     // session 単独で生きていた task (Claude 直接起動 + 即終了の残骸) のみ filter で落とす。
     let allTasks: [Gozd_V1_Task]
     if let ids = registeredSessionIds {

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -591,9 +591,7 @@ public actor RpcDispatcher {
     let allTasks: [Gozd_V1_Task]
     if let ids = registeredSessionIds {
       allTasks = listedTasks.filter { task in
-        if !task.body.isEmpty || task.prNumber > 0 || task.issueNumber > 0 {
-          return true
-        }
+        if task.hasNonSessionIdentity { return true }
         return !task.sessionID.isEmpty && ids.contains(task.sessionID)
       }
     } else {
@@ -986,8 +984,7 @@ public actor RpcDispatcher {
       dir: req.dir,
       body: req.body,
       worktreeDir: req.worktreeDir,
-      prNumber: req.prNumber,
-      issueNumber: req.issueNumber
+      ghRef: req.hasGhRef ? req.ghRef : nil
     )
     var resp = Gozd_V1_TaskAddResponse()
     resp.task = task

--- a/apps/native/Sources/GozdCore/TaskStore.swift
+++ b/apps/native/Sources/GozdCore/TaskStore.swift
@@ -306,3 +306,21 @@ extension Gozd_V1_Task {
     !hasNonSessionIdentity && sessionID.isEmpty
   }
 }
+
+extension Gozd_V1_GhRef {
+  /// kind を取り違える可能性を構造的に排除するためのドメインファクトリ。
+  /// TS 側 `ghRefForPr` / `ghRefForIssue` (proto-ts/src/helpers.ts) と対称。
+  public static func forPr(_ number: UInt32) -> Gozd_V1_GhRef {
+    var ref = Gozd_V1_GhRef()
+    ref.kind = .pr
+    ref.number = number
+    return ref
+  }
+
+  public static func forIssue(_ number: UInt32) -> Gozd_V1_GhRef {
+    var ref = Gozd_V1_GhRef()
+    ref.kind = .issue
+    ref.number = number
+    return ref
+  }
+}

--- a/apps/native/Sources/GozdCore/TaskStore.swift
+++ b/apps/native/Sources/GozdCore/TaskStore.swift
@@ -125,12 +125,12 @@ public actor TaskStore {
   }
 
   /// 起動時の reconcile。dead session を attach したまま放置された task の sessionID を
-  /// クリアし、加えて「body / pr / issue いずれも空」かつ「sessionID も dead」の
+  /// クリアし、加えて「body / gh_ref いずれも空」かつ「sessionID も dead」の
   /// task は孤児として削除する (AND 条件)。
   ///
   /// task.sessionID は SessionEnd でも保持する設計なので、resume が永久に効かなくなった
   /// dead session id をクリアして次回クリック時に「素の claude」を起動できる状態に戻す。
-  /// pr / issue / body が残っていれば task 本体は維持する。
+  /// body / gh_ref が残っていれば task 本体は維持する。
   /// この経路が無いと、アプリクラッシュ / kill -9 / transcript 削除で session-end hook も
   /// removeByPty も来なかった残骸が永続化に居座り続け、サイドバーに `New session` の
   /// ゾンビ行として現れる。
@@ -218,7 +218,7 @@ public actor TaskStore {
 
       let before = taskList.tasks.count
       var mutated = false
-      // dead sessionID をクリア (task 本体は保持。pr/issue/body の有無に依らない)。
+      // dead sessionID をクリア (task 本体は保持。body / gh_ref の有無に依らない)。
       for idx in taskList.tasks.indices {
         let sid = taskList.tasks[idx].sessionID
         if !sid.isEmpty && !liveSessionIds.contains(sid) {

--- a/apps/native/Sources/GozdCore/TaskStore.swift
+++ b/apps/native/Sources/GozdCore/TaskStore.swift
@@ -15,7 +15,7 @@ import GozdProto
 //    無ければ新規 task を作る (Claude 直接起動 = PR/issue 経由でないケース)。
 //
 // 3. **SessionEnd hook**: task.sessionID を切り離さず保持する。次回 `claude --resume`
-//    の起点に使う。body / pr_number / issue_number がいずれも空の task のみ削除する。
+//    の起点に使う。body / gh_ref がいずれも空の task のみ削除する。
 //
 // 4. **projectKey の算出は `ProjectKey` を参照**。worktree 配下のどの dir から呼ばれても
 //    main repo root に解決した上で同一 projectKey に揃える（`resolveAndCompute`）。
@@ -43,7 +43,7 @@ public actor TaskStore {
   /// `createdAt` を省略すると現在時刻 (ISO 8601) を埋める。テスト時に明示的な順序を
   /// 仕込みたい場合のみ caller が文字列で与える (本体経路では渡さない)。
   public func add(
-    dir: String, body: String, worktreeDir: String, prNumber: UInt32, issueNumber: UInt32,
+    dir: String, body: String, worktreeDir: String, ghRef: Gozd_V1_GhRef?,
     createdAt: String? = nil
   ) throws -> Gozd_V1_Task {
     var list = try loadFile(for: dir)
@@ -51,8 +51,7 @@ public actor TaskStore {
     task.id = UUID().uuidString
     task.body = body
     task.worktreeDir = worktreeDir
-    task.prNumber = prNumber
-    task.issueNumber = issueNumber
+    if let ghRef { task.ghRef = ghRef }
     task.createdAt = createdAt ?? ISO8601DateFormatter().string(from: Date())
     list.tasks.append(task)
     try saveFile(list, for: dir)
@@ -100,31 +99,19 @@ public actor TaskStore {
   }
 
   /// SessionEnd hook 由来。task.sessionID は保持して `claude --resume` の起点に使う。
-  /// 削除判定は `hasNonSessionIdentity` (body / pr / issue の 3 項) で行う。sessionID を
+  /// 削除判定は `hasNonSessionIdentity` (body / gh_ref) で行う。sessionID を
   /// この判定に含めると「再 resume 用に sessionID を残す」設計と矛盾するため除外する。
   public func detachSession(dir: String, sessionId: String) throws {
     var list = try loadFile(for: dir)
     guard let idx = list.tasks.firstIndex(where: { $0.sessionID == sessionId }) else {
       return
     }
-    if !Self.hasNonSessionIdentity(list.tasks[idx]) {
+    if !list.tasks[idx].hasNonSessionIdentity {
       list.tasks.remove(at: idx)
     }
-    // identity (body / pr / issue) があれば sessionID は保持。worktreeList の filter は
+    // identity (body / gh_ref) があれば sessionID は保持。worktreeList の filter は
     // identity の有無で判定するため、sessionID を残してもサイドバー表示には影響しない。
     try saveFile(list, for: dir)
-  }
-
-  /// task が session 以外の identity 源 (body / pr / issue) を持つか。1 項でもあれば true。
-  /// detachSession の保持判定 と reconcileAll の孤児判定 (sessionID 込み 4 項) で共通利用する。
-  private static func hasNonSessionIdentity(_ task: Gozd_V1_Task) -> Bool {
-    return !task.body.isEmpty || task.prNumber != 0 || task.issueNumber != 0
-  }
-
-  /// 「task の identity が完全に消えた」判定 (reconcileAll 専用)。body / pr / issue / sessionID
-  /// すべて空が条件 (= `hasNonSessionIdentity` false かつ sessionID 空)。
-  private static func isOrphan(_ task: Gozd_V1_Task) -> Bool {
-    return !hasNonSessionIdentity(task) && task.sessionID.isEmpty
   }
 
   /// worktree 物理削除 (handleWorktreeRemove) からの連動掃除。
@@ -240,7 +227,7 @@ public actor TaskStore {
         }
       }
       // identity 源が完全に消えた task を削除 (detachSession と SSOT)。
-      taskList.tasks.removeAll { Self.isOrphan($0) }
+      taskList.tasks.removeAll { $0.isOrphan }
       let dropped = before - taskList.tasks.count
       if dropped > 0 { mutated = true }
       if mutated {
@@ -304,4 +291,18 @@ public actor TaskStore {
 public enum TaskStoreError: Error, Equatable {
   case notFound(String)
   case fileDecodeFailed(String)
+}
+
+extension Gozd_V1_Task {
+  /// task が session 以外の identity 源 (body / gh_ref) を持つか。1 項でもあれば true。
+  /// detachSession の保持判定 / handleGitWorktreeList の filter / reconcileAll の孤児判定で共通利用する。
+  public var hasNonSessionIdentity: Bool {
+    !body.isEmpty || hasGhRef
+  }
+
+  /// 「task の identity が完全に消えた」判定 (reconcileAll 専用)。body / gh_ref / sessionID
+  /// すべて空が条件 (= `hasNonSessionIdentity` false かつ sessionID 空)。
+  public var isOrphan: Bool {
+    !hasNonSessionIdentity && sessionID.isEmpty
+  }
 }

--- a/apps/native/Tests/GozdCoreTests/TaskStoreTests.swift
+++ b/apps/native/Tests/GozdCoreTests/TaskStoreTests.swift
@@ -147,12 +147,9 @@ struct TaskStoreTests {
     defer { cleanup(env) }
     let store = TaskStore(configDir: env.configDir)
 
-    var prRef = Gozd_V1_GhRef()
-    prRef.kind = .pr
-    prRef.number = 42
     _ = try await store.add(
       dir: env.worktreeA, body: "", worktreeDir: env.worktreeA,
-      ghRef: prRef
+      ghRef: .forPr(42)
     )
     try await store.attachSession(
       dir: env.worktreeA, sessionId: "pr-sid", worktreeDir: env.worktreeA)

--- a/apps/native/Tests/GozdCoreTests/TaskStoreTests.swift
+++ b/apps/native/Tests/GozdCoreTests/TaskStoreTests.swift
@@ -16,7 +16,7 @@ struct TaskStoreTests {
 
     let task = try await store.add(
       dir: env.worktreeA, body: "existing", worktreeDir: env.worktreeA,
-      prNumber: 0, issueNumber: 0
+      ghRef: nil
     )
     try await store.attachSession(
       dir: env.worktreeA, sessionId: "s1", worktreeDir: env.worktreeA)
@@ -40,12 +40,11 @@ struct TaskStoreTests {
     // createdAt をテストフックで明示注入し、時間ベース待機を避ける。
     let older = try await store.add(
       dir: env.worktreeA, body: "older", worktreeDir: env.worktreeA,
-      prNumber: 0, issueNumber: 0,
-      createdAt: "2026-05-15T00:00:00Z"
+      ghRef: nil, createdAt: "2026-05-15T00:00:00Z"
     )
     let newer = try await store.add(
       dir: env.worktreeA, body: "newer", worktreeDir: env.worktreeA,
-      prNumber: 0, issueNumber: 0,
+      ghRef: nil,
       createdAt: "2026-05-16T00:00:00Z"
     )
 
@@ -87,7 +86,7 @@ struct TaskStoreTests {
 
     let foreign = try await store.add(
       dir: env.worktreeA, body: "for-b", worktreeDir: env.worktreeB,
-      prNumber: 0, issueNumber: 0
+      ghRef: nil
     )
 
     try await store.attachSession(
@@ -127,7 +126,7 @@ struct TaskStoreTests {
 
     let task = try await store.add(
       dir: env.worktreeA, body: "Refactor X", worktreeDir: env.worktreeA,
-      prNumber: 0, issueNumber: 0
+      ghRef: nil
     )
     try await store.attachSession(
       dir: env.worktreeA, sessionId: "live", worktreeDir: env.worktreeA)
@@ -142,15 +141,18 @@ struct TaskStoreTests {
     #expect(kept.sessionID == "live") // 再 resume 用に保持
   }
 
-  @Test("detachSession: prNumber > 0 でも task を残す (PR/issue 由来 task の永続性)")
+  @Test("detachSession: ghRef があれば task を残す (PR/issue 由来 task の永続性)")
   func detachSessionKeepsPrTask() async throws {
     let env = try await makeEnv()
     defer { cleanup(env) }
     let store = TaskStore(configDir: env.configDir)
 
+    var prRef = Gozd_V1_GhRef()
+    prRef.kind = .pr
+    prRef.number = 42
     _ = try await store.add(
       dir: env.worktreeA, body: "", worktreeDir: env.worktreeA,
-      prNumber: 42, issueNumber: 0
+      ghRef: prRef
     )
     try await store.attachSession(
       dir: env.worktreeA, sessionId: "pr-sid", worktreeDir: env.worktreeA)
@@ -159,7 +161,9 @@ struct TaskStoreTests {
 
     let list = try await store.list(dir: env.worktreeA)
     let kept = try #require(list.first)
-    #expect(kept.prNumber == 42)
+    #expect(kept.hasGhRef)
+    #expect(kept.ghRef.kind == .pr)
+    #expect(kept.ghRef.number == 42)
     #expect(kept.sessionID == "pr-sid")
   }
 
@@ -171,7 +175,7 @@ struct TaskStoreTests {
 
     _ = try await store.add(
       dir: env.worktreeA, body: "alive", worktreeDir: env.worktreeA,
-      prNumber: 0, issueNumber: 0
+      ghRef: nil
     )
     try await store.attachSession(
       dir: env.worktreeA, sessionId: "live", worktreeDir: env.worktreeA)
@@ -193,7 +197,7 @@ struct TaskStoreTests {
 
     _ = try await store.add(
       dir: env.worktreeA, body: "identified", worktreeDir: env.worktreeA,
-      prNumber: 0, issueNumber: 0
+      ghRef: nil
     )
     try await store.attachSession(
       dir: env.worktreeA, sessionId: "dead", worktreeDir: env.worktreeA)
@@ -233,7 +237,7 @@ struct TaskStoreTests {
 
     _ = try await store.add(
       dir: env.worktreeA, body: "active", worktreeDir: env.worktreeA,
-      prNumber: 0, issueNumber: 0
+      ghRef: nil
     )
     try await store.attachSession(
       dir: env.worktreeA, sessionId: "live", worktreeDir: env.worktreeA)

--- a/apps/native/Tests/GozdCoreTests/TaskStoreTests.swift
+++ b/apps/native/Tests/GozdCoreTests/TaskStoreTests.swift
@@ -102,7 +102,7 @@ struct TaskStoreTests {
 
   // MARK: - detachSession
 
-  @Test("detachSession: body / pr / issue がすべて空なら task 削除 (Claude 直接起動 + 即終了の残骸)")
+  @Test("detachSession: body / gh_ref がすべて空なら task 削除 (Claude 直接起動 + 即終了の残骸)")
   func detachSessionRemovesEmpty() async throws {
     let env = try await makeEnv()
     defer { cleanup(env) }
@@ -212,7 +212,7 @@ struct TaskStoreTests {
     #expect(kept.sessionID == "") // dead セッション ID はクリア
   }
 
-  @Test("reconcileAll: identity 完全消失 (body / pr / issue / sessionId すべて空) の task は孤児削除")
+  @Test("reconcileAll: identity 完全消失 (body / gh_ref / sessionId すべて空) の task は孤児削除")
   func reconcileDropsOrphans() async throws {
     let env = try await makeEnv()
     defer { cleanup(env) }

--- a/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
+++ b/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
@@ -4,7 +4,7 @@
  * issue を選択して worktree を作成する。
  */
 
-import { GhRefKind } from "@gozd/proto";
+import { ghRefForIssue } from "@gozd/proto";
 import { tryCatch } from "@gozd/shared";
 import { useCommandRegistry } from "../../../../shared/command";
 import { useNotificationStore } from "../../../../shared/notification";
@@ -146,7 +146,7 @@ export function registerIssueCommand(): () => void {
                 dir: rootDir,
                 body: issue.title,
                 worktreeDir: result.value.dir,
-                ghRef: { kind: GhRefKind.GH_REF_KIND_ISSUE, number: issue.number },
+                ghRef: ghRefForIssue(issue.number),
               }),
             );
             // taskAdd 失敗時は autostart を抑止する。続けると attachSession が

--- a/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
+++ b/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
@@ -4,6 +4,7 @@
  * issue を選択して worktree を作成する。
  */
 
+import { GhRefKind } from "@gozd/proto";
 import { tryCatch } from "@gozd/shared";
 import { useCommandRegistry } from "../../../../shared/command";
 import { useNotificationStore } from "../../../../shared/notification";
@@ -145,8 +146,7 @@ export function registerIssueCommand(): () => void {
                 dir: rootDir,
                 body: issue.title,
                 worktreeDir: result.value.dir,
-                prNumber: 0,
-                issueNumber: issue.number,
+                ghRef: { kind: GhRefKind.GH_REF_KIND_ISSUE, number: issue.number },
               }),
             );
             // taskAdd 失敗時は autostart を抑止する。続けると attachSession が

--- a/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
+++ b/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
@@ -4,7 +4,7 @@
  * PR を選択して worktree を作成する。既にブランチの worktree が存在する場合はそちらに切り替える。
  */
 
-import { GhRefKind } from "@gozd/proto";
+import { ghRefForPr } from "@gozd/proto";
 import { tryCatch } from "@gozd/shared";
 import { useCommandRegistry } from "../../../../shared/command";
 import { useNotificationStore } from "../../../../shared/notification";
@@ -97,7 +97,7 @@ export function registerPrCommand(): () => void {
                 dir: rootDir,
                 body: pr.title,
                 worktreeDir: result.value.dir,
-                ghRef: { kind: GhRefKind.GH_REF_KIND_PR, number: pr.number },
+                ghRef: ghRefForPr(pr.number),
               }),
             );
             // taskAdd 失敗時は autostart を抑止する。続けると attachSession が

--- a/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
+++ b/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
@@ -4,6 +4,7 @@
  * PR を選択して worktree を作成する。既にブランチの worktree が存在する場合はそちらに切り替える。
  */
 
+import { GhRefKind } from "@gozd/proto";
 import { tryCatch } from "@gozd/shared";
 import { useCommandRegistry } from "../../../../shared/command";
 import { useNotificationStore } from "../../../../shared/notification";
@@ -96,8 +97,7 @@ export function registerPrCommand(): () => void {
                 dir: rootDir,
                 body: pr.title,
                 worktreeDir: result.value.dir,
-                prNumber: pr.number,
-                issueNumber: 0,
+                ghRef: { kind: GhRefKind.GH_REF_KIND_PR, number: pr.number },
               }),
             );
             // taskAdd 失敗時は autostart を抑止する。続けると attachSession が

--- a/apps/renderer/src/features/sidebar/utils.ts
+++ b/apps/renderer/src/features/sidebar/utils.ts
@@ -41,7 +41,7 @@ export function branchLabel(branch: string | undefined): string {
 }
 
 /**
- * Task の PR / issue 番号をプレフィックス文字列 (`#123 `) として返す。
+ * Task の GitHub 参照番号をプレフィックス文字列 (`#123 `) として返す。
  * GitHub では PR と issue が同一の番号空間を共有するため kind を見ずに番号だけ表示する。
  */
 function taskNumberPrefix(task: Task): string {
@@ -51,7 +51,7 @@ function taskNumberPrefix(task: Task): string {
 
 /**
  * worktree の表示名: 任意 Task に有効なタイトルがあればそれ、なければブランチ名。
- * PR / issue 番号付き task は `#N タイトル` の形で先頭に番号を付ける。
+ * gh_ref 付き task は `#N タイトル` の形で先頭に番号を付ける。
  * Claude プレースホルダ (`CLAUDE_PLACEHOLDER_TITLE`) は無効扱いし、
  * confirm / error メッセージで "Claude Code" が露出するのを防ぐ。
  */
@@ -87,9 +87,9 @@ export function formatRelativeTime(from: number, now: number): string {
 }
 
 /**
- * Task title を表示用に正規化。PR / issue 番号付き task は `#N タイトル` を返す。
- * body が空 (Claude プレースホルダ含む) の場合、番号ありなら `#N` 単体、番号無しなら
- * `New session` にフォールバックする。番号付きで body 空の状態は PR/issue picker 直後
+ * Task title を表示用に正規化。gh_ref 付き task は `#N タイトル` を返す。
+ * body が空 (Claude プレースホルダ含む) の場合、gh_ref ありなら `#N` 単体、無しなら
+ * `New session` にフォールバックする。gh_ref ありで body 空の状態は PR/issue picker 直後
  * (Claude 未起動 + OSC title 未到達) の過渡状態で、Not started アイコンと併せて識別される。
  */
 export function taskDisplayTitle(task: Task): string {

--- a/apps/renderer/src/features/sidebar/utils.ts
+++ b/apps/renderer/src/features/sidebar/utils.ts
@@ -42,12 +42,11 @@ export function branchLabel(branch: string | undefined): string {
 
 /**
  * Task の PR / issue 番号をプレフィックス文字列 (`#123 `) として返す。
- * 両方 0 なら空文字。両方 > 0 は仕様上発生しないが、PR を優先する。
+ * GitHub では PR と issue が同一の番号空間を共有するため kind を見ずに番号だけ表示する。
  */
 function taskNumberPrefix(task: Task): string {
-  if (task.prNumber > 0) return `#${task.prNumber} `;
-  if (task.issueNumber > 0) return `#${task.issueNumber} `;
-  return "";
+  if (task.ghRef === undefined) return "";
+  return `#${task.ghRef.number} `;
 }
 
 /**

--- a/apps/renderer/src/features/terminal/useTerminalStore.ts
+++ b/apps/renderer/src/features/terminal/useTerminalStore.ts
@@ -249,7 +249,7 @@ export const useTerminalStore = defineStore("terminal", () => {
               // 内の任意 dir として projectKey 解決に使える。
               await refreshSavedSessionCounts([dir], dir);
               // Swift 側で TaskStore.detachSession が走り、sessionId を切り離した task は
-              // 残し (body / pr / issue 残存時)、identity 完全消失なら削除する。
+              // 残し (body / gh_ref 残存時)、identity 完全消失なら削除する。
               // useSidebarData がこの ref を watch して所属 repo を refetch することで、
               // WorktreeEntry.tasks 側の sessionId 切り離し / 削除を反映する。
               // terminalStore は repoStore に依存させない (Pinia setup での循環を避ける)。

--- a/docs/task.md
+++ b/docs/task.md
@@ -9,16 +9,21 @@ interface Task {
   id: string; // UUID (Swift 側 TaskStore.add で生成)
   body: string; // git commit 形式: 一行目=タイトル、残り=本文
   worktreeDir: string; // 紐づいた worktree のパス
-  prNumber: number; // PR 番号。0 は未設定 (proto3 uint32)
-  issueNumber: number; // issue 番号。0 は未設定 (proto3 uint32)
+  ghRef?: GhRef; // GitHub PR/issue 参照。両方同時設定は型で排他 (number 単一)
   createdAt: string; // ISO 8601
   sessionId: string; // 最後に attach した Claude session の ID。空文字は未起動 / SessionEnd 済み
 }
+interface GhRef {
+  kind: GhRefKind; // GH_REF_KIND_PR | GH_REF_KIND_ISSUE
+  number: number;
+}
 ```
+
+GitHub では PR と issue が同一の番号空間を共有するため、種別 + 番号の組で表現する。`ghRef` 自体の有無で「PR/issue 由来 task かどうか」を判定する。
 
 - `id` は Claude session id と独立した UUID。session の生成 / 消滅で task は再作成されない
 - `body` は git commit メッセージと同じ構造。一行目をタイトルとして表示に使う
-- `body` が空かつ `prNumber == 0` かつ `issueNumber == 0` のとき表示は「(無題)」相当
+- `body` が空かつ `ghRef` 未設定のとき表示は「(無題)」相当
 - `sessionId` は SessionEnd でも保持し、次回 `claude --resume` の起点に使う
 
 ## task と session の関係
@@ -43,14 +48,14 @@ SessionStart hook で呼ばれる。以下の優先順位で attach 先を決め
 SessionEnd hook / terminal close で呼ばれる。
 
 - task.sessionId は保持する (再 resume の起点)
-- `body == ""` かつ `prNumber == 0` かつ `issueNumber == 0` の task のみ削除する (Claude 直接起動 + 即終了の残骸掃除)
+- `body == ""` かつ `ghRef` 未設定の task のみ削除する (Claude 直接起動 + 即終了の残骸掃除)
 
 ### reconcile (`TaskStore.reconcileAll`)
 
 起動時に `claude-sessions.json` の生存 sessionId 集合と突き合わせる。
 
 - dead sessionId は task からクリアする (task 本体は維持)
-- `body / prNumber / issueNumber / sessionId` すべて空の task のみ削除する (AND 条件)
+- `body / ghRef / sessionId` すべて空の task のみ削除する (AND 条件)
 
 ## 保存
 
@@ -62,7 +67,7 @@ SessionEnd hook / terminal close で呼ばれる。
 
 ```text
 "Workspace: Open Pull Request" → PR 選択 → worktree 作成 + Task 作成
-  (body=PR タイトル、prNumber=PR 番号、sessionId="")
+  (body=PR タイトル、ghRef={kind: PR, number: PR 番号}、sessionId="")
 ```
 
 サイドバーで該当行をクリックすると素の `claude` が起動し、SessionStart hook で attach される。
@@ -71,7 +76,7 @@ SessionEnd hook / terminal close で呼ばれる。
 
 ```text
 "Workspace: Open Issue" → issue 選択 → worktree 作成 (branch=issue-<N>) + Task 作成
-  (body=issue タイトル、issueNumber=issue 番号、sessionId="")
+  (body=issue タイトル、ghRef={kind: ISSUE, number: issue 番号}、sessionId="")
 ```
 
 ### Claude を worktree で直接起動 (PR/issue 経由なし)
@@ -82,11 +87,11 @@ worktree visit → ターミナル起動 → ユーザーが `claude` を実行
   → 該当無しなら新規 task を作成 (body=""、sessionId=新 sid)
 ```
 
-OSC title が反映されて body が埋まった task は SessionEnd 後も `sessionId` を保持して永続化される (`detachSession` の孤児判定 `body / pr / issue / sessionId` AND で身元残存のため削除されない)。サイドバーでは `Resumable` 状態で残り、再クリックすると `claude --resume` 経路で同じ task に再 attach される。Claude を完全に捨てたい場合は次のアプリ起動時 reconcile を経て `transcript` が dead 判定されると `sessionId` がクリアされ、body は残ったまま `Not started` に降格する。
+OSC title が反映されて body が埋まった task は SessionEnd 後も `sessionId` を保持して永続化される (`detachSession` の孤児判定 `body / ghRef / sessionId` AND で身元残存のため削除されない)。サイドバーでは `Resumable` 状態で残り、再クリックすると `claude --resume` 経路で同じ task に再 attach される。Claude を完全に捨てたい場合は次のアプリ起動時 reconcile を経て `transcript` が dead 判定されると `sessionId` がクリアされ、body は残ったまま `Not started` に降格する。
 
 ### autostart で起動した claude を終了したあとの挙動
 
-PR/issue picker や session 未紐付け task クリックで `claude` を autostart した leaf でユーザーが `/exit` すると、claude プロセスは終了して素の zsh プロンプトに戻る。task 側は SessionEnd hook 経由で `detachSession` が走り、`sessionId` を切り離す (body が埋まっていれば task は残り `Resumable` 表示、body / pr / issue / sessionId すべて空なら task ごと削除)。
+PR/issue picker や session 未紐付け task クリックで `claude` を autostart した leaf でユーザーが `/exit` すると、claude プロセスは終了して素の zsh プロンプトに戻る。task 側は SessionEnd hook 経由で `detachSession` が走り、`sessionId` を切り離す (body が埋まっていれば task は残り `Resumable` 表示、body / ghRef / sessionId すべて空なら task ごと削除)。
 
 ターミナル自体は素の zsh として残る (`claude` プロセスのみ終了して shell は kill しない)。サイドバーで再度 task をクリックすると `claude --resume <sessionId>` 経路 (sessionId 保持時) または新規 claude 経路 (`Not started` 降格後) に乗る。
 
@@ -103,7 +108,7 @@ PR/issue picker や session 未紐付け task クリックで `claude` を autos
 | トリガー                              | 挙動                                                                      |
 | ------------------------------------- | ------------------------------------------------------------------------- |
 | worktree 行 `[⋮]` → "Remove worktree" | worktree 削除 + 該当 `worktreeDir` の全 Task 削除                         |
-| ターミナル close (PTY 終了)           | `detachSession`: sessionId 切り離し。body/pr/issue が空なら task 削除     |
+| ターミナル close (PTY 終了)           | `detachSession`: sessionId 切り離し。body/ghRef が空なら task 削除        |
 | SessionEnd hook                       | `detachSession`: 同上                                                     |
 | 外部で worktree 消失                  | `gitWorktreeList` 取得時に存在しない `worktreeDir` を検出し Task 自動削除 |
 | 起動時 reconcile                      | dead sessionId クリア + identity が完全に消えた task のみ削除             |
@@ -111,7 +116,7 @@ PR/issue picker や session 未紐付け task クリックで `claude` を autos
 ## RPC
 
 ```text
-taskAdd:    { dir, body, worktreeDir, prNumber, issueNumber } → Task
+taskAdd:    { dir, body, worktreeDir, ghRef? } → Task
 taskUpdate: { dir, id, body } → Task            (OSC title 同期で使用)
 ```
 
@@ -125,7 +130,7 @@ ROOT
 
 WORKTREES
   ● feature-aの実装    [⋮]
-  ● #123 Fix bug       [⋮]   ← prNumber > 0 で `#番号` プレフィックス
+  ● #123 Fix bug       [⋮]   ← ghRef が設定済みなら `#番号` プレフィックス
   ● (無題)              [⋮]
 ```
 

--- a/docs/task.md
+++ b/docs/task.md
@@ -9,7 +9,7 @@ interface Task {
   id: string; // UUID (Swift 側 TaskStore.add で生成)
   body: string; // git commit 形式: 一行目=タイトル、残り=本文
   worktreeDir: string; // 紐づいた worktree のパス
-  ghRef?: GhRef; // GitHub PR/issue 参照。両方同時設定は型で排他 (number 単一)
+  ghRef?: GhRef; // GitHub PR/issue 参照。task 1 件あたり最大 1 つ
   createdAt: string; // ISO 8601
   sessionId: string; // 最後に attach した Claude session の ID。空文字は未起動 / SessionEnd 済み
 }

--- a/docs/task.md
+++ b/docs/task.md
@@ -87,11 +87,11 @@ worktree visit → ターミナル起動 → ユーザーが `claude` を実行
   → 該当無しなら新規 task を作成 (body=""、sessionId=新 sid)
 ```
 
-OSC title が反映されて body が埋まった task は SessionEnd 後も `sessionId` を保持して永続化される (`detachSession` の孤児判定 `body / ghRef / sessionId` AND で身元残存のため削除されない)。サイドバーでは `Resumable` 状態で残り、再クリックすると `claude --resume` 経路で同じ task に再 attach される。Claude を完全に捨てたい場合は次のアプリ起動時 reconcile を経て `transcript` が dead 判定されると `sessionId` がクリアされ、body は残ったまま `Not started` に降格する。
+OSC title が反映されて body が埋まった task は SessionEnd 後も `sessionId` を保持して永続化される (`detachSession` は `body / ghRef` のいずれかが残っていれば task と `sessionID` を保持する)。サイドバーでは `Resumable` 状態で残り、再クリックすると `claude --resume` 経路で同じ task に再 attach される。Claude を完全に捨てたい場合は次のアプリ起動時 reconcile を経て `transcript` が dead 判定されると `sessionId` がクリアされ、body は残ったまま `Not started` に降格する。
 
 ### autostart で起動した claude を終了したあとの挙動
 
-PR/issue picker や session 未紐付け task クリックで `claude` を autostart した leaf でユーザーが `/exit` すると、claude プロセスは終了して素の zsh プロンプトに戻る。task 側は SessionEnd hook 経由で `detachSession` が走り、`sessionId` を切り離す (body が埋まっていれば task は残り `Resumable` 表示、body / ghRef / sessionId すべて空なら task ごと削除)。
+PR/issue picker や session 未紐付け task クリックで `claude` を autostart した leaf でユーザーが `/exit` すると、claude プロセスは終了して素の zsh プロンプトに戻る。task 側は SessionEnd hook 経由で `detachSession` が走り、`body / ghRef` のいずれかが残っていれば task と `sessionID` を保持 (`Resumable` 表示)、両方空なら task ごと削除する。
 
 ターミナル自体は素の zsh として残る (`claude` プロセスのみ終了して shell は kill しない)。サイドバーで再度 task をクリックすると `claude --resume <sessionId>` 経路 (sessionId 保持時) または新規 claude 経路 (`Not started` 降格後) に乗る。
 

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_common.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_common.pb.swift
@@ -20,6 +20,44 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
   typealias Version = _2
 }
 
+public enum Gozd_V1_GhRefKind: SwiftProtobuf.Enum, Swift.CaseIterable {
+  public typealias RawValue = Int
+  case unspecified // = 0
+  case pr // = 1
+  case issue // = 2
+  case UNRECOGNIZED(Int)
+
+  public init() {
+    self = .unspecified
+  }
+
+  public init?(rawValue: Int) {
+    switch rawValue {
+    case 0: self = .unspecified
+    case 1: self = .pr
+    case 2: self = .issue
+    default: self = .UNRECOGNIZED(rawValue)
+    }
+  }
+
+  public var rawValue: Int {
+    switch self {
+    case .unspecified: return 0
+    case .pr: return 1
+    case .issue: return 2
+    case .UNRECOGNIZED(let i): return i
+    }
+  }
+
+  // The compiler won't synthesize support with the UNRECOGNIZED case.
+  public static let allCases: [Gozd_V1_GhRefKind] = [
+    .unspecified,
+    .pr,
+    .issue,
+  ]
+
+}
+
 public struct Gozd_V1_WorktreeEntry: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
@@ -55,9 +93,16 @@ public struct Gozd_V1_Task: Sendable {
 
   public var worktreeDir: String = String()
 
-  public var prNumber: UInt32 = 0
-
-  public var issueNumber: UInt32 = 0
+  /// GitHub PR / issue 参照。両方同時設定は型で排他 (GhRef 内で number は単一)。
+  /// GitHub では PR と issue が同一の番号空間を共有するため、種別 + 番号の組で表現する。
+  public var ghRef: Gozd_V1_GhRef {
+    get {_ghRef ?? Gozd_V1_GhRef()}
+    set {_ghRef = newValue}
+  }
+  /// Returns true if `ghRef` has been explicitly set.
+  public var hasGhRef: Bool {self._ghRef != nil}
+  /// Clears the value of `ghRef`. Subsequent reads from it will return its default value.
+  public mutating func clearGhRef() {self._ghRef = nil}
 
   /// ISO 8601
   public var createdAt: String = String()
@@ -65,6 +110,23 @@ public struct Gozd_V1_Task: Sendable {
   /// 最後に attach された Claude session の ID。空文字は session 未起動 / 終了済み。
   /// SessionEnd では消さず保持し、サイドバークリック時の `claude --resume` 起点に使う。
   public var sessionID: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _ghRef: Gozd_V1_GhRef? = nil
+}
+
+/// GitHub PR / issue 参照。issue #531 で pr_number / issue_number から統合。
+public struct Gozd_V1_GhRef: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var kind: Gozd_V1_GhRefKind = .unspecified
+
+  public var number: UInt32 = 0
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -247,6 +309,10 @@ public struct Gozd_V1_ProjectConfig: Sendable {
 
 fileprivate let _protobuf_package = "gozd.v1"
 
+extension Gozd_V1_GhRefKind: SwiftProtobuf._ProtoNameProviding {
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0GH_REF_KIND_UNSPECIFIED\0\u{1}GH_REF_KIND_PR\0\u{1}GH_REF_KIND_ISSUE\0")
+}
+
 extension Gozd_V1_WorktreeEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WorktreeEntry"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}path\0\u{1}head\0\u{1}branch\0\u{3}is_main\0\u{3}git_statuses\0\u{1}tasks\0")
@@ -304,7 +370,7 @@ extension Gozd_V1_WorktreeEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
 
 extension Gozd_V1_Task: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".Task"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}body\0\u{3}worktree_dir\0\u{3}pr_number\0\u{3}issue_number\0\u{3}created_at\0\u{3}session_id\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}id\0\u{1}body\0\u{3}worktree_dir\0\u{3}gh_ref\0\u{3}created_at\0\u{3}session_id\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -315,16 +381,19 @@ extension Gozd_V1_Task: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
       case 1: try { try decoder.decodeSingularStringField(value: &self.id) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self.body) }()
       case 3: try { try decoder.decodeSingularStringField(value: &self.worktreeDir) }()
-      case 4: try { try decoder.decodeSingularUInt32Field(value: &self.prNumber) }()
-      case 5: try { try decoder.decodeSingularUInt32Field(value: &self.issueNumber) }()
-      case 6: try { try decoder.decodeSingularStringField(value: &self.createdAt) }()
-      case 7: try { try decoder.decodeSingularStringField(value: &self.sessionID) }()
+      case 4: try { try decoder.decodeSingularMessageField(value: &self._ghRef) }()
+      case 5: try { try decoder.decodeSingularStringField(value: &self.createdAt) }()
+      case 6: try { try decoder.decodeSingularStringField(value: &self.sessionID) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.id.isEmpty {
       try visitor.visitSingularStringField(value: self.id, fieldNumber: 1)
     }
@@ -334,17 +403,14 @@ extension Gozd_V1_Task: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
     if !self.worktreeDir.isEmpty {
       try visitor.visitSingularStringField(value: self.worktreeDir, fieldNumber: 3)
     }
-    if self.prNumber != 0 {
-      try visitor.visitSingularUInt32Field(value: self.prNumber, fieldNumber: 4)
-    }
-    if self.issueNumber != 0 {
-      try visitor.visitSingularUInt32Field(value: self.issueNumber, fieldNumber: 5)
-    }
+    try { if let v = self._ghRef {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    } }()
     if !self.createdAt.isEmpty {
-      try visitor.visitSingularStringField(value: self.createdAt, fieldNumber: 6)
+      try visitor.visitSingularStringField(value: self.createdAt, fieldNumber: 5)
     }
     if !self.sessionID.isEmpty {
-      try visitor.visitSingularStringField(value: self.sessionID, fieldNumber: 7)
+      try visitor.visitSingularStringField(value: self.sessionID, fieldNumber: 6)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -353,10 +419,44 @@ extension Gozd_V1_Task: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementat
     if lhs.id != rhs.id {return false}
     if lhs.body != rhs.body {return false}
     if lhs.worktreeDir != rhs.worktreeDir {return false}
-    if lhs.prNumber != rhs.prNumber {return false}
-    if lhs.issueNumber != rhs.issueNumber {return false}
+    if lhs._ghRef != rhs._ghRef {return false}
     if lhs.createdAt != rhs.createdAt {return false}
     if lhs.sessionID != rhs.sessionID {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Gozd_V1_GhRef: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GhRef"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}kind\0\u{1}number\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularEnumField(value: &self.kind) }()
+      case 2: try { try decoder.decodeSingularUInt32Field(value: &self.number) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.kind != .unspecified {
+      try visitor.visitSingularEnumField(value: self.kind, fieldNumber: 1)
+    }
+    if self.number != 0 {
+      try visitor.visitSingularUInt32Field(value: self.number, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Gozd_V1_GhRef, rhs: Gozd_V1_GhRef) -> Bool {
+    if lhs.kind != rhs.kind {return false}
+    if lhs.number != rhs.number {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_common.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_common.pb.swift
@@ -93,8 +93,8 @@ public struct Gozd_V1_Task: Sendable {
 
   public var worktreeDir: String = String()
 
-  /// GitHub PR / issue 参照。両方同時設定は型で排他 (GhRef 内で number は単一)。
-  /// GitHub では PR と issue が同一の番号空間を共有するため、種別 + 番号の組で表現する。
+  /// GitHub PR / issue 参照。GitHub の PR / issue は同一の番号空間を共有するため、
+  /// 種別 + 番号の組で 1 件を表す。task 1 件あたり最大 1 つ。
   public var ghRef: Gozd_V1_GhRef {
     get {_ghRef ?? Gozd_V1_GhRef()}
     set {_ghRef = newValue}
@@ -118,7 +118,7 @@ public struct Gozd_V1_Task: Sendable {
   fileprivate var _ghRef: Gozd_V1_GhRef? = nil
 }
 
-/// GitHub PR / issue 参照。issue #531 で pr_number / issue_number から統合。
+/// GitHub PR / issue 参照。
 public struct Gozd_V1_GhRef: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_task.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_task.pb.swift
@@ -44,13 +44,21 @@ public struct Gozd_V1_TaskAddRequest: Sendable {
 
   public var worktreeDir: String = String()
 
-  public var prNumber: UInt32 = 0
-
-  public var issueNumber: UInt32 = 0
+  /// GitHub PR / issue 参照。手動作成時は未指定で OK。
+  public var ghRef: Gozd_V1_GhRef {
+    get {_ghRef ?? Gozd_V1_GhRef()}
+    set {_ghRef = newValue}
+  }
+  /// Returns true if `ghRef` has been explicitly set.
+  public var hasGhRef: Bool {self._ghRef != nil}
+  /// Clears the value of `ghRef`. Subsequent reads from it will return its default value.
+  public mutating func clearGhRef() {self._ghRef = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
+
+  fileprivate var _ghRef: Gozd_V1_GhRef? = nil
 }
 
 public struct Gozd_V1_TaskAddResponse: Sendable {
@@ -147,7 +155,7 @@ extension Gozd_V1_TaskList: SwiftProtobuf.Message, SwiftProtobuf._MessageImpleme
 
 extension Gozd_V1_TaskAddRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".TaskAddRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}dir\0\u{1}body\0\u{3}worktree_dir\0\u{3}pr_number\0\u{3}issue_number\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}dir\0\u{1}body\0\u{3}worktree_dir\0\u{3}gh_ref\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -158,14 +166,17 @@ extension Gozd_V1_TaskAddRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageI
       case 1: try { try decoder.decodeSingularStringField(value: &self.dir) }()
       case 2: try { try decoder.decodeSingularStringField(value: &self.body) }()
       case 3: try { try decoder.decodeSingularStringField(value: &self.worktreeDir) }()
-      case 4: try { try decoder.decodeSingularUInt32Field(value: &self.prNumber) }()
-      case 5: try { try decoder.decodeSingularUInt32Field(value: &self.issueNumber) }()
+      case 4: try { try decoder.decodeSingularMessageField(value: &self._ghRef) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.dir.isEmpty {
       try visitor.visitSingularStringField(value: self.dir, fieldNumber: 1)
     }
@@ -175,12 +186,9 @@ extension Gozd_V1_TaskAddRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     if !self.worktreeDir.isEmpty {
       try visitor.visitSingularStringField(value: self.worktreeDir, fieldNumber: 3)
     }
-    if self.prNumber != 0 {
-      try visitor.visitSingularUInt32Field(value: self.prNumber, fieldNumber: 4)
-    }
-    if self.issueNumber != 0 {
-      try visitor.visitSingularUInt32Field(value: self.issueNumber, fieldNumber: 5)
-    }
+    try { if let v = self._ghRef {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 4)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -188,8 +196,7 @@ extension Gozd_V1_TaskAddRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     if lhs.dir != rhs.dir {return false}
     if lhs.body != rhs.body {return false}
     if lhs.worktreeDir != rhs.worktreeDir {return false}
-    if lhs.prNumber != rhs.prNumber {return false}
-    if lhs.issueNumber != rhs.issueNumber {return false}
+    if lhs._ghRef != rhs._ghRef {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/packages/proto-ts/src/generated/gozd/v1/common.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/common.ts
@@ -69,8 +69,8 @@ export interface Task {
   body: string;
   worktreeDir: string;
   /**
-   * GitHub PR / issue 参照。両方同時設定は型で排他 (GhRef 内で number は単一)。
-   * GitHub では PR と issue が同一の番号空間を共有するため、種別 + 番号の組で表現する。
+   * GitHub PR / issue 参照。GitHub の PR / issue は同一の番号空間を共有するため、
+   * 種別 + 番号の組で 1 件を表す。task 1 件あたり最大 1 つ。
    */
   ghRef?:
     | GhRef
@@ -84,7 +84,7 @@ export interface Task {
   sessionId: string;
 }
 
-/** GitHub PR / issue 参照。issue #531 で pr_number / issue_number から統合。 */
+/** GitHub PR / issue 参照。 */
 export interface GhRef {
   kind: GhRefKind;
   number: number;

--- a/packages/proto-ts/src/generated/gozd/v1/common.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/common.ts
@@ -9,6 +9,45 @@ import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
 
 export const protobufPackage = "gozd.v1";
 
+export enum GhRefKind {
+  GH_REF_KIND_UNSPECIFIED = 0,
+  GH_REF_KIND_PR = 1,
+  GH_REF_KIND_ISSUE = 2,
+  UNRECOGNIZED = -1,
+}
+
+export function ghRefKindFromJSON(object: any): GhRefKind {
+  switch (object) {
+    case 0:
+    case "GH_REF_KIND_UNSPECIFIED":
+      return GhRefKind.GH_REF_KIND_UNSPECIFIED;
+    case 1:
+    case "GH_REF_KIND_PR":
+      return GhRefKind.GH_REF_KIND_PR;
+    case 2:
+    case "GH_REF_KIND_ISSUE":
+      return GhRefKind.GH_REF_KIND_ISSUE;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return GhRefKind.UNRECOGNIZED;
+  }
+}
+
+export function ghRefKindToJSON(object: GhRefKind): string {
+  switch (object) {
+    case GhRefKind.GH_REF_KIND_UNSPECIFIED:
+      return "GH_REF_KIND_UNSPECIFIED";
+    case GhRefKind.GH_REF_KIND_PR:
+      return "GH_REF_KIND_PR";
+    case GhRefKind.GH_REF_KIND_ISSUE:
+      return "GH_REF_KIND_ISSUE";
+    case GhRefKind.UNRECOGNIZED:
+    default:
+      return "UNRECOGNIZED";
+  }
+}
+
 export interface WorktreeEntry {
   path: string;
   head: string;
@@ -29,8 +68,13 @@ export interface Task {
   id: string;
   body: string;
   worktreeDir: string;
-  prNumber: number;
-  issueNumber: number;
+  /**
+   * GitHub PR / issue 参照。両方同時設定は型で排他 (GhRef 内で number は単一)。
+   * GitHub では PR と issue が同一の番号空間を共有するため、種別 + 番号の組で表現する。
+   */
+  ghRef?:
+    | GhRef
+    | undefined;
   /** ISO 8601 */
   createdAt: string;
   /**
@@ -38,6 +82,12 @@ export interface Task {
    * SessionEnd では消さず保持し、サイドバークリック時の `claude --resume` 起点に使う。
    */
   sessionId: string;
+}
+
+/** GitHub PR / issue 参照。issue #531 で pr_number / issue_number から統合。 */
+export interface GhRef {
+  kind: GhRefKind;
+  number: number;
 }
 
 /** ディレクトリエントリ。fs/readDir / filer 用。 */
@@ -368,7 +418,7 @@ export const WorktreeEntry_GitStatusesEntry: MessageFns<WorktreeEntry_GitStatuse
 };
 
 function createBaseTask(): Task {
-  return { id: "", body: "", worktreeDir: "", prNumber: 0, issueNumber: 0, createdAt: "", sessionId: "" };
+  return { id: "", body: "", worktreeDir: "", ghRef: undefined, createdAt: "", sessionId: "" };
 }
 
 export const Task: MessageFns<Task> = {
@@ -382,17 +432,14 @@ export const Task: MessageFns<Task> = {
     if (message.worktreeDir !== "") {
       writer.uint32(26).string(message.worktreeDir);
     }
-    if (message.prNumber !== 0) {
-      writer.uint32(32).uint32(message.prNumber);
-    }
-    if (message.issueNumber !== 0) {
-      writer.uint32(40).uint32(message.issueNumber);
+    if (message.ghRef !== undefined) {
+      GhRef.encode(message.ghRef, writer.uint32(34).fork()).join();
     }
     if (message.createdAt !== "") {
-      writer.uint32(50).string(message.createdAt);
+      writer.uint32(42).string(message.createdAt);
     }
     if (message.sessionId !== "") {
-      writer.uint32(58).string(message.sessionId);
+      writer.uint32(50).string(message.sessionId);
     }
     return writer;
   },
@@ -429,31 +476,23 @@ export const Task: MessageFns<Task> = {
           continue;
         }
         case 4: {
-          if (tag !== 32) {
+          if (tag !== 34) {
             break;
           }
 
-          message.prNumber = reader.uint32();
+          message.ghRef = GhRef.decode(reader, reader.uint32());
           continue;
         }
         case 5: {
-          if (tag !== 40) {
-            break;
-          }
-
-          message.issueNumber = reader.uint32();
-          continue;
-        }
-        case 6: {
-          if (tag !== 50) {
+          if (tag !== 42) {
             break;
           }
 
           message.createdAt = reader.string();
           continue;
         }
-        case 7: {
-          if (tag !== 58) {
+        case 6: {
+          if (tag !== 50) {
             break;
           }
 
@@ -478,16 +517,11 @@ export const Task: MessageFns<Task> = {
         : isSet(object.worktree_dir)
         ? globalThis.String(object.worktree_dir)
         : "",
-      prNumber: isSet(object.prNumber)
-        ? globalThis.Number(object.prNumber)
-        : isSet(object.pr_number)
-        ? globalThis.Number(object.pr_number)
-        : 0,
-      issueNumber: isSet(object.issueNumber)
-        ? globalThis.Number(object.issueNumber)
-        : isSet(object.issue_number)
-        ? globalThis.Number(object.issue_number)
-        : 0,
+      ghRef: isSet(object.ghRef)
+        ? GhRef.fromJSON(object.ghRef)
+        : isSet(object.gh_ref)
+        ? GhRef.fromJSON(object.gh_ref)
+        : undefined,
       createdAt: isSet(object.createdAt)
         ? globalThis.String(object.createdAt)
         : isSet(object.created_at)
@@ -512,11 +546,8 @@ export const Task: MessageFns<Task> = {
     if (message.worktreeDir !== "") {
       obj.worktreeDir = message.worktreeDir;
     }
-    if (message.prNumber !== 0) {
-      obj.prNumber = Math.round(message.prNumber);
-    }
-    if (message.issueNumber !== 0) {
-      obj.issueNumber = Math.round(message.issueNumber);
+    if (message.ghRef !== undefined) {
+      obj.ghRef = GhRef.toJSON(message.ghRef);
     }
     if (message.createdAt !== "") {
       obj.createdAt = message.createdAt;
@@ -535,10 +566,85 @@ export const Task: MessageFns<Task> = {
     message.id = object.id ?? "";
     message.body = object.body ?? "";
     message.worktreeDir = object.worktreeDir ?? "";
-    message.prNumber = object.prNumber ?? 0;
-    message.issueNumber = object.issueNumber ?? 0;
+    message.ghRef = (object.ghRef !== undefined && object.ghRef !== null) ? GhRef.fromPartial(object.ghRef) : undefined;
     message.createdAt = object.createdAt ?? "";
     message.sessionId = object.sessionId ?? "";
+    return message;
+  },
+};
+
+function createBaseGhRef(): GhRef {
+  return { kind: 0, number: 0 };
+}
+
+export const GhRef: MessageFns<GhRef> = {
+  encode(message: GhRef, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.kind !== 0) {
+      writer.uint32(8).int32(message.kind);
+    }
+    if (message.number !== 0) {
+      writer.uint32(16).uint32(message.number);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GhRef {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGhRef();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.kind = reader.int32() as any;
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.number = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GhRef {
+    return {
+      kind: isSet(object.kind) ? ghRefKindFromJSON(object.kind) : 0,
+      number: isSet(object.number) ? globalThis.Number(object.number) : 0,
+    };
+  },
+
+  toJSON(message: GhRef): unknown {
+    const obj: any = {};
+    if (message.kind !== 0) {
+      obj.kind = ghRefKindToJSON(message.kind);
+    }
+    if (message.number !== 0) {
+      obj.number = Math.round(message.number);
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<GhRef>): GhRef {
+    return GhRef.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<GhRef>): GhRef {
+    const message = createBaseGhRef();
+    message.kind = object.kind ?? 0;
+    message.number = object.number ?? 0;
     return message;
   },
 };

--- a/packages/proto-ts/src/generated/gozd/v1/task.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/task.ts
@@ -6,7 +6,7 @@
 
 /* eslint-disable */
 import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
-import { Task } from "./common";
+import { GhRef, Task } from "./common";
 
 export const protobufPackage = "gozd.v1";
 
@@ -19,8 +19,8 @@ export interface TaskAddRequest {
   dir: string;
   body: string;
   worktreeDir: string;
-  prNumber: number;
-  issueNumber: number;
+  /** GitHub PR / issue 参照。手動作成時は未指定で OK。 */
+  ghRef?: GhRef | undefined;
 }
 
 export interface TaskAddResponse {
@@ -96,7 +96,7 @@ export const TaskList: MessageFns<TaskList> = {
 };
 
 function createBaseTaskAddRequest(): TaskAddRequest {
-  return { dir: "", body: "", worktreeDir: "", prNumber: 0, issueNumber: 0 };
+  return { dir: "", body: "", worktreeDir: "", ghRef: undefined };
 }
 
 export const TaskAddRequest: MessageFns<TaskAddRequest> = {
@@ -110,11 +110,8 @@ export const TaskAddRequest: MessageFns<TaskAddRequest> = {
     if (message.worktreeDir !== "") {
       writer.uint32(26).string(message.worktreeDir);
     }
-    if (message.prNumber !== 0) {
-      writer.uint32(32).uint32(message.prNumber);
-    }
-    if (message.issueNumber !== 0) {
-      writer.uint32(40).uint32(message.issueNumber);
+    if (message.ghRef !== undefined) {
+      GhRef.encode(message.ghRef, writer.uint32(34).fork()).join();
     }
     return writer;
   },
@@ -151,19 +148,11 @@ export const TaskAddRequest: MessageFns<TaskAddRequest> = {
           continue;
         }
         case 4: {
-          if (tag !== 32) {
+          if (tag !== 34) {
             break;
           }
 
-          message.prNumber = reader.uint32();
-          continue;
-        }
-        case 5: {
-          if (tag !== 40) {
-            break;
-          }
-
-          message.issueNumber = reader.uint32();
+          message.ghRef = GhRef.decode(reader, reader.uint32());
           continue;
         }
       }
@@ -184,16 +173,11 @@ export const TaskAddRequest: MessageFns<TaskAddRequest> = {
         : isSet(object.worktree_dir)
         ? globalThis.String(object.worktree_dir)
         : "",
-      prNumber: isSet(object.prNumber)
-        ? globalThis.Number(object.prNumber)
-        : isSet(object.pr_number)
-        ? globalThis.Number(object.pr_number)
-        : 0,
-      issueNumber: isSet(object.issueNumber)
-        ? globalThis.Number(object.issueNumber)
-        : isSet(object.issue_number)
-        ? globalThis.Number(object.issue_number)
-        : 0,
+      ghRef: isSet(object.ghRef)
+        ? GhRef.fromJSON(object.ghRef)
+        : isSet(object.gh_ref)
+        ? GhRef.fromJSON(object.gh_ref)
+        : undefined,
     };
   },
 
@@ -208,11 +192,8 @@ export const TaskAddRequest: MessageFns<TaskAddRequest> = {
     if (message.worktreeDir !== "") {
       obj.worktreeDir = message.worktreeDir;
     }
-    if (message.prNumber !== 0) {
-      obj.prNumber = Math.round(message.prNumber);
-    }
-    if (message.issueNumber !== 0) {
-      obj.issueNumber = Math.round(message.issueNumber);
+    if (message.ghRef !== undefined) {
+      obj.ghRef = GhRef.toJSON(message.ghRef);
     }
     return obj;
   },
@@ -225,8 +206,7 @@ export const TaskAddRequest: MessageFns<TaskAddRequest> = {
     message.dir = object.dir ?? "";
     message.body = object.body ?? "";
     message.worktreeDir = object.worktreeDir ?? "";
-    message.prNumber = object.prNumber ?? 0;
-    message.issueNumber = object.issueNumber ?? 0;
+    message.ghRef = (object.ghRef !== undefined && object.ghRef !== null) ? GhRef.fromPartial(object.ghRef) : undefined;
     return message;
   },
 };

--- a/packages/proto-ts/src/helpers.ts
+++ b/packages/proto-ts/src/helpers.ts
@@ -1,0 +1,14 @@
+import { type GhRef, GhRefKind } from "./generated/gozd/v1/common";
+
+// `kind` の hardcode を呼び出し側から消し、proto enum (GhRefKind) を業務コードに
+// 露出させないためのドメインヘルパー。GitHub の番号空間共有を踏まえ、PR / issue を
+// 1 行で表現する。
+export const ghRefForPr = (number: number): GhRef => ({
+  kind: GhRefKind.GH_REF_KIND_PR,
+  number,
+});
+
+export const ghRefForIssue = (number: number): GhRef => ({
+  kind: GhRefKind.GH_REF_KIND_ISSUE,
+  number,
+});

--- a/packages/proto-ts/src/helpers.ts
+++ b/packages/proto-ts/src/helpers.ts
@@ -1,8 +1,7 @@
 import { type GhRef, GhRefKind } from "./generated/gozd/v1/common";
 
-// `kind` の hardcode を呼び出し側から消し、proto enum (GhRefKind) を業務コードに
-// 露出させないためのドメインヘルパー。GitHub の番号空間共有を踏まえ、PR / issue を
-// 1 行で表現する。
+// `GhRefKind` は barrel から export せず、本ヘルパー越しでしか `kind` を組み立てられない
+// ようにする。呼び出し側で `kind` を取り違える可能性を構造的に排除する。
 export const ghRefForPr = (number: number): GhRef => ({
   kind: GhRefKind.GH_REF_KIND_PR,
   number,

--- a/packages/proto-ts/src/index.ts
+++ b/packages/proto-ts/src/index.ts
@@ -40,7 +40,6 @@ export {
   FileEntry,
   FileReadResult,
   GhRef,
-  GhRefKind,
   GitCommit,
   GitFileChange,
   GitIssue,

--- a/packages/proto-ts/src/index.ts
+++ b/packages/proto-ts/src/index.ts
@@ -35,6 +35,7 @@ export {
   ClaudeSessionRemoveByPtyResponse,
 } from "./generated/gozd/v1/claude_session";
 export { ClientMessage, HookMessage, OpenMessage } from "./generated/gozd/v1/client_message";
+export { ghRefForIssue, ghRefForPr } from "./helpers";
 export {
   FileEntry,
   FileReadResult,

--- a/packages/proto-ts/src/index.ts
+++ b/packages/proto-ts/src/index.ts
@@ -38,6 +38,8 @@ export { ClientMessage, HookMessage, OpenMessage } from "./generated/gozd/v1/cli
 export {
   FileEntry,
   FileReadResult,
+  GhRef,
+  GhRefKind,
   GitCommit,
   GitFileChange,
   GitIssue,

--- a/packages/proto/gozd/v1/common.proto
+++ b/packages/proto/gozd/v1/common.proto
@@ -20,8 +20,8 @@ message Task {
   string id = 1;
   string body = 2;
   string worktree_dir = 3;
-  // GitHub PR / issue 参照。両方同時設定は型で排他 (GhRef 内で number は単一)。
-  // GitHub では PR と issue が同一の番号空間を共有するため、種別 + 番号の組で表現する。
+  // GitHub PR / issue 参照。GitHub の PR / issue は同一の番号空間を共有するため、
+  // 種別 + 番号の組で 1 件を表す。task 1 件あたり最大 1 つ。
   optional GhRef gh_ref = 4;
   // ISO 8601
   string created_at = 5;
@@ -30,7 +30,7 @@ message Task {
   string session_id = 6;
 }
 
-// GitHub PR / issue 参照。issue #531 で pr_number / issue_number から統合。
+// GitHub PR / issue 参照。
 message GhRef {
   GhRefKind kind = 1;
   uint32 number = 2;

--- a/packages/proto/gozd/v1/common.proto
+++ b/packages/proto/gozd/v1/common.proto
@@ -20,13 +20,26 @@ message Task {
   string id = 1;
   string body = 2;
   string worktree_dir = 3;
-  uint32 pr_number = 4;
-  uint32 issue_number = 5;
+  // GitHub PR / issue 参照。両方同時設定は型で排他 (GhRef 内で number は単一)。
+  // GitHub では PR と issue が同一の番号空間を共有するため、種別 + 番号の組で表現する。
+  optional GhRef gh_ref = 4;
   // ISO 8601
-  string created_at = 6;
+  string created_at = 5;
   // 最後に attach された Claude session の ID。空文字は session 未起動 / 終了済み。
   // SessionEnd では消さず保持し、サイドバークリック時の `claude --resume` 起点に使う。
-  string session_id = 7;
+  string session_id = 6;
+}
+
+// GitHub PR / issue 参照。issue #531 で pr_number / issue_number から統合。
+message GhRef {
+  GhRefKind kind = 1;
+  uint32 number = 2;
+}
+
+enum GhRefKind {
+  GH_REF_KIND_UNSPECIFIED = 0;
+  GH_REF_KIND_PR = 1;
+  GH_REF_KIND_ISSUE = 2;
 }
 
 // ディレクトリエントリ。fs/readDir / filer 用。

--- a/packages/proto/gozd/v1/task.proto
+++ b/packages/proto/gozd/v1/task.proto
@@ -22,8 +22,8 @@ message TaskAddRequest {
   string dir = 1;
   string body = 2;
   string worktree_dir = 3;
-  uint32 pr_number = 4;
-  uint32 issue_number = 5;
+  // GitHub PR / issue 参照。手動作成時は未指定で OK。
+  optional GhRef gh_ref = 4;
 }
 message TaskAddResponse {
   Task task = 1;


### PR DESCRIPTION
## 概要

`Task` proto の `pr_number` / `issue_number` を 1 つの `GhRef { kind, number }` に統合した。GitHub では PR と issue が同一の番号空間を共有するため、種別 + 番号の組で表現する。両方同時設定が型・JSON ファイル両層で不可能な構造になる。

## 背景

issue ( #531 ) の元方針は `pr_number` / `issue_number` を `optional uint32` 化して presence check に切り替えるというものだった。検討中に「2 つのフィールドがあるとデータ上両方同時設定されうる」「proto3 oneof でも JSON ではフラット展開されるためファイル物理形では両方持ちうる」という懸念が出た。

GitHub では PR と issue が同一連番空間を共有しており、同 repo 内で同番号の PR と issue は同時存在しえない (REST `/repos/.../issues/{number}` でも PR が引ける)。本来「種別 + 番号」が 1 セットの値であり、2 フィールドに分けて持つこと自体が GitHub のデータモデルとずれていた。

`oneof` も検討したが、proto3 JSON では oneof branch が top-level に flat 展開されるため (`{ "prNumber": N, "issueNumber": M }` という不正 JSON が parser 実装によって throw / last-wins と挙動が割れる)、JSON 物理形では排他を強制できない。ネスト sub-message + enum discriminator にすることで JSON 構造レベルで「両方同時」を表現する手段自体を消した。

設計案は `/claude-review` で別 context の Claude に検証し、`hasNonSessionIdentity` / `isOrphan` を `extension Gozd_V1_Task` に移植して呼び出し側を `task.hasNonSessionIdentity` の述語形に揃える追加方針を採用した。

## 変更内容

### proto schema

- `Task` から `pr_number` (field 4) / `issue_number` (field 5) を削除し、`optional GhRef gh_ref = 4` を追加。`created_at` / `session_id` の field 番号も詰めて再採番 (後方互換不要のため reserved 句は置かない)
- `TaskAddRequest` も同じ `optional GhRef gh_ref = 4` を受ける形に変更
- `GhRef { GhRefKind kind, uint32 number }` と `GhRefKind { GH_REF_KIND_UNSPECIFIED, GH_REF_KIND_PR, GH_REF_KIND_ISSUE }` を新設
- `@gozd/proto` barrel から `GhRef` / `GhRefKind` を export

### Swift (GozdCore)

- `TaskStore.add` のシグネチャを `prNumber: UInt32, issueNumber: UInt32` から `ghRef: Gozd_V1_GhRef?` に変更
- `extension Gozd_V1_Task` に `hasNonSessionIdentity` / `isOrphan` を新設。`TaskStore.detachSession` / `TaskStore.reconcileAll` から `private static` 経由を廃止
- `RpcDispatcher.handleGitWorktreeList` の filter を `task.hasNonSessionIdentity || (sessionID live)` に統合 (SSOT 違反を解消)
- `RpcDispatcher.handleTaskAdd` は `req.hasGhRef ? req.ghRef : nil` を `TaskStore.add` に渡す

### renderer (TS)

- `sidebar/utils.ts` の `taskNumberPrefix` を `task.ghRef === undefined` の presence check に簡素化 (kind 参照不要、PR/issue 共通の `#N` 表示)
- `pr-picker/registerPrCommand.ts` / `issue-picker/registerIssueCommand.ts` で `rpcTaskAdd` に `ghRef: { kind: GhRefKind.GH_REF_KIND_PR | _ISSUE, number }` を渡す

### test / docs

- `TaskStoreTests.swift` の `prNumber/issueNumber` sentinel を `ghRef` presence ベースに書き換え。PR テストは `hasGhRef` + `kind == .pr` + `number == 42` の 3 アサーションに分解
- `docs/task.md` のデータモデル / 削除判定 / ライフサイクル / RPC スキーマ / サイドバー UI 例を更新

## 今回含めない点

- **既存 `tasks.json` の migration**: 後方互換不要の方針 ( CLAUDE.md「後方互換性を作らない」) のため、proto JSON parser の unknown field silent drop に任せる。既存 task の PR/issue 番号プレフィックスは初期化される

## 確認事項

- [ ] PR から worktree 作成: `#N PR タイトル` がサイドバーに表示される
- [ ] Issue から worktree 作成: `#N issue タイトル` がサイドバーに表示される
- [ ] Claude 直接起動 (PR/issue 経由なし): task に `ghRef` 無しで作成され、`/exit` 後の自動削除が body / sessionID の状態に応じて正しく走る
- [ ] アプリ起動時の reconcile で dead session 付き orphan task が削除される
