### PR TITLE
feat(sidebar): サイドバートップに常駐時計を追加

### DIFF
--- a/apps/renderer/src/features/sidebar/SidebarClock.vue
+++ b/apps/renderer/src/features/sidebar/SidebarClock.vue
@@ -1,0 +1,75 @@
+<doc lang="md">
+サイドバートップに常駐する現在時刻表示。
+
+クラシック Mac メニューバーの時計を踏襲し、左にアナログ時計、右に HH:MM の
+24 時間表記デジタル時計を並べる。秒針 / 秒表示は持たず分単位で更新する。
+
+更新は分境界まで 1 回 setTimeout する adaptive 方式。1 秒ごとの polling を避け、
+表示が変わらない時間は wakeup しない。
+</doc>
+
+<script setup lang="ts">
+import { useTimeoutFn } from "@vueuse/core";
+import { computed, ref } from "vue";
+
+const formatter = new Intl.DateTimeFormat(undefined, {
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+});
+
+const now = ref(new Date());
+
+const MINUTE_MS = 60 * 1000;
+
+/** 次の分境界（次の :00 秒）までの ms */
+function msToNextMinute(d: Date): number {
+  return MINUTE_MS - (d.getSeconds() * 1000 + d.getMilliseconds());
+}
+
+const delay = ref(msToNextMinute(now.value));
+const { start, stop } = useTimeoutFn(
+  () => {
+    now.value = new Date();
+    delay.value = msToNextMinute(now.value);
+    stop();
+    start();
+  },
+  delay,
+  { immediate: true },
+);
+
+const display = computed(() => formatter.format(now.value));
+
+const minuteAngle = computed(() => now.value.getMinutes() * 6);
+const hourAngle = computed(() => (now.value.getHours() % 12) * 30 + now.value.getMinutes() * 0.5);
+</script>
+
+<template>
+  <div class="flex items-center gap-1.5 text-zinc-400">
+    <svg viewBox="-10 -10 20 20" class="size-4 shrink-0" role="img" aria-label="Analog clock">
+      <circle cx="0" cy="0" r="9" fill="none" stroke="currentColor" stroke-width="2" />
+      <line
+        x1="0"
+        y1="0"
+        x2="0"
+        y2="-4.5"
+        stroke="currentColor"
+        stroke-width="1"
+        stroke-linecap="round"
+        :transform="`rotate(${hourAngle})`"
+      />
+      <line
+        x1="0"
+        y1="0"
+        x2="0"
+        y2="-7"
+        stroke="currentColor"
+        stroke-width="1"
+        stroke-linecap="round"
+        :transform="`rotate(${minuteAngle})`"
+      />
+    </svg>
+    <span class="font-sans text-xs tabular-nums" aria-label="Current time">{{ display }}</span>
+  </div>
+</template>

--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -39,6 +39,7 @@ import { useWorktreeStore } from "../worktree";
 import { RepoSection } from "./features/repo";
 import { useWorktreeActions } from "./features/worktree";
 import ProjectConfigPanel from "./ProjectConfigPanel.vue";
+import SidebarClock from "./SidebarClock.vue";
 import SidebarMenu from "./SidebarMenu.vue";
 import { useDialogs } from "./useDialogs";
 import { useSidebarData } from "./useSidebarData";
@@ -197,23 +198,26 @@ const activeRootWorktree = computed(() => {
           <span class="icon-[lucide--bot] text-base" />
         </button>
       </div>
-      <button
-        type="button"
-        :aria-label="editMode ? 'Exit edit mode' : 'Edit repositories'"
-        :title="editMode ? 'Done' : 'Edit repositories'"
-        class="grid size-7 place-items-center rounded-sm transition-colors"
-        :class="
-          editMode
-            ? 'bg-blue-600 text-white hover:bg-blue-500'
-            : 'text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100'
-        "
-        @click="toggleEditMode"
-      >
-        <span
-          class="text-base"
-          :class="editMode ? 'icon-[lucide--check]' : 'icon-[lucide--pencil]'"
-        />
-      </button>
+      <div class="flex items-center gap-2">
+        <SidebarClock />
+        <button
+          type="button"
+          :aria-label="editMode ? 'Exit edit mode' : 'Edit repositories'"
+          :title="editMode ? 'Done' : 'Edit repositories'"
+          class="grid size-7 place-items-center rounded-sm transition-colors"
+          :class="
+            editMode
+              ? 'bg-blue-600 text-white hover:bg-blue-500'
+              : 'text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100'
+          "
+          @click="toggleEditMode"
+        >
+          <span
+            class="text-base"
+            :class="editMode ? 'icon-[lucide--check]' : 'icon-[lucide--pencil]'"
+          />
+        </button>
+      </div>
     </div>
 
     <div class="_sidebar-scroll flex flex-1 scrollbar-none flex-col overflow-y-auto py-4">


### PR DESCRIPTION
## 概要

サイドバートップに常駐の時計を追加する。アナログ時計（円 + 時針 / 分針）と HH:MM 表記のデジタル時計を並べ、編集ボタンの左側に配置する。

## 背景

作業に没頭すると時間の確認がしづらいという課題（ #395 ）。ターミナルや git graph に視線が固定されていても、サイドバー上端で時刻が読めるようにする。

クラシック Mac メニューバーの analog clock 流儀を踏襲する。実機スクリーンショットを観察した結果、装飾要素（12 時マーカー / 中心ピボット / 時針 / 分針の太さ差）は持たず、円 + 長さの異なる 2 本の針のみで構成されていることを確認したため、これに揃えている。

## 変更内容

### サイドバー時計コンポーネント追加

- `apps/renderer/src/features/sidebar/SidebarClock.vue` を新規作成
- アナログ時計は SVG（viewBox 中心原点）で実装。円のアウトラインと時針 (`y2=-4.5`) / 分針 (`y2=-7`) の 2 本のみ
- デジタル表示は `font-sans tabular-nums` の HH:MM。`0` に斜線が入らず幅が安定する組み合わせ
- 24 時間表記 (`hour12: false`)

### 更新スケジュール

- 秒表示を持たないため、1 秒 polling は使わず分境界まで 1 回 `setTimeout` する adaptive 方式（`useRelativeTime` と同形）
- `useTimeoutFn` の callback 内で `now` を更新し、次の分境界までの差分で再 schedule する

### SidebarPane への組み込み

- トップツールバーの右側、編集ボタンの左隣に配置（同一 flex group にまとめて右寄せ）

## 確認事項

- [ ] サイドバー上端に「アナログ時計 + HH:MM」が表示されること
- [ ] HH:MM が 1 分ごとに更新されること（秒は表示しない）
- [ ] 編集ボタンを押した際にレイアウトが崩れないこと
- [ ] 24 時 → 0 時の繰り上がりで表示が崩れないこと（hour modulo 12 で針の角度計算）
