### PR TITLE
fix(pty): hold parent slave fd to defeat tty flush-on-close race

### DIFF
--- a/apps/native/Sources/CPty/CPty.c
+++ b/apps/native/Sources/CPty/CPty.c
@@ -1,4 +1,5 @@
 #include "CPty.h"
+#include <errno.h>
 
 int gozd_pty_spawn(
     int *out_master,
@@ -22,7 +23,7 @@ int gozd_pty_spawn(
         close(master);
         close(slave);
         errno = err;
-        return -1;
+        return -2;
     }
 
     if (pid == 0) {
@@ -49,14 +50,32 @@ int gozd_pty_spawn(
         // 子側で master を閉じる。child は slave 側だけ持つ。
         close(master);
         // setsid + TIOCSCTTY + dup2(slave, 0/1/2) + close(slave > 2) を 1 呼び出しで行う。
-        // forkpty が内部で呼んでいるのと同じ標準ヘルパー。
-        login_tty(slave);
+        // forkpty が内部で呼んでいるのと同じ標準ヘルパー。失敗時は親が
+        // PTYExitReason.exited(code: 125) として観測できるよう専用 exit code で抜ける。
+        if (login_tty(slave) == -1) {
+            _exit(125);
+        }
 
         if (cwd != NULL) {
-            (void)chdir(cwd);
+            // chdir 失敗（権限なし / ENOENT / symlink 切れ等）を silent に握り潰すと、
+            // 子は親の cwd か `/` で execve に進み production で「想定外のディレクトリ
+            // で claude が起動して別 repo を見る」等の症状が出るが原因が観測できなく
+            // なる。専用 exit code で親に伝える。
+            if (chdir(cwd) != 0) {
+                _exit(124);
+            }
         }
         execve(executable, argv, envp);
-        _exit(127);
+        // execve 失敗時は errno に応じて POSIX shell 慣例の exit code に倒す。
+        // 親は exit code から失敗 syscall + 大まかな errno を判別できる。
+        switch (errno) {
+            case EACCES:
+                _exit(126);
+            case ENOENT:
+                _exit(127);
+            default:
+                _exit(123);
+        }
     }
 
     // parent

--- a/apps/native/Sources/CPty/CPty.c
+++ b/apps/native/Sources/CPty/CPty.c
@@ -1,1 +1,67 @@
 #include "CPty.h"
+
+int gozd_pty_spawn(
+    int *out_master,
+    int *out_slave,
+    pid_t *out_pid,
+    struct winsize *winsize_p,
+    const char *executable,
+    char *const argv[],
+    char *const envp[],
+    const char *cwd
+) {
+    int master = -1;
+    int slave = -1;
+    if (openpty(&master, &slave, NULL, NULL, winsize_p) == -1) {
+        return -1;
+    }
+
+    pid_t pid = fork();
+    if (pid == -1) {
+        int err = errno;
+        close(master);
+        close(slave);
+        errno = err;
+        return -1;
+    }
+
+    if (pid == 0) {
+        // child: async-signal-safe な C 呼び出しのみ。
+        //
+        // signal mask / disposition のクリーンアップ:
+        //
+        // - sigprocmask: 親が block している signal は execve を超えて子に継承され、
+        //   子側で SIG_DFL にしても delivery されない。swift test ランナーや
+        //   libdispatch worker は SIGHUP 等を block しているため明示的に空 mask に
+        //   戻さないと kill(SIGHUP) が効かない（spike で検証）。
+        // - signal(SIG_DFL): 親が SIG_IGN している signal も子側で default に戻す。
+        sigset_t empty_mask;
+        sigemptyset(&empty_mask);
+        sigprocmask(SIG_SETMASK, &empty_mask, NULL);
+
+        signal(SIGHUP, SIG_DFL);
+        signal(SIGINT, SIG_DFL);
+        signal(SIGQUIT, SIG_DFL);
+        signal(SIGTERM, SIG_DFL);
+        signal(SIGPIPE, SIG_DFL);
+        signal(SIGCHLD, SIG_DFL);
+
+        // 子側で master を閉じる。child は slave 側だけ持つ。
+        close(master);
+        // setsid + TIOCSCTTY + dup2(slave, 0/1/2) + close(slave > 2) を 1 呼び出しで行う。
+        // forkpty が内部で呼んでいるのと同じ標準ヘルパー。
+        login_tty(slave);
+
+        if (cwd != NULL) {
+            (void)chdir(cwd);
+        }
+        execve(executable, argv, envp);
+        _exit(127);
+    }
+
+    // parent
+    *out_master = master;
+    *out_slave = slave;
+    *out_pid = pid;
+    return 0;
+}

--- a/apps/native/Sources/CPty/include/CPty.h
+++ b/apps/native/Sources/CPty/include/CPty.h
@@ -7,7 +7,6 @@
 #include <unistd.h>
 #include <signal.h>
 #include <stdlib.h>
-#include <errno.h>
 
 // openpty + fork + login_tty + execve を 1 関数にまとめた wrapper（issue #544）。
 //
@@ -31,7 +30,20 @@
 //
 // 戻り値:
 //   - 0: 成功。out_master / out_slave / out_pid に値が入る。
-//   - -1: 失敗。errno が set される（openpty 失敗 / fork 失敗）。
+//   - -1: openpty 失敗（errno が set される）。
+//   - -2: fork 失敗（errno が set される）。
+//
+// 親プロセスは戻り値で openpty / fork のどちらが失敗したかを区別できる。errno のみ
+// では EAGAIN を openpty / fork 双方が返し得るため、syscall を取り違える。
+//
+// child 側で setup に失敗した場合は execve まで到達せず以下の exit code で抜ける。
+// 親は `PTYExitReason.exited(code: N)` から失敗段階を判別できる:
+//
+//   - 123: execve 失敗（EACCES / ENOENT 以外の errno、例: E2BIG / ENOEXEC）。
+//   - 124: chdir 失敗（指定 cwd へ移れない: 権限・存在しない・symlink 切れ等）。
+//   - 125: login_tty 失敗（PTY セットアップ失敗: setsid / TIOCSCTTY / dup2）。
+//   - 126: execve EACCES（POSIX 慣例: not executable）。
+//   - 127: execve ENOENT（POSIX 慣例: command not found）。
 int gozd_pty_spawn(
     int *out_master,
     int *out_slave,

--- a/apps/native/Sources/CPty/include/CPty.h
+++ b/apps/native/Sources/CPty/include/CPty.h
@@ -7,5 +7,40 @@
 #include <unistd.h>
 #include <signal.h>
 #include <stdlib.h>
+#include <errno.h>
+
+// openpty + fork + login_tty + execve を 1 関数にまとめた wrapper（issue #544）。
+//
+// 設計理由:
+//
+// 1. `fork(2)` は Darwin SDK で Swift から直接呼べない（unavailable とマークされている）。
+//    `forkpty(3)` は呼べるが、それを使うと「親側に slave fd を保持しない」設計になり、
+//    macOS xnu の tty driver の flush-on-close race（issue #544 / 過去 issue #450）で
+//    短命 child の最終出力が drop する。よって C bridge 経由で fork を呼ぶしかない。
+//
+// 2. 子側コードを C に隔離することで、Swift runtime / ARC に触れる可能性をゼロにする。
+//    fork 後の子側で async-signal-safe でない関数を呼ぶと未定義動作になるリスクがある。
+//
+// 3. `login_tty(3)` で setsid + TIOCSCTTY + dup2(slave, 0/1/2) + close(slave>2) を
+//    1 呼び出しで行う。これは forkpty が内部で呼んでいるのと同じ標準ヘルパー。
+//
+// 4. master fd は親が drain / write に使うため open のまま返す。slave fd も親が
+//    保持し続けてアンカーにする（child の `_exit` で tty reference が 0 にならない
+//    ようにし、ttyclose → ttyflush で pending output が drop されるのを防ぐ）。
+//    drain 完了後に親が明示的に slave を close する責務を持つ。
+//
+// 戻り値:
+//   - 0: 成功。out_master / out_slave / out_pid に値が入る。
+//   - -1: 失敗。errno が set される（openpty 失敗 / fork 失敗）。
+int gozd_pty_spawn(
+    int *out_master,
+    int *out_slave,
+    pid_t *out_pid,
+    struct winsize *winsize_p,
+    const char *executable,
+    char *const argv[],
+    char *const envp[],
+    const char *cwd
+);
 
 #endif

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -11,13 +11,11 @@ import Foundation
 //
 // 2. **read source の closure は self をキャプチャしない**。setEventHandler は
 //    `@Sendable () -> Void` を要求するため、non-Sendable self を捕まえると Swift 6.2
-//    strict concurrency 下でエラー。closure には `fd: Int32`、`onData: @Sendable`、
-//    `source` だけを渡し、EOF / read error 時は `source.cancel()` → cancelHandler の
-//    `close(fd)` で片付ける。
+//    strict concurrency 下でエラー。closure には `state: PTYFinishState`、`onData: @Sendable`、
+//    `source` だけを渡し、EOF / read error 時は `source.cancel()` → state 経由で fd close。
 //
-// 3. **fork 子側は C 呼び出しのみ**。`chdir / login_tty / execve / _exit` のみ使用。
-//    argv / envp / cwd / executable は呼び出し前に C 配列として確保し、親側で fork 後に
-//    free する（COW なので子に影響しない）。
+// 3. **fork 子側は C 呼び出しのみ**。CPty.c の `gozd_pty_spawn` にまとめ、Swift 側に
+//    子プロセスのコードは一切持たない。fork 後の async-signal-safe 違反の余地をゼロにする。
 //
 // 4. **kill は SIGHUP**。SIGTERM では interactive zsh が無視するため SIGHUP 固定
 //    （spike で検証）。
@@ -35,16 +33,17 @@ import Foundation
 //    tty reference は 0 にならず ttyclose が走らない。`waitpid` で child の死亡を
 //    確定し、master を drain し切ってから親が secondary fd を明示的に close すると
 //    ようやく tty が close される（その時点で read queue は空なので flush 対象なし）。
+//
+// 7. **fd 状態は PTYFinishState に集約する（SSOT）**。primary / secondary fd の保持・
+//    close 判定・write / resize / read source の close 後 race ガードを全て
+//    `PTYFinishState` で行う。PTYManager 側は fd 番号を直接保持せず、`state` 経由で
+//    操作する。close 後の操作は state 内 lock + フラグで silent に no-op に倒す。
 public final class PTYManager {
   public typealias DataHandler = @Sendable (Data) -> Void
   public typealias ExitHandler = @Sendable (PTYExitReason) -> Void
 
-  public private(set) var primaryFd: Int32 = -1
-  /// 親側で保持する slave (secondary) fd。`forkpty` 相当の child setup 後も
-  /// close せず維持することで、child `_exit` で tty reference が 0 になることを
-  /// 防ぐアンカー。exit handler が drain 完了後に明示的に close する。
-  public private(set) var secondaryFd: Int32 = -1
   public private(set) var pid: pid_t = -1
+  private var state: PTYFinishState?
   private var readSource: DispatchSourceRead?
   private var exitSource: DispatchSourceProcess?
 
@@ -121,16 +120,19 @@ public final class PTYManager {
       envp,
       cCwd
     )
-    if spawnRet == -1 {
-      // openpty か fork のいずれかが失敗。errno で見分けがつく
-      // （openpty は ENOENT / ENXIO / EAGAIN 等、fork は EAGAIN / ENOMEM 等）。
+    // gozd_pty_spawn 戻り値: 0=成功 / -1=openpty 失敗 / -2=fork 失敗。
+    // errno のみで判別すると EAGAIN を openpty / fork 双方が返し得るため取り違える。
+    // 戻り値で syscall を確実に区別する。
+    if spawnRet != 0 {
       let err = errno
       freeCStrings(argEntries, envEntries, cExecutable, cCwd, argv, envp)
-      throw PTYError.spawnFailed(errno: err)
+      switch spawnRet {
+      case -1: throw PTYError.openptyFailed(errno: err)
+      case -2: throw PTYError.forkFailed(errno: err)
+      default: throw PTYError.spawnFailed(errno: err)
+      }
     }
 
-    primaryFd = masterFd
-    secondaryFd = slaveFd
     pid = childPid
     ptyTrace(
       "spawn", pid: childPid,
@@ -162,18 +164,18 @@ public final class PTYManager {
     // が両方揃ってから onExit を 1 度だけ呼ぶ）で「onExit は drain 済みを意味する」契約に揃える。
     let queue = DispatchQueue(label: "io.github.miyaoka.gozd.PTYManager.\(childPid)")
     let state = PTYFinishState(primaryFd: masterFd, secondaryFd: slaveFd)
+    self.state = state
 
-    let fd = masterFd  // closure キャプチャ用エイリアス（既存コードの可読性維持）
     let source = DispatchSource.makeReadSource(
-      fileDescriptor: fd,
+      fileDescriptor: masterFd,
       queue: queue
     )
     // self をキャプチャしないことで Sendable closure 制約を満たす。
     // 単発 read だと「event 1 回で data + EOF が同時に観測される」ケースで data を取りこぼす
     // 可能性があり、event coalescing による flaky の温床になる。drain loop で吸い切る。
-    source.setEventHandler { [source] in
+    source.setEventHandler { [source, state] in
       ptyTrace("read", pid: childPid, "eventHandler fired")
-      switch drainPTY(fd: fd, pid: childPid, caller: "read-source", onData: onData) {
+      switch drainPTY(fd: masterFd, pid: childPid, caller: "read-source", onData: onData) {
       case .drained:
         return
       case .closed:
@@ -182,8 +184,8 @@ public final class PTYManager {
         state.markReadClosed(pid: childPid, onComplete: onExit)
       }
     }
-    // 注意: ここで close(fd) を呼ばない。exit handler 側の final drain が fd を読むため、
-    // close は `PTYFinishState.tryFinish` の completion 時に 1 度だけ実行する。
+    // 注意: ここで close(masterFd) を呼ばない。exit handler 側の final drain が fd を読むため、
+    // close は `PTYFinishState` が finish 完了時に 1 度だけ実行する。
     source.resume()
     ptyTrace("spawn", pid: childPid, "read source resumed")
     readSource = source
@@ -194,12 +196,12 @@ public final class PTYManager {
       eventMask: .exit,
       queue: queue
     )
-    exit.setEventHandler { [exit, source] in
+    exit.setEventHandler { [exit, source, state] in
       ptyTrace("exit", pid: childPid, "eventHandler fired (pre-waitpid drain)")
       // exit event と read readiness の到着順に依存しないよう、waitpid 前にも drain する。
       // 親側で slave fd を保持しているため、この段階では EOF は来ない（EAGAIN が期待値）が、
       // child の死亡前に書かれた bytes は読める。
-      _ = drainPTY(fd: fd, pid: childPid, caller: "exit-pre", onData: onData)
+      _ = drainPTY(fd: masterFd, pid: childPid, caller: "exit-pre", onData: onData)
 
       // process source の exit handler 内では子は zombie 確定。`WNOHANG` を使うと
       // 戻り値 0（reap 未完）と exit code 0 の区別が曖昧になるため、blocking
@@ -227,19 +229,27 @@ public final class PTYManager {
 
       // waitpid 直後にもう一度 drain。child の最終 write は kernel buffer まで届いており、
       // 親保持の slave fd のおかげで ttyflush で消されていない。ここで master を吸い切る。
-      _ = drainPTY(fd: fd, pid: childPid, caller: "exit-post-waitpid", onData: onData)
+      _ = drainPTY(fd: masterFd, pid: childPid, caller: "exit-post-waitpid", onData: onData)
 
       // ここで親側の slave fd を close する。tty reference が 0 になり ttyclose →
       // ttyflush が走るが、read queue は drain 済みなので flush 対象は空。
       // 直後の master read で EOF が観測できるようになる。
       state.closeSecondary(pid: childPid)
 
-      // final drain: slave close 後の EOF を観測して finish に進める。read source 側でも
-      // EOF event が拾える経路を残しているが、ここで確定させる方が race window が狭い。
-      if case .closed = drainPTY(fd: fd, pid: childPid, caller: "exit-final", onData: onData) {
+      // **正規 finish 経路**: secondary close 後に final drain で EOF を取って markReadClosed。
+      // ここで `.drained` (EAGAIN) になるケースは、tty hangup の伝播より早く drain を
+      // 呼んだ場合のみ。その場合は **read source 側が二重防御**として残っており、kqueue
+      // が EOF を dispatch すると read-source event handler で markReadClosed が走る。
+      // どちらの経路でも `PTYFinishState` が `finished` フラグで 1 度だけの finish を保証する。
+      if case .closed = drainPTY(fd: masterFd, pid: childPid, caller: "exit-final", onData: onData)
+      {
         ptyTrace("exit", pid: childPid, "final-drain → .closed → cancel + markReadClosed")
         source.cancel()
         state.markReadClosed(pid: childPid, onComplete: onExit)
+      } else {
+        ptyTrace(
+          "exit", pid: childPid,
+          "final-drain → .drained → defer markReadClosed to read-source fallback")
       }
 
       state.setExitReason(exitReason, pid: childPid, onComplete: onExit)
@@ -255,36 +265,38 @@ public final class PTYManager {
   /// `write(2)` は短いバッファでも部分書き込みが起き得る（特に大きな paste や
   /// 連続入力）。全バイト書き切るまで loop し、`EINTR` は retry、`EAGAIN` /
   /// `EWOULDBLOCK` は短い sleep で待つ。`EPIPE` 等の致命的 errno は諦める。
+  /// state 経由で書き込むことで、close 後 race で EBADF / 別 fd 誤書き込みを防ぐ。
   public func write(_ data: Data) {
-    guard primaryFd >= 0 else { return }
+    guard let state else { return }
     data.withUnsafeBytes { buffer in
       guard let base = buffer.baseAddress else { return }
       let total = buffer.count
       var written = 0
       while written < total {
-        let n = Darwin.write(primaryFd, base.advanced(by: written), total - written)
-        if n > 0 {
+        let result = state.write(base.advanced(by: written), len: total - written)
+        switch result {
+        case .closed:
+          return
+        case .wrote(let n):
           written += n
-          continue
+        case .retry(let err):
+          if err == EAGAIN || err == EWOULDBLOCK {
+            // PTY master は通常 blocking だが、念のため 1ms 待って retry。
+            // busy-loop 暴走を避ける。
+            usleep(1_000)
+            continue
+          }
+          // EINTR は即時 retry
+          if err == EINTR { continue }
+          return
         }
-        let err = errno
-        if err == EINTR { continue }
-        if err == EAGAIN || err == EWOULDBLOCK {
-          // PTY master は通常 blocking だが、念のため 1ms 待って retry。
-          // busy-loop 暴走を避ける。
-          usleep(1_000)
-          continue
-        }
-        return
       }
     }
   }
 
   /// terminal サイズを子プロセスに通知する（xterm.js のリサイズ連動）。
   public func resize(rows: UInt16, cols: UInt16) {
-    guard primaryFd >= 0 else { return }
-    var ws = winsize(ws_row: rows, ws_col: cols, ws_xpixel: 0, ws_ypixel: 0)
-    _ = ioctl(primaryFd, TIOCSWINSZ, &ws)
+    state?.resize(rows: rows, cols: cols)
   }
 
   /// 子プロセスに SIGHUP を送る。SIGTERM は interactive zsh が無視するため不可。
@@ -295,7 +307,11 @@ public final class PTYManager {
 }
 
 public enum PTYError: Error, Equatable {
-  /// `gozd_pty_spawn`（openpty + fork）の失敗。errno で内訳判別する。
+  /// `openpty(3)` の失敗（C bridge 戻り値 -1）。
+  case openptyFailed(errno: Int32)
+  /// `fork(2)` の失敗（C bridge 戻り値 -2）。
+  case forkFailed(errno: Int32)
+  /// 想定外の戻り値（fallback）。通常到達しない。
   case spawnFailed(errno: Int32)
   /// spawn 前段の strdup などで OOM 検出した場合。spawn syscall 自体は呼ばれていないので
   /// `spawnFailed` を流用すると上位 log で失敗 syscall を取り違える。
@@ -326,22 +342,35 @@ public enum PTYExitReason: Sendable, Equatable {
   }
 }
 
-/// `PTYManager.spawn` の readSource / exitSource ハンドラ間で共有する終了確定状態。
+/// `PTYFinishState.write` の戻り値。
+/// 旧来の `Int` 戻り値 + `errno` 経由通知より明示的にする。
+enum PTYWriteResult {
+  /// `n` バイト書き込めた（partial / full）。
+  case wrote(Int)
+  /// EINTR / EAGAIN / EWOULDBLOCK。`errno` を含める。呼び出し側が retry / sleep を判断する。
+  case retry(Int32)
+  /// fd は close 済み、または致命的 errno（EBADF / EPIPE 等）。呼び出し側は書き込みを諦める。
+  case closed
+}
+
+/// `PTYManager.spawn` の readSource / exitSource ハンドラ間で共有する終了確定状態 + fd 所有者。
 /// 両ハンドラは同じ per-PTY serial queue に載っており、queue 自体が直列化を保証する。
 /// それでも `@Sendable` クロージャに reference 型をキャプチャする以上、
 /// Swift 6.2 の strict concurrency が Sendable を要求するため `@unchecked Sendable` を
 /// 付ける。NSLock を併用して値変更を atomic にし、queue 直列化と二重防御にする。
 ///
+/// **SSOT**: primary (master) / secondary (slave) fd の保持・close 判定・write / resize の
+/// race ガードを全てここで行う。`PTYManager` 側は fd 番号を持たず、本 state 経由で操作する。
+/// これにより close 後に write が EBADF / 別 fd 誤書き込みするレースを防ぐ。
+///
 /// finish の意味は「readClosed && exitReason」の両方が揃った時で、その時に 1 度だけ
-/// `onComplete(reason)` を呼び、`primaryFd` を close する。fd close をここに集約する
-/// ことで、readSource cancel と exit handler の final drain が同 fd を競合 close する
-/// 事故を避ける。
+/// `onComplete(reason)` を呼び、`primaryFd` を close する。
 ///
 /// `secondaryFd` は親側で保持する slave fd。child の `_exit` で tty reference が 0 に
 /// なって ttyflush で出力が drop するのを防ぐアンカー（issue #544 / 方針 A）。
 /// `closeSecondary` で exit handler が drain 済みのタイミングで close する。leak を防ぐ
-/// ため `deinit` でも未 close なら close する。
-private final class PTYFinishState: @unchecked Sendable {
+/// ため `deinit` でも未 close なら state 経由で close する（lock + フラグで double close 防ぐ）。
+final class PTYFinishState: @unchecked Sendable {
   private let lock = NSLock()
   private let primaryFd: Int32
   private let secondaryFd: Int32
@@ -368,13 +397,38 @@ private final class PTYFinishState: @unchecked Sendable {
   /// ttyclose → ttyflush を起こす。drain 済みのタイミングで呼べば flush 対象は空。
   func closeSecondary(pid: Int32 = 0) {
     lock.lock()
-    let already = secondaryClosed
-    if !secondaryClosed {
+    let closedNow = !secondaryClosed
+    if closedNow {
       secondaryClosed = true
       close(secondaryFd)
     }
     lock.unlock()
-    ptyTrace("fin", pid: pid, "closeSecondary fd=\(secondaryFd) already=\(already)")
+    ptyTrace("fin", pid: pid, "closeSecondary fd=\(secondaryFd) closed-now=\(closedNow)")
+  }
+
+  /// `PTYManager.write` から呼ぶ writer。close 済みなら `.closed` を返す。
+  /// EAGAIN / EINTR / EWOULDBLOCK は `.retry(errno)`、それ以外の致命的 errno は `.closed` に
+  /// 倒す（write 経路で EBADF を観測したら以後の write は意味が無い）。
+  func write(_ ptr: UnsafeRawPointer, len: Int) -> PTYWriteResult {
+    lock.lock()
+    defer { lock.unlock() }
+    if primaryClosed { return .closed }
+    let n = Darwin.write(primaryFd, ptr, len)
+    if n > 0 { return .wrote(n) }
+    let err = errno
+    if err == EINTR || err == EAGAIN || err == EWOULDBLOCK {
+      return .retry(err)
+    }
+    return .closed
+  }
+
+  /// terminal サイズ通知。close 済みなら no-op。
+  func resize(rows: UInt16, cols: UInt16) {
+    lock.lock()
+    defer { lock.unlock() }
+    if primaryClosed { return }
+    var ws = winsize(ws_row: rows, ws_col: cols, ws_xpixel: 0, ws_ypixel: 0)
+    _ = ioctl(primaryFd, TIOCSWINSZ, &ws)
   }
 
   func markReadClosed(pid: Int32 = 0, onComplete: (PTYExitReason) -> Void) {
@@ -416,13 +470,17 @@ private final class PTYFinishState: @unchecked Sendable {
   }
 
   /// PTYManager が finish 前に解放された場合の保険。double close は各フラグで防ぐ。
+  /// `deinit` は ARC 経由で任意の thread から呼ばれ得るため、lock を取って flag を見て
+  /// から close する（直接 close すると finish 経路と double close の余地が残る）。
   deinit {
-    if !primaryClosed {
-      close(primaryFd)
-    }
-    if !secondaryClosed {
-      close(secondaryFd)
-    }
+    lock.lock()
+    let primaryNeedsClose = !primaryClosed
+    let secondaryNeedsClose = !secondaryClosed
+    if primaryNeedsClose { primaryClosed = true }
+    if secondaryNeedsClose { secondaryClosed = true }
+    lock.unlock()
+    if primaryNeedsClose { close(primaryFd) }
+    if secondaryNeedsClose { close(secondaryFd) }
   }
 }
 

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -421,40 +421,38 @@ final class PTYFinishState: @unchecked Sendable {
   ///
   /// trace は lock 開放後に出す。`ptyTrace` は内部で別 lock を取るため、`PTYFinishState.lock`
   /// を保持したまま呼ぶと潜在的なロック順序違反になる（closeSecondary も同じ形を採用）。
+  /// lock 内本処理は `writeLocked` に切り出し、本関数は lock + 呼び出し + unlock + trace の
+  /// フラットな構造に保つ（CLAUDE.md「if-else の分岐は関数に切り出す」）。
   func write(_ ptr: UnsafeRawPointer, len: Int) -> PTYWriteResult {
     lock.lock()
-    let result: PTYWriteResult
-    let traceMessage: String?
-    if primaryClosed {
-      result = .closed
-      traceMessage = nil
-    } else {
-      let n = Darwin.write(primaryFd, ptr, len)
-      if n > 0 {
-        result = .wrote(n)
-        traceMessage = nil
-      } else if n == 0 {
-        // POSIX 上 write が 0 を返すのは未定義。観測できるよう trace に残す。
-        result = .closed
-        traceMessage =
-          "Darwin.write returned 0 (POSIX undefined) fd=\(primaryFd) len=\(len) → closed"
-      } else {
-        let err = errno
-        if err == EINTR || err == EAGAIN || err == EWOULDBLOCK {
-          result = .retry(err)
-          traceMessage = nil
-        } else {
-          // EBADF / EPIPE / EIO 等の致命的 errno。caller 側で観測できないため trace を残す。
-          result = .closed
-          traceMessage = "fatal errno=\(err) fd=\(primaryFd) len=\(len) → closed"
-        }
-      }
-    }
+    let (result, traceMessage) = writeLocked(ptr, len: len)
     lock.unlock()
     if let traceMessage {
       ptyTrace("write", pid: pid, traceMessage)
     }
     return result
+  }
+
+  /// `write` の lock 保持中処理。早期 return で if-else ネストを潰すため切り出した。
+  /// 戻り値の 2 要素目は trace に残すべきメッセージ（nil なら trace 出力なし）。
+  /// 呼び出し側で lock を取得済みであること。
+  private func writeLocked(_ ptr: UnsafeRawPointer, len: Int) -> (PTYWriteResult, String?) {
+    if primaryClosed { return (.closed, nil) }
+    let n = Darwin.write(primaryFd, ptr, len)
+    if n > 0 { return (.wrote(n), nil) }
+    if n == 0 {
+      // POSIX 上 write が 0 を返すのは未定義。観測できるよう trace に残す。
+      return (
+        .closed,
+        "Darwin.write returned 0 (POSIX undefined) fd=\(primaryFd) len=\(len) → closed"
+      )
+    }
+    let err = errno
+    if err == EINTR || err == EAGAIN || err == EWOULDBLOCK {
+      return (.retry(err), nil)
+    }
+    // EBADF / EPIPE / EIO 等の致命的 errno。caller 側で観測できないため trace を残す。
+    return (.closed, "fatal errno=\(err) fd=\(primaryFd) len=\(len) → closed")
   }
 
   /// terminal サイズ通知。close 済みなら no-op。

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -42,7 +42,9 @@ public final class PTYManager {
   public typealias DataHandler = @Sendable (Data) -> Void
   public typealias ExitHandler = @Sendable (PTYExitReason) -> Void
 
-  public private(set) var pid: pid_t = -1
+  // `PTYRegistry.spawn` が `pidTracker.add(pty.pid)` で参照するため internal は必要。
+  // モジュール外には露出しない（暗黙的 internal）。
+  private(set) var pid: pid_t = -1
   private var state: PTYFinishState?
   private var readSource: DispatchSourceRead?
   private var exitSource: DispatchSourceProcess?
@@ -123,13 +125,16 @@ public final class PTYManager {
     // gozd_pty_spawn 戻り値: 0=成功 / -1=openpty 失敗 / -2=fork 失敗。
     // errno のみで判別すると EAGAIN を openpty / fork 双方が返し得るため取り違える。
     // 戻り値で syscall を確実に区別する。
+    // 0/-1/-2 以外は C bridge 側のバグなので `fatalError` で即座に落とす。
+    // 「想定外なら fallback enum で握り潰す」設計だと観察可能性を失う。
     if spawnRet != 0 {
       let err = errno
       freeCStrings(argEntries, envEntries, cExecutable, cCwd, argv, envp)
       switch spawnRet {
       case -1: throw PTYError.openptyFailed(errno: err)
       case -2: throw PTYError.forkFailed(errno: err)
-      default: throw PTYError.spawnFailed(errno: err)
+      default:
+        fatalError("gozd_pty_spawn returned unexpected code: \(spawnRet) (errno: \(err))")
       }
     }
 
@@ -311,10 +316,8 @@ public enum PTYError: Error, Equatable {
   case openptyFailed(errno: Int32)
   /// `fork(2)` の失敗（C bridge 戻り値 -2）。
   case forkFailed(errno: Int32)
-  /// 想定外の戻り値（fallback）。通常到達しない。
-  case spawnFailed(errno: Int32)
   /// spawn 前段の strdup などで OOM 検出した場合。spawn syscall 自体は呼ばれていないので
-  /// `spawnFailed` を流用すると上位 log で失敗 syscall を取り違える。
+  /// `openptyFailed` / `forkFailed` を流用すると上位 log で失敗 syscall を取り違える。
   case preforkAllocFailed(errno: Int32)
 }
 
@@ -408,17 +411,29 @@ final class PTYFinishState: @unchecked Sendable {
 
   /// `PTYManager.write` から呼ぶ writer。close 済みなら `.closed` を返す。
   /// EAGAIN / EINTR / EWOULDBLOCK は `.retry(errno)`、それ以外の致命的 errno は `.closed` に
-  /// 倒す（write 経路で EBADF を観測したら以後の write は意味が無い）。
+  /// 倒す（write 経路で EBADF / EPIPE / EIO を観測したら以後の write は意味が無い）。
+  /// 致命的 errno と `n == 0`（POSIX 上未定義動作）は `ptyTrace` で観測可能に残す。
+  /// silent に `.closed` に倒すと「write が永続的に何も書かなくなった」事象を後追いできない。
   func write(_ ptr: UnsafeRawPointer, len: Int) -> PTYWriteResult {
     lock.lock()
     defer { lock.unlock() }
     if primaryClosed { return .closed }
     let n = Darwin.write(primaryFd, ptr, len)
     if n > 0 { return .wrote(n) }
+    if n == 0 {
+      // POSIX 上 write が 0 を返すのは未定義。観測できるよう trace に残す。
+      ptyTrace(
+        "write",
+        "Darwin.write returned 0 (POSIX undefined) fd=\(primaryFd) len=\(len) → closed")
+      return .closed
+    }
     let err = errno
     if err == EINTR || err == EAGAIN || err == EWOULDBLOCK {
       return .retry(err)
     }
+    // EBADF / EPIPE / EIO 等の致命的 errno。caller 側で観測できないため trace を残す。
+    ptyTrace(
+      "write", "fatal errno=\(err) fd=\(primaryFd) len=\(len) → closed")
     return .closed
   }
 

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -168,7 +168,7 @@ public final class PTYManager {
     // 落ちる（onExit 後に onData が来る race）。同 queue + ガード（readClosed && exitReason
     // が両方揃ってから onExit を 1 度だけ呼ぶ）で「onExit は drain 済みを意味する」契約に揃える。
     let queue = DispatchQueue(label: "io.github.miyaoka.gozd.PTYManager.\(childPid)")
-    let state = PTYFinishState(primaryFd: masterFd, secondaryFd: slaveFd)
+    let state = PTYFinishState(primaryFd: masterFd, secondaryFd: slaveFd, pid: childPid)
     self.state = state
 
     let source = DispatchSource.makeReadSource(
@@ -186,7 +186,7 @@ public final class PTYManager {
       case .closed:
         ptyTrace("read", pid: childPid, "drain → .closed → cancel + markReadClosed")
         source.cancel()
-        state.markReadClosed(pid: childPid, onComplete: onExit)
+        state.markReadClosed(onComplete: onExit)
       }
     }
     // 注意: ここで close(masterFd) を呼ばない。exit handler 側の final drain が fd を読むため、
@@ -239,7 +239,7 @@ public final class PTYManager {
       // ここで親側の slave fd を close する。tty reference が 0 になり ttyclose →
       // ttyflush が走るが、read queue は drain 済みなので flush 対象は空。
       // 直後の master read で EOF が観測できるようになる。
-      state.closeSecondary(pid: childPid)
+      state.closeSecondary()
 
       // **正規 finish 経路**: secondary close 後に final drain で EOF を取って markReadClosed。
       // ここで `.drained` (EAGAIN) になるケースは、tty hangup の伝播より早く drain を
@@ -250,14 +250,14 @@ public final class PTYManager {
       {
         ptyTrace("exit", pid: childPid, "final-drain → .closed → cancel + markReadClosed")
         source.cancel()
-        state.markReadClosed(pid: childPid, onComplete: onExit)
+        state.markReadClosed(onComplete: onExit)
       } else {
         ptyTrace(
           "exit", pid: childPid,
           "final-drain → .drained → defer markReadClosed to read-source fallback")
       }
 
-      state.setExitReason(exitReason, pid: childPid, onComplete: onExit)
+      state.setExitReason(exitReason, onComplete: onExit)
       exit.cancel()
     }
     exit.resume()
@@ -377,15 +377,19 @@ final class PTYFinishState: @unchecked Sendable {
   private let lock = NSLock()
   private let primaryFd: Int32
   private let secondaryFd: Int32
+  /// trace ログの pid タグに使う。caller 側で毎回引数で渡す重複を排除し、各 trace 行
+  /// （write 含む）で同一の pid が出力される一貫性を保証する。
+  private let pid: Int32
   private var readClosed = false
   private var exitReason: PTYExitReason?
   private var finished = false
   private var primaryClosed = false
   private var secondaryClosed = false
 
-  init(primaryFd: Int32, secondaryFd: Int32) {
+  init(primaryFd: Int32, secondaryFd: Int32, pid: Int32) {
     self.primaryFd = primaryFd
     self.secondaryFd = secondaryFd
+    self.pid = pid
   }
 
   /// primary (master) fd を 1 度だけ close する。lock 保持の前提で呼ぶ。
@@ -398,7 +402,7 @@ final class PTYFinishState: @unchecked Sendable {
 
   /// secondary (slave) fd を 1 度だけ close する。tty の最後の reference を release し、
   /// ttyclose → ttyflush を起こす。drain 済みのタイミングで呼べば flush 対象は空。
-  func closeSecondary(pid: Int32 = 0) {
+  func closeSecondary() {
     lock.lock()
     let closedNow = !secondaryClosed
     if closedNow {
@@ -414,27 +418,43 @@ final class PTYFinishState: @unchecked Sendable {
   /// 倒す（write 経路で EBADF / EPIPE / EIO を観測したら以後の write は意味が無い）。
   /// 致命的 errno と `n == 0`（POSIX 上未定義動作）は `ptyTrace` で観測可能に残す。
   /// silent に `.closed` に倒すと「write が永続的に何も書かなくなった」事象を後追いできない。
+  ///
+  /// trace は lock 開放後に出す。`ptyTrace` は内部で別 lock を取るため、`PTYFinishState.lock`
+  /// を保持したまま呼ぶと潜在的なロック順序違反になる（closeSecondary も同じ形を採用）。
   func write(_ ptr: UnsafeRawPointer, len: Int) -> PTYWriteResult {
     lock.lock()
-    defer { lock.unlock() }
-    if primaryClosed { return .closed }
-    let n = Darwin.write(primaryFd, ptr, len)
-    if n > 0 { return .wrote(n) }
-    if n == 0 {
-      // POSIX 上 write が 0 を返すのは未定義。観測できるよう trace に残す。
-      ptyTrace(
-        "write",
-        "Darwin.write returned 0 (POSIX undefined) fd=\(primaryFd) len=\(len) → closed")
-      return .closed
+    let result: PTYWriteResult
+    let traceMessage: String?
+    if primaryClosed {
+      result = .closed
+      traceMessage = nil
+    } else {
+      let n = Darwin.write(primaryFd, ptr, len)
+      if n > 0 {
+        result = .wrote(n)
+        traceMessage = nil
+      } else if n == 0 {
+        // POSIX 上 write が 0 を返すのは未定義。観測できるよう trace に残す。
+        result = .closed
+        traceMessage =
+          "Darwin.write returned 0 (POSIX undefined) fd=\(primaryFd) len=\(len) → closed"
+      } else {
+        let err = errno
+        if err == EINTR || err == EAGAIN || err == EWOULDBLOCK {
+          result = .retry(err)
+          traceMessage = nil
+        } else {
+          // EBADF / EPIPE / EIO 等の致命的 errno。caller 側で観測できないため trace を残す。
+          result = .closed
+          traceMessage = "fatal errno=\(err) fd=\(primaryFd) len=\(len) → closed"
+        }
+      }
     }
-    let err = errno
-    if err == EINTR || err == EAGAIN || err == EWOULDBLOCK {
-      return .retry(err)
+    lock.unlock()
+    if let traceMessage {
+      ptyTrace("write", pid: pid, traceMessage)
     }
-    // EBADF / EPIPE / EIO 等の致命的 errno。caller 側で観測できないため trace を残す。
-    ptyTrace(
-      "write", "fatal errno=\(err) fd=\(primaryFd) len=\(len) → closed")
-    return .closed
+    return result
   }
 
   /// terminal サイズ通知。close 済みなら no-op。
@@ -446,7 +466,7 @@ final class PTYFinishState: @unchecked Sendable {
     _ = ioctl(primaryFd, TIOCSWINSZ, &ws)
   }
 
-  func markReadClosed(pid: Int32 = 0, onComplete: (PTYExitReason) -> Void) {
+  func markReadClosed(onComplete: (PTYExitReason) -> Void) {
     lock.lock()
     let alreadyReadClosed = readClosed
     readClosed = true
@@ -466,7 +486,7 @@ final class PTYFinishState: @unchecked Sendable {
   }
 
   func setExitReason(
-    _ reason: PTYExitReason, pid: Int32 = 0, onComplete: (PTYExitReason) -> Void
+    _ reason: PTYExitReason, onComplete: (PTYExitReason) -> Void
   ) {
     lock.lock()
     exitReason = reason

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -2,7 +2,7 @@ import CPty
 import Darwin
 import Foundation
 
-// forkpty + DispatchSourceRead をラップする PTY マネージャー。
+// openpty + fork + login_tty + DispatchSourceRead をラップする PTY マネージャー。
 //
 // 設計判断（spike `gozd-spike` で検証済み）:
 //
@@ -15,20 +15,35 @@ import Foundation
 //    `source` だけを渡し、EOF / read error 時は `source.cancel()` → cancelHandler の
 //    `close(fd)` で片付ける。
 //
-// 3. **fork 子側は C 呼び出しのみ**。`chdir / execve / _exit` のみ使用。argv / envp /
-//    cwd / executable は呼び出し前に C 配列として確保し、親側で fork 後に free する
-//    （COW なので子に影響しない）。
+// 3. **fork 子側は C 呼び出しのみ**。`chdir / login_tty / execve / _exit` のみ使用。
+//    argv / envp / cwd / executable は呼び出し前に C 配列として確保し、親側で fork 後に
+//    free する（COW なので子に影響しない）。
 //
 // 4. **kill は SIGHUP**。SIGTERM では interactive zsh が無視するため SIGHUP 固定
 //    （spike で検証）。
 //
 // 5. **waitpid status decode は手動**。`WIFEXITED` 等の C マクロは Swift から不可視
 //    のため、ビット演算で `.exited / .signaled / .stopped` を判別する。
+//
+// 6. **forkpty ではなく openpty + fork を使い、親側で slave fd を保持する**（issue #544）。
+//    macOS xnu の tty driver は tty の最後の reference が release されると `ttyclose`
+//    → `ttyflush(FREAD|FWRITE)` で **pending output queue を破棄** する。`/bin/echo`
+//    のような ms 未満で `_exit` する child では、master fd が kqueue 経由で
+//    `EVFILT_READ` を dispatch する前に slave 全 close（child の 3 references が
+//    `_exit` で同時に drop）→ tty flush で 7 bytes が消える race が発生する。
+//    親側で slave fd を 1 reference 持ち続けるアンカーを置けば、child `_exit` 後も
+//    tty reference は 0 にならず ttyclose が走らない。`waitpid` で child の死亡を
+//    確定し、master を drain し切ってから親が secondary fd を明示的に close すると
+//    ようやく tty が close される（その時点で read queue は空なので flush 対象なし）。
 public final class PTYManager {
   public typealias DataHandler = @Sendable (Data) -> Void
   public typealias ExitHandler = @Sendable (PTYExitReason) -> Void
 
   public private(set) var primaryFd: Int32 = -1
+  /// 親側で保持する slave (secondary) fd。`forkpty` 相当の child setup 後も
+  /// close せず維持することで、child `_exit` で tty reference が 0 になることを
+  /// 防ぐアンカー。exit handler が drain 完了後に明示的に close する。
+  public private(set) var secondaryFd: Int32 = -1
   public private(set) var pid: pid_t = -1
   private var readSource: DispatchSourceRead?
   private var exitSource: DispatchSourceProcess?
@@ -88,51 +103,38 @@ public final class PTYManager {
       throw PTYError.preforkAllocFailed(errno: ENOMEM)
     }
 
+    // openpty + fork + login_tty + execve を C 側にまとめて隔離する（CPty.c）。
+    // `fork(2)` は Darwin SDK で Swift から直接呼べないため、C bridge 経由で呼ぶ必要が
+    // ある。同時に、子側コードを完全に C に置くことで Swift runtime / ARC に触れる
+    // 可能性をゼロにする。
     var ws = winsize(ws_row: rows, ws_col: cols, ws_xpixel: 0, ws_ypixel: 0)
-    var fd: Int32 = -1
-    let childPid = forkpty(&fd, nil, nil, &ws)
-
-    if childPid == -1 {
+    var masterFd: Int32 = -1
+    var slaveFd: Int32 = -1
+    var childPid: pid_t = -1
+    let spawnRet = gozd_pty_spawn(
+      &masterFd,
+      &slaveFd,
+      &childPid,
+      &ws,
+      cExecutable,
+      argv,
+      envp,
+      cCwd
+    )
+    if spawnRet == -1 {
+      // openpty か fork のいずれかが失敗。errno で見分けがつく
+      // （openpty は ENOENT / ENXIO / EAGAIN 等、fork は EAGAIN / ENOMEM 等）。
       let err = errno
       freeCStrings(argEntries, envEntries, cExecutable, cCwd, argv, envp)
-      throw PTYError.forkptyFailed(errno: err)
+      throw PTYError.spawnFailed(errno: err)
     }
 
-    if childPid == 0 {
-      // 子側: Swift heap / ARC に触れない。C 呼び出しのみ。
-      //
-      // fork-exec 標準衛生（POSIX 系の shell / spawner 全般がやっている）:
-      //
-      // (1) signal mask をクリア。
-      //     `man 2 execve`: 「Blocked signals remain blocked regardless of changes to
-      //     the signal action.」 → 親が sigprocmask で block している signal は
-      //     execve を超えて子に継承され、子側で SIG_DFL にしても delivery されない。
-      //     swift test ランナー / libdispatch worker は SIGHUP 等を block しているため、
-      //     ここで明示的に空 mask に戻さないと kill(SIGHUP) が効かない。
-      //
-      // (2) signal disposition を SIG_DFL に戻す。
-      //     `man 2 execve`: 「Signals set to be ignored in the calling process are
-      //     set to be ignored in the new process.」 → SIG_IGN は execve でも継承される。
-      //     親が SIG_IGN している signal も子側で default に戻す。
-      var emptyMask = sigset_t()
-      sigemptyset(&emptyMask)
-      sigprocmask(SIG_SETMASK, &emptyMask, nil)
-
-      signal(SIGHUP, SIG_DFL)
-      signal(SIGINT, SIG_DFL)
-      signal(SIGQUIT, SIG_DFL)
-      signal(SIGTERM, SIG_DFL)
-      signal(SIGPIPE, SIG_DFL)
-      signal(SIGCHLD, SIG_DFL)
-
-      chdir(cCwd)
-      execve(cExecutable, argv, envp)
-      _exit(127)
-    }
-
-    primaryFd = fd
+    primaryFd = masterFd
+    secondaryFd = slaveFd
     pid = childPid
-    ptyTrace("spawn", pid: childPid, "forkpty returned fd=\(fd) executable=\(executable)")
+    ptyTrace(
+      "spawn", pid: childPid,
+      "gozd_pty_spawn master=\(masterFd) slave=\(slaveFd) executable=\(executable)")
 
     // 親側のコピーを開放（子は COW で別アドレス空間）。
     freeCStrings(argEntries, envEntries, cExecutable, cCwd, argv, envp)
@@ -140,12 +142,12 @@ public final class PTYManager {
     // master fd を non-blocking にする。drain loop が EAGAIN で止まれるようにし、
     // また exit handler 側からの drain が「データがなければ即抜ける」形で安全に呼べる。
     // write 側は既に EAGAIN を usleep + retry で扱っているので互換。
-    let flags = fcntl(fd, F_GETFL)
+    let flags = fcntl(masterFd, F_GETFL)
     let getFlagsErrno: Int32 = flags == -1 ? errno : 0
     var setFlagsRet: Int32 = -1
     var setFlagsErrno: Int32 = 0
     if flags >= 0 {
-      setFlagsRet = fcntl(fd, F_SETFL, flags | O_NONBLOCK)
+      setFlagsRet = fcntl(masterFd, F_SETFL, flags | O_NONBLOCK)
       if setFlagsRet == -1 { setFlagsErrno = errno }
     }
     ptyTrace(
@@ -159,8 +161,9 @@ public final class PTYManager {
     // 落ちる（onExit 後に onData が来る race）。同 queue + ガード（readClosed && exitReason
     // が両方揃ってから onExit を 1 度だけ呼ぶ）で「onExit は drain 済みを意味する」契約に揃える。
     let queue = DispatchQueue(label: "io.github.miyaoka.gozd.PTYManager.\(childPid)")
-    let state = PTYFinishState(fd: fd)
+    let state = PTYFinishState(primaryFd: masterFd, secondaryFd: slaveFd)
 
+    let fd = masterFd  // closure キャプチャ用エイリアス（既存コードの可読性維持）
     let source = DispatchSource.makeReadSource(
       fileDescriptor: fd,
       queue: queue
@@ -194,12 +197,9 @@ public final class PTYManager {
     exit.setEventHandler { [exit, source] in
       ptyTrace("exit", pid: childPid, "eventHandler fired (pre-waitpid drain)")
       // exit event と read readiness の到着順に依存しないよう、waitpid 前にも drain する。
-      // 子はもう書かないので、ここで読める bytes は最終出力として確定。
-      if case .closed = drainPTY(fd: fd, pid: childPid, caller: "exit-pre", onData: onData) {
-        ptyTrace("exit", pid: childPid, "pre-drain → .closed → cancel + markReadClosed")
-        source.cancel()
-        state.markReadClosed(pid: childPid, onComplete: onExit)
-      }
+      // 親側で slave fd を保持しているため、この段階では EOF は来ない（EAGAIN が期待値）が、
+      // child の死亡前に書かれた bytes は読める。
+      _ = drainPTY(fd: fd, pid: childPid, caller: "exit-pre", onData: onData)
 
       // process source の exit handler 内では子は zombie 確定。`WNOHANG` を使うと
       // 戻り値 0（reap 未完）と exit code 0 の区別が曖昧になるため、blocking
@@ -225,9 +225,19 @@ public final class PTYManager {
       let exitReason: PTYExitReason =
         waitRet == -1 ? .waitpidFailed(errno: waitErrno) : PTYExitReason.decode(status: status)
 
-      // waitpid 後にもう一度 drain。exit と read の event 順序によらず最終 data を吸う。
-      if case .closed = drainPTY(fd: fd, pid: childPid, caller: "exit-post", onData: onData) {
-        ptyTrace("exit", pid: childPid, "post-drain → .closed → cancel + markReadClosed")
+      // waitpid 直後にもう一度 drain。child の最終 write は kernel buffer まで届いており、
+      // 親保持の slave fd のおかげで ttyflush で消されていない。ここで master を吸い切る。
+      _ = drainPTY(fd: fd, pid: childPid, caller: "exit-post-waitpid", onData: onData)
+
+      // ここで親側の slave fd を close する。tty reference が 0 になり ttyclose →
+      // ttyflush が走るが、read queue は drain 済みなので flush 対象は空。
+      // 直後の master read で EOF が観測できるようになる。
+      state.closeSecondary(pid: childPid)
+
+      // final drain: slave close 後の EOF を観測して finish に進める。read source 側でも
+      // EOF event が拾える経路を残しているが、ここで確定させる方が race window が狭い。
+      if case .closed = drainPTY(fd: fd, pid: childPid, caller: "exit-final", onData: onData) {
+        ptyTrace("exit", pid: childPid, "final-drain → .closed → cancel + markReadClosed")
         source.cancel()
         state.markReadClosed(pid: childPid, onComplete: onExit)
       }
@@ -285,9 +295,10 @@ public final class PTYManager {
 }
 
 public enum PTYError: Error, Equatable {
-  case forkptyFailed(errno: Int32)
-  /// `forkpty` 前段の strdup などで OOM 検出した場合。forkpty syscall 自体は呼ばれていない
-  /// ので `forkptyFailed` を流用すると上位 log で失敗 syscall を取り違える。
+  /// `gozd_pty_spawn`（openpty + fork）の失敗。errno で内訳判別する。
+  case spawnFailed(errno: Int32)
+  /// spawn 前段の strdup などで OOM 検出した場合。spawn syscall 自体は呼ばれていないので
+  /// `spawnFailed` を流用すると上位 log で失敗 syscall を取り違える。
   case preforkAllocFailed(errno: Int32)
 }
 
@@ -322,24 +333,48 @@ public enum PTYExitReason: Sendable, Equatable {
 /// 付ける。NSLock を併用して値変更を atomic にし、queue 直列化と二重防御にする。
 ///
 /// finish の意味は「readClosed && exitReason」の両方が揃った時で、その時に 1 度だけ
-/// `onComplete(reason)` を呼び、`fd` を close する。fd close をここに集約することで、
-/// readSource cancel と exit handler の final drain が同 fd を競合 close する事故を避ける。
+/// `onComplete(reason)` を呼び、`primaryFd` を close する。fd close をここに集約する
+/// ことで、readSource cancel と exit handler の final drain が同 fd を競合 close する
+/// 事故を避ける。
+///
+/// `secondaryFd` は親側で保持する slave fd。child の `_exit` で tty reference が 0 に
+/// なって ttyflush で出力が drop するのを防ぐアンカー（issue #544 / 方針 A）。
+/// `closeSecondary` で exit handler が drain 済みのタイミングで close する。leak を防ぐ
+/// ため `deinit` でも未 close なら close する。
 private final class PTYFinishState: @unchecked Sendable {
   private let lock = NSLock()
-  private let fd: Int32
+  private let primaryFd: Int32
+  private let secondaryFd: Int32
   private var readClosed = false
   private var exitReason: PTYExitReason?
   private var finished = false
-  private var fdClosed = false
+  private var primaryClosed = false
+  private var secondaryClosed = false
 
-  init(fd: Int32) { self.fd = fd }
+  init(primaryFd: Int32, secondaryFd: Int32) {
+    self.primaryFd = primaryFd
+    self.secondaryFd = secondaryFd
+  }
 
-  /// fd を 1 度だけ close する。lock 保持の前提で呼ぶ。
-  private func closeFdLocked() {
-    if !fdClosed {
-      fdClosed = true
-      close(fd)
+  /// primary (master) fd を 1 度だけ close する。lock 保持の前提で呼ぶ。
+  private func closePrimaryLocked() {
+    if !primaryClosed {
+      primaryClosed = true
+      close(primaryFd)
     }
+  }
+
+  /// secondary (slave) fd を 1 度だけ close する。tty の最後の reference を release し、
+  /// ttyclose → ttyflush を起こす。drain 済みのタイミングで呼べば flush 対象は空。
+  func closeSecondary(pid: Int32 = 0) {
+    lock.lock()
+    let already = secondaryClosed
+    if !secondaryClosed {
+      secondaryClosed = true
+      close(secondaryFd)
+    }
+    lock.unlock()
+    ptyTrace("fin", pid: pid, "closeSecondary fd=\(secondaryFd) already=\(already)")
   }
 
   func markReadClosed(pid: Int32 = 0, onComplete: (PTYExitReason) -> Void) {
@@ -349,7 +384,7 @@ private final class PTYFinishState: @unchecked Sendable {
     let canFinish = !finished && exitReason != nil
     if canFinish { finished = true }
     let reason = exitReason
-    if canFinish { closeFdLocked() }
+    if canFinish { closePrimaryLocked() }
     lock.unlock()
     ptyTrace(
       "fin", pid: pid,
@@ -368,7 +403,7 @@ private final class PTYFinishState: @unchecked Sendable {
     exitReason = reason
     let canFinish = !finished && readClosed
     if canFinish { finished = true }
-    if canFinish { closeFdLocked() }
+    if canFinish { closePrimaryLocked() }
     let observedReadClosed = readClosed
     lock.unlock()
     ptyTrace(
@@ -380,11 +415,13 @@ private final class PTYFinishState: @unchecked Sendable {
     }
   }
 
-  /// PTYManager が finish 前に解放された場合の保険。fd の double close は
-  /// `fdClosed` フラグで防ぐ。
+  /// PTYManager が finish 前に解放された場合の保険。double close は各フラグで防ぐ。
   deinit {
-    if !fdClosed {
-      close(fd)
+    if !primaryClosed {
+      close(primaryFd)
+    }
+    if !secondaryClosed {
+      close(secondaryFd)
     }
   }
 }

--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -144,12 +144,19 @@ struct PTYManagerTests {
     let exit = ExitCollector()
     let pty = PTYManager()
 
+    // 実行時に確実に存在しないパスを動的生成。固定文字列ハードコードだと
+    // 偶発的にユーザーがそのパスを作っていると test が偽陰性になる。
+    // CLAUDE.md 「`/tmp` をハードコードしない、`NSTemporaryDirectory()` を使う」に準拠。
+    let nonexistentCwd =
+      (NSTemporaryDirectory() as NSString)
+      .appendingPathComponent("gozd-chdir-test-\(UUID().uuidString)")
+
     try pty.spawn(
       executable: "/usr/bin/true",
       args: ["true"],
       env: ProcessInfo.processInfo.environment,
-      // 一意に存在しないパス。CPty.c の chdir() != 0 経路で _exit(124)。
-      cwd: "/nonexistent-gozd-chdir-test-target-zzzz",
+      // 動的生成した「絶対に存在しない」パス。CPty.c の chdir() != 0 経路で _exit(124)。
+      cwd: nonexistentCwd,
       rows: 24,
       cols: 80,
       onData: { data.append($0) },

--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -138,6 +138,51 @@ struct PTYManagerTests {
     #expect(exit.snapshot() == .exited(code: 0))
   }
 
+  @Test("存在しない cwd を指定すると exited(code: 124) を返す (chdir 失敗)")
+  func chdirFailureReportedAsExit124() async throws {
+    let data = DataCollector()
+    let exit = ExitCollector()
+    let pty = PTYManager()
+
+    try pty.spawn(
+      executable: "/usr/bin/true",
+      args: ["true"],
+      env: ProcessInfo.processInfo.environment,
+      // 一意に存在しないパス。CPty.c の chdir() != 0 経路で _exit(124)。
+      cwd: "/nonexistent-gozd-chdir-test-target-zzzz",
+      rows: 24,
+      cols: 80,
+      onData: { data.append($0) },
+      onExit: { exit.set($0) }
+    )
+
+    try await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
+    #expect(exit.snapshot() == .exited(code: 124))
+  }
+
+  @Test("ディレクトリを executable に指定すると exited(code: 126) を返す (execve EACCES)")
+  func execveEACCESReportedAsExit126() async throws {
+    let data = DataCollector()
+    let exit = ExitCollector()
+    let pty = PTYManager()
+
+    // /tmp はディレクトリで execute bit は付くが execve は EACCES を返す
+    // （macOS execve(2): 「The new process file is not a regular file」も含めて EACCES）。
+    try pty.spawn(
+      executable: "/tmp",
+      args: ["tmp"],
+      env: ProcessInfo.processInfo.environment,
+      cwd: "/tmp",
+      rows: 24,
+      cols: 80,
+      onData: { data.append($0) },
+      onExit: { exit.set($0) }
+    )
+
+    try await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
+    #expect(exit.snapshot() == .exited(code: 126))
+  }
+
   @Test("実行できないパス (/path/does/not/exist) は exited(code: 127) を返す")
   func execveENOENTReportedAsExit127() async throws {
     let data = DataCollector()

--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -87,19 +87,100 @@ struct PTYManagerTests {
     try await waitUntil(timeout: .seconds(2)) { exit.snapshot() != nil }
     #expect(exit.snapshot() != nil)
   }
+
+  @Test("0 byte 出力で正常終了する child (/usr/bin/true) でも onExit が発火する")
+  func zeroByteOutput() async throws {
+    let data = DataCollector()
+    let exit = ExitCollector()
+    let pty = PTYManager()
+
+    try pty.spawn(
+      executable: "/usr/bin/true",
+      args: ["true"],
+      env: ProcessInfo.processInfo.environment,
+      cwd: "/tmp",
+      rows: 24,
+      cols: 80,
+      onData: { data.append($0) },
+      onExit: { exit.set($0) }
+    )
+
+    try await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
+
+    // /usr/bin/true は何も出力せず exit 0 で終わる。
+    // tty mode で promptless なので、データは 0 byte または echo 由来の数 byte のみ。
+    #expect(exit.snapshot() == .exited(code: 0))
+  }
+
+  @Test("stderr のみに書く child の出力も master fd から読める")
+  func stderrIsCapturedThroughSlave() async throws {
+    let data = DataCollector()
+    let exit = ExitCollector()
+    let pty = PTYManager()
+
+    try pty.spawn(
+      executable: "/bin/sh",
+      args: ["sh", "-c", "echo stderr-marker >&2"],
+      env: ProcessInfo.processInfo.environment,
+      cwd: "/tmp",
+      rows: 24,
+      cols: 80,
+      onData: { data.append($0) },
+      onExit: { exit.set($0) }
+    )
+
+    try await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
+
+    // login_tty で slave fd は stdin/stdout/stderr すべてに dup2 されているため
+    // stderr 出力も master 経由で観測できる。
+    let text = String(decoding: data.snapshot(), as: UTF8.self)
+    #expect(text.contains("stderr-marker"))
+    #expect(exit.snapshot() == .exited(code: 0))
+  }
+
+  @Test("実行できないパス (/path/does/not/exist) は exited(code: 127) を返す")
+  func execveENOENTReportedAsExit127() async throws {
+    let data = DataCollector()
+    let exit = ExitCollector()
+    let pty = PTYManager()
+
+    try pty.spawn(
+      executable: "/path/does/not/exist",
+      args: ["nonexistent"],
+      env: ProcessInfo.processInfo.environment,
+      cwd: "/tmp",
+      rows: 24,
+      cols: 80,
+      onData: { data.append($0) },
+      onExit: { exit.set($0) }
+    )
+
+    try await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
+
+    // POSIX shell 慣例 / CPty.c の child で execve ENOENT → _exit(127)。
+    #expect(exit.snapshot() == .exited(code: 127))
+  }
 }
 
 // MARK: - Helpers
 
+/// `condition()` が true を返すまで小さくポーリングで待つ。timeout 到達時に
+/// `Issue.record` で test を fail させる。silent return すると後段の `#expect` が
+/// 別の症状（exit が nil など）で間接 fail し、timeout だった事象を追跡できなくなる。
 private func waitUntil(
   timeout: Duration,
-  _ condition: @escaping @Sendable () -> Bool
+  description: String = "condition",
+  _ condition: @escaping @Sendable () -> Bool,
+  sourceLocation: SourceLocation = #_sourceLocation
 ) async throws {
   let deadline = ContinuousClock.now.advanced(by: timeout)
   while ContinuousClock.now < deadline {
     if condition() { return }
     try await Task.sleep(for: .milliseconds(50))
   }
+  Issue.record(
+    "waitUntil timed out after \(timeout) waiting for: \(description)",
+    sourceLocation: sourceLocation)
 }
 
 private final class DataCollector: @unchecked Sendable {

--- a/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
@@ -164,15 +164,23 @@ struct PTYRegistryTests {
 
 // MARK: - Helpers
 
+/// `condition()` が true を返すまで小さくポーリングで待つ。timeout 到達時に
+/// `Issue.record` で test を fail させる。silent return すると後段の `#expect` が
+/// 別の症状（exit が nil など）で間接 fail し、timeout だった事象を追跡できなくなる。
 private func waitUntil(
   timeout: Duration,
-  _ condition: @escaping @Sendable () -> Bool
+  description: String = "condition",
+  _ condition: @escaping @Sendable () -> Bool,
+  sourceLocation: SourceLocation = #_sourceLocation
 ) async throws {
   let deadline = ContinuousClock.now.advanced(by: timeout)
   while ContinuousClock.now < deadline {
     if condition() { return }
     try await Task.sleep(for: .milliseconds(50))
   }
+  Issue.record(
+    "waitUntil timed out after \(timeout) waiting for: \(description)",
+    sourceLocation: sourceLocation)
 }
 
 private final class EventCollector: @unchecked Sendable {


### PR DESCRIPTION
## 概要

PTY 系テストで `/bin/echo` のような ms 未満で `_exit` する短命 child の最終出力が CI ( `macos-26` runner ) で低頻度に drop する race を根治する。`forkpty` を捨て `openpty + fork + login_tty + execve` 経路を C bridge ( `gozd_pty_spawn` ) で実装し、親側で slave fd を 1 reference 保持するアンカー設計に変更した。

レビューで指摘された付随事項（child setup の silent エラー、fd 二重管理、観察可能性、テストカバレッジ、lock ordering、リファクタ）も同時に潰している。

## 背景

`PTYManagerTests / 子プロセスの stdout を受け取り、正常終了 (.exited(0)) を検知する` および `PTYRegistryTests / spawn は連番の ptyId を返し、onText / onExit が ID 付きで配送される` が CI で flake していた ( issue #544 )。

過去対応の系譜:

- PR #420: `readSource` / `exitSource` を per-PTY serial queue に統合、`PTYFinishState` で readClosed + exitReason を両方揃えてから onExit 発火。onExit 順序問題は解消したが頻度は減っただけ
- PR #449 / issue #450: 同症状を観測しつつ未着手のまま PR #454 でクローズ
- PR #454: `GOZD_PTY_TRACE=1` で stderr 直書きの trace logging を追加 ( 観測機構のみ )
- 今回再発を 2 度観測、trace ( issue #544 内に貼付 ) が `dataReads=0 totalBytes=0` で root cause を確定的に示した

### root cause

macOS xnu の tty driver は、tty の最後の reference が release されると `ttyclose` を呼び、その中で `ttyflush(FREAD|FWRITE)` を実行して pending output queue を **discard** する。`forkpty` 経由だと parent 側に slave fd の reference が残らないため、child が `_exit` で stdin/stdout/stderr の 3 references を同時に drop すると tty reference が 0 になり、master fd が kqueue 経由で `EVFILT_READ` を dispatch する前に slave 全 close → tty flush で `hello\r\n` の 7 bytes が消える。

`/bin/echo` は `write` 1 回 + `_exit(0)` を ms 未満で完了するため master 側 dispatch が間に合わずこの race が表面化する。`zsh` / `claude` / `cat` などの長命 child では観測されない。

## 変更内容

### `apps/native/Sources/CPty/`

- `gozd_pty_spawn` を新規実装。`openpty + fork + login_tty + execve` を 1 関数にまとめ、子側コード ( signal cleanup / login_tty / execve ) を C 側に隔離。Swift runtime / ARC に触れる可能性をゼロにする
- 戻り値を `0 / -1 / -2` の負数で識別 ( 0=成功 / -1=openpty 失敗 / -2=fork 失敗 )。errno のみでは EAGAIN を openpty / fork 双方が返し得るため取り違える
- child setup の各失敗を専用 exit code に倒す: `123` = execve その他 errno, `124` = chdir 失敗, `125` = login_tty 失敗, `126` = execve EACCES, `127` = execve ENOENT。親は `PTYExitReason.exited(code: N)` から失敗段階を判別可能
- `fork(2)` は Darwin SDK で Swift から直接呼べない ( `unavailable` マーク ) ため、C bridge 経由で呼ぶ必要があるという制約に対応

### `apps/native/Sources/GozdCore/PTYManager.swift`

- `primaryFd` ( master ) / `secondaryFd` ( 親保持 slave ) を `PTYFinishState` に集約 ( SSOT )。`PTYManager` 側は fd を保持せず `state` 経由で操作する
- `PTYFinishState.write` を実装し、close 後 race ( EBADF / 別 fd 誤書き込み ) を構造的に防ぐ。致命的 errno と `n == 0` を `ptyTrace` で観測可能に残す
- `PTYWriteResult` enum ( `wrote / retry / closed` ) で caller に明示的に close 状態を伝える
- exit handler のフローを 5 段階に再構築: `exit-pre` drain → `waitpid` → `exit-post-waitpid` drain → `closeSecondary` → `exit-final` drain → `markReadClosed`
- 「正規 finish 経路 = exit-final、二重防御 = read source」をコメントで明示し、`.drained` 時の trace `defer markReadClosed to read-source fallback` で経路の使い分けを観測可能に
- `PTYFinishState` の lock を `closeSecondary` / `markReadClosed` / `setExitReason` / `write` で「lock → 操作 → unlock → trace → return」の同一パターンに揃え、`ptyTrace` ( 内部で別 lock 取得 ) の保持中呼び出しを排除
- `writeLocked` ヘルパーに lock 内本処理を切り出し、CLAUDE.md「if-else の分岐は関数に切り出す」「早期リターンで else を消す」に揃える
- `PTYFinishState` に `pid` フィールドを追加。caller 毎の `pid: childPid` 引数渡し重複を排除
- `PTYError` を `openptyFailed` / `forkFailed` / `preforkAllocFailed` の 3 case に整理 ( `forkptyFailed` / `spawnFailed` を削除 )
- 想定外の `gozd_pty_spawn` 戻り値は `fatalError` で即時可視化 ( 観察を妨げる fallback を排除 )
- `PTYManager.pid` を `public private(set)` から暗黙的 internal に絞る ( `PTYRegistry` 経由参照のため private には絞れず )
- `PTYFinishState.deinit` を lock 取得 + フラグ参照に変更し double close を構造的に防ぐ

### `apps/native/Tests/GozdCoreTests/`

- `waitUntil` ヘルパーを timeout 時に `Issue.record` で fail させる形に変更 ( silent return が間接 fail で timeout 事象を埋もれさせるのを防ぐ )
- 境界条件テスト追加:
  - 0 byte 出力 ( `/usr/bin/true` )
  - stderr 出力 ( `/bin/sh -c 'echo ... >&2'` ) — login_tty で stderr も master 経由で観測できる契約
  - exit 124 ( cwd: `NSTemporaryDirectory()` + UUID で動的生成、chdir 失敗 )
  - exit 126 ( executable: `/tmp` ディレクトリ、execve EACCES )
  - exit 127 ( executable: `/path/does/not/exist`、execve ENOENT )

## 確認事項

- [x] `swift build` 成功
- [x] `swift test --filter 'PTYManager|PTYRegistry'` 50 連続実行 ( 後続 commit の確認では 20-30 回 ) で 0 fail
- [x] フルテストスイート 191 tests 全 pass
- [x] `pnpm lint:all` 0 errors / 0 warnings
- [x] `GOZD_PTY_TRACE=1` で `/bin/echo` テストの trace が `dataReads=1 totalBytes=7` を観測 ( 受け入れ条件 )
- [x] 別 context の Claude による独立レビュー 5 pass で構造的問題収束
- [ ] production の `claude` / `zsh` / `cat` 起動 ( 起動 + 入力 + 終了 ) に regression が無いことを手動確認
