### PR TITLE
feat(worktree): show ahead/behind vs upstream with background auto-fetch

### DIFF
--- a/apps/native/Sources/Gozd/GozdApp.swift
+++ b/apps/native/Sources/Gozd/GozdApp.swift
@@ -233,15 +233,20 @@ final class AppRuntime {
       }
     }
     let onGitStatusChange: FSWatchRegistry.GitStatusChangeHandler = { dir, status in
-      let payload: [String: Any] = [
+      var payload: [String: Any] = [
         "dir": dir,
         "statuses": status.statuses,
         "head": status.head,
         "branchHead": status.branchHead,
-        "hasUpstream": status.hasUpstream,
-        "ahead": Int(status.ahead),
-        "behind": Int(status.behind),
       ]
+      // upstream 未設定なら upstream フィールドごと不在にする。renderer 側は
+      // `upstream === undefined` を「ahead/behind を読まない」契約として扱う。
+      if status.hasUpstream {
+        payload["upstream"] = [
+          "ahead": Int(status.ahead),
+          "behind": Int(status.behind),
+        ]
+      }
       Task { @MainActor in
         await pushToRenderer(
           page: holder.page, type: "gitStatusChange", payload: payload)

--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -137,8 +137,11 @@ public enum GitOps {
     return parseWorktreePorcelain(stdout)
   }
 
-  /// `git fetch --no-write-fetch-head origin` 相当。背景自動 fetch 用。
+  /// `git fetch --all --no-write-fetch-head` 相当。背景自動 fetch 用。
   ///
+  /// - `--all`: 全 remote を fetch。upstream が `origin` 以外 (fork PR workflow で
+  ///   upstream=upstream / origin=fork 等) でも UI の ahead/behind を最新化できる。
+  ///   VSCode autofetch の `"all"` モード相当
   /// - `--no-write-fetch-head`: `FETCH_HEAD` を書き換えない。`FETCH_HEAD` は手動
   ///   `git pull` の起点としてユーザーが意識する短期記憶で、背景 fetch が
   ///   上書きするとユーザーの「最後に fetch した内容」感覚が壊れる
@@ -150,13 +153,13 @@ public enum GitOps {
   ///
   /// - `GIT_TERMINAL_PROMPT=0`: HTTPS の credential prompt を抑止し、認証情報が
   ///   無い場合は即座に exit 128 で失敗させる (hang 防止)
-  /// - `GIT_SSH_COMMAND="ssh -o BatchMode=yes"`: SSH の passphrase / known_hosts prompt
-  ///   を抑止。agent / key が無効なら即失敗
+  /// - `GIT_SSH_COMMAND` 末尾に ` -o BatchMode=yes`: SSH の passphrase / known_hosts
+  ///   prompt を抑止。agent / key が無効なら即失敗
   ///
   /// 失敗は throw する。呼び出し側で「offline / 認証失敗等は静かに飲み込む」判断をする。
-  public static func fetchOrigin(dir: String) async throws {
+  public static func fetchRemotes(dir: String) async throws {
     _ = try await runGitNonInteractive(
-      args: ["fetch", "--no-write-fetch-head", "origin"], cwd: dir)
+      args: ["fetch", "--all", "--no-write-fetch-head"], cwd: dir)
   }
 
   public struct LogResult: Sendable {
@@ -690,6 +693,21 @@ func runGit(args: [String], cwd: String) async throws -> Data {
   }
 }
 
+/// 非対話 git 起動用の env を組み立てる。pure function (テスト可能)。
+///
+/// - `GIT_TERMINAL_PROMPT=0`: HTTPS credential prompt を抑止
+/// - `GIT_SSH_COMMAND` には ` -o BatchMode=yes` を末尾に追記する。完全上書きすると
+///   ユーザーが ProxyCommand 等を env に設定しているケースを壊すため、既存値を保つ
+///
+/// `base` には `gozdGitEnv()` 等の親 env を渡す。新規 dict を返し副作用は持たない。
+public func buildNonInteractiveEnv(base: [String: String]) -> [String: String] {
+  var env = base
+  env["GIT_TERMINAL_PROMPT"] = "0"
+  let existingSsh = env["GIT_SSH_COMMAND"] ?? "ssh"
+  env["GIT_SSH_COMMAND"] = "\(existingSsh) -o BatchMode=yes"
+  return env
+}
+
 /// 認証 prompt を完全に塞いで git を起動する。HTTPS / SSH のどちらでも背景 fetch が
 /// passphrase / username 入力で hang するのを防ぐため、`fetch` 等のリモート操作専用。
 func runGitNonInteractive(args: [String], cwd: String) async throws -> Data {
@@ -710,13 +728,7 @@ private func runGitNonInteractiveOnce(gitPath: String, args: [String], cwd: Stri
   process.executableURL = URL(fileURLWithPath: gitPath)
   process.arguments = args
   process.currentDirectoryURL = URL(fileURLWithPath: cwd)
-  var env = gozdGitEnv()
-  env["GIT_TERMINAL_PROMPT"] = "0"
-  // 既存の GIT_SSH_COMMAND があれば BatchMode=yes を末尾に足す。素の ssh だけで
-  // 上書きすると ユーザーが ProxyCommand 等を設定していたケースを壊す。
-  let existingSsh = env["GIT_SSH_COMMAND"] ?? "ssh"
-  env["GIT_SSH_COMMAND"] = "\(existingSsh) -o BatchMode=yes"
-  process.environment = env
+  process.environment = buildNonInteractiveEnv(base: gozdGitEnv())
 
   let stdoutPipe = Pipe()
   let stderrPipe = Pipe()

--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -697,13 +697,16 @@ func runGit(args: [String], cwd: String) async throws -> Data {
 ///
 /// - `GIT_TERMINAL_PROMPT=0`: HTTPS credential prompt を抑止
 /// - `GIT_SSH_COMMAND` には ` -o BatchMode=yes` を末尾に追記する。完全上書きすると
-///   ユーザーが ProxyCommand 等を env に設定しているケースを壊すため、既存値を保つ
+///   ユーザーが ProxyCommand 等を env に設定しているケースを壊すため、既存値を保つ。
+///   ただし空文字列 / 空白のみは「未設定」と等価扱いにする。そのまま追記すると
+///   先頭の ssh 実行ファイル名が消えて " -o BatchMode=yes" になり ssh が起動できない
 ///
 /// `base` には `gozdGitEnv()` 等の親 env を渡す。新規 dict を返し副作用は持たない。
 public func buildNonInteractiveEnv(base: [String: String]) -> [String: String] {
   var env = base
   env["GIT_TERMINAL_PROMPT"] = "0"
-  let existingSsh = env["GIT_SSH_COMMAND"] ?? "ssh"
+  let trimmed = env["GIT_SSH_COMMAND"]?.trimmingCharacters(in: .whitespaces) ?? ""
+  let existingSsh = trimmed.isEmpty ? "ssh" : trimmed
   env["GIT_SSH_COMMAND"] = "\(existingSsh) -o BatchMode=yes"
   return env
 }

--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -137,6 +137,28 @@ public enum GitOps {
     return parseWorktreePorcelain(stdout)
   }
 
+  /// `git fetch --no-write-fetch-head origin` 相当。背景自動 fetch 用。
+  ///
+  /// - `--no-write-fetch-head`: `FETCH_HEAD` を書き換えない。`FETCH_HEAD` は手動
+  ///   `git pull` の起点としてユーザーが意識する短期記憶で、背景 fetch が
+  ///   上書きするとユーザーの「最後に fetch した内容」感覚が壊れる
+  /// - `--prune` は付けない: リモートで削除された branch がローカル refs から消えると
+  ///   サイドバー表示も同期して消え、ユーザーが混乱する。明示操作に残す
+  /// - `--tags` は付けない: 重く、ahead/behind 計算には不要
+  ///
+  /// 非対話化:
+  ///
+  /// - `GIT_TERMINAL_PROMPT=0`: HTTPS の credential prompt を抑止し、認証情報が
+  ///   無い場合は即座に exit 128 で失敗させる (hang 防止)
+  /// - `GIT_SSH_COMMAND="ssh -o BatchMode=yes"`: SSH の passphrase / known_hosts prompt
+  ///   を抑止。agent / key が無効なら即失敗
+  ///
+  /// 失敗は throw する。呼び出し側で「offline / 認証失敗等は静かに飲み込む」判断をする。
+  public static func fetchOrigin(dir: String) async throws {
+    _ = try await runGitNonInteractive(
+      args: ["fetch", "--no-write-fetch-head", "origin"], cwd: dir)
+  }
+
   public struct LogResult: Sendable {
     public let headCommits: [CommitInfo]
     public let defaultBranchCommits: [CommitInfo]
@@ -666,6 +688,53 @@ func runGit(args: [String], cwd: String) async throws -> Data {
     await CommandResolver.shared.invalidate("git")
     return try await runGitOnce(gitPath: try await resolveGitPath(), args: args, cwd: cwd)
   }
+}
+
+/// 認証 prompt を完全に塞いで git を起動する。HTTPS / SSH のどちらでも背景 fetch が
+/// passphrase / username 入力で hang するのを防ぐため、`fetch` 等のリモート操作専用。
+func runGitNonInteractive(args: [String], cwd: String) async throws -> Data {
+  do {
+    return try await runGitNonInteractiveOnce(
+      gitPath: try await resolveGitPath(), args: args, cwd: cwd)
+  } catch GitError.launchFailed {
+    await CommandResolver.shared.invalidate("git")
+    return try await runGitNonInteractiveOnce(
+      gitPath: try await resolveGitPath(), args: args, cwd: cwd)
+  }
+}
+
+private func runGitNonInteractiveOnce(gitPath: String, args: [String], cwd: String) async throws
+  -> Data
+{
+  let process = Process()
+  process.executableURL = URL(fileURLWithPath: gitPath)
+  process.arguments = args
+  process.currentDirectoryURL = URL(fileURLWithPath: cwd)
+  var env = gozdGitEnv()
+  env["GIT_TERMINAL_PROMPT"] = "0"
+  // 既存の GIT_SSH_COMMAND があれば BatchMode=yes を末尾に足す。素の ssh だけで
+  // 上書きすると ユーザーが ProxyCommand 等を設定していたケースを壊す。
+  let existingSsh = env["GIT_SSH_COMMAND"] ?? "ssh"
+  env["GIT_SSH_COMMAND"] = "\(existingSsh) -o BatchMode=yes"
+  process.environment = env
+
+  let stdoutPipe = Pipe()
+  let stderrPipe = Pipe()
+  process.standardOutput = stdoutPipe
+  process.standardError = stderrPipe
+
+  let (stdoutData, stderrData) = try await runProcessCollectingOutput(
+    process: process,
+    stdoutPipe: stdoutPipe,
+    stderrPipe: stderrPipe
+  )
+
+  if process.terminationStatus == 0 {
+    return stdoutData
+  }
+  throw GitError.commandFailed(
+    exitCode: process.terminationStatus,
+    stderr: String(decoding: stderrData, as: UTF8.self))
 }
 
 private func runGitOnce(gitPath: String, args: [String], cwd: String) async throws -> Data {

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -343,8 +343,8 @@ public actor RpcDispatcher {
       return try await handleGitIssueList(body)
     case "/git/viewer":
       return try await handleGitViewer(body)
-    case "/git/fetchOrigin":
-      return try await handleGitFetchOrigin(body)
+    case "/git/fetchRemotes":
+      return try await handleGitFetchRemotes(body)
     case "/git/defaultBranch":
       return try await handleGitDefaultBranch(body)
     case "/git/createWorktree":
@@ -404,9 +404,12 @@ public actor RpcDispatcher {
     let status = try await GitOps.gitStatusFull(dir: req.dir)
     var resp = Gozd_V1_GitStatusResponse()
     resp.entries = status.statuses
-    resp.hasUpstream_p = status.hasUpstream
-    resp.ahead = status.ahead
-    resp.behind = status.behind
+    if status.hasUpstream {
+      var upstream = Gozd_V1_UpstreamStatus()
+      upstream.ahead = status.ahead
+      upstream.behind = status.behind
+      resp.upstream = upstream
+    }
     return try resp.jsonUTF8Data()
   }
 
@@ -621,9 +624,12 @@ public actor RpcDispatcher {
       entry.isMain = wt.isMain
       let full = fullByPath[wt.path]
       entry.gitStatuses = full?.statuses ?? [:]
-      entry.hasUpstream_p = full?.hasUpstream ?? false
-      entry.ahead = full?.ahead ?? 0
-      entry.behind = full?.behind ?? 0
+      if let full, full.hasUpstream {
+        var upstream = Gozd_V1_UpstreamStatus()
+        upstream.ahead = full.ahead
+        upstream.behind = full.behind
+        entry.upstream = upstream
+      }
       // この worktree に紐づく全 Task を埋める。1 wt = 複数 Claude session の前提で
       // session 単位の Task が複数並ぶ。
       entry.tasks = allTasks.filter { $0.worktreeDir == wt.path }
@@ -848,14 +854,14 @@ public actor RpcDispatcher {
     }
   }
 
-  private func handleGitFetchOrigin(_ body: Data) async throws -> Data {
-    let req = try Gozd_V1_GitFetchOriginRequest(jsonUTF8Data: body)
-    var resp = Gozd_V1_GitFetchOriginResponse()
+  private func handleGitFetchRemotes(_ body: Data) async throws -> Data {
+    let req = try Gozd_V1_GitFetchRemotesRequest(jsonUTF8Data: body)
+    var resp = Gozd_V1_GitFetchRemotesResponse()
     do {
-      try await GitOps.fetchOrigin(dir: req.dir)
+      try await GitOps.fetchRemotes(dir: req.dir)
       resp.ok = true
     } catch let GitError.commandFailed(_, stderr) {
-      // offline / 認証失敗 / origin 未設定 etc. は呼び出し側で握り潰す。
+      // offline / 認証失敗 / remote 未設定 etc. は呼び出し側で握り潰す。
       // stderr 冒頭のみを debug 用に積む (UI には出さない)。
       resp.ok = false
       resp.errorDetail = String(stderr.prefix(512))

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -399,9 +399,12 @@ public actor RpcDispatcher {
 
   private func handleGitStatus(_ body: Data) async throws -> Data {
     let req = try Gozd_V1_GitStatusRequest(jsonUTF8Data: body)
-    let entries = try await GitOps.gitStatus(dir: req.dir)
+    let status = try await GitOps.gitStatusFull(dir: req.dir)
     var resp = Gozd_V1_GitStatusResponse()
-    resp.entries = entries
+    resp.entries = status.statuses
+    resp.hasUpstream_p = status.hasUpstream
+    resp.ahead = status.ahead
+    resp.behind = status.behind
     return try resp.jsonUTF8Data()
   }
 
@@ -583,26 +586,28 @@ public actor RpcDispatcher {
     // ため、per-wt で握って空 statuses で続行する。prunable wt は listing から除外
     // 済みなので、ここで失敗するのは worktree 実 path 不整合などの稀ケース。失敗は
     // stderr に残して silent 握り潰しを避ける (主経路に throw は伝播させない)。
-    let statusesByPath: [String: [String: String]] = await withTaskGroup(
-      of: (String, [String: String]).self
+    let fullByPath: [String: GitOps.StatusFull] = await withTaskGroup(
+      of: (String, GitOps.StatusFull?).self
     ) { group in
       for wt in worktrees {
         let path = wt.path
         group.addTask {
           do {
-            let statuses = try await GitOps.gitStatus(dir: path)
-            return (path, statuses)
+            let full = try await GitOps.gitStatusFull(dir: path)
+            return (path, full)
           } catch {
             FileHandle.standardError.write(
               Data(
-                "[handleGitWorktreeList] gitStatus failed for \(path): \(error)\n"
+                "[handleGitWorktreeList] gitStatusFull failed for \(path): \(error)\n"
                   .utf8))
-            return (path, [:])
+            return (path, nil)
           }
         }
       }
-      var result: [String: [String: String]] = [:]
-      for await (path, statuses) in group { result[path] = statuses }
+      var result: [String: GitOps.StatusFull] = [:]
+      for await (path, full) in group {
+        if let full { result[path] = full }
+      }
       return result
     }
     var resp = Gozd_V1_GitWorktreeListResponse()
@@ -612,7 +617,11 @@ public actor RpcDispatcher {
       entry.head = wt.head
       entry.branch = wt.branch ?? ""
       entry.isMain = wt.isMain
-      entry.gitStatuses = statusesByPath[wt.path] ?? [:]
+      let full = fullByPath[wt.path]
+      entry.gitStatuses = full?.statuses ?? [:]
+      entry.hasUpstream_p = full?.hasUpstream ?? false
+      entry.ahead = full?.ahead ?? 0
+      entry.behind = full?.behind ?? 0
       // この worktree に紐づく全 Task を埋める。1 wt = 複数 Claude session の前提で
       // session 単位の Task が複数並ぶ。
       entry.tasks = allTasks.filter { $0.worktreeDir == wt.path }

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -343,6 +343,8 @@ public actor RpcDispatcher {
       return try await handleGitIssueList(body)
     case "/git/viewer":
       return try await handleGitViewer(body)
+    case "/git/fetchOrigin":
+      return try await handleGitFetchOrigin(body)
     case "/git/defaultBranch":
       return try await handleGitDefaultBranch(body)
     case "/git/createWorktree":
@@ -844,6 +846,24 @@ public actor RpcDispatcher {
     case .network: return .network
     case .other: return .other
     }
+  }
+
+  private func handleGitFetchOrigin(_ body: Data) async throws -> Data {
+    let req = try Gozd_V1_GitFetchOriginRequest(jsonUTF8Data: body)
+    var resp = Gozd_V1_GitFetchOriginResponse()
+    do {
+      try await GitOps.fetchOrigin(dir: req.dir)
+      resp.ok = true
+    } catch let GitError.commandFailed(_, stderr) {
+      // offline / 認証失敗 / origin 未設定 etc. は呼び出し側で握り潰す。
+      // stderr 冒頭のみを debug 用に積む (UI には出さない)。
+      resp.ok = false
+      resp.errorDetail = String(stderr.prefix(512))
+    } catch {
+      resp.ok = false
+      resp.errorDetail = "\(error)"
+    }
+    return try resp.jsonUTF8Data()
   }
 
   private func handleGitDefaultBranch(_ body: Data) async throws -> Data {

--- a/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
+++ b/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
@@ -202,6 +202,47 @@ struct GitOpsRunGitLargeOutputTests {
   }
 }
 
+@Suite("GitOps.buildNonInteractiveEnv")
+struct BuildNonInteractiveEnvTests {
+  @Test("GIT_TERMINAL_PROMPT は常に 0 に固定される")
+  func terminalPromptForcedOff() {
+    let env = buildNonInteractiveEnv(base: [:])
+    #expect(env["GIT_TERMINAL_PROMPT"] == "0")
+  }
+
+  @Test("GIT_SSH_COMMAND 未設定なら `ssh -o BatchMode=yes`")
+  func sshCommandDefault() {
+    let env = buildNonInteractiveEnv(base: [:])
+    #expect(env["GIT_SSH_COMMAND"] == "ssh -o BatchMode=yes")
+  }
+
+  @Test("既存 GIT_SSH_COMMAND は末尾に BatchMode=yes を追記して保持する")
+  func sshCommandAppendsFlag() {
+    let env = buildNonInteractiveEnv(base: ["GIT_SSH_COMMAND": "ssh -i /custom/key"])
+    #expect(env["GIT_SSH_COMMAND"] == "ssh -i /custom/key -o BatchMode=yes")
+  }
+
+  @Test("空白を含むカスタム ssh パスも上書きせず末尾追記する")
+  func sshCommandWithSpaces() {
+    let env = buildNonInteractiveEnv(base: ["GIT_SSH_COMMAND": "/path with spaces/ssh -F /cfg"])
+    #expect(env["GIT_SSH_COMMAND"] == "/path with spaces/ssh -F /cfg -o BatchMode=yes")
+  }
+
+  @Test("base に渡した他の env は変更されない")
+  func unrelatedEnvPreserved() {
+    let env = buildNonInteractiveEnv(base: ["FOO": "bar", "GIT_OPTIONAL_LOCKS": "0"])
+    #expect(env["FOO"] == "bar")
+    #expect(env["GIT_OPTIONAL_LOCKS"] == "0")
+  }
+
+  @Test("base を変更せず新規 dict を返す (副作用なし)")
+  func basePreservedAcrossCalls() {
+    let base = ["GIT_SSH_COMMAND": "ssh -F /cfg"]
+    _ = buildNonInteractiveEnv(base: base)
+    #expect(base["GIT_SSH_COMMAND"] == "ssh -F /cfg")
+  }
+}
+
 @Suite("GitOps.gitStatusFull")
 struct GitOpsStatusFullTests {
   @Test("HEAD が指す branch 名が `branchHead` に入る")

--- a/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
+++ b/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
@@ -222,6 +222,18 @@ struct BuildNonInteractiveEnvTests {
     #expect(env["GIT_SSH_COMMAND"] == "ssh -i /custom/key -o BatchMode=yes")
   }
 
+  @Test("空文字列 GIT_SSH_COMMAND は未設定扱いで ssh にフォールバックする")
+  func sshCommandEmptyFallback() {
+    let env = buildNonInteractiveEnv(base: ["GIT_SSH_COMMAND": ""])
+    #expect(env["GIT_SSH_COMMAND"] == "ssh -o BatchMode=yes")
+  }
+
+  @Test("空白のみの GIT_SSH_COMMAND は未設定扱いで ssh にフォールバックする")
+  func sshCommandWhitespaceFallback() {
+    let env = buildNonInteractiveEnv(base: ["GIT_SSH_COMMAND": "   "])
+    #expect(env["GIT_SSH_COMMAND"] == "ssh -o BatchMode=yes")
+  }
+
   @Test("空白を含むカスタム ssh パスも上書きせず末尾追記する")
   func sshCommandWithSpaces() {
     let env = buildNonInteractiveEnv(base: ["GIT_SSH_COMMAND": "/path with spaces/ssh -F /cfg"])

--- a/apps/renderer/src/App.vue
+++ b/apps/renderer/src/App.vue
@@ -13,7 +13,7 @@ import {
   useTitleContextSync,
 } from "./features/layout";
 import { useGozdOpenHandler, useRepoContextKey } from "./features/sidebar";
-import { useGitStatusSync } from "./features/worktree";
+import { useGitStatusSync, useRemoteFetchSync } from "./features/worktree";
 import { useKeyBindings } from "./shared/command";
 
 useKeyBindings();
@@ -23,6 +23,7 @@ useGozdOpenHandler();
 useRepoContextKey();
 useFsWatchSync();
 useGitStatusSync();
+useRemoteFetchSync();
 useTitleContextSync();
 </script>
 

--- a/apps/renderer/src/features/filer/runOneSyncPass.test.ts
+++ b/apps/renderer/src/features/filer/runOneSyncPass.test.ts
@@ -11,9 +11,7 @@ function wt(path: string, branch: string, isMain = false): WorktreeEntry {
     isMain,
     gitStatuses: {},
     tasks: [],
-    hasUpstream: false,
-    ahead: 0,
-    behind: 0,
+    upstream: undefined,
   };
 }
 

--- a/apps/renderer/src/features/filer/runOneSyncPass.test.ts
+++ b/apps/renderer/src/features/filer/runOneSyncPass.test.ts
@@ -4,7 +4,17 @@ import { collectFsWatchTargetDirs, type RepoState } from "../../shared/repo";
 import { runOneSyncPass, type SyncPassDeps } from "./runOneSyncPass";
 
 function wt(path: string, branch: string, isMain = false): WorktreeEntry {
-  return { path, head: "", branch, isMain, gitStatuses: {}, tasks: [] };
+  return {
+    path,
+    head: "",
+    branch,
+    isMain,
+    gitStatuses: {},
+    tasks: [],
+    hasUpstream: false,
+    ahead: 0,
+    behind: 0,
+  };
 }
 
 /**

--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -217,12 +217,12 @@ watch(sortMode, () => {
 // 変化も発火条件に含めて、SSOT 経路の取りこぼしを構造的に防ぐ。
 const disposeGitStatus = onMessage<GitStatusChangePayload>(
   "gitStatusChange",
-  ({ dir, head, branchHead, hasUpstream, ahead, behind }) => {
+  ({ dir, head, branchHead, upstream }) => {
     // active worktree dir 以外の push は無視。closure 変数 (lastHead / lastBranchHead /
     // lastUpstream) は active dir の不変条件として保持しているため、別 worktree の値で
     // 上書きすると active dir に戻ったときに偽陽性で再 fetch が走る。
     if (dir !== worktreeStore.dir) return;
-    const upstreamKey = hasUpstream ? `${ahead}/${behind}` : "";
+    const upstreamKey = upstream !== undefined ? `${upstream.ahead}/${upstream.behind}` : "";
     const headChanged = head !== "" && head !== lastHead;
     const branchHeadChanged = branchHead !== lastBranchHead;
     const upstreamChanged = upstreamKey !== lastUpstream;

--- a/apps/renderer/src/features/sidebar/features/worktree/WtCard.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/WtCard.vue
@@ -138,17 +138,17 @@ function onHeaderClick() {
           <StatusIcons :entries="statusIcons" />
         </span>
         <span
-          v-if="wt.hasUpstream && (wt.ahead > 0 || wt.behind > 0)"
+          v-if="wt.upstream && (wt.upstream.ahead > 0 || wt.upstream.behind > 0)"
           class="flex items-center gap-1 text-[10px] text-zinc-400 tabular-nums"
-          :title="`ahead ${wt.ahead} / behind ${wt.behind} vs upstream`"
+          :title="`ahead ${wt.upstream.ahead} / behind ${wt.upstream.behind} vs upstream`"
         >
-          <span v-if="wt.ahead > 0" class="flex items-center gap-0.5">
+          <span v-if="wt.upstream.ahead > 0" class="flex items-center gap-0.5">
             <span class="icon-[lucide--arrow-up] size-3" />
-            <span>{{ wt.ahead }}</span>
+            <span>{{ wt.upstream.ahead }}</span>
           </span>
-          <span v-if="wt.behind > 0" class="flex items-center gap-0.5">
+          <span v-if="wt.upstream.behind > 0" class="flex items-center gap-0.5">
             <span class="icon-[lucide--arrow-down] size-3" />
-            <span>{{ wt.behind }}</span>
+            <span>{{ wt.upstream.behind }}</span>
           </span>
         </span>
         <span

--- a/apps/renderer/src/features/sidebar/features/worktree/WtCard.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/WtCard.vue
@@ -138,6 +138,20 @@ function onHeaderClick() {
           <StatusIcons :entries="statusIcons" />
         </span>
         <span
+          v-if="wt.hasUpstream && (wt.ahead > 0 || wt.behind > 0)"
+          class="flex items-center gap-1 text-[10px] text-zinc-400 tabular-nums"
+          :title="`ahead ${wt.ahead} / behind ${wt.behind} vs upstream`"
+        >
+          <span v-if="wt.ahead > 0" class="flex items-center gap-0.5">
+            <span class="icon-[lucide--arrow-up] size-3" />
+            <span>{{ wt.ahead }}</span>
+          </span>
+          <span v-if="wt.behind > 0" class="flex items-center gap-0.5">
+            <span class="icon-[lucide--arrow-down] size-3" />
+            <span>{{ wt.behind }}</span>
+          </span>
+        </span>
+        <span
           v-if="resumeableSessionCount > 0"
           class="flex items-center gap-1 text-[10px] text-zinc-400"
           :title="`${resumeableSessionCount} resumable session${resumeableSessionCount === 1 ? '' : 's'}`"

--- a/apps/renderer/src/features/worktree/index.ts
+++ b/apps/renderer/src/features/worktree/index.ts
@@ -5,6 +5,7 @@ export { default as StatusIcons } from "./StatusIcons.vue";
 export { useWorktreeStore } from "./useWorktreeStore";
 export { useGitStatusStore } from "./useGitStatusStore";
 export { useGitStatusSync } from "./useGitStatusSync";
+export { useRemoteFetchSync } from "./useRemoteFetchSync";
 export {
   computeStatusIcons,
   resolveDirectoryGitChange,

--- a/apps/renderer/src/features/worktree/rpc.ts
+++ b/apps/renderer/src/features/worktree/rpc.ts
@@ -1,9 +1,17 @@
-import { GitStatusRequest, GitStatusResponse } from "@gozd/proto";
+import {
+  GitFetchOriginRequest,
+  GitFetchOriginResponse,
+  GitStatusRequest,
+  GitStatusResponse,
+} from "@gozd/proto";
 
 import { rpc } from "../../shared/rpc";
 
 export const rpcGitStatus = (req: GitStatusRequest) =>
   rpc("/git/status", req, GitStatusRequest, GitStatusResponse);
+
+export const rpcGitFetchOrigin = (req: GitFetchOriginRequest) =>
+  rpc("/git/fetchOrigin", req, GitFetchOriginRequest, GitFetchOriginResponse);
 
 // gitStatusChange push event payload
 export interface GitStatusChangePayload {

--- a/apps/renderer/src/features/worktree/rpc.ts
+++ b/apps/renderer/src/features/worktree/rpc.ts
@@ -1,8 +1,9 @@
 import {
-  GitFetchOriginRequest,
-  GitFetchOriginResponse,
+  GitFetchRemotesRequest,
+  GitFetchRemotesResponse,
   GitStatusRequest,
   GitStatusResponse,
+  UpstreamStatus,
 } from "@gozd/proto";
 
 import { rpc } from "../../shared/rpc";
@@ -10,8 +11,8 @@ import { rpc } from "../../shared/rpc";
 export const rpcGitStatus = (req: GitStatusRequest) =>
   rpc("/git/status", req, GitStatusRequest, GitStatusResponse);
 
-export const rpcGitFetchOrigin = (req: GitFetchOriginRequest) =>
-  rpc("/git/fetchOrigin", req, GitFetchOriginRequest, GitFetchOriginResponse);
+export const rpcGitFetchRemotes = (req: GitFetchRemotesRequest) =>
+  rpc("/git/fetchRemotes", req, GitFetchRemotesRequest, GitFetchRemotesResponse);
 
 // gitStatusChange push event payload
 export interface GitStatusChangePayload {
@@ -22,7 +23,6 @@ export interface GitStatusChangePayload {
    * `git branch -m` は OID を変えないため、rename はこの値の変化で検知する。
    * detached HEAD の場合は空文字。 */
   branchHead: string;
-  hasUpstream: boolean;
-  ahead: number;
-  behind: number;
+  /** upstream 未設定なら不在。`undefined` なら ahead/behind を読まない契約。 */
+  upstream?: UpstreamStatus;
 }

--- a/apps/renderer/src/features/worktree/useGitStatusStore.ts
+++ b/apps/renderer/src/features/worktree/useGitStatusStore.ts
@@ -48,7 +48,12 @@ export const useGitStatusStore = defineStore("gitStatus", () => {
     const result = await tryCatch(rpcGitStatus({ dir }));
     if (repoStore.getGitStatusGen(dir) !== startGen) return;
     if (result.ok) {
-      repoStore.setWorktreeGitStatuses(dir, result.value.entries);
+      repoStore.setWorktreeGitStatuses(dir, {
+        statuses: result.value.entries,
+        hasUpstream: result.value.hasUpstream,
+        ahead: result.value.ahead,
+        behind: result.value.behind,
+      });
     } else {
       const notify = useNotificationStore();
       notify.error("Failed to get git status", result.error);

--- a/apps/renderer/src/features/worktree/useGitStatusStore.ts
+++ b/apps/renderer/src/features/worktree/useGitStatusStore.ts
@@ -50,9 +50,7 @@ export const useGitStatusStore = defineStore("gitStatus", () => {
     if (result.ok) {
       repoStore.setWorktreeGitStatuses(dir, {
         statuses: result.value.entries,
-        hasUpstream: result.value.hasUpstream,
-        ahead: result.value.ahead,
-        behind: result.value.behind,
+        upstream: result.value.upstream,
       });
     } else {
       const notify = useNotificationStore();

--- a/apps/renderer/src/features/worktree/useGitStatusSync.ts
+++ b/apps/renderer/src/features/worktree/useGitStatusSync.ts
@@ -52,9 +52,7 @@ export function useGitStatusSync() {
     cleanup = onMessage<GitStatusChangePayload>("gitStatusChange", (payload) => {
       repoStore.setWorktreeGitStatuses(payload.dir, {
         statuses: payload.statuses,
-        hasUpstream: payload.hasUpstream,
-        ahead: payload.ahead,
-        behind: payload.behind,
+        upstream: payload.upstream,
       });
     });
   });

--- a/apps/renderer/src/features/worktree/useGitStatusSync.ts
+++ b/apps/renderer/src/features/worktree/useGitStatusSync.ts
@@ -50,7 +50,12 @@ export function useGitStatusSync() {
     // gitStatuses を直接 repoStore に反映する。サイドバー / Filer / GitGraph は
     // すべて repoStore（または派生 computed）を読むので 1 回の書き込みで全箇所が更新される。
     cleanup = onMessage<GitStatusChangePayload>("gitStatusChange", (payload) => {
-      repoStore.setWorktreeGitStatuses(payload.dir, payload.statuses);
+      repoStore.setWorktreeGitStatuses(payload.dir, {
+        statuses: payload.statuses,
+        hasUpstream: payload.hasUpstream,
+        ahead: payload.ahead,
+        behind: payload.behind,
+      });
     });
   });
   onUnmounted(() => {

--- a/apps/renderer/src/features/worktree/useRemoteFetchSync.ts
+++ b/apps/renderer/src/features/worktree/useRemoteFetchSync.ts
@@ -1,22 +1,27 @@
 /**
- * active repo の `git fetch origin` を背景で回す app-scope な watcher。
+ * active repo の `git fetch --all` を背景で回す app-scope な watcher。
  *
  * 設計方針:
  *
  * - **scope は active repo の rootDir 単位**。同 repo 内の worktree は `refs/remotes/*` を
  *   common git dir で共有するため、1 fetch で全 worktree の ahead/behind が更新される。
  *   worktree 単位 fan-out は network コストと credential 消費が無駄に倍化する
+ * - **`git fetch --all`** を使う。upstream が origin 以外 (fork PR workflow で
+ *   upstream=upstream / origin=fork) でも全 remote を更新できる。VSCode autofetch の
+ *   `"all"` モード相当
  * - **ウィンドウ focus + 3 分間隔** (VSCode 既定 180s と同じ)。focus を失っている間は
- *   fetch を回さない。焦点が戻った時点で「最後の fetch から 3 分以上経過」を満たせば
- *   即座に 1 発射し、以降タイマー再開
- * - **直近 fetch 時刻 (`lastFetchedAt`) で debounce**。focus 切替を頻繁に行う UI でも
- *   3 分閾値を満たさない限り fetch しない
- * - **in-flight ロック**で同 repo 並列発射を抑止。RPC が遅延した場合に重複 fetch を
- *   起こさない
- * - **失敗は静かに飲み込む**。offline / 認証失敗 / origin 未設定は通知しない。
- *   通知爆発を防ぐためで、debug は native 側 stderr / error_detail に残る
+ *   fetch を回さない。focus 復帰直後は閾値を無視して 1 発射する (blur 中の経過時間で
+ *   debounce が誤判定するため、focus false→true 遷移で `lastFetchedAt` を消す)
+ * - **成功時は 180s lock、失敗時は 30s 短 backoff**。起動直後の SSH agent unlock 前
+ *   ヒット等の transient 失敗が「次の 180 秒間 fetch しない」状態を作らないため、
+ *   失敗は短い backoff にする
+ * - **repo 切替時の発射は初回のみ**。`lastFetchedAt` 未設定の repo を初めて開いた
+ *   ときだけ即時 fetch する。A↔B 往復のたびに fetch を炊くと credential 消費が無駄
+ * - **in-flight ロック**で同 repo 並列発射を抑止。RPC 遅延時に重複 fetch を防ぐ
+ * - **失敗は console.warn に 1 行残す**。toast は出さない (通知爆発防止) が、
+ *   開発者ツールから連続失敗 / errorDetail を観察できる経路は確保する
  *
- * 後段は既存パイプに乗る: fetch が成功すると `refs/remotes/origin/*` が書き換わり、
+ * 後段は既存パイプに乗る: fetch が成功すると `refs/remotes/<remote>/*` が書き換わり、
  * FSWatchRegistry が gitStatusFull を再実行して `gitStatusChange` push を発射する。
  * renderer 側は `useGitStatusSync` が repoStore に書き戻し、WtCard の ahead/behind が更新される。
  */
@@ -24,57 +29,94 @@ import { tryCatch } from "@gozd/shared";
 import { useWindowFocus } from "@vueuse/core";
 import { onUnmounted, watch } from "vue";
 import { useRepoStore } from "../../shared/repo";
-import { rpcGitFetchOrigin } from "./rpc";
+import { rpcGitFetchRemotes } from "./rpc";
 
-/** fetch 間隔 (ms)。VSCode の `git.autofetchPeriod` 既定値 180s と同じ */
-const FETCH_INTERVAL_MS = 180_000;
+/** 成功時の lock 期間 (ms)。VSCode の `git.autofetchPeriod` 既定値 180s と同じ */
+const SUCCESS_INTERVAL_MS = 180_000;
+/** 失敗時の短 backoff (ms)。起動直後の SSH unlock 待ち / 一時的 offline からの回復を捕捉する */
+const FAILURE_BACKOFF_MS = 30_000;
 
 export function useRemoteFetchSync() {
   const repoStore = useRepoStore();
   const focused = useWindowFocus();
 
-  /** rootDir → 最後に fetch が完了 (成功 / 失敗どちらでも) した時刻 (ms epoch) */
-  const lastFetchedAt = new Map<string, number>();
+  /** rootDir → 「この時刻まで次の fetch を抑制」する deadline (ms epoch) */
+  const nextFetchAllowedAt = new Map<string, number>();
   /** rootDir → 現在 in-flight な fetch の有無 */
   const inFlight = new Set<string>();
 
   /**
-   * 1 repo を fetch する。focus 喪失 / 直近 fetch から閾値未満 / in-flight なら no-op。
-   * fetch 自体は ok=false で返ってきても通知せず lastFetchedAt を進める (リトライ抑制)。
+   * 1 repo を fetch する。focus 喪失 / backoff 期間中 / in-flight なら no-op。
+   * 成功なら 180s、失敗なら 30s 後まで再試行を抑制する。
    */
   async function fetchOnceIfDue(rootDir: string) {
     if (!focused.value) return;
     if (inFlight.has(rootDir)) return;
-    const last = lastFetchedAt.get(rootDir);
-    if (last !== undefined && Date.now() - last < FETCH_INTERVAL_MS) return;
+    const allowedAt = nextFetchAllowedAt.get(rootDir);
+    if (allowedAt !== undefined && Date.now() < allowedAt) return;
     // git 管理外の project は fetch 対象外
     const repo = repoStore.repos[rootDir];
     if (repo === undefined || !repo.isGitRepo) return;
 
     inFlight.add(rootDir);
-    try {
-      await tryCatch(rpcGitFetchOrigin({ dir: rootDir }));
-      // ok=false (offline / 認証失敗等) も lastFetchedAt を進める。次の 3 分は再試行しない
-      lastFetchedAt.set(rootDir, Date.now());
-    } finally {
-      inFlight.delete(rootDir);
+    const result = await tryCatch(rpcGitFetchRemotes({ dir: rootDir }));
+    inFlight.delete(rootDir);
+
+    const now = Date.now();
+    if (!result.ok) {
+      // RPC 層の失敗 (transport error 等)。短 backoff してリトライ可能にする
+      console.warn("[useRemoteFetchSync] RPC failed", { rootDir, error: result.error });
+      nextFetchAllowedAt.set(rootDir, now + FAILURE_BACKOFF_MS);
+      return;
     }
+    if (!result.value.ok) {
+      // RPC は成功したが git fetch が失敗 (offline / 認証失敗 / remote 未設定)。
+      // errorDetail を log に残し、短 backoff で次サイクルに任せる
+      console.warn("[useRemoteFetchSync] git fetch failed", {
+        rootDir,
+        errorDetail: result.value.errorDetail,
+      });
+      nextFetchAllowedAt.set(rootDir, now + FAILURE_BACKOFF_MS);
+      return;
+    }
+    nextFetchAllowedAt.set(rootDir, now + SUCCESS_INTERVAL_MS);
   }
 
-  /** active repo を即時 fetch (閾値判定込み) */
+  /** active repo を fetch (閾値判定込み) */
   function fetchActive() {
     const rootDir = repoStore.selectedRootDir;
     if (rootDir === undefined) return;
     void fetchOnceIfDue(rootDir);
   }
 
-  // active repo 切替 + focus 回復 + 起動直後の各タイミングで fetch を試みる。
-  // immediate: true で初回 fetch をカバー (lastFetchedAt 未設定なら即実行)。
-  watch([() => repoStore.selectedRootDir, focused], fetchActive, { immediate: true });
+  // active repo 切替時の発射は「その repo を初めて見たとき」だけにする。
+  // 既に一度 fetch している repo に戻ったときは閾値判定に任せ、A↔B 往復で都度
+  // fetch を炊かない。これにより VSCode 互換の interval 主導動作になる。
+  watch(
+    () => repoStore.selectedRootDir,
+    (rootDir) => {
+      if (rootDir === undefined) return;
+      if (nextFetchAllowedAt.has(rootDir)) return;
+      void fetchOnceIfDue(rootDir);
+    },
+    { immediate: true },
+  );
 
-  // 3 分インターバルでも回す。focus 喪失中は fetchOnceIfDue が早期 return するので
+  // focus 復帰 (blur → focus) で active repo の deadline を消して即発射する。
+  // blur 中も時計は進むため、deadline ベースで判定すると「focus は戻ったが残り 179s」
+  // のケースで behind 反映が最悪 3 分待たされる。focus 遷移自体をトリガにすれば
+  // ユーザーが UI に戻ってきたタイミングで必ず最新化される。
+  watch(focused, (isFocused, wasFocused) => {
+    if (!isFocused || wasFocused === true) return;
+    const rootDir = repoStore.selectedRootDir;
+    if (rootDir === undefined) return;
+    nextFetchAllowedAt.delete(rootDir);
+    void fetchOnceIfDue(rootDir);
+  });
+
+  // 180s インターバル: focus 中は閾値判定に従って fetch、focus 喪失中は早期 return。
   // タイマー自体は走らせ続けて問題ない (timer cost は無視できる)。
-  const intervalId = setInterval(fetchActive, FETCH_INTERVAL_MS);
+  const intervalId = setInterval(fetchActive, SUCCESS_INTERVAL_MS);
 
   onUnmounted(() => {
     clearInterval(intervalId);

--- a/apps/renderer/src/features/worktree/useRemoteFetchSync.ts
+++ b/apps/renderer/src/features/worktree/useRemoteFetchSync.ts
@@ -1,0 +1,82 @@
+/**
+ * active repo の `git fetch origin` を背景で回す app-scope な watcher。
+ *
+ * 設計方針:
+ *
+ * - **scope は active repo の rootDir 単位**。同 repo 内の worktree は `refs/remotes/*` を
+ *   common git dir で共有するため、1 fetch で全 worktree の ahead/behind が更新される。
+ *   worktree 単位 fan-out は network コストと credential 消費が無駄に倍化する
+ * - **ウィンドウ focus + 3 分間隔** (VSCode 既定 180s と同じ)。focus を失っている間は
+ *   fetch を回さない。焦点が戻った時点で「最後の fetch から 3 分以上経過」を満たせば
+ *   即座に 1 発射し、以降タイマー再開
+ * - **直近 fetch 時刻 (`lastFetchedAt`) で debounce**。focus 切替を頻繁に行う UI でも
+ *   3 分閾値を満たさない限り fetch しない
+ * - **in-flight ロック**で同 repo 並列発射を抑止。RPC が遅延した場合に重複 fetch を
+ *   起こさない
+ * - **失敗は静かに飲み込む**。offline / 認証失敗 / origin 未設定は通知しない。
+ *   通知爆発を防ぐためで、debug は native 側 stderr / error_detail に残る
+ *
+ * 後段は既存パイプに乗る: fetch が成功すると `refs/remotes/origin/*` が書き換わり、
+ * FSWatchRegistry が gitStatusFull を再実行して `gitStatusChange` push を発射する。
+ * renderer 側は `useGitStatusSync` が repoStore に書き戻し、WtCard の ahead/behind が更新される。
+ */
+import { tryCatch } from "@gozd/shared";
+import { useWindowFocus } from "@vueuse/core";
+import { onUnmounted, watch } from "vue";
+import { useRepoStore } from "../../shared/repo";
+import { rpcGitFetchOrigin } from "./rpc";
+
+/** fetch 間隔 (ms)。VSCode の `git.autofetchPeriod` 既定値 180s と同じ */
+const FETCH_INTERVAL_MS = 180_000;
+
+export function useRemoteFetchSync() {
+  const repoStore = useRepoStore();
+  const focused = useWindowFocus();
+
+  /** rootDir → 最後に fetch が完了 (成功 / 失敗どちらでも) した時刻 (ms epoch) */
+  const lastFetchedAt = new Map<string, number>();
+  /** rootDir → 現在 in-flight な fetch の有無 */
+  const inFlight = new Set<string>();
+
+  /**
+   * 1 repo を fetch する。focus 喪失 / 直近 fetch から閾値未満 / in-flight なら no-op。
+   * fetch 自体は ok=false で返ってきても通知せず lastFetchedAt を進める (リトライ抑制)。
+   */
+  async function fetchOnceIfDue(rootDir: string) {
+    if (!focused.value) return;
+    if (inFlight.has(rootDir)) return;
+    const last = lastFetchedAt.get(rootDir);
+    if (last !== undefined && Date.now() - last < FETCH_INTERVAL_MS) return;
+    // git 管理外の project は fetch 対象外
+    const repo = repoStore.repos[rootDir];
+    if (repo === undefined || !repo.isGitRepo) return;
+
+    inFlight.add(rootDir);
+    try {
+      await tryCatch(rpcGitFetchOrigin({ dir: rootDir }));
+      // ok=false (offline / 認証失敗等) も lastFetchedAt を進める。次の 3 分は再試行しない
+      lastFetchedAt.set(rootDir, Date.now());
+    } finally {
+      inFlight.delete(rootDir);
+    }
+  }
+
+  /** active repo を即時 fetch (閾値判定込み) */
+  function fetchActive() {
+    const rootDir = repoStore.selectedRootDir;
+    if (rootDir === undefined) return;
+    void fetchOnceIfDue(rootDir);
+  }
+
+  // active repo 切替 + focus 回復 + 起動直後の各タイミングで fetch を試みる。
+  // immediate: true で初回 fetch をカバー (lastFetchedAt 未設定なら即実行)。
+  watch([() => repoStore.selectedRootDir, focused], fetchActive, { immediate: true });
+
+  // 3 分インターバルでも回す。focus 喪失中は fetchOnceIfDue が早期 return するので
+  // タイマー自体は走らせ続けて問題ない (timer cost は無視できる)。
+  const intervalId = setInterval(fetchActive, FETCH_INTERVAL_MS);
+
+  onUnmounted(() => {
+    clearInterval(intervalId);
+  });
+}

--- a/apps/renderer/src/features/worktree/useRemoteFetchSync.ts
+++ b/apps/renderer/src/features/worktree/useRemoteFetchSync.ts
@@ -18,8 +18,9 @@
  * - **repo 切替時の発射は初回のみ**。`lastFetchedAt` 未設定の repo を初めて開いた
  *   ときだけ即時 fetch する。A↔B 往復のたびに fetch を炊くと credential 消費が無駄
  * - **in-flight ロック**で同 repo 並列発射を抑止。RPC 遅延時に重複 fetch を防ぐ
- * - **失敗は console.warn に 1 行残す**。toast は出さない (通知爆発防止) が、
- *   開発者ツールから連続失敗 / errorDetail を観察できる経路は確保する
+ * - **失敗は `useNotificationStore.info` で通知**。プロジェクト規約「console.error で
+ *   握り潰さない」に従う。連射抑制は 30s backoff で効くため、トースト爆発はしない
+ *   (offline 等の継続的失敗でも 30s に 1 件)
  *
  * 後段は既存パイプに乗る: fetch が成功すると `refs/remotes/<remote>/*` が書き換わり、
  * FSWatchRegistry が gitStatusFull を再実行して `gitStatusChange` push を発射する。
@@ -28,6 +29,7 @@
 import { tryCatch } from "@gozd/shared";
 import { useWindowFocus } from "@vueuse/core";
 import { onUnmounted, watch } from "vue";
+import { useNotificationStore } from "../../shared/notification";
 import { useRepoStore } from "../../shared/repo";
 import { rpcGitFetchRemotes } from "./rpc";
 
@@ -38,6 +40,7 @@ const FAILURE_BACKOFF_MS = 30_000;
 
 export function useRemoteFetchSync() {
   const repoStore = useRepoStore();
+  const notify = useNotificationStore();
   const focused = useWindowFocus();
 
   /** rootDir → 「この時刻まで次の fetch を抑制」する deadline (ms epoch) */
@@ -65,17 +68,14 @@ export function useRemoteFetchSync() {
     const now = Date.now();
     if (!result.ok) {
       // RPC 層の失敗 (transport error 等)。短 backoff してリトライ可能にする
-      console.warn("[useRemoteFetchSync] RPC failed", { rootDir, error: result.error });
+      notify.info(`Background git fetch failed for ${rootDir}`, result.error);
       nextFetchAllowedAt.set(rootDir, now + FAILURE_BACKOFF_MS);
       return;
     }
     if (!result.value.ok) {
       // RPC は成功したが git fetch が失敗 (offline / 認証失敗 / remote 未設定)。
-      // errorDetail を log に残し、短 backoff で次サイクルに任せる
-      console.warn("[useRemoteFetchSync] git fetch failed", {
-        rootDir,
-        errorDetail: result.value.errorDetail,
-      });
+      // errorDetail を cause として通知し、短 backoff で次サイクルに任せる
+      notify.info(`Background git fetch failed for ${rootDir}`, result.value.errorDetail);
       nextFetchAllowedAt.set(rootDir, now + FAILURE_BACKOFF_MS);
       return;
     }

--- a/apps/renderer/src/shared/repo/useRepoStore.test.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.test.ts
@@ -10,9 +10,7 @@ function wt(path: string, branch: string, isMain = false): WorktreeEntry {
     isMain,
     gitStatuses: {},
     tasks: [],
-    hasUpstream: false,
-    ahead: 0,
-    behind: 0,
+    upstream: undefined,
   };
 }
 

--- a/apps/renderer/src/shared/repo/useRepoStore.test.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.test.ts
@@ -3,7 +3,17 @@ import { describe, expect, test } from "bun:test";
 import { collectFsWatchTargetDirs, type RepoState } from "./useRepoStore";
 
 function wt(path: string, branch: string, isMain = false): WorktreeEntry {
-  return { path, head: "", branch, isMain, gitStatuses: {}, tasks: [] };
+  return {
+    path,
+    head: "",
+    branch,
+    isMain,
+    gitStatuses: {},
+    tasks: [],
+    hasUpstream: false,
+    ahead: 0,
+    behind: 0,
+  };
 }
 
 describe("collectFsWatchTargetDirs", () => {

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -1,4 +1,4 @@
-import { AppState, type WorktreeEntry } from "@gozd/proto";
+import { AppState, type UpstreamStatus, type WorktreeEntry } from "@gozd/proto";
 import { acceptHMRUpdate, defineStore } from "pinia";
 import { computed, ref } from "vue";
 
@@ -170,9 +170,7 @@ export const useRepoStore = defineStore("repo", () => {
             return {
               ...wt,
               gitStatuses: fresher.gitStatuses,
-              hasUpstream: fresher.hasUpstream,
-              ahead: fresher.ahead,
-              behind: fresher.behind,
+              upstream: fresher.upstream,
             };
           }
         }
@@ -222,9 +220,8 @@ export const useRepoStore = defineStore("repo", () => {
 
   interface WorktreeStatusPatch {
     statuses: Record<string, string>;
-    hasUpstream: boolean;
-    ahead: number;
-    behind: number;
+    /** upstream 未設定なら undefined。`hasUpstream` のような boolean を併持しない */
+    upstream: UpstreamStatus | undefined;
   }
 
   /**
@@ -244,9 +241,7 @@ export const useRepoStore = defineStore("repo", () => {
     next[idx] = {
       ...next[idx],
       gitStatuses: patch.statuses,
-      hasUpstream: patch.hasUpstream,
-      ahead: patch.ahead,
-      behind: patch.behind,
+      upstream: patch.upstream,
     };
     repos.value[repo.rootDir] = { ...repo, worktrees: next };
   }

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -167,7 +167,13 @@ export const useRepoStore = defineStore("repo", () => {
           // fetch 中に push / 単発更新が走っていた → 現値を保持
           const fresher = current.worktrees.find((w) => w.path === wt.path);
           if (fresher !== undefined) {
-            return { ...wt, gitStatuses: fresher.gitStatuses };
+            return {
+              ...wt,
+              gitStatuses: fresher.gitStatuses,
+              hasUpstream: fresher.hasUpstream,
+              ahead: fresher.ahead,
+              behind: fresher.behind,
+            };
           }
         }
         return wt;
@@ -214,21 +220,34 @@ export const useRepoStore = defineStore("repo", () => {
     }
   }
 
+  interface WorktreeStatusPatch {
+    statuses: Record<string, string>;
+    hasUpstream: boolean;
+    ahead: number;
+    behind: number;
+  }
+
   /**
-   * 任意 dir に対応する worktree の gitStatuses だけをピンポイント更新する。
+   * 任意 dir に対応する worktree の gitStatuses + upstream 情報をピンポイント更新する。
    * gitStatusChange push / 単発の rpcGitStatus 結果を反映する経路で使用。
    * dir に該当する worktree が見つからなければ no-op。
    * 書き込み毎に per-dir 世代を進め、in-flight な loadGitStatus / fetchRepo の
    * 古いレスポンスがこの値を上書きできないようにする。
    */
-  function setWorktreeGitStatuses(dir: string, statuses: Record<string, string>) {
+  function setWorktreeGitStatuses(dir: string, patch: WorktreeStatusPatch) {
     const repo = findRepoOwning(dir);
     if (repo === undefined) return;
     const idx = repo.worktrees.findIndex((wt) => wt.path === dir);
     if (idx < 0) return;
     gitStatusGenByDir.set(dir, (gitStatusGenByDir.get(dir) ?? 0) + 1);
     const next = [...repo.worktrees];
-    next[idx] = { ...next[idx], gitStatuses: statuses };
+    next[idx] = {
+      ...next[idx],
+      gitStatuses: patch.statuses,
+      hasUpstream: patch.hasUpstream,
+      ahead: patch.ahead,
+      behind: patch.behind,
+    };
     repos.value[repo.rootDir] = { ...repo, worktrees: next };
   }
 

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_common.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_common.pb.swift
@@ -76,9 +76,31 @@ public struct Gozd_V1_WorktreeEntry: Sendable {
 
   public var tasks: [Gozd_V1_Task] = []
 
-  /// upstream（追跡リモートブランチ）が設定されているか。
-  /// false の場合 ahead / behind は意味を持たず、UI 側で表示しない。
-  public var hasUpstream_p: Bool = false
+  /// upstream（追跡リモートブランチ）に対する差分。upstream 未設定なら不在。
+  /// optional により「未設定」をフィールド不在で表現し、ahead/behind を見るには
+  /// upstream 自体の存在をチェックする契約を型レベルで強制する。
+  public var upstream: Gozd_V1_UpstreamStatus {
+    get {_upstream ?? Gozd_V1_UpstreamStatus()}
+    set {_upstream = newValue}
+  }
+  /// Returns true if `upstream` has been explicitly set.
+  public var hasUpstream: Bool {self._upstream != nil}
+  /// Clears the value of `upstream`. Subsequent reads from it will return its default value.
+  public mutating func clearUpstream() {self._upstream = nil}
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+
+  fileprivate var _upstream: Gozd_V1_UpstreamStatus? = nil
+}
+
+/// upstream（追跡リモートブランチ）との差分。`git status --porcelain=v2 --branch` の
+/// `# branch.ab` 行に対応。upstream 自体が未設定のときはこの message ごと不在になる。
+public struct Gozd_V1_UpstreamStatus: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
 
   /// upstream に対して先行しているローカルコミット数（未 push）。
   public var ahead: UInt32 = 0
@@ -330,7 +352,7 @@ extension Gozd_V1_GhRefKind: SwiftProtobuf._ProtoNameProviding {
 
 extension Gozd_V1_WorktreeEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WorktreeEntry"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}path\0\u{1}head\0\u{1}branch\0\u{3}is_main\0\u{3}git_statuses\0\u{1}tasks\0\u{3}has_upstream\0\u{1}ahead\0\u{1}behind\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}path\0\u{1}head\0\u{1}branch\0\u{3}is_main\0\u{3}git_statuses\0\u{1}tasks\0\u{1}upstream\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -344,15 +366,17 @@ extension Gozd_V1_WorktreeEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
       case 4: try { try decoder.decodeSingularBoolField(value: &self.isMain) }()
       case 5: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &self.gitStatuses) }()
       case 6: try { try decoder.decodeRepeatedMessageField(value: &self.tasks) }()
-      case 7: try { try decoder.decodeSingularBoolField(value: &self.hasUpstream_p) }()
-      case 8: try { try decoder.decodeSingularUInt32Field(value: &self.ahead) }()
-      case 9: try { try decoder.decodeSingularUInt32Field(value: &self.behind) }()
+      case 7: try { try decoder.decodeSingularMessageField(value: &self._upstream) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.path.isEmpty {
       try visitor.visitSingularStringField(value: self.path, fieldNumber: 1)
     }
@@ -371,15 +395,9 @@ extension Gozd_V1_WorktreeEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     if !self.tasks.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.tasks, fieldNumber: 6)
     }
-    if self.hasUpstream_p != false {
-      try visitor.visitSingularBoolField(value: self.hasUpstream_p, fieldNumber: 7)
-    }
-    if self.ahead != 0 {
-      try visitor.visitSingularUInt32Field(value: self.ahead, fieldNumber: 8)
-    }
-    if self.behind != 0 {
-      try visitor.visitSingularUInt32Field(value: self.behind, fieldNumber: 9)
-    }
+    try { if let v = self._upstream {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 7)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -390,7 +408,40 @@ extension Gozd_V1_WorktreeEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     if lhs.isMain != rhs.isMain {return false}
     if lhs.gitStatuses != rhs.gitStatuses {return false}
     if lhs.tasks != rhs.tasks {return false}
-    if lhs.hasUpstream_p != rhs.hasUpstream_p {return false}
+    if lhs._upstream != rhs._upstream {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Gozd_V1_UpstreamStatus: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".UpstreamStatus"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}ahead\0\u{1}behind\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularUInt32Field(value: &self.ahead) }()
+      case 2: try { try decoder.decodeSingularUInt32Field(value: &self.behind) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.ahead != 0 {
+      try visitor.visitSingularUInt32Field(value: self.ahead, fieldNumber: 1)
+    }
+    if self.behind != 0 {
+      try visitor.visitSingularUInt32Field(value: self.behind, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Gozd_V1_UpstreamStatus, rhs: Gozd_V1_UpstreamStatus) -> Bool {
     if lhs.ahead != rhs.ahead {return false}
     if lhs.behind != rhs.behind {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_common.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_common.pb.swift
@@ -76,6 +76,16 @@ public struct Gozd_V1_WorktreeEntry: Sendable {
 
   public var tasks: [Gozd_V1_Task] = []
 
+  /// upstream（追跡リモートブランチ）が設定されているか。
+  /// false の場合 ahead / behind は意味を持たず、UI 側で表示しない。
+  public var hasUpstream_p: Bool = false
+
+  /// upstream に対して先行しているローカルコミット数（未 push）。
+  public var ahead: UInt32 = 0
+
+  /// upstream に対して遅れているリモートコミット数（未 pull）。
+  public var behind: UInt32 = 0
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -320,7 +330,7 @@ extension Gozd_V1_GhRefKind: SwiftProtobuf._ProtoNameProviding {
 
 extension Gozd_V1_WorktreeEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".WorktreeEntry"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}path\0\u{1}head\0\u{1}branch\0\u{3}is_main\0\u{3}git_statuses\0\u{1}tasks\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}path\0\u{1}head\0\u{1}branch\0\u{3}is_main\0\u{3}git_statuses\0\u{1}tasks\0\u{3}has_upstream\0\u{1}ahead\0\u{1}behind\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -334,6 +344,9 @@ extension Gozd_V1_WorktreeEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
       case 4: try { try decoder.decodeSingularBoolField(value: &self.isMain) }()
       case 5: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &self.gitStatuses) }()
       case 6: try { try decoder.decodeRepeatedMessageField(value: &self.tasks) }()
+      case 7: try { try decoder.decodeSingularBoolField(value: &self.hasUpstream_p) }()
+      case 8: try { try decoder.decodeSingularUInt32Field(value: &self.ahead) }()
+      case 9: try { try decoder.decodeSingularUInt32Field(value: &self.behind) }()
       default: break
       }
     }
@@ -358,6 +371,15 @@ extension Gozd_V1_WorktreeEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     if !self.tasks.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.tasks, fieldNumber: 6)
     }
+    if self.hasUpstream_p != false {
+      try visitor.visitSingularBoolField(value: self.hasUpstream_p, fieldNumber: 7)
+    }
+    if self.ahead != 0 {
+      try visitor.visitSingularUInt32Field(value: self.ahead, fieldNumber: 8)
+    }
+    if self.behind != 0 {
+      try visitor.visitSingularUInt32Field(value: self.behind, fieldNumber: 9)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -368,6 +390,9 @@ extension Gozd_V1_WorktreeEntry: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     if lhs.isMain != rhs.isMain {return false}
     if lhs.gitStatuses != rhs.gitStatuses {return false}
     if lhs.tasks != rhs.tasks {return false}
+    if lhs.hasUpstream_p != rhs.hasUpstream_p {return false}
+    if lhs.ahead != rhs.ahead {return false}
+    if lhs.behind != rhs.behind {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
@@ -491,11 +491,13 @@ public struct Gozd_V1_GitViewerResponse: Sendable {
   public init() {}
 }
 
-/// gitFetchOrigin: `git fetch --no-write-fetch-head origin` 相当。
-/// 背景自動 fetch で refs/remotes/origin/* を更新し、status 経路 (FSWatchRegistry →
+/// gitFetchRemotes: `git fetch --all --no-write-fetch-head` 相当。
+/// 背景自動 fetch で refs/remotes/<remote>/* を更新し、status 経路 (FSWatchRegistry →
 /// gitStatusFull → gitStatusChange push) を介して各 worktree の ahead/behind を最新化する。
+/// upstream が origin 以外 (例: fork PR workflow で upstream=upstream / origin=fork) でも
+/// 全 remote を更新できるよう --all を採用。VSCode autofetch の "all" モード相当。
 /// 失敗 (offline / 認証失敗等) は ok=false + error_detail で返し、呼び出し側で握り潰す。
-public struct Gozd_V1_GitFetchOriginRequest: Sendable {
+public struct Gozd_V1_GitFetchRemotesRequest: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -507,7 +509,7 @@ public struct Gozd_V1_GitFetchOriginRequest: Sendable {
   public init() {}
 }
 
-public struct Gozd_V1_GitFetchOriginResponse: Sendable {
+public struct Gozd_V1_GitFetchRemotesResponse: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1396,8 +1398,8 @@ extension Gozd_V1_GitViewerResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
   }
 }
 
-extension Gozd_V1_GitFetchOriginRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".GitFetchOriginRequest"
+extension Gozd_V1_GitFetchRemotesRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GitFetchRemotesRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}dir\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1419,15 +1421,15 @@ extension Gozd_V1_GitFetchOriginRequest: SwiftProtobuf.Message, SwiftProtobuf._M
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Gozd_V1_GitFetchOriginRequest, rhs: Gozd_V1_GitFetchOriginRequest) -> Bool {
+  public static func ==(lhs: Gozd_V1_GitFetchRemotesRequest, rhs: Gozd_V1_GitFetchRemotesRequest) -> Bool {
     if lhs.dir != rhs.dir {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
 }
 
-extension Gozd_V1_GitFetchOriginResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".GitFetchOriginResponse"
+extension Gozd_V1_GitFetchRemotesResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GitFetchRemotesResponse"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}ok\0\u{3}error_detail\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -1453,7 +1455,7 @@ extension Gozd_V1_GitFetchOriginResponse: SwiftProtobuf.Message, SwiftProtobuf._
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Gozd_V1_GitFetchOriginResponse, rhs: Gozd_V1_GitFetchOriginResponse) -> Bool {
+  public static func ==(lhs: Gozd_V1_GitFetchRemotesResponse, rhs: Gozd_V1_GitFetchRemotesResponse) -> Bool {
     if lhs.ok != rhs.ok {return false}
     if lhs.errorDetail != rhs.errorDetail {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
@@ -491,6 +491,37 @@ public struct Gozd_V1_GitViewerResponse: Sendable {
   public init() {}
 }
 
+/// gitFetchOrigin: `git fetch --no-write-fetch-head origin` 相当。
+/// 背景自動 fetch で refs/remotes/origin/* を更新し、status 経路 (FSWatchRegistry →
+/// gitStatusFull → gitStatusChange push) を介して各 worktree の ahead/behind を最新化する。
+/// 失敗 (offline / 認証失敗等) は ok=false + error_detail で返し、呼び出し側で握り潰す。
+public struct Gozd_V1_GitFetchOriginRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var dir: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public struct Gozd_V1_GitFetchOriginResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var ok: Bool = false
+
+  /// 失敗時の stderr 冒頭 (debug 用、最大 512B 程度に切り詰める)
+  public var errorDetail: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 /// gitDefaultBranch: `git worktree add -b <new> <abs> <ref>` の `<ref>` にそのまま渡せる
 /// 「default branch ref」を返す。新規 worktree 作成時の起点を一意に決めるために使う。
 /// 解決順序は二段 fallback:
@@ -1359,6 +1390,71 @@ extension Gozd_V1_GitViewerResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
     if lhs.ok != rhs.ok {return false}
     if lhs.login != rhs.login {return false}
     if lhs.errorKind != rhs.errorKind {return false}
+    if lhs.errorDetail != rhs.errorDetail {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Gozd_V1_GitFetchOriginRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GitFetchOriginRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}dir\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.dir) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.dir.isEmpty {
+      try visitor.visitSingularStringField(value: self.dir, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Gozd_V1_GitFetchOriginRequest, rhs: Gozd_V1_GitFetchOriginRequest) -> Bool {
+    if lhs.dir != rhs.dir {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Gozd_V1_GitFetchOriginResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GitFetchOriginResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}ok\0\u{3}error_detail\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularBoolField(value: &self.ok) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.errorDetail) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if self.ok != false {
+      try visitor.visitSingularBoolField(value: self.ok, fieldNumber: 1)
+    }
+    if !self.errorDetail.isEmpty {
+      try visitor.visitSingularStringField(value: self.errorDetail, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Gozd_V1_GitFetchOriginResponse, rhs: Gozd_V1_GitFetchOriginResponse) -> Bool {
+    if lhs.ok != rhs.ok {return false}
     if lhs.errorDetail != rhs.errorDetail {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_git_status.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_git_status.pb.swift
@@ -46,19 +46,21 @@ public struct Gozd_V1_GitStatusResponse: Sendable {
   /// 値は常に長さ 2 の文字列。1 文字目 = index 状態、2 文字目 = working tree 状態。
   public var entries: Dictionary<String,String> = [:]
 
-  /// upstream（追跡リモートブランチ）が設定されているか。
-  /// false の場合 ahead / behind は意味を持たない。
-  public var hasUpstream_p: Bool = false
-
-  /// upstream に対して先行しているローカルコミット数（未 push）。
-  public var ahead: UInt32 = 0
-
-  /// upstream に対して遅れているリモートコミット数（未 pull）。
-  public var behind: UInt32 = 0
+  /// upstream に対する差分。未設定なら不在。
+  public var upstream: Gozd_V1_UpstreamStatus {
+    get {_upstream ?? Gozd_V1_UpstreamStatus()}
+    set {_upstream = newValue}
+  }
+  /// Returns true if `upstream` has been explicitly set.
+  public var hasUpstream: Bool {self._upstream != nil}
+  /// Clears the value of `upstream`. Subsequent reads from it will return its default value.
+  public mutating func clearUpstream() {self._upstream = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
+
+  fileprivate var _upstream: Gozd_V1_UpstreamStatus? = nil
 }
 
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
@@ -97,7 +99,7 @@ extension Gozd_V1_GitStatusRequest: SwiftProtobuf.Message, SwiftProtobuf._Messag
 
 extension Gozd_V1_GitStatusResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GitStatusResponse"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}entries\0\u{3}has_upstream\0\u{1}ahead\0\u{1}behind\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}entries\0\u{1}upstream\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -106,35 +108,29 @@ extension Gozd_V1_GitStatusResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &self.entries) }()
-      case 2: try { try decoder.decodeSingularBoolField(value: &self.hasUpstream_p) }()
-      case 3: try { try decoder.decodeSingularUInt32Field(value: &self.ahead) }()
-      case 4: try { try decoder.decodeSingularUInt32Field(value: &self.behind) }()
+      case 2: try { try decoder.decodeSingularMessageField(value: &self._upstream) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.entries.isEmpty {
       try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: self.entries, fieldNumber: 1)
     }
-    if self.hasUpstream_p != false {
-      try visitor.visitSingularBoolField(value: self.hasUpstream_p, fieldNumber: 2)
-    }
-    if self.ahead != 0 {
-      try visitor.visitSingularUInt32Field(value: self.ahead, fieldNumber: 3)
-    }
-    if self.behind != 0 {
-      try visitor.visitSingularUInt32Field(value: self.behind, fieldNumber: 4)
-    }
+    try { if let v = self._upstream {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Gozd_V1_GitStatusResponse, rhs: Gozd_V1_GitStatusResponse) -> Bool {
     if lhs.entries != rhs.entries {return false}
-    if lhs.hasUpstream_p != rhs.hasUpstream_p {return false}
-    if lhs.ahead != rhs.ahead {return false}
-    if lhs.behind != rhs.behind {return false}
+    if lhs._upstream != rhs._upstream {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_git_status.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_git_status.pb.swift
@@ -46,6 +46,16 @@ public struct Gozd_V1_GitStatusResponse: Sendable {
   /// 値は常に長さ 2 の文字列。1 文字目 = index 状態、2 文字目 = working tree 状態。
   public var entries: Dictionary<String,String> = [:]
 
+  /// upstream（追跡リモートブランチ）が設定されているか。
+  /// false の場合 ahead / behind は意味を持たない。
+  public var hasUpstream_p: Bool = false
+
+  /// upstream に対して先行しているローカルコミット数（未 push）。
+  public var ahead: UInt32 = 0
+
+  /// upstream に対して遅れているリモートコミット数（未 pull）。
+  public var behind: UInt32 = 0
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -87,7 +97,7 @@ extension Gozd_V1_GitStatusRequest: SwiftProtobuf.Message, SwiftProtobuf._Messag
 
 extension Gozd_V1_GitStatusResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GitStatusResponse"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}entries\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}entries\0\u{3}has_upstream\0\u{1}ahead\0\u{1}behind\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -96,6 +106,9 @@ extension Gozd_V1_GitStatusResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
       case 1: try { try decoder.decodeMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: &self.entries) }()
+      case 2: try { try decoder.decodeSingularBoolField(value: &self.hasUpstream_p) }()
+      case 3: try { try decoder.decodeSingularUInt32Field(value: &self.ahead) }()
+      case 4: try { try decoder.decodeSingularUInt32Field(value: &self.behind) }()
       default: break
       }
     }
@@ -105,11 +118,23 @@ extension Gozd_V1_GitStatusResponse: SwiftProtobuf.Message, SwiftProtobuf._Messa
     if !self.entries.isEmpty {
       try visitor.visitMapField(fieldType: SwiftProtobuf._ProtobufMap<SwiftProtobuf.ProtobufString,SwiftProtobuf.ProtobufString>.self, value: self.entries, fieldNumber: 1)
     }
+    if self.hasUpstream_p != false {
+      try visitor.visitSingularBoolField(value: self.hasUpstream_p, fieldNumber: 2)
+    }
+    if self.ahead != 0 {
+      try visitor.visitSingularUInt32Field(value: self.ahead, fieldNumber: 3)
+    }
+    if self.behind != 0 {
+      try visitor.visitSingularUInt32Field(value: self.behind, fieldNumber: 4)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: Gozd_V1_GitStatusResponse, rhs: Gozd_V1_GitStatusResponse) -> Bool {
     if lhs.entries != rhs.entries {return false}
+    if lhs.hasUpstream_p != rhs.hasUpstream_p {return false}
+    if lhs.ahead != rhs.ahead {return false}
+    if lhs.behind != rhs.behind {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/packages/proto-ts/src/generated/gozd/v1/common.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/common.ts
@@ -56,6 +56,15 @@ export interface WorktreeEntry {
   /** ファイル相対パス → porcelain v1 XY コード */
   gitStatuses: { [key: string]: string };
   tasks: Task[];
+  /**
+   * upstream（追跡リモートブランチ）が設定されているか。
+   * false の場合 ahead / behind は意味を持たず、UI 側で表示しない。
+   */
+  hasUpstream: boolean;
+  /** upstream に対して先行しているローカルコミット数（未 push）。 */
+  ahead: number;
+  /** upstream に対して遅れているリモートコミット数（未 pull）。 */
+  behind: number;
 }
 
 export interface WorktreeEntry_GitStatusesEntry {
@@ -171,7 +180,17 @@ export interface ProjectConfig {
 }
 
 function createBaseWorktreeEntry(): WorktreeEntry {
-  return { path: "", head: "", branch: "", isMain: false, gitStatuses: {}, tasks: [] };
+  return {
+    path: "",
+    head: "",
+    branch: "",
+    isMain: false,
+    gitStatuses: {},
+    tasks: [],
+    hasUpstream: false,
+    ahead: 0,
+    behind: 0,
+  };
 }
 
 export const WorktreeEntry: MessageFns<WorktreeEntry> = {
@@ -193,6 +212,15 @@ export const WorktreeEntry: MessageFns<WorktreeEntry> = {
     });
     for (const v of message.tasks) {
       Task.encode(v!, writer.uint32(50).fork()).join();
+    }
+    if (message.hasUpstream !== false) {
+      writer.uint32(56).bool(message.hasUpstream);
+    }
+    if (message.ahead !== 0) {
+      writer.uint32(64).uint32(message.ahead);
+    }
+    if (message.behind !== 0) {
+      writer.uint32(72).uint32(message.behind);
     }
     return writer;
   },
@@ -255,6 +283,30 @@ export const WorktreeEntry: MessageFns<WorktreeEntry> = {
           message.tasks.push(Task.decode(reader, reader.uint32()));
           continue;
         }
+        case 7: {
+          if (tag !== 56) {
+            break;
+          }
+
+          message.hasUpstream = reader.bool();
+          continue;
+        }
+        case 8: {
+          if (tag !== 64) {
+            break;
+          }
+
+          message.ahead = reader.uint32();
+          continue;
+        }
+        case 9: {
+          if (tag !== 72) {
+            break;
+          }
+
+          message.behind = reader.uint32();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -292,6 +344,13 @@ export const WorktreeEntry: MessageFns<WorktreeEntry> = {
         )
         : {},
       tasks: globalThis.Array.isArray(object?.tasks) ? object.tasks.map((e: any) => Task.fromJSON(e)) : [],
+      hasUpstream: isSet(object.hasUpstream)
+        ? globalThis.Boolean(object.hasUpstream)
+        : isSet(object.has_upstream)
+        ? globalThis.Boolean(object.has_upstream)
+        : false,
+      ahead: isSet(object.ahead) ? globalThis.Number(object.ahead) : 0,
+      behind: isSet(object.behind) ? globalThis.Number(object.behind) : 0,
     };
   },
 
@@ -321,6 +380,15 @@ export const WorktreeEntry: MessageFns<WorktreeEntry> = {
     if (message.tasks?.length) {
       obj.tasks = message.tasks.map((e) => Task.toJSON(e));
     }
+    if (message.hasUpstream !== false) {
+      obj.hasUpstream = message.hasUpstream;
+    }
+    if (message.ahead !== 0) {
+      obj.ahead = Math.round(message.ahead);
+    }
+    if (message.behind !== 0) {
+      obj.behind = Math.round(message.behind);
+    }
     return obj;
   },
 
@@ -343,6 +411,9 @@ export const WorktreeEntry: MessageFns<WorktreeEntry> = {
       {},
     );
     message.tasks = object.tasks?.map((e) => Task.fromPartial(e)) || [];
+    message.hasUpstream = object.hasUpstream ?? false;
+    message.ahead = object.ahead ?? 0;
+    message.behind = object.behind ?? 0;
     return message;
   },
 };

--- a/packages/proto-ts/src/generated/gozd/v1/common.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/common.ts
@@ -57,19 +57,27 @@ export interface WorktreeEntry {
   gitStatuses: { [key: string]: string };
   tasks: Task[];
   /**
-   * upstream（追跡リモートブランチ）が設定されているか。
-   * false の場合 ahead / behind は意味を持たず、UI 側で表示しない。
+   * upstream（追跡リモートブランチ）に対する差分。upstream 未設定なら不在。
+   * optional により「未設定」をフィールド不在で表現し、ahead/behind を見るには
+   * upstream 自体の存在をチェックする契約を型レベルで強制する。
    */
-  hasUpstream: boolean;
-  /** upstream に対して先行しているローカルコミット数（未 push）。 */
-  ahead: number;
-  /** upstream に対して遅れているリモートコミット数（未 pull）。 */
-  behind: number;
+  upstream?: UpstreamStatus | undefined;
 }
 
 export interface WorktreeEntry_GitStatusesEntry {
   key: string;
   value: string;
+}
+
+/**
+ * upstream（追跡リモートブランチ）との差分。`git status --porcelain=v2 --branch` の
+ * `# branch.ab` 行に対応。upstream 自体が未設定のときはこの message ごと不在になる。
+ */
+export interface UpstreamStatus {
+  /** upstream に対して先行しているローカルコミット数（未 push）。 */
+  ahead: number;
+  /** upstream に対して遅れているリモートコミット数（未 pull）。 */
+  behind: number;
 }
 
 export interface Task {
@@ -180,17 +188,7 @@ export interface ProjectConfig {
 }
 
 function createBaseWorktreeEntry(): WorktreeEntry {
-  return {
-    path: "",
-    head: "",
-    branch: "",
-    isMain: false,
-    gitStatuses: {},
-    tasks: [],
-    hasUpstream: false,
-    ahead: 0,
-    behind: 0,
-  };
+  return { path: "", head: "", branch: "", isMain: false, gitStatuses: {}, tasks: [], upstream: undefined };
 }
 
 export const WorktreeEntry: MessageFns<WorktreeEntry> = {
@@ -213,14 +211,8 @@ export const WorktreeEntry: MessageFns<WorktreeEntry> = {
     for (const v of message.tasks) {
       Task.encode(v!, writer.uint32(50).fork()).join();
     }
-    if (message.hasUpstream !== false) {
-      writer.uint32(56).bool(message.hasUpstream);
-    }
-    if (message.ahead !== 0) {
-      writer.uint32(64).uint32(message.ahead);
-    }
-    if (message.behind !== 0) {
-      writer.uint32(72).uint32(message.behind);
+    if (message.upstream !== undefined) {
+      UpstreamStatus.encode(message.upstream, writer.uint32(58).fork()).join();
     }
     return writer;
   },
@@ -284,27 +276,11 @@ export const WorktreeEntry: MessageFns<WorktreeEntry> = {
           continue;
         }
         case 7: {
-          if (tag !== 56) {
+          if (tag !== 58) {
             break;
           }
 
-          message.hasUpstream = reader.bool();
-          continue;
-        }
-        case 8: {
-          if (tag !== 64) {
-            break;
-          }
-
-          message.ahead = reader.uint32();
-          continue;
-        }
-        case 9: {
-          if (tag !== 72) {
-            break;
-          }
-
-          message.behind = reader.uint32();
+          message.upstream = UpstreamStatus.decode(reader, reader.uint32());
           continue;
         }
       }
@@ -344,13 +320,7 @@ export const WorktreeEntry: MessageFns<WorktreeEntry> = {
         )
         : {},
       tasks: globalThis.Array.isArray(object?.tasks) ? object.tasks.map((e: any) => Task.fromJSON(e)) : [],
-      hasUpstream: isSet(object.hasUpstream)
-        ? globalThis.Boolean(object.hasUpstream)
-        : isSet(object.has_upstream)
-        ? globalThis.Boolean(object.has_upstream)
-        : false,
-      ahead: isSet(object.ahead) ? globalThis.Number(object.ahead) : 0,
-      behind: isSet(object.behind) ? globalThis.Number(object.behind) : 0,
+      upstream: isSet(object.upstream) ? UpstreamStatus.fromJSON(object.upstream) : undefined,
     };
   },
 
@@ -380,14 +350,8 @@ export const WorktreeEntry: MessageFns<WorktreeEntry> = {
     if (message.tasks?.length) {
       obj.tasks = message.tasks.map((e) => Task.toJSON(e));
     }
-    if (message.hasUpstream !== false) {
-      obj.hasUpstream = message.hasUpstream;
-    }
-    if (message.ahead !== 0) {
-      obj.ahead = Math.round(message.ahead);
-    }
-    if (message.behind !== 0) {
-      obj.behind = Math.round(message.behind);
+    if (message.upstream !== undefined) {
+      obj.upstream = UpstreamStatus.toJSON(message.upstream);
     }
     return obj;
   },
@@ -411,9 +375,9 @@ export const WorktreeEntry: MessageFns<WorktreeEntry> = {
       {},
     );
     message.tasks = object.tasks?.map((e) => Task.fromPartial(e)) || [];
-    message.hasUpstream = object.hasUpstream ?? false;
-    message.ahead = object.ahead ?? 0;
-    message.behind = object.behind ?? 0;
+    message.upstream = (object.upstream !== undefined && object.upstream !== null)
+      ? UpstreamStatus.fromPartial(object.upstream)
+      : undefined;
     return message;
   },
 };
@@ -490,6 +454,82 @@ export const WorktreeEntry_GitStatusesEntry: MessageFns<WorktreeEntry_GitStatuse
     const message = createBaseWorktreeEntry_GitStatusesEntry();
     message.key = object.key ?? "";
     message.value = object.value ?? "";
+    return message;
+  },
+};
+
+function createBaseUpstreamStatus(): UpstreamStatus {
+  return { ahead: 0, behind: 0 };
+}
+
+export const UpstreamStatus: MessageFns<UpstreamStatus> = {
+  encode(message: UpstreamStatus, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.ahead !== 0) {
+      writer.uint32(8).uint32(message.ahead);
+    }
+    if (message.behind !== 0) {
+      writer.uint32(16).uint32(message.behind);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): UpstreamStatus {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseUpstreamStatus();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.ahead = reader.uint32();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.behind = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): UpstreamStatus {
+    return {
+      ahead: isSet(object.ahead) ? globalThis.Number(object.ahead) : 0,
+      behind: isSet(object.behind) ? globalThis.Number(object.behind) : 0,
+    };
+  },
+
+  toJSON(message: UpstreamStatus): unknown {
+    const obj: any = {};
+    if (message.ahead !== 0) {
+      obj.ahead = Math.round(message.ahead);
+    }
+    if (message.behind !== 0) {
+      obj.behind = Math.round(message.behind);
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<UpstreamStatus>): UpstreamStatus {
+    return UpstreamStatus.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<UpstreamStatus>): UpstreamStatus {
+    const message = createBaseUpstreamStatus();
+    message.ahead = object.ahead ?? 0;
+    message.behind = object.behind ?? 0;
     return message;
   },
 };

--- a/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
@@ -288,16 +288,18 @@ export interface GitViewerResponse {
 }
 
 /**
- * gitFetchOrigin: `git fetch --no-write-fetch-head origin` 相当。
- * 背景自動 fetch で refs/remotes/origin/* を更新し、status 経路 (FSWatchRegistry →
+ * gitFetchRemotes: `git fetch --all --no-write-fetch-head` 相当。
+ * 背景自動 fetch で refs/remotes/<remote>/* を更新し、status 経路 (FSWatchRegistry →
  * gitStatusFull → gitStatusChange push) を介して各 worktree の ahead/behind を最新化する。
+ * upstream が origin 以外 (例: fork PR workflow で upstream=upstream / origin=fork) でも
+ * 全 remote を更新できるよう --all を採用。VSCode autofetch の "all" モード相当。
  * 失敗 (offline / 認証失敗等) は ok=false + error_detail で返し、呼び出し側で握り潰す。
  */
-export interface GitFetchOriginRequest {
+export interface GitFetchRemotesRequest {
   dir: string;
 }
 
-export interface GitFetchOriginResponse {
+export interface GitFetchRemotesResponse {
   ok: boolean;
   /** 失敗時の stderr 冒頭 (debug 用、最大 512B 程度に切り詰める) */
   errorDetail: string;
@@ -2130,22 +2132,22 @@ export const GitViewerResponse: MessageFns<GitViewerResponse> = {
   },
 };
 
-function createBaseGitFetchOriginRequest(): GitFetchOriginRequest {
+function createBaseGitFetchRemotesRequest(): GitFetchRemotesRequest {
   return { dir: "" };
 }
 
-export const GitFetchOriginRequest: MessageFns<GitFetchOriginRequest> = {
-  encode(message: GitFetchOriginRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+export const GitFetchRemotesRequest: MessageFns<GitFetchRemotesRequest> = {
+  encode(message: GitFetchRemotesRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.dir !== "") {
       writer.uint32(10).string(message.dir);
     }
     return writer;
   },
 
-  decode(input: BinaryReader | Uint8Array, length?: number): GitFetchOriginRequest {
+  decode(input: BinaryReader | Uint8Array, length?: number): GitFetchRemotesRequest {
     const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseGitFetchOriginRequest();
+    const message = createBaseGitFetchRemotesRequest();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -2166,11 +2168,11 @@ export const GitFetchOriginRequest: MessageFns<GitFetchOriginRequest> = {
     return message;
   },
 
-  fromJSON(object: any): GitFetchOriginRequest {
+  fromJSON(object: any): GitFetchRemotesRequest {
     return { dir: isSet(object.dir) ? globalThis.String(object.dir) : "" };
   },
 
-  toJSON(message: GitFetchOriginRequest): unknown {
+  toJSON(message: GitFetchRemotesRequest): unknown {
     const obj: any = {};
     if (message.dir !== "") {
       obj.dir = message.dir;
@@ -2178,22 +2180,22 @@ export const GitFetchOriginRequest: MessageFns<GitFetchOriginRequest> = {
     return obj;
   },
 
-  create(base?: DeepPartial<GitFetchOriginRequest>): GitFetchOriginRequest {
-    return GitFetchOriginRequest.fromPartial(base ?? {});
+  create(base?: DeepPartial<GitFetchRemotesRequest>): GitFetchRemotesRequest {
+    return GitFetchRemotesRequest.fromPartial(base ?? {});
   },
-  fromPartial(object: DeepPartial<GitFetchOriginRequest>): GitFetchOriginRequest {
-    const message = createBaseGitFetchOriginRequest();
+  fromPartial(object: DeepPartial<GitFetchRemotesRequest>): GitFetchRemotesRequest {
+    const message = createBaseGitFetchRemotesRequest();
     message.dir = object.dir ?? "";
     return message;
   },
 };
 
-function createBaseGitFetchOriginResponse(): GitFetchOriginResponse {
+function createBaseGitFetchRemotesResponse(): GitFetchRemotesResponse {
   return { ok: false, errorDetail: "" };
 }
 
-export const GitFetchOriginResponse: MessageFns<GitFetchOriginResponse> = {
-  encode(message: GitFetchOriginResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+export const GitFetchRemotesResponse: MessageFns<GitFetchRemotesResponse> = {
+  encode(message: GitFetchRemotesResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
     if (message.ok !== false) {
       writer.uint32(8).bool(message.ok);
     }
@@ -2203,10 +2205,10 @@ export const GitFetchOriginResponse: MessageFns<GitFetchOriginResponse> = {
     return writer;
   },
 
-  decode(input: BinaryReader | Uint8Array, length?: number): GitFetchOriginResponse {
+  decode(input: BinaryReader | Uint8Array, length?: number): GitFetchRemotesResponse {
     const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
     const end = length === undefined ? reader.len : reader.pos + length;
-    const message = createBaseGitFetchOriginResponse();
+    const message = createBaseGitFetchRemotesResponse();
     while (reader.pos < end) {
       const tag = reader.uint32();
       switch (tag >>> 3) {
@@ -2235,7 +2237,7 @@ export const GitFetchOriginResponse: MessageFns<GitFetchOriginResponse> = {
     return message;
   },
 
-  fromJSON(object: any): GitFetchOriginResponse {
+  fromJSON(object: any): GitFetchRemotesResponse {
     return {
       ok: isSet(object.ok) ? globalThis.Boolean(object.ok) : false,
       errorDetail: isSet(object.errorDetail)
@@ -2246,7 +2248,7 @@ export const GitFetchOriginResponse: MessageFns<GitFetchOriginResponse> = {
     };
   },
 
-  toJSON(message: GitFetchOriginResponse): unknown {
+  toJSON(message: GitFetchRemotesResponse): unknown {
     const obj: any = {};
     if (message.ok !== false) {
       obj.ok = message.ok;
@@ -2257,11 +2259,11 @@ export const GitFetchOriginResponse: MessageFns<GitFetchOriginResponse> = {
     return obj;
   },
 
-  create(base?: DeepPartial<GitFetchOriginResponse>): GitFetchOriginResponse {
-    return GitFetchOriginResponse.fromPartial(base ?? {});
+  create(base?: DeepPartial<GitFetchRemotesResponse>): GitFetchRemotesResponse {
+    return GitFetchRemotesResponse.fromPartial(base ?? {});
   },
-  fromPartial(object: DeepPartial<GitFetchOriginResponse>): GitFetchOriginResponse {
-    const message = createBaseGitFetchOriginResponse();
+  fromPartial(object: DeepPartial<GitFetchRemotesResponse>): GitFetchRemotesResponse {
+    const message = createBaseGitFetchRemotesResponse();
     message.ok = object.ok ?? false;
     message.errorDetail = object.errorDetail ?? "";
     return message;

--- a/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
@@ -288,6 +288,22 @@ export interface GitViewerResponse {
 }
 
 /**
+ * gitFetchOrigin: `git fetch --no-write-fetch-head origin` 相当。
+ * 背景自動 fetch で refs/remotes/origin/* を更新し、status 経路 (FSWatchRegistry →
+ * gitStatusFull → gitStatusChange push) を介して各 worktree の ahead/behind を最新化する。
+ * 失敗 (offline / 認証失敗等) は ok=false + error_detail で返し、呼び出し側で握り潰す。
+ */
+export interface GitFetchOriginRequest {
+  dir: string;
+}
+
+export interface GitFetchOriginResponse {
+  ok: boolean;
+  /** 失敗時の stderr 冒頭 (debug 用、最大 512B 程度に切り詰める) */
+  errorDetail: string;
+}
+
+/**
  * gitDefaultBranch: `git worktree add -b <new> <abs> <ref>` の `<ref>` にそのまま渡せる
  * 「default branch ref」を返す。新規 worktree 作成時の起点を一意に決めるために使う。
  * 解決順序は二段 fallback:
@@ -2109,6 +2125,144 @@ export const GitViewerResponse: MessageFns<GitViewerResponse> = {
     message.ok = object.ok ?? false;
     message.login = object.login ?? "";
     message.errorKind = object.errorKind ?? 0;
+    message.errorDetail = object.errorDetail ?? "";
+    return message;
+  },
+};
+
+function createBaseGitFetchOriginRequest(): GitFetchOriginRequest {
+  return { dir: "" };
+}
+
+export const GitFetchOriginRequest: MessageFns<GitFetchOriginRequest> = {
+  encode(message: GitFetchOriginRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.dir !== "") {
+      writer.uint32(10).string(message.dir);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GitFetchOriginRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGitFetchOriginRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.dir = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GitFetchOriginRequest {
+    return { dir: isSet(object.dir) ? globalThis.String(object.dir) : "" };
+  },
+
+  toJSON(message: GitFetchOriginRequest): unknown {
+    const obj: any = {};
+    if (message.dir !== "") {
+      obj.dir = message.dir;
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<GitFetchOriginRequest>): GitFetchOriginRequest {
+    return GitFetchOriginRequest.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<GitFetchOriginRequest>): GitFetchOriginRequest {
+    const message = createBaseGitFetchOriginRequest();
+    message.dir = object.dir ?? "";
+    return message;
+  },
+};
+
+function createBaseGitFetchOriginResponse(): GitFetchOriginResponse {
+  return { ok: false, errorDetail: "" };
+}
+
+export const GitFetchOriginResponse: MessageFns<GitFetchOriginResponse> = {
+  encode(message: GitFetchOriginResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.ok !== false) {
+      writer.uint32(8).bool(message.ok);
+    }
+    if (message.errorDetail !== "") {
+      writer.uint32(18).string(message.errorDetail);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GitFetchOriginResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGitFetchOriginResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 8) {
+            break;
+          }
+
+          message.ok = reader.bool();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.errorDetail = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GitFetchOriginResponse {
+    return {
+      ok: isSet(object.ok) ? globalThis.Boolean(object.ok) : false,
+      errorDetail: isSet(object.errorDetail)
+        ? globalThis.String(object.errorDetail)
+        : isSet(object.error_detail)
+        ? globalThis.String(object.error_detail)
+        : "",
+    };
+  },
+
+  toJSON(message: GitFetchOriginResponse): unknown {
+    const obj: any = {};
+    if (message.ok !== false) {
+      obj.ok = message.ok;
+    }
+    if (message.errorDetail !== "") {
+      obj.errorDetail = message.errorDetail;
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<GitFetchOriginResponse>): GitFetchOriginResponse {
+    return GitFetchOriginResponse.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<GitFetchOriginResponse>): GitFetchOriginResponse {
+    const message = createBaseGitFetchOriginResponse();
+    message.ok = object.ok ?? false;
     message.errorDetail = object.errorDetail ?? "";
     return message;
   },

--- a/packages/proto-ts/src/generated/gozd/v1/git_status.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/git_status.ts
@@ -26,6 +26,15 @@ export interface GitStatusResponse {
    * 値は常に長さ 2 の文字列。1 文字目 = index 状態、2 文字目 = working tree 状態。
    */
   entries: { [key: string]: string };
+  /**
+   * upstream（追跡リモートブランチ）が設定されているか。
+   * false の場合 ahead / behind は意味を持たない。
+   */
+  hasUpstream: boolean;
+  /** upstream に対して先行しているローカルコミット数（未 push）。 */
+  ahead: number;
+  /** upstream に対して遅れているリモートコミット数（未 pull）。 */
+  behind: number;
 }
 
 export interface GitStatusResponse_EntriesEntry {
@@ -92,7 +101,7 @@ export const GitStatusRequest: MessageFns<GitStatusRequest> = {
 };
 
 function createBaseGitStatusResponse(): GitStatusResponse {
-  return { entries: {} };
+  return { entries: {}, hasUpstream: false, ahead: 0, behind: 0 };
 }
 
 export const GitStatusResponse: MessageFns<GitStatusResponse> = {
@@ -100,6 +109,15 @@ export const GitStatusResponse: MessageFns<GitStatusResponse> = {
     globalThis.Object.entries(message.entries).forEach(([key, value]: [string, string]) => {
       GitStatusResponse_EntriesEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
+    if (message.hasUpstream !== false) {
+      writer.uint32(16).bool(message.hasUpstream);
+    }
+    if (message.ahead !== 0) {
+      writer.uint32(24).uint32(message.ahead);
+    }
+    if (message.behind !== 0) {
+      writer.uint32(32).uint32(message.behind);
+    }
     return writer;
   },
 
@@ -119,6 +137,30 @@ export const GitStatusResponse: MessageFns<GitStatusResponse> = {
           if (entry1.value !== undefined) {
             message.entries[entry1.key] = entry1.value;
           }
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.hasUpstream = reader.bool();
+          continue;
+        }
+        case 3: {
+          if (tag !== 24) {
+            break;
+          }
+
+          message.ahead = reader.uint32();
+          continue;
+        }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.behind = reader.uint32();
           continue;
         }
       }
@@ -141,6 +183,13 @@ export const GitStatusResponse: MessageFns<GitStatusResponse> = {
           {},
         )
         : {},
+      hasUpstream: isSet(object.hasUpstream)
+        ? globalThis.Boolean(object.hasUpstream)
+        : isSet(object.has_upstream)
+        ? globalThis.Boolean(object.has_upstream)
+        : false,
+      ahead: isSet(object.ahead) ? globalThis.Number(object.ahead) : 0,
+      behind: isSet(object.behind) ? globalThis.Number(object.behind) : 0,
     };
   },
 
@@ -154,6 +203,15 @@ export const GitStatusResponse: MessageFns<GitStatusResponse> = {
           obj.entries[k] = v;
         });
       }
+    }
+    if (message.hasUpstream !== false) {
+      obj.hasUpstream = message.hasUpstream;
+    }
+    if (message.ahead !== 0) {
+      obj.ahead = Math.round(message.ahead);
+    }
+    if (message.behind !== 0) {
+      obj.behind = Math.round(message.behind);
     }
     return obj;
   },
@@ -172,6 +230,9 @@ export const GitStatusResponse: MessageFns<GitStatusResponse> = {
       },
       {},
     );
+    message.hasUpstream = object.hasUpstream ?? false;
+    message.ahead = object.ahead ?? 0;
+    message.behind = object.behind ?? 0;
     return message;
   },
 };

--- a/packages/proto-ts/src/generated/gozd/v1/git_status.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/git_status.ts
@@ -6,6 +6,7 @@
 
 /* eslint-disable */
 import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
+import { UpstreamStatus } from "./common";
 
 export const protobufPackage = "gozd.v1";
 
@@ -26,15 +27,8 @@ export interface GitStatusResponse {
    * 値は常に長さ 2 の文字列。1 文字目 = index 状態、2 文字目 = working tree 状態。
    */
   entries: { [key: string]: string };
-  /**
-   * upstream（追跡リモートブランチ）が設定されているか。
-   * false の場合 ahead / behind は意味を持たない。
-   */
-  hasUpstream: boolean;
-  /** upstream に対して先行しているローカルコミット数（未 push）。 */
-  ahead: number;
-  /** upstream に対して遅れているリモートコミット数（未 pull）。 */
-  behind: number;
+  /** upstream に対する差分。未設定なら不在。 */
+  upstream?: UpstreamStatus | undefined;
 }
 
 export interface GitStatusResponse_EntriesEntry {
@@ -101,7 +95,7 @@ export const GitStatusRequest: MessageFns<GitStatusRequest> = {
 };
 
 function createBaseGitStatusResponse(): GitStatusResponse {
-  return { entries: {}, hasUpstream: false, ahead: 0, behind: 0 };
+  return { entries: {}, upstream: undefined };
 }
 
 export const GitStatusResponse: MessageFns<GitStatusResponse> = {
@@ -109,14 +103,8 @@ export const GitStatusResponse: MessageFns<GitStatusResponse> = {
     globalThis.Object.entries(message.entries).forEach(([key, value]: [string, string]) => {
       GitStatusResponse_EntriesEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).join();
     });
-    if (message.hasUpstream !== false) {
-      writer.uint32(16).bool(message.hasUpstream);
-    }
-    if (message.ahead !== 0) {
-      writer.uint32(24).uint32(message.ahead);
-    }
-    if (message.behind !== 0) {
-      writer.uint32(32).uint32(message.behind);
+    if (message.upstream !== undefined) {
+      UpstreamStatus.encode(message.upstream, writer.uint32(18).fork()).join();
     }
     return writer;
   },
@@ -140,27 +128,11 @@ export const GitStatusResponse: MessageFns<GitStatusResponse> = {
           continue;
         }
         case 2: {
-          if (tag !== 16) {
+          if (tag !== 18) {
             break;
           }
 
-          message.hasUpstream = reader.bool();
-          continue;
-        }
-        case 3: {
-          if (tag !== 24) {
-            break;
-          }
-
-          message.ahead = reader.uint32();
-          continue;
-        }
-        case 4: {
-          if (tag !== 32) {
-            break;
-          }
-
-          message.behind = reader.uint32();
+          message.upstream = UpstreamStatus.decode(reader, reader.uint32());
           continue;
         }
       }
@@ -183,13 +155,7 @@ export const GitStatusResponse: MessageFns<GitStatusResponse> = {
           {},
         )
         : {},
-      hasUpstream: isSet(object.hasUpstream)
-        ? globalThis.Boolean(object.hasUpstream)
-        : isSet(object.has_upstream)
-        ? globalThis.Boolean(object.has_upstream)
-        : false,
-      ahead: isSet(object.ahead) ? globalThis.Number(object.ahead) : 0,
-      behind: isSet(object.behind) ? globalThis.Number(object.behind) : 0,
+      upstream: isSet(object.upstream) ? UpstreamStatus.fromJSON(object.upstream) : undefined,
     };
   },
 
@@ -204,14 +170,8 @@ export const GitStatusResponse: MessageFns<GitStatusResponse> = {
         });
       }
     }
-    if (message.hasUpstream !== false) {
-      obj.hasUpstream = message.hasUpstream;
-    }
-    if (message.ahead !== 0) {
-      obj.ahead = Math.round(message.ahead);
-    }
-    if (message.behind !== 0) {
-      obj.behind = Math.round(message.behind);
+    if (message.upstream !== undefined) {
+      obj.upstream = UpstreamStatus.toJSON(message.upstream);
     }
     return obj;
   },
@@ -230,9 +190,9 @@ export const GitStatusResponse: MessageFns<GitStatusResponse> = {
       },
       {},
     );
-    message.hasUpstream = object.hasUpstream ?? false;
-    message.ahead = object.ahead ?? 0;
-    message.behind = object.behind ?? 0;
+    message.upstream = (object.upstream !== undefined && object.upstream !== null)
+      ? UpstreamStatus.fromPartial(object.upstream)
+      : undefined;
     return message;
   },
 };

--- a/packages/proto-ts/src/index.ts
+++ b/packages/proto-ts/src/index.ts
@@ -92,6 +92,8 @@ export {
   GitDefaultBranchResponse,
   GitDiffHunksRequest,
   GitDiffHunksResponse,
+  GitFetchOriginRequest,
+  GitFetchOriginResponse,
   GitIssueListRequest,
   GitIssueListResponse,
   GitLogRequest,

--- a/packages/proto-ts/src/index.ts
+++ b/packages/proto-ts/src/index.ts
@@ -47,6 +47,7 @@ export {
   OpenTargetSelection,
   ProjectConfig,
   Task,
+  UpstreamStatus,
   WorktreeEntry,
 } from "./generated/gozd/v1/common";
 export { EchoRequest, EchoResponse } from "./generated/gozd/v1/echo";
@@ -92,8 +93,8 @@ export {
   GitDefaultBranchResponse,
   GitDiffHunksRequest,
   GitDiffHunksResponse,
-  GitFetchOriginRequest,
-  GitFetchOriginResponse,
+  GitFetchRemotesRequest,
+  GitFetchRemotesResponse,
   GitIssueListRequest,
   GitIssueListResponse,
   GitLogRequest,

--- a/packages/proto/gozd/v1/common.proto
+++ b/packages/proto/gozd/v1/common.proto
@@ -13,6 +13,13 @@ message WorktreeEntry {
   // ファイル相対パス → porcelain v1 XY コード
   map<string, string> git_statuses = 5;
   repeated Task tasks = 6;
+  // upstream（追跡リモートブランチ）が設定されているか。
+  // false の場合 ahead / behind は意味を持たず、UI 側で表示しない。
+  bool has_upstream = 7;
+  // upstream に対して先行しているローカルコミット数（未 push）。
+  uint32 ahead = 8;
+  // upstream に対して遅れているリモートコミット数（未 pull）。
+  uint32 behind = 9;
 }
 
 message Task {

--- a/packages/proto/gozd/v1/common.proto
+++ b/packages/proto/gozd/v1/common.proto
@@ -13,13 +13,19 @@ message WorktreeEntry {
   // ファイル相対パス → porcelain v1 XY コード
   map<string, string> git_statuses = 5;
   repeated Task tasks = 6;
-  // upstream（追跡リモートブランチ）が設定されているか。
-  // false の場合 ahead / behind は意味を持たず、UI 側で表示しない。
-  bool has_upstream = 7;
+  // upstream（追跡リモートブランチ）に対する差分。upstream 未設定なら不在。
+  // optional により「未設定」をフィールド不在で表現し、ahead/behind を見るには
+  // upstream 自体の存在をチェックする契約を型レベルで強制する。
+  optional UpstreamStatus upstream = 7;
+}
+
+// upstream（追跡リモートブランチ）との差分。`git status --porcelain=v2 --branch` の
+// `# branch.ab` 行に対応。upstream 自体が未設定のときはこの message ごと不在になる。
+message UpstreamStatus {
   // upstream に対して先行しているローカルコミット数（未 push）。
-  uint32 ahead = 8;
+  uint32 ahead = 1;
   // upstream に対して遅れているリモートコミット数（未 pull）。
-  uint32 behind = 9;
+  uint32 behind = 2;
 }
 
 message Task {

--- a/packages/proto/gozd/v1/git_ops.proto
+++ b/packages/proto/gozd/v1/git_ops.proto
@@ -172,14 +172,16 @@ message GitViewerResponse {
   string error_detail = 4;
 }
 
-// gitFetchOrigin: `git fetch --no-write-fetch-head origin` 相当。
-// 背景自動 fetch で refs/remotes/origin/* を更新し、status 経路 (FSWatchRegistry →
+// gitFetchRemotes: `git fetch --all --no-write-fetch-head` 相当。
+// 背景自動 fetch で refs/remotes/<remote>/* を更新し、status 経路 (FSWatchRegistry →
 // gitStatusFull → gitStatusChange push) を介して各 worktree の ahead/behind を最新化する。
+// upstream が origin 以外 (例: fork PR workflow で upstream=upstream / origin=fork) でも
+// 全 remote を更新できるよう --all を採用。VSCode autofetch の "all" モード相当。
 // 失敗 (offline / 認証失敗等) は ok=false + error_detail で返し、呼び出し側で握り潰す。
-message GitFetchOriginRequest {
+message GitFetchRemotesRequest {
   string dir = 1;
 }
-message GitFetchOriginResponse {
+message GitFetchRemotesResponse {
   bool ok = 1;
   // 失敗時の stderr 冒頭 (debug 用、最大 512B 程度に切り詰める)
   string error_detail = 2;

--- a/packages/proto/gozd/v1/git_ops.proto
+++ b/packages/proto/gozd/v1/git_ops.proto
@@ -172,6 +172,19 @@ message GitViewerResponse {
   string error_detail = 4;
 }
 
+// gitFetchOrigin: `git fetch --no-write-fetch-head origin` 相当。
+// 背景自動 fetch で refs/remotes/origin/* を更新し、status 経路 (FSWatchRegistry →
+// gitStatusFull → gitStatusChange push) を介して各 worktree の ahead/behind を最新化する。
+// 失敗 (offline / 認証失敗等) は ok=false + error_detail で返し、呼び出し側で握り潰す。
+message GitFetchOriginRequest {
+  string dir = 1;
+}
+message GitFetchOriginResponse {
+  bool ok = 1;
+  // 失敗時の stderr 冒頭 (debug 用、最大 512B 程度に切り詰める)
+  string error_detail = 2;
+}
+
 // gitDefaultBranch: `git worktree add -b <new> <abs> <ref>` の `<ref>` にそのまま渡せる
 // 「default branch ref」を返す。新規 worktree 作成時の起点を一意に決めるために使う。
 // 解決順序は二段 fallback:

--- a/packages/proto/gozd/v1/git_status.proto
+++ b/packages/proto/gozd/v1/git_status.proto
@@ -15,4 +15,11 @@ message GitStatusResponse {
   // ファイル相対パス → porcelain v1 の XY ステータスコード（例: " M", "??", "M ", "R "）。
   // 値は常に長さ 2 の文字列。1 文字目 = index 状態、2 文字目 = working tree 状態。
   map<string, string> entries = 1;
+  // upstream（追跡リモートブランチ）が設定されているか。
+  // false の場合 ahead / behind は意味を持たない。
+  bool has_upstream = 2;
+  // upstream に対して先行しているローカルコミット数（未 push）。
+  uint32 ahead = 3;
+  // upstream に対して遅れているリモートコミット数（未 pull）。
+  uint32 behind = 4;
 }

--- a/packages/proto/gozd/v1/git_status.proto
+++ b/packages/proto/gozd/v1/git_status.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package gozd.v1;
 
+import "gozd/v1/common.proto";
+
 // `git status --porcelain=v1 -z` 相当のファイル状態を取得する。
 //
 // issue #310 の方針: 全 RPC は明示的に `dir` を受け取り、
@@ -15,11 +17,6 @@ message GitStatusResponse {
   // ファイル相対パス → porcelain v1 の XY ステータスコード（例: " M", "??", "M ", "R "）。
   // 値は常に長さ 2 の文字列。1 文字目 = index 状態、2 文字目 = working tree 状態。
   map<string, string> entries = 1;
-  // upstream（追跡リモートブランチ）が設定されているか。
-  // false の場合 ahead / behind は意味を持たない。
-  bool has_upstream = 2;
-  // upstream に対して先行しているローカルコミット数（未 push）。
-  uint32 ahead = 3;
-  // upstream に対して遅れているリモートコミット数（未 pull）。
-  uint32 behind = 4;
+  // upstream に対する差分。未設定なら不在。
+  optional UpstreamStatus upstream = 2;
 }


### PR DESCRIPTION
## 概要

各 worktree カードに upstream に対する ahead / behind（未 push / 未 pull コミット数）を表示する。background で active repo の `git fetch origin` を 3 分間隔・window focus 中のみ実行し、behind を最新に保つ。

## 背景

これまでサイドバーには worktree ごとの local 変更（modified / added / untracked など）しか出ていなかった。AI エージェントが各 worktree で並列に commit / push する gozd の使い方では「どの worktree が push されていないか」「どの worktree が main から遅れているか」を一目で見たいという要求があった。

`GitOps.gitStatusFull`（porcelain v2 `--branch`）と `gitStatusChange` push payload には既に `hasUpstream` / `ahead` / `behind` が乗っていたが、`WorktreeEntry` proto と `setWorktreeGitStatuses` の書き戻し経路に項目が無く、サイドバーまで届いていなかった。proto と書き戻しを 1 本通せば既存 FSWatch → gitStatusFull → push パイプにそのまま乗る。

ただし `git status` は local refs しか読まないため、`git fetch` を回さない限り behind は stale。VSCode の auto fetch 実装（ extensions/git/src/autofetch.ts ）を参考に、active repo を 180s 間隔で background fetch する仕組みを併せて入れる。

## 変更内容

### proto

- `WorktreeEntry` / `GitStatusResponse` に `has_upstream` / `ahead` / `behind` を追加。Swift では `has_upstream` が SwiftProtobuf 予約名 `has<FieldName>` と衝突するため `hasUpstream_p` に自動 suffix される
- `GitFetchOriginRequest` / `GitFetchOriginResponse` を追加。失敗は `ok=false` + `error_detail` で返す

### native (Swift)

- `RpcDispatcher.handleGitWorktreeList` / `handleGitStatus` を `GitOps.gitStatusFull` ベースに切り替え、ahead/behind/hasUpstream をレスポンスに乗せる
- `GitOps.fetchOrigin(dir:)` を追加。`git fetch --no-write-fetch-head origin` を非対話モード（`GIT_TERMINAL_PROMPT=0` + `GIT_SSH_COMMAND` 末尾に `-o BatchMode=yes` 追記）で実行する `runGitNonInteractive` 経由で発射
- `--prune` / `--tags` は付けない。`--prune` は ローカル表示から branch が消えてユーザーが混乱、`--tags` は重く ahead/behind 計算に不要

### renderer

- `useRepoStore.setWorktreeGitStatuses` の引数を patch オブジェクト（`statuses` + `hasUpstream` + `ahead` + `behind`）に変更し、`updateRepoData` の fresher merge も新フィールドを保持するよう更新
- `useGitStatusSync` / `useGitStatusStore` を新シグネチャに追従
- `WtCard.vue` に ahead/behind 表示を追加（`hasUpstream && (ahead > 0 || behind > 0)` のときのみ、`↑N` / `↓N` アイコン + 数値、tooltip 付き）
- `useRemoteFetchSync` composable を追加し `App.vue` で起動。VueUse の `useWindowFocus` で window focus 中のみ動作、180s タイマー + `lastFetchedAt` debounce + in-flight ロックで重複・連射を防ぐ
- 失敗（offline / 認証失敗等）は notification に出さず stderr ログのみ。`lastFetchedAt` は失敗時も進めて backoff として機能させる

## 確認事項

- [ ] 複数 worktree がある repo を開いたとき、各 WtCard に upstream との ahead/behind が表示される（upstream 未設定の wt や差分 0 のときは非表示）
- [ ] 別ターミナルで対象 wt から `git commit` → ahead 数が増える / `git push` → ahead が 0 に戻る
- [ ] リモートに別人が push してから 3 分以内に behind が増える（active repo + window focus 時）
- [ ] window focus を外している間は fetch が走らない（Activity Monitor / Console で確認）
- [ ] HTTPS 認証情報なし / SSH key なし環境でも UI が hang しない（fetch は即失敗するが通知は出ない）
