### PR TITLE
fix(pty): finish exit handler without waiting for master EOF event

### DIFF
--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -180,10 +180,11 @@ public final class PTYManager {
     // 可能性があり、event coalescing による flaky の温床になる。drain loop で吸い切る。
     //
     // finish 経路の本筋は exit handler 側 (waitpid + closeSecondary + final drain 後の
-    // markReadClosed)。read source 側で `.closed` を観測して markReadClosed を呼ぶのは、
-    // 子が自発的に exit する前に master の EOF を観測した場合 (例: 子が stdout を明示 close
-    // しただけで生存しているケース) と、exit handler 完了後に遅延配信される EOF event を
-    // 受けた場合の両方を兼ねる。後者は `alreadyReadClosed` / `finished` フラグで idempotent。
+    // markReadClosed)。設計判断 6 (親側で slave fd を 1 reference 保持) の下では、
+    // `closeSecondary` が呼ばれる exit handler 内まで master の EOF は正常系で到達しない。
+    // つまり read source 側で `.closed` を観測して markReadClosed を呼ぶのは、exit handler
+    // 完了後に遅延配信される EOF event を受けた場合のための冗長化経路。
+    // `alreadyReadClosed` / `finished` フラグで idempotent なので二重発火しても no-op。
     source.setEventHandler { [source, state] in
       ptyTrace("read", pid: childPid, "eventHandler fired")
       switch drainPTY(fd: masterFd, pid: childPid, caller: "read-source", onData: onData) {

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -178,6 +178,12 @@ public final class PTYManager {
     // self をキャプチャしないことで Sendable closure 制約を満たす。
     // 単発 read だと「event 1 回で data + EOF が同時に観測される」ケースで data を取りこぼす
     // 可能性があり、event coalescing による flaky の温床になる。drain loop で吸い切る。
+    //
+    // finish 経路の本筋は exit handler 側 (waitpid + closeSecondary + final drain 後の
+    // markReadClosed)。read source 側で `.closed` を観測して markReadClosed を呼ぶのは、
+    // 子が自発的に exit する前に master の EOF を観測した場合 (例: 子が stdout を明示 close
+    // しただけで生存しているケース) と、exit handler 完了後に遅延配信される EOF event を
+    // 受けた場合の両方を兼ねる。後者は `alreadyReadClosed` / `finished` フラグで idempotent。
     source.setEventHandler { [source, state] in
       ptyTrace("read", pid: childPid, "eventHandler fired")
       switch drainPTY(fd: masterFd, pid: childPid, caller: "read-source", onData: onData) {
@@ -250,8 +256,8 @@ public final class PTYManager {
       //
       // 以前は exit-final が `.closed` の時のみ markReadClosed を呼び、`.drained` の場合は
       // 「read source が EOF を観測したら markReadClosed」に委ねていた。CI macOS-26 runner で
-      // tty hangup 伝搬 (`closeSecondary` → master の NOTE_EOF) に 2 秒以上かかるケースを
-      // 観測し、onExit 配送がその分だけ遅延して test が timeout した (issue #549)。
+      // tty hangup 伝搬 (`closeSecondary` → master の NOTE_EOF) に 2 秒以上かかるケースが
+      // 確認されており、その経路では onExit 配送が同分遅延する。
       // EOF event を待つ意味は無いので read source を即時 cancel + markReadClosed する。
       // 遅延配信される EOF event が read source handler に届いても、`markReadClosed` は
       // `alreadyReadClosed` フラグで idempotent なので no-op。

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -241,21 +241,26 @@ public final class PTYManager {
       // 直後の master read で EOF が観測できるようになる。
       state.closeSecondary()
 
-      // **正規 finish 経路**: secondary close 後に final drain で EOF を取って markReadClosed。
-      // ここで `.drained` (EAGAIN) になるケースは、tty hangup の伝播より早く drain を
-      // 呼んだ場合のみ。その場合は **read source 側が二重防御**として残っており、kqueue
-      // が EOF を dispatch すると read-source event handler で markReadClosed が走る。
-      // どちらの経路でも `PTYFinishState` が `finished` フラグで 1 度だけの finish を保証する。
-      if case .closed = drainPTY(fd: masterFd, pid: childPid, caller: "exit-final", onData: onData)
-      {
-        ptyTrace("exit", pid: childPid, "final-drain → .closed → cancel + markReadClosed")
-        source.cancel()
-        state.markReadClosed(onComplete: onExit)
-      } else {
-        ptyTrace(
-          "exit", pid: childPid,
-          "final-drain → .drained → defer markReadClosed to read-source fallback")
-      }
+      // **finish 経路は exit handler に一本化する**。次の 3 条件が揃った時点で master fd へ
+      // 新規 data が到達することは原理的に無い:
+      //
+      //   1. waitpid 成功 → 子 reap 済み (writer 不在)
+      //   2. closeSecondary → tty reference 0、ttyclose → ttyflush が走るが queue は既に空
+      //   3. exit-final drain → EAGAIN または EOF (現時点で kernel buffer 空)
+      //
+      // 以前は exit-final が `.closed` の時のみ markReadClosed を呼び、`.drained` の場合は
+      // 「read source が EOF を観測したら markReadClosed」に委ねていた。CI macOS-26 runner で
+      // tty hangup 伝搬 (`closeSecondary` → master の NOTE_EOF) に 2 秒以上かかるケースを
+      // 観測し、onExit 配送がその分だけ遅延して test が timeout した (issue #549)。
+      // EOF event を待つ意味は無いので read source を即時 cancel + markReadClosed する。
+      // 遅延配信される EOF event が read source handler に届いても、`markReadClosed` は
+      // `alreadyReadClosed` フラグで idempotent なので no-op。
+      let finalResult = drainPTY(
+        fd: masterFd, pid: childPid, caller: "exit-final", onData: onData)
+      ptyTrace(
+        "exit", pid: childPid, "final-drain → \(finalResult) → cancel + markReadClosed")
+      source.cancel()
+      state.markReadClosed(onComplete: onExit)
 
       state.setExitReason(exitReason, onComplete: onExit)
       exit.cancel()


### PR DESCRIPTION
## 概要

PTY exit handler の finish 経路から「master fd への NOTE_EOF event 待ち」を排除し、`PTYManagerTests/resizeIsSafe` が CI macOS-26 runner で稀に 2 秒 timeout する flake を根治する。

## 背景

issue ( #549 ) で報告した flake の trace を CI ログ ( `GOZD_PTY_TRACE=1` ) から再構成すると、root cause は kqueue NOTE_EOF の遅延配信であることが確定した。失敗 run の pid=9149 ( resizeIsSafe で spawn された `/bin/cat` ) の時系列は次のとおり:

```text
t=+0.0188s spawn
t=+0.0556s exit handler 開始
  exit-pre drain        : EAGAIN (drained)
  waitpid               : status=1 (SIGHUP)
  exit-post-waitpid     : EAGAIN
  closeSecondary fd=30
  exit-final drain      : EAGAIN  ← tty hangup が master に未伝搬
  setExitReason         : readClosed=false canFinish=false ← onComplete fired せず
t=+2.175s read source eventHandler fired (EOF)  ← 2.12 秒後にようやく到達
  → markReadClosed → onComplete fired
```

旧設計は「正規 finish 経路 = exit-final が EOF を観測して markReadClosed、二重防御 = `.drained` のときは read source が EOF を拾うまで待つ」という構成だった。本来「ms オーダー」と想定していた tty hangup 伝搬が CI で 2 秒以上かかり、onExit 配送がその分だけ遅延して `waitUntil(timeout: .seconds(2))` を越えた。

構造的に、次の 3 条件が揃った時点で master fd へ新規 data が到達することは原理的に無い:

- `waitpid` 成功 → 子 reap 済み ( writer 不在 )
- `closeSecondary` → tty reference 0、`ttyclose` → `ttyflush` が走るが queue は既に空
- `exit-final drain` → EAGAIN または EOF ( 現時点で kernel buffer 空 )

つまり async な NOTE_EOF event を待つ必要は無く、待つ実装は CI で観測されたとおり onExit 配送遅延を発生させる単一原因になる。

## 変更内容

### `apps/native/Sources/GozdCore/PTYManager.swift`

- exit handler の最終フェーズで `drainPTY(caller: "exit-final")` の戻り値 ( `.closed` / `.drained` ) に依らず常に `source.cancel()` + `state.markReadClosed(onComplete:)` を呼ぶ
- 旧コメント「正規 finish 経路 / read source 側が二重防御」を「finish 経路は exit handler に一本化」に書き換え、root cause と NOTE_EOF を待たない判断理由を明記
- 遅延配信される NOTE_EOF event が read source handler 側に届いても `markReadClosed` は `alreadyReadClosed` フラグで idempotent なので no-op

## 今回含めない点

- **今回は対応しない**: `waitUntil` の timeout を 2s から伸ばす band-aid 修正。症状を隠すだけで onExit 配送遅延の根本を放置するため不採用

## 確認事項

- [x] `swift build` 成功
- [x] `swift test --filter "PTYManager|PTYRegistry"` 30 連続実行で 0 fail
- [x] フルテストスイート 214 tests 全 pass
- [x] `GOZD_PTY_TRACE=1` での local trace で exit-final が `.closed` でも `.drained` でも同一 finish 経路を通ることを確認
- [ ] CI macOS-26 runner で再 flake しないこと ( ローカルでは EOF が μs オーダーで返るため、`.drained` 経路は確率的にしか踏まない )
