### PR TITLE
fix(preview): wire fsChange to root files and active worktree

### DIFF
--- a/apps/renderer/src/features/filer/FilerPane.vue
+++ b/apps/renderer/src/features/filer/FilerPane.vue
@@ -119,8 +119,9 @@ function handleFsChange(eventDir: string, relDir: string) {
   // useFsWatchSync は全 worktree を watch するため、別 repo / 別 worktree の
   // fsChange も到達する。active worktree dir 以外は無視する。
   if (eventDir !== dir.value) return;
-  // ルートディレクトリの変更（"" or "."）は loadRoot で全件再構築
-  if (relDir === "" || relDir === ".") {
+  // worktree 直下の変更は loadRoot で全件再構築。relDir 表現は Swift
+  // `FSWatchRegistry.relativeDir()` の SSOT に従い、直下は常に `""`。
+  if (relDir === "") {
     void loadRoot();
     return;
   }

--- a/apps/renderer/src/features/filer/index.ts
+++ b/apps/renderer/src/features/filer/index.ts
@@ -1,4 +1,5 @@
 export { default as FilerPane } from "./FilerPane.vue";
+export { relDirOf } from "./relDirOf";
 export { rpcFsReadFile, rpcFsReadFileAbsolute } from "./rpc";
 export type { FsChangePayload } from "./rpc";
 export { getFileIconUrl, getFolderIconUrl } from "./useFileIcon";

--- a/apps/renderer/src/features/filer/relDirOf.test.ts
+++ b/apps/renderer/src/features/filer/relDirOf.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { relDirOf } from "./relDirOf";
+
+describe("relDirOf", () => {
+  // Swift `FSWatchRegistry.relativeDir(path:dir:dirWithSlash:)` の出力と一致させる境界。
+  // 表現が乖離すると fsChange.relDir との `===` 比較が永久に外れる。
+  test.each([
+    ["worktree 直下ファイルは空文字", "foo.ts", ""],
+    ["拡張子なしの直下ファイルも空文字", "Makefile", ""],
+    ["1 階層下は親 dir", "src/foo.ts", "src"],
+    ["多階層下は末尾スラッシュなしの dir", "apps/renderer/src/foo.ts", "apps/renderer/src"],
+    ["空文字入力は空文字", "", ""],
+  ])("%s: %s → %p", (_title, input, expected) => {
+    expect(relDirOf(input)).toBe(expected);
+  });
+});

--- a/apps/renderer/src/features/filer/relDirOf.ts
+++ b/apps/renderer/src/features/filer/relDirOf.ts
@@ -1,0 +1,16 @@
+/**
+ * worktree 相対パスから親ディレクトリの worktree 相対表現を返す。
+ *
+ * Swift `FSWatchRegistry.relativeDir()` の出力と一致する形を SSOT とする。
+ * - 直下ファイル（"/" を含まないパス）: `""`
+ * - サブディレクトリ配下: 末尾 "/" を含まないディレクトリ相対パス
+ *
+ * fsChange.relDir と選択中ファイルから導出した親 dir を `===` で比較するための境界関数。
+ * 表現が乖離すると fsChange の取りこぼしが起きるため、ユニットテストで Swift 側の出力と
+ * 表を揃えて検証する。
+ */
+export function relDirOf(path: string): string {
+  const idx = path.lastIndexOf("/");
+  if (idx < 0) return "";
+  return path.substring(0, idx);
+}

--- a/apps/renderer/src/features/filer/rpc.ts
+++ b/apps/renderer/src/features/filer/rpc.ts
@@ -33,7 +33,11 @@ export const rpcFsUnwatch = (req: FsUnwatchRequest) =>
 export const rpcFsUnwatchAll = (req: FsUnwatchAllRequest) =>
   rpc("/fs/unwatchAll", req, FsUnwatchAllRequest, FsUnwatchAllResponse);
 
-// fsChange push event payload
+// fsChange push event payload.
+// `dir` は購読時に渡した dir（renderer 側 worktree dir と文字列同一）。
+// `relDir` は変更ファイルの親 dir を `dir` からの相対パスで表現する。
+// Swift `FSWatchRegistry.relativeDir()` の SSOT に従い、worktree 直下は `""`、
+// サブディレクトリ配下は末尾 "/" を含まないディレクトリ相対パス。
 export interface FsChangePayload {
   dir: string;
   relDir: string;

--- a/apps/renderer/src/features/filer/useFilerEventStore.ts
+++ b/apps/renderer/src/features/filer/useFilerEventStore.ts
@@ -13,7 +13,7 @@ import { ref } from "vue";
  * 発火させるため（オブジェクト reference の同一性で watch がスキップされるのを防ぐ）。
  */
 export const useFilerEventStore = defineStore("filer-event", () => {
-  /** 最後の fsChange イベント。relDir は worktree 相対パス（"" / "." はルート扱い） */
+  /** 最後の fsChange イベント。relDir は worktree 相対パスで、直下は `""`（Swift SSOT） */
   const fsChangeEvent = ref<{ version: number; relDir: string }>();
   let fsChangeVersion = 0;
   function emitFsChange(relDir: string) {

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -28,7 +28,7 @@ import { storeToRefs } from "pinia";
 import { computed, onUnmounted, ref, watch } from "vue";
 import { useNotificationStore } from "../../shared/notification";
 import { onMessage } from "../../shared/rpc";
-import { getFileIconUrl, rpcFsReadFile, rpcFsReadFileAbsolute } from "../filer";
+import { getFileIconUrl, relDirOf, rpcFsReadFile, rpcFsReadFileAbsolute } from "../filer";
 import type { FsChangePayload } from "../filer";
 import { useGitGraphStore } from "../git-graph";
 import { UNCOMMITTED_HASH, useWorktreeStore } from "../worktree";
@@ -426,20 +426,7 @@ watch(
   { immediate: true },
 );
 
-/**
- * ファイル変更通知で選択中ファイルの内容を再取得（モード・UI状態は維持）。
- *
- * Swift `FSWatchRegistry.relativeDir()` は worktree 直下のファイル変更に対して `""` を返す
- * (`<dir>/foo.txt` → `""`)。renderer 側の親 dir 表現も `""` に揃え、root file の比較が
- * 永久に外れないようにする (`lastIndexOf("/") < 0` を `"."` に倒す旧実装で root file の
- * fsChange を取りこぼし、diff ビューが追従しなくなる回帰の原因)。
- */
-function parentDir(filePath: string): string {
-  const idx = filePath.lastIndexOf("/");
-  if (idx < 0) return "";
-  return filePath.substring(0, idx);
-}
-
+/** ファイル変更通知で選択中ファイルの内容を再取得（モード・UI状態は維持） */
 const unsubscribeFsChange = onMessage<FsChangePayload>("fsChange", ({ dir: eventDir, relDir }) => {
   if (!selectedPath.value) return;
   // コミットモードではファイル変更通知を無視（表示内容は git オブジェクトから取得済み）
@@ -448,7 +435,7 @@ const unsubscribeFsChange = onMessage<FsChangePayload>("fsChange", ({ dir: event
   }
   // useFsWatchSync は全 worktree を watch するため、active dir 以外の event は無視する。
   if (eventDir !== worktreeStore.dir) return;
-  if (relDir !== parentDir(selectedPath.value)) return;
+  if (relDir !== relDirOf(selectedPath.value)) return;
   void fetchContent(selectedPath.value, selectedGitChange.value);
 });
 onUnmounted(unsubscribeFsChange);

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -426,17 +426,28 @@ watch(
   { immediate: true },
 );
 
-/** ファイル変更通知で選択中ファイルの内容を再取得（モード・UI状態は維持） */
+/**
+ * ファイル変更通知で選択中ファイルの内容を再取得（モード・UI状態は維持）。
+ *
+ * Swift `FSWatchRegistry.relativeDir()` は worktree 直下のファイル変更に対して `""` を返す
+ * (`<dir>/foo.txt` → `""`)。renderer 側の親 dir 表現も `""` に揃え、root file の比較が
+ * 永久に外れないようにする (`lastIndexOf("/") < 0` を `"."` に倒す旧実装で root file の
+ * fsChange を取りこぼし、diff ビューが追従しなくなる回帰の原因)。
+ */
 function parentDir(filePath: string): string {
   const idx = filePath.lastIndexOf("/");
-  if (idx < 0) return ".";
+  if (idx < 0) return "";
   return filePath.substring(0, idx);
 }
 
-const unsubscribeFsChange = onMessage<FsChangePayload>("fsChange", ({ relDir }) => {
+const unsubscribeFsChange = onMessage<FsChangePayload>("fsChange", ({ dir: eventDir, relDir }) => {
   if (!selectedPath.value) return;
   // コミットモードではファイル変更通知を無視（表示内容は git オブジェクトから取得済み）
-  if (gitGraphStore.selectedHash !== UNCOMMITTED_HASH || gitGraphStore.compareHash !== null) return;
+  if (gitGraphStore.selectedHash !== UNCOMMITTED_HASH || gitGraphStore.compareHash !== null) {
+    return;
+  }
+  // useFsWatchSync は全 worktree を watch するため、active dir 以外の event は無視する。
+  if (eventDir !== worktreeStore.dir) return;
   if (relDir !== parentDir(selectedPath.value)) return;
   void fetchContent(selectedPath.value, selectedGitChange.value);
 });

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -110,6 +110,8 @@ git 変更ファイルには Original / Diff / Current の3タブを表示する
 
 desktop からの `fsChange` メッセージを購読し、選択中ファイルの親ディレクトリが変更対象なら `fetchContent()` を再実行する。モードや Preview チェックボックスの状態は維持する。コミットモードでは git オブジェクトからの取得済み内容を表示するため、ファイル変更通知は無視する。
 
+`useFsWatchSync` は全 worktree を watch するため、`fsChange.dir` が active dir と一致する event のみ反応する（[architecture.md の SSOT push の dir filter 規律](architecture.md#ssot-push-の-dir-filter-規律)）。親ディレクトリの照合では worktree 直下ファイルの relDir を native 側の `""` 表現に揃え、root file の通知を取りこぼさないようにしている。
+
 ### 非同期レース防止
 
 バージョンカウンター（`fetchVersion`）で管理する。`fetchContent()` 呼び出し時にインクリメントし、レスポンス到着時にバージョンが一致しなければ結果を破棄する。


### PR DESCRIPTION
## 概要

`PreviewPane` の diff ビューで working tree 直下のファイル (例: `README.md`, `CLAUDE.md`) を編集しても表示が追従しない問題を修正した。あわせて renderer 全体で `relDir` 表現を Swift `FSWatchRegistry.relativeDir()` の SSOT (`""` 単一) に揃え、`fsChange` ハンドラに active dir フィルタを追加した。親 dir 導出を `relDirOf()` として feature ローカルの export に切り出し、Swift 側 SSOT との contract boundary を境界テストで構造的に保護する。

## 背景

`useFsWatchSync` は開いている全 worktree を watch しており、各 `fsChange` push は `dir` と `relDir` を持つ。Swift 側 `FSWatchRegistry.relativeDir()` (`apps/native/Sources/GozdCore/FSWatchRegistry.swift:513-524`) は worktree 直下ファイルでは `""` のみを返し、`"."` を返す経路はない。

`PreviewPane` 側の `parentDir()` は `lastIndexOf("/") < 0` で `"."` を返していたため、root file では native の `""` と永久にミスマッチし `fsChange` を取りこぼしていた。`FilerPane` は `relDir === "" || relDir === "."` の両方を扱う実装になっており Filer 表示は更新されていたが、これは過去の `@parcel/watcher` 経路の名残で現行 SSOT と整合していない。renderer 全体で `""` 表現を SSOT として強制し、`"."` を許容する shim を全箇所から除去する。

さらに `PreviewPane` の `fsChange` ハンドラは `eventDir` を見ておらず、`architecture.md` の「SSOT push の dir filter 規律」に違反していた。別 worktree の event でも active dir の `fetchContent` が走る無駄打ち経路になっていた。

## 変更内容

### apps/renderer/src/features/filer/relDirOf.ts (新規)

- worktree 相対パスから親 dir の worktree 相対表現を返す境界関数。Swift `relativeDir()` の出力と一致する形を SSOT とする
- 直下ファイル `→ ""`、サブディレクトリ配下 `→ 末尾 "/" を含まないディレクトリ相対パス`

### apps/renderer/src/features/filer/relDirOf.test.ts (新規)

- 境界 (`""` / `"foo"` / `"a/b"` / `"a/b/c"`) の出力を表で検証し、Swift SSOT との contract boundary を回帰で潰す

### apps/renderer/src/features/filer/FilerPane.vue

- `handleFsChange` のルート判定から `|| relDir === "."` 分岐を削除し、`relDir === ""` のみで判定するように変更。Swift SSOT に揃える

### apps/renderer/src/features/filer/useFilerEventStore.ts

- `fsChangeEvent` JSDoc から `"."` 許容の表現を削除

### apps/renderer/src/features/filer/rpc.ts

- `FsChangePayload` の JSDoc に `dir` / `relDir` の表現契約を明文化し、上流 Swift SSOT を renderer 型でも宣言

### apps/renderer/src/features/filer/index.ts

- `relDirOf` を re-export

### apps/renderer/src/features/preview/PreviewPane.vue

- ローカル `parentDir()` を削除し `relDirOf()` を `../filer` から import
- `fsChange` ハンドラに `eventDir !== worktreeStore.dir` の active dir フィルタを追加

### docs/preview.md

- 「ファイル内容変更時」セクションに active dir フィルタと relDir 表現の SSOT について追記

## 確認事項

- [ ] worktree 直下ファイル (`README.md` 等) を選んで diff モードを開き、外部から編集すると即座に diff が更新される
- [ ] サブディレクトリ配下ファイルでも従来通り diff が更新される (回帰なし)
- [ ] 別 worktree の同名 relDir のファイルを変更しても active worktree 側の diff ビューが再 fetch されない
- [ ] `pnpm test:all` で `relDirOf` の境界テストが pass する
