### PR TITLE
docs(readme): move Xcode / mise prereqs into install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,16 @@ gozd はスロベニア語で「森」（[ɡɔ́st]、「ゴスト」）。
 
 ## インストール
 
-初回はビルドしてアプリを起動する。
+ソースからビルドして配置する。事前に以下を導入しておく。
+
+- Xcode 26 以降（Swift 6.2 / macOS 26 SDK が含まれる）
+- [mise](https://mise.jdx.dev/)（残りのツールチェインを `mise install` でまとめて揃える）
+
+初回はツールチェイン / 依存をインストールし、ビルドしてアプリを起動する。
 
 ```bash
+mise install
+pnpm install
 pnpm run bootstrap
 ```
 
@@ -73,13 +80,8 @@ gozd src/main.ts  # src/ で開き、main.ts を開く
 
 ## 開発
 
-事前に以下を導入しておく。
-
-- Xcode 26 以降（Swift 6.2 / macOS 26 SDK が含まれる）
-- [mise](https://mise.jdx.dev/)（残りのツールチェインを `mise install` でまとめて揃える）
+インストール手順でツールチェイン / 依存を導入済みの前提。開発ビルドを起動する。
 
 ```bash
-mise install
-pnpm install
 pnpm run dev
 ```


### PR DESCRIPTION
## 概要

README のインストール / 開発セクションを整理し、Xcode と mise を build prerequisites として「インストール」側に移動。「開発」セクションは `pnpm run dev` のみに縮約した。

## 背景

現状の README では Xcode 26+ と mise が「開発」セクションだけに記載されていた。一方で `pnpm run bootstrap` は内部で `pnpm build` を呼び、Swift コンパイル経路で Xcode SDK を要求するため、初回 install 時にも両ツールが必要になる。読者が「動かしてみたい」だけのつもりで install 手順を踏むと、Xcode 未導入で bootstrap が失敗する構造。

加えて、`pnpm run bootstrap` の実体は `pnpm build && open ...Gozd.app` のみで `pnpm install` を呼ばない。これまでの install 手順は `pnpm run bootstrap` 1 行だけだったため、依存解決ステップが暗黙のまま欠落していた。

## 変更内容

### README

- 「インストール」セクションに build prerequisites リスト（Xcode 26 以降 / mise）を移設
- インストール手順を `mise install` → `pnpm install` → `pnpm run bootstrap` の 3 ステップに明示化
- 「開発」セクションは前提リストを削除し、`pnpm run dev` のみに縮約。前提はインストール手順で導入済みであることを明記
- 「動作環境」セクション（macOS 26 Tahoe / zsh）はそのまま runtime 要件として維持し、build 前提と分離

## 確認事項

- [ ] README のインストール手順をクリーン環境で順に実行して bootstrap まで通ることを確認
- [ ] 「動作環境」と「インストール」前提が役割で分離されていて、読み手が混乱しないかレビュー観点で確認
