### PR TITLE
feat(git-graph): linkify PR badges and #N refs with origin URL SSOT

### DIFF
--- a/apps/native/Sources/Gozd/ExternalLinkNavigationDecider.swift
+++ b/apps/native/Sources/Gozd/ExternalLinkNavigationDecider.swift
@@ -1,0 +1,101 @@
+import AppKit
+import Foundation
+import WebKit
+
+/// http(s) かつ非 dev origin への navigation を OS のデフォルトブラウザに渡す NavigationDecider。
+/// WWDC25 #231 "Meet WebKit for SwiftUI" が示す `WebPage.NavigationDeciding` 公式パターン。
+///
+/// NavigationDeciding 未設定では WebView の main frame が外部 URL に置換されようとし、
+/// renderer (Vue) を単一 WebPage にロードして UI 全体を構築している gozd では UI 自体が
+/// 消える事故になる。これを構造的に防ぐ。
+///
+/// 判定は **scheme による 3 分岐** で完結する: `<a href>` / `window.open` / `<form action>` /
+/// meta refresh / `.reload` など `navigationType` や `action.target` の値には依存しない。
+struct ExternalLinkNavigationDecider: WebPage.NavigationDeciding {
+  /// dev mode の Vite dev server origin ($GOZD_DEV_VITE_URL を分解したもの)。
+  /// 同一 scheme + host + port への自己 navigation は内部とみなして allow する。
+  let internalDevOrigin: (scheme: String, host: String, port: Int?)?
+
+  init() {
+    self.internalDevOrigin = Self.parseInternalDevOrigin()
+  }
+
+  /// `$GOZD_DEV_VITE_URL` を origin として解釈する。path が `/` または空でない値が指定されたら
+  /// 想定外として nil に倒し起動時 stderr に残す。`isInternalDevURL` は host:port 一致のみを
+  /// 見るため、`http://localhost:5173/anything` のような path 付き設定が紛れると path の異なる
+  /// external URL も internal allow に倒れる事故が起きる。それを起動時に弾く検証ポイント。
+  private static func parseInternalDevOrigin() -> (scheme: String, host: String, port: Int?)? {
+    guard let viteURLString = ProcessInfo.processInfo.environment["GOZD_DEV_VITE_URL"],
+      !viteURLString.isEmpty
+    else { return nil }
+    guard let viteURL = URL(string: viteURLString),
+      let scheme = viteURL.scheme?.lowercased(),
+      let host = viteURL.host
+    else {
+      FileHandle.standardError.write(
+        Data("[NavigationDecider] GOZD_DEV_VITE_URL is malformed: \(viteURLString)\n".utf8))
+      return nil
+    }
+    let path = viteURL.path
+    if !path.isEmpty, path != "/" {
+      FileHandle.standardError.write(
+        Data(
+          "[NavigationDecider] GOZD_DEV_VITE_URL must be an origin (no path); got: \(viteURLString)\n"
+            .utf8))
+      return nil
+    }
+    return (scheme: scheme, host: host, port: viteURL.port)
+  }
+
+  func decidePolicy(
+    for action: WebPage.NavigationAction,
+    preferences: inout WebPage.NavigationPreferences
+  ) async -> WKNavigationActionPolicy {
+    guard let url = action.request.url else { return .allow }
+    let scheme = url.scheme?.lowercased()
+    let isHTTP = scheme == "http" || scheme == "https"
+
+    // 判定軸は **scheme による 3 分岐** に統一する:
+    //   1. http(s) かつ dev mode の Vite dev server origin → 内部扱いで allow
+    //   2. http(s) かつそれ以外 → 外部とみなして OS のデフォルトブラウザに渡し cancel
+    //   3. それ以外の scheme (`gozd-rpc://` / `gozd-app://` / `about:` / `file:` 等) → allow
+    //
+    // navigationType (`linkActivated` / `formSubmitted` / `.other` / `.reload` 等) や
+    // `action.target` の値に依存しない。renderer は単一 WebPage 上に Vue UI を構築する
+    // 設計のため、main frame であれ subframe であれ http(s) への遷移は「OS ブラウザで開く」
+    // のがユーザー期待挙動であり、それ以外の経路 (form submit / window.open / meta refresh
+    // 等) でも外部 host への遷移は構造的に外部送りで揃える。
+    //
+    // 起動時の `page.load(http://localhost:5173/)` は dev origin allow 経路で透過する。
+    if isHTTP {
+      if isInternalDevURL(url) {
+        return .allow
+      }
+      await openInDefaultBrowser(url)
+      return .cancel
+    }
+
+    return .allow
+  }
+
+  private func openInDefaultBrowser(_ url: URL) async {
+    // `NSWorkspace.shared.open(_:configuration:)` の async 版は launch 失敗時に NSError を
+    // throw するため、Bool 版より失敗理由が具体的に残せる (silent drop 禁止規律と整合)。
+    let config = NSWorkspace.OpenConfiguration()
+    do {
+      _ = try await NSWorkspace.shared.open(url, configuration: config)
+    } catch {
+      FileHandle.standardError.write(
+        Data(
+          "[NavigationDecider] failed to open external URL: \(url.absoluteString): \(error)\n"
+            .utf8))
+    }
+  }
+
+  private func isInternalDevURL(_ url: URL) -> Bool {
+    guard let origin = internalDevOrigin else { return false }
+    return url.scheme?.lowercased() == origin.scheme
+      && url.host == origin.host
+      && url.port == origin.port
+  }
+}

--- a/apps/native/Sources/Gozd/GozdApp.swift
+++ b/apps/native/Sources/Gozd/GozdApp.swift
@@ -322,7 +322,9 @@ final class AppRuntime {
     var config = WebPage.Configuration()
     config.urlSchemeHandlers[URLScheme("gozd-rpc")!] = RpcSchemeHandler(dispatcher: createdDispatcher)
     config.urlSchemeHandlers[URLScheme("gozd-app")!] = BundleAssetSchemeHandler()
-    let page = WebPage(configuration: config)
+    // 外部リンク (`<a target="_blank">` / `window.open`) を OS のブラウザに渡す。
+    // 未設定だと主フレームを置換しようとして renderer の UI 全体が消える。
+    let page = WebPage(configuration: config, navigationDecider: ExternalLinkNavigationDecider())
     page.isInspectable = true
     holder.page = page
     self.page = page

--- a/apps/native/Sources/GozdCore/GitHubOps.swift
+++ b/apps/native/Sources/GozdCore/GitHubOps.swift
@@ -63,9 +63,32 @@ public enum GitHubOps {
     }
     """
 
+  /// `RepoIdentity` を `Result<(owner, repo), GhError>` に正規化する。`prList` / `issueList`
+  /// など「GitHub identity が取れなければ GhError で即失敗したい」呼び出し側に共通する適応層。
+  /// 失敗 detail 文字列もここで 1 箇所に集約することで、prList / issueList で文言が乖離しない。
+  private static func resolveGitHubRepoOrError(
+    dir: String
+  ) async throws -> Result<(owner: String, repo: String), GhError> {
+    switch try await repoOwnerName(dir: dir) {
+    case .ok(let owner, let repo):
+      return .success((owner: owner, repo: repo))
+    case .unsetRemote:
+      return .failure(GhError(kind: .repoNotFound, detail: "remote.origin not set"))
+    case .parserRejected:
+      // raw URL は credential 漏出防止のため `detail` に載せない (固定文言のみ)
+      return .failure(GhError(kind: .repoNotFound, detail: "unsupported remote URL"))
+    }
+  }
+
   public static func prList(dir: String) async throws -> PrListResult {
-    guard let (owner, repo) = try await repoOwnerName(dir: dir) else {
-      return .failure(GhError(kind: .repoNotFound, detail: "no remote.origin.url"))
+    let owner: String
+    let repo: String
+    switch try await resolveGitHubRepoOrError(dir: dir) {
+    case .success(let pair):
+      owner = pair.owner
+      repo = pair.repo
+    case .failure(let err):
+      return .failure(err)
     }
     let data: Data
     do {
@@ -122,8 +145,14 @@ public enum GitHubOps {
   }
 
   public static func issueList(dir: String) async throws -> IssueListResult {
-    guard let (owner, repo) = try await repoOwnerName(dir: dir) else {
-      return .failure(GhError(kind: .repoNotFound, detail: "no remote.origin.url"))
+    let owner: String
+    let repo: String
+    switch try await resolveGitHubRepoOrError(dir: dir) {
+    case .success(let pair):
+      owner = pair.owner
+      repo = pair.repo
+    case .failure(let err):
+      return .failure(err)
     }
     let data: Data
     do {
@@ -177,6 +206,20 @@ public enum GitHubOps {
     ]
   }
 
+  /// `repoOwnerName` の戻り型。「remote 未設定」と「parser が拒否した」を区別して
+  /// 観察可能性を確保する (silent fallback で「あれ動かない」をなくす)。`parserRejected` は
+  /// 非 github.com host / path セグメント数不一致 / 想定外形式すべてを含む (parser 内部の
+  /// 詳細粒度は外に出さない)。
+  ///
+  /// raw URL は意図的に associated value として保持しない。`https://<token>@github.com/owner/repo`
+  /// のような credential 埋め込み remote (GitHub Actions の `actions/checkout` で典型) を
+  /// stderr / GhError.detail 経由で renderer や ログに漏出させないため。
+  enum RepoIdentity {
+    case ok(owner: String, repo: String)
+    case unsetRemote
+    case parserRejected
+  }
+
   /// `git config --get remote.origin.url` をパースして GitHub の owner/repo を取得する。
   ///
   /// 以前は `gh repo view --json owner,name` を使っていたが、これは picker / PR 一覧の
@@ -188,20 +231,27 @@ public enum GitHubOps {
   /// - `git@github.com:<owner>/<repo>(.git)?`
   /// - `ssh://git@github.com/<owner>/<repo>(.git)?`
   ///
-  /// GitLab / Bitbucket / GitHub Enterprise 等の non-github.com remote は nil を返す
-  /// (`gh` のデフォルト host は github.com なので、別ホスト remote で `gh api graphql` を
-  /// 実行すると認証失敗が混入し、観察可能性を汚す)。
-  private static func repoOwnerName(dir: String) async throws -> (owner: String, repo: String)? {
+  /// 戻り値:
+  /// - `.ok(owner, repo)`: 上記形式の github.com remote が見つかった
+  /// - `.unsetRemote`: `remote.origin` が設定されていない (新規 repo / clone なし)
+  /// - `.parserRejected`: 非 github.com host (GitLab / Bitbucket / GHE 等) /
+  ///   path セグメント数不一致 / 想定外形式。`gh` のデフォルト host は github.com なので、
+  ///   別ホスト remote で `gh api graphql` を実行すると認証失敗が混入し観察可能性を汚すため、
+  ///   そもそも host policy で弾く設計。raw URL は credential 漏出防止のため呼び出し側に渡さない
+  static func repoOwnerName(dir: String) async throws -> RepoIdentity {
     let data: Data
     do {
       data = try await runGit(args: ["config", "--get", "remote.origin.url"], cwd: dir)
     } catch GitError.commandFailed {
       // remote.origin 未設定（新規 repo / fork なし）。PR 一覧自体が成立しない。
-      return nil
+      return .unsetRemote
     }
     let url = String(decoding: data, as: UTF8.self)
       .trimmingCharacters(in: .whitespacesAndNewlines)
-    return parseGitHubOwnerRepo(url: url)
+    guard let parsed = parseGitHubOwnerRepo(url: url) else {
+      return .parserRejected
+    }
+    return .ok(owner: parsed.owner, repo: parsed.repo)
   }
 
   /// `gh api user --jq .login` で認証中ユーザーの login を返す。

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -351,6 +351,8 @@ public actor RpcDispatcher {
       return try await handleGitFetchRemotes(body)
     case "/git/defaultBranch":
       return try await handleGitDefaultBranch(body)
+    case "/git/githubIdentity":
+      return try await handleGitGithubIdentity(body)
     case "/git/createWorktree":
       return try await handleCreateWorktree(body)
     case "/git/worktreeRemove":
@@ -935,6 +937,34 @@ public actor RpcDispatcher {
     let stdout = try await runGit(args: ["symbolic-ref", "--short", "HEAD"], cwd: dir)
     return String(decoding: stdout, as: UTF8.self).trimmingCharacters(
       in: .whitespacesAndNewlines)
+  }
+
+  private func handleGitGithubIdentity(_ body: Data) async throws -> Data {
+    let req = try Gozd_V1_GitGithubIdentityRequest(jsonUTF8Data: body)
+    // `repoOwnerName` 内部の `runGit` が `GitError.launchFailed` (git CLI 解決失敗 / PATH 不在等)
+    // を throw した場合は rethrow して renderer に通知する (silent drop 禁止規律と整合)。
+    // `commandFailed` (git config が remote.origin 未設定で exit) は `RepoIdentity.unsetRemote`
+    // に倒され、ここでは throw されない。
+    //
+    // `repoOwnerName` は `gh pr list` 経路と共有することで、git CLI への入力 / parser /
+    // host policy をすべて 1 箇所に集約する SSOT 設計。これにより `gh pr list` で PR が拾える
+    // repo では必ず `#N` リンクの base も導出できる、という整合性が構造的に保証される。
+    var resp = Gozd_V1_GitGithubIdentityResponse()
+    switch try await GitHubOps.repoOwnerName(dir: req.dir) {
+    case .ok(let owner, let repo):
+      resp.owner = owner
+      resp.repo = repo
+    case .unsetRemote:
+      // remote 未設定 (新規 repo / fork なし)。UI には出ないが観察可能にする。
+      FileHandle.standardError.write(
+        Data("[handleGitGithubIdentity] remote.origin not set for dir=\(req.dir)\n".utf8))
+    case .parserRejected:
+      // 非 github.com host / 想定外 URL 形式。raw URL は credential 漏出防止のため
+      // stderr にも載せない (固定文言 + dir のみで切り分け)。
+      FileHandle.standardError.write(
+        Data("[handleGitGithubIdentity] unsupported remote URL for dir=\(req.dir)\n".utf8))
+    }
+    return try resp.jsonUTF8Data()
   }
 
   private func handleCreateWorktree(_ body: Data) async throws -> Data {

--- a/apps/renderer/src/features/git-graph/CommitDetailPane.vue
+++ b/apps/renderer/src/features/git-graph/CommitDetailPane.vue
@@ -9,14 +9,29 @@ Commit detail pane showing metadata for selected commits in the git graph.
 
 <script setup lang="ts">
 import type { GitCommit } from "@gozd/proto";
+import { computed } from "vue";
 import { UNCOMMITTED_HASH } from "../worktree";
+import CommitSegmentList from "./CommitSegmentList";
+import { linkifyCommitMessage } from "./linkifyCommitMessage";
 
 interface Props {
   /** 表示対象のコミット配列 */
   commits: GitCommit[];
+  /** GitHub repo base URL。`#番号` を issue/PR リンクに変換するのに使う */
+  baseUrl: string | undefined;
 }
 
-defineProps<Props>();
+const props = defineProps<Props>();
+
+/** subject / body の linkify 結果を `(commits, baseUrl)` が変わったときだけ再計算する。
+ * template から関数呼び出しすると毎 render で `linkifyCommitMessage` (string.matchAll の O(n))
+ * が走るので、`commits.length` × `(message + body)` の再計算を抑える。 */
+const subjectSegmentsList = computed(() =>
+  props.commits.map((c) => linkifyCommitMessage(c.message, props.baseUrl)),
+);
+const bodySegmentsList = computed(() =>
+  props.commits.map((c) => linkifyCommitMessage(c.body, props.baseUrl)),
+);
 
 function isUncommitted(hash: string): boolean {
   return hash === UNCOMMITTED_HASH;
@@ -58,11 +73,14 @@ function formatDetailDate(timestamp: number): string {
       <template v-else>
         <!-- Subject -->
         <div class="text-sm font-semibold text-zinc-200">
-          {{ commit.message }}
+          <CommitSegmentList :segments="subjectSegmentsList[i]" />
         </div>
 
-        <!-- Body -->
-        <pre v-if="commit.body" class="whitespace-pre-wrap text-zinc-400">{{ commit.body }}</pre>
+        <!-- Body: `<pre>` 配下でも `CommitSegmentList` は render function 実装のため
+             template 改行由来の whitespace text node 混入が構造的に起きない。 -->
+        <pre v-if="commit.body" class="whitespace-pre-wrap text-zinc-400"><CommitSegmentList
+          :segments="bodySegmentsList[i]"
+        /></pre>
 
         <!-- Meta fields -->
         <div class="flex flex-col gap-1.5">

--- a/apps/renderer/src/features/git-graph/CommitSegmentList.ts
+++ b/apps/renderer/src/features/git-graph/CommitSegmentList.ts
@@ -1,0 +1,43 @@
+import { defineComponent, h, type PropType } from "vue";
+import type { CommitMessageSegment } from "./linkifyCommitMessage";
+
+/** `linkifyCommitMessage` の戻り値 (`CommitMessageSegment[]`) を render する dumb component。
+ *
+ * SFC ではなく render function (`h()`) で書くのは、SFC template に書いた改行・インデントが
+ * Vue compiler 経由で text node 化して preformatted 親要素 (`<pre white-space:pre-wrap>`) 配下の
+ * commit body の whitespace を壊すリスクを構造的に消すため。`h()` は VNode を直接組み立てるため
+ * source の整形に関係なく余分な text node が混入しない。
+ *
+ * `<a>` の class / title / rel / target / `@click.stop` の組み合わせは renderer 内で 1 箇所に
+ * 集約 (SSOT)。利用側 (GitGraphPane の commit row / CommitDetailPane の subject + body) は
+ * `<CommitSegmentList :segments="...">` を呼ぶだけで、`a` の attribute 揃え漏れが起きない。 */
+export default defineComponent({
+  name: "CommitSegmentList",
+  props: {
+    segments: {
+      type: Array as PropType<CommitMessageSegment[]>,
+      required: true,
+    },
+  },
+  setup(props) {
+    return () =>
+      props.segments.map((seg) => {
+        if (seg.type === "issue") {
+          return h(
+            "a",
+            {
+              href: seg.href,
+              target: "_blank",
+              rel: "noopener noreferrer",
+              class: "text-blue-400 hover:underline",
+              title: `Open ${seg.value} on GitHub`,
+              // 行クリック (commit 選択) の伝播を止めて、リンクだけを発火させる
+              onClick: (e: MouseEvent) => e.stopPropagation(),
+            },
+            seg.value,
+          );
+        }
+        return seg.value;
+      });
+  },
+});

--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -32,13 +32,16 @@ import {
   useWorktreeStore,
 } from "../worktree";
 import CommitDetailPane from "./CommitDetailPane.vue";
+import CommitSegmentList from "./CommitSegmentList";
 import type { DisplayRef } from "./displayRef";
 import { computeGraphLayout } from "./graphLayout";
 import type { GraphLayout } from "./graphLayout";
+import type { CommitMessageSegment } from "./linkifyCommitMessage";
+import { buildRepoBaseUrl, linkifyCommitMessage } from "./linkifyCommitMessage";
 import { mergeCommitStreams } from "./mergeCommitStreams";
 import type { SortMode } from "./mergeCommitStreams";
 import RefBadge from "./RefBadge.vue";
-import { rpcGitLog } from "./rpc";
+import { rpcGitGithubIdentity, rpcGitLog } from "./rpc";
 import { useGitGraphStore } from "./useGitGraphStore";
 
 const rootRef = useTemplateRef<HTMLElement>("root");
@@ -382,6 +385,50 @@ async function loadPrList() {
   prByBranch.value = map;
 }
 
+// --- GitHub repo identity (コミットメッセージ `#N` リンク化の SSOT) ---
+
+/** active worktree の origin remote を parse した `(owner, repo)`。
+ * Swift 側 `GitHubOps.parseGitHubOwnerRepo` 経由のため、`gh pr list` と同じ host policy
+ * (github.com 限定) で揃う。remote 未設定 / 非 github.com host は両フィールドが空文字で届く。
+ * worktree 切替時に 1 回だけ取得。push / fetch 等の SSOT push 経路では再取得不要
+ * (remote URL は `git remote set-url` でしか変わらず、それは FSEvents の射程外で
+ * 低頻度な手動操作のため、active 切替時の取得で実用上十分)。 */
+const repoIdentity = ref({ owner: "", repo: "" });
+/** loadRepoIdentity の世代管理。並行実行で古いレスポンスが後着して上書きするのを防ぐ */
+let loadRepoIdentityGen = 0;
+
+async function loadRepoIdentity() {
+  const gen = ++loadRepoIdentityGen;
+  const dir = worktreeStore.dir;
+  if (dir === undefined) return;
+  const result = await tryCatch(rpcGitGithubIdentity({ dir }));
+  if (gen !== loadRepoIdentityGen) return;
+  if (!result.ok) {
+    // launch failure は git CLI 解決失敗 (PATH 不在等) のみ。
+    // remote 未設定 / 非 github は native 側で空文字 + stderr ログに倒すため、ここには来ない。
+    notify.error("Failed to load GitHub identity", result.error);
+    return;
+  }
+  repoIdentity.value = { owner: result.value.owner, repo: result.value.repo };
+}
+
+/** GitHub repo base URL (`https://github.com/<owner>/<repo>`)。
+ * コミットメッセージの `#N` リンク化に使う。remote 未設定 / 非 github.com host は undefined。 */
+const issueLinkBaseUrl = computed(() => buildRepoBaseUrl(repoIdentity.value));
+
+/** 表示中の各 commit の subject を linkify した segments を hash で引ける map。
+ * template から関数呼び出しすると毎 render で `linkifyCommitMessage` (string.matchAll の O(n)
+ * コスト) が全 commit 分実行されるため、computed で `(commits, baseUrl)` が変わったときだけ
+ * 再計算する形に変える。row hover / 選択変更 等の再 render では再計算しない。 */
+const commitMessageSegmentsByHash = computed(() => {
+  const baseUrl = issueLinkBaseUrl.value;
+  const map = new Map<string, CommitMessageSegment[]>();
+  for (const node of layout.value.nodes) {
+    map.set(node.commit.hash, linkifyCommitMessage(node.commit.message, baseUrl));
+  }
+  return map;
+});
+
 // active worktree の PR 一覧を 60 秒間隔で取得する。
 // gozd の primary use case は「Claude / ユーザーが worktree で `gh pr create` する」ことであり、
 // 既 push branch での `gh pr create` / `gh pr edit` / `gh pr comment` / `gh pr review` 等は
@@ -397,15 +444,23 @@ const { pause: pausePrPolling, resume: resumePrPolling } = useIntervalFn(
 
 onMounted(() => {
   void loadPrList();
+  void loadRepoIdentity();
 });
 
-// worktree 切り替え時に PR 再取得 + interval を新 dir 基準に再スタート。
+// worktree 切り替え時に PR / repo identity 再取得 + interval を新 dir 基準に再スタート。
 // 切替直後に間隔分待たされず、かつ古い dir のタイマーで二重発火しない。
+//
+// fetch 完了前の async 窓で旧 repo の identity / PR map が残ると、新 repo の commit が描画
+// された瞬間に「新 repo の #N を旧 repo の URL にリンク」「新 branch を旧 PR バッジに紐付け」
+// 等の cross-repo 事故が起きる。これを構造的に防ぐため、fetch 発射前に同期で空に倒す。
 watch(
   () => worktreeStore.dir,
   () => {
     pausePrPolling();
+    repoIdentity.value = { owner: "", repo: "" };
+    prByBranch.value = new Map();
     void loadPrList();
+    void loadRepoIdentity();
     resumePrPolling();
   },
 );
@@ -994,7 +1049,9 @@ const isWorkingTreeActive = computed(
                   :pr-by-branch="prByBranch"
                 />
                 <span class="truncate">
-                  {{ node.commit.message }}
+                  <CommitSegmentList
+                    :segments="commitMessageSegmentsByHash.get(node.commit.hash) ?? []"
+                  />
                 </span>
               </div>
 
@@ -1030,7 +1087,7 @@ const isWorkingTreeActive = computed(
           class="shrink-0 overflow-hidden border-l border-zinc-700"
           :style="{ width: `${detailWidth}px` }"
         >
-          <CommitDetailPane :commits="gitGraphStore.selectedCommits" />
+          <CommitDetailPane :commits="gitGraphStore.selectedCommits" :base-url="issueLinkBaseUrl" />
         </div>
       </template>
     </div>

--- a/apps/renderer/src/features/git-graph/RefBadge.vue
+++ b/apps/renderer/src/features/git-graph/RefBadge.vue
@@ -32,24 +32,27 @@ const REF_TYPE_CLASS: Record<DisplayRef["type"], string> = {
 const CURRENT_LOCAL_CLASS = "bg-yellow-500 text-black";
 const CURRENT_REMOTE_CLASS = "bg-yellow-500 text-black opacity-50";
 const DEFAULT_CLASS = "ring-1 ring-inset ring-current";
-
-function openPrUrl(url: string) {
-  window.open(url);
-}
 </script>
 
 <template>
   <!-- PR number badge (left of branch label) -->
-  <span
+  <!-- 外部リンクは native 側の `ExternalLinkNavigationDecider` が OS のブラウザに渡す。
+       `target="_blank" rel="noopener noreferrer"` は decider 経路が完全に握る前 (decider が
+       cancel するまでの thin window) に WebKit が referrer / opener を組み立てる可能性に対する
+       defense in depth。行クリック伝播は `@click.stop` で止める。 -->
+  <a
     v-if="pr"
-    class="flex shrink-0 cursor-pointer items-center gap-0.5 rounded-sm px-1 py-0.5 text-[10px] leading-none font-medium"
+    :href="pr.url"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="flex shrink-0 items-center gap-0.5 rounded-sm px-1 py-0.5 text-[10px] leading-none font-medium no-underline"
     :class="pr.isDraft ? 'bg-zinc-700 text-zinc-300' : 'bg-purple-800 text-purple-200'"
     :title="`PR #${pr.number}${pr.isDraft ? ' (draft)' : ''}`"
-    @click.stop="openPrUrl(pr.url)"
+    @click.stop
   >
     <span class="icon-[lucide--git-pull-request] size-3" />
     #{{ pr.number }}
-  </span>
+  </a>
   <!-- Branch label -->
   <span
     class="flex shrink-0 items-center gap-0.5 rounded-sm px-1 py-0.5 text-[10px] leading-none font-medium"

--- a/apps/renderer/src/features/git-graph/linkifyCommitMessage.test.ts
+++ b/apps/renderer/src/features/git-graph/linkifyCommitMessage.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import { buildRepoBaseUrl, linkifyCommitMessage } from "./linkifyCommitMessage";
+
+describe("buildRepoBaseUrl", () => {
+  test("builds base URL from (owner, repo) identity", () => {
+    expect(buildRepoBaseUrl({ owner: "miyaoka", repo: "gozd" })).toBe(
+      "https://github.com/miyaoka/gozd",
+    );
+  });
+
+  test("returns undefined when identity is undefined", () => {
+    expect(buildRepoBaseUrl(undefined)).toBeUndefined();
+  });
+
+  test("returns undefined when owner is empty (remote unset / non-github host)", () => {
+    expect(buildRepoBaseUrl({ owner: "", repo: "gozd" })).toBeUndefined();
+  });
+
+  test("returns undefined when repo is empty (remote unset / non-github host)", () => {
+    expect(buildRepoBaseUrl({ owner: "miyaoka", repo: "" })).toBeUndefined();
+  });
+
+  test("returns undefined when both empty", () => {
+    expect(buildRepoBaseUrl({ owner: "", repo: "" })).toBeUndefined();
+  });
+});
+
+describe("linkifyCommitMessage", () => {
+  const base = "https://github.com/miyaoka/gozd";
+
+  test("no baseUrl returns plain text segment", () => {
+    expect(linkifyCommitMessage("Fix #123 bug", undefined)).toEqual([
+      { type: "text", value: "Fix #123 bug" },
+    ]);
+  });
+
+  test("linkifies a single issue reference", () => {
+    expect(linkifyCommitMessage("Fix #123 bug", base)).toEqual([
+      { type: "text", value: "Fix " },
+      { type: "issue", value: "#123", href: `${base}/issues/123` },
+      { type: "text", value: " bug" },
+    ]);
+  });
+
+  test("linkifies merge commit subject", () => {
+    const result = linkifyCommitMessage("Merge pull request #561 from miyaoka/docs", base);
+    expect(result).toEqual([
+      { type: "text", value: "Merge pull request " },
+      { type: "issue", value: "#561", href: `${base}/issues/561` },
+      { type: "text", value: " from miyaoka/docs" },
+    ]);
+  });
+
+  test("linkifies multiple references", () => {
+    const result = linkifyCommitMessage("Closes #1 and #22", base);
+    expect(result).toEqual([
+      { type: "text", value: "Closes " },
+      { type: "issue", value: "#1", href: `${base}/issues/1` },
+      { type: "text", value: " and " },
+      { type: "issue", value: "#22", href: `${base}/issues/22` },
+    ]);
+  });
+
+  test("does not linkify HTML entity-like sequences", () => {
+    expect(linkifyCommitMessage("foo &#123; bar", base)).toEqual([
+      { type: "text", value: "foo &#123; bar" },
+    ]);
+  });
+
+  test("does not linkify hash inside a word boundary", () => {
+    // `foo#456` looks like a fragment / disambiguator, not a GitHub issue reference.
+    expect(linkifyCommitMessage("foo#456 bar", base)).toEqual([
+      { type: "text", value: "foo#456 bar" },
+    ]);
+  });
+
+  test("linkifies reference at start of string", () => {
+    expect(linkifyCommitMessage("#42 done", base)).toEqual([
+      { type: "issue", value: "#42", href: `${base}/issues/42` },
+      { type: "text", value: " done" },
+    ]);
+  });
+
+  test("linkifies reference at end of string", () => {
+    expect(linkifyCommitMessage("see #99", base)).toEqual([
+      { type: "text", value: "see " },
+      { type: "issue", value: "#99", href: `${base}/issues/99` },
+    ]);
+  });
+
+  test("empty message returns single empty text segment", () => {
+    expect(linkifyCommitMessage("", base)).toEqual([{ type: "text", value: "" }]);
+  });
+
+  test("linkifies #0 even though GitHub has no issue #0 (regex contract)", () => {
+    expect(linkifyCommitMessage("regress #0", base)).toEqual([
+      { type: "text", value: "regress " },
+      { type: "issue", value: "#0", href: `${base}/issues/0` },
+    ]);
+  });
+
+  test("linkifies the second `#` in `##123` (regex contract)", () => {
+    expect(linkifyCommitMessage("see ##123 note", base)).toEqual([
+      { type: "text", value: "see #" },
+      { type: "issue", value: "#123", href: `${base}/issues/123` },
+      { type: "text", value: " note" },
+    ]);
+  });
+
+  test("does not linkify `# 123` (whitespace between hash and digits)", () => {
+    expect(linkifyCommitMessage("note # 123 ok", base)).toEqual([
+      { type: "text", value: "note # 123 ok" },
+    ]);
+  });
+
+  test("does not linkify `#1a2` (digits trailed by letters)", () => {
+    expect(linkifyCommitMessage("v #1a2 ok", base)).toEqual([{ type: "text", value: "v #1a2 ok" }]);
+  });
+
+  // `buildRepoBaseUrl` -> `linkifyCommitMessage` の暗黙契約 (= 末尾スラッシュ無し absolute URL) を
+  // 統合テストで縛る。`buildRepoBaseUrl` が将来「末尾スラッシュ付き」「`.git` 付き」等を
+  // 返すように変更されると `//issues/N` / `.git/issues/N` のような壊れたパスになり、
+  // 単体テストでは検知できないため。
+  test("integration: buildRepoBaseUrl output is consumable by linkifyCommitMessage", () => {
+    const baseFromBuild = buildRepoBaseUrl({ owner: "miyaoka", repo: "gozd" });
+    expect(linkifyCommitMessage("Fix #123", baseFromBuild)).toEqual([
+      { type: "text", value: "Fix " },
+      { type: "issue", value: "#123", href: "https://github.com/miyaoka/gozd/issues/123" },
+    ]);
+  });
+});

--- a/apps/renderer/src/features/git-graph/linkifyCommitMessage.ts
+++ b/apps/renderer/src/features/git-graph/linkifyCommitMessage.ts
@@ -1,0 +1,70 @@
+interface TextSegment {
+  type: "text";
+  value: string;
+}
+
+interface IssueSegment {
+  type: "issue";
+  value: string;
+  href: string;
+}
+
+export type CommitMessageSegment = TextSegment | IssueSegment;
+
+/** Swift 側 `GitHubOps.parseGitHubOwnerRepo` で parse 済みの `(owner, repo)` から GitHub の
+ * repo base URL を組み立てる。remote 未設定 / 非 github.com host (parser が nil で返す経路) は
+ * 両方が空文字で届くため undefined に倒し、renderer は `#N` を plain text に保つ。
+ *
+ * remote URL の文字列 parse / SSH 形式の正規化 / `.git` suffix 剥がし / host policy 判定は
+ * Swift 側 1 箇所 (`GitHubOps.parseGitHubOwnerRepo`) で完結している。renderer は構造化済み
+ * identifier を受け取って文字列を組み立てるだけ。
+ *
+ * GitHub は `/issues/<n>` も `/pull/<n>` も互いにリダイレクトするため、base から
+ * `/issues/<n>` を組み立てれば issue / PR の判別なしに飛べる。 */
+export function buildRepoBaseUrl(
+  identity: { owner: string; repo: string } | undefined,
+): string | undefined {
+  if (identity === undefined) return undefined;
+  if (identity.owner === "" || identity.repo === "") return undefined;
+  return `https://github.com/${identity.owner}/${identity.repo}`;
+}
+
+/** `#数字` パターン。前が単語境界 (英数字 / `&` 直後を除外) で数字が連続するもの。
+ * `&#123;` のような HTML entity 風や `foo#456` のような fragment は対象外。 */
+const ISSUE_REF_RE = /(?<![\w&])#(\d+)(?!\w)/g;
+
+/** コミットメッセージを linkify 可能なセグメント列に分割する。
+ * baseUrl が undefined のときは全文を text 1 セグメントで返す。
+ * baseUrl は `buildRepoBaseUrl` 経由で構築された `https://github.com/<owner>/<repo>` のため、
+ * `${baseUrl}/issues/${numberStr}` の補間は安全 (注入経路なし)。 */
+export function linkifyCommitMessage(
+  message: string,
+  baseUrl: string | undefined,
+): CommitMessageSegment[] {
+  if (baseUrl === undefined || message === "") {
+    return [{ type: "text", value: message }];
+  }
+
+  const segments: CommitMessageSegment[] = [];
+  let lastIndex = 0;
+
+  for (const match of message.matchAll(ISSUE_REF_RE)) {
+    const start = match.index;
+    if (start > lastIndex) {
+      segments.push({ type: "text", value: message.slice(lastIndex, start) });
+    }
+    const numberStr = match[1];
+    segments.push({
+      type: "issue",
+      value: match[0],
+      href: `${baseUrl}/issues/${numberStr}`,
+    });
+    lastIndex = start + match[0].length;
+  }
+
+  if (lastIndex < message.length) {
+    segments.push({ type: "text", value: message.slice(lastIndex) });
+  }
+
+  return segments;
+}

--- a/apps/renderer/src/features/git-graph/rpc.ts
+++ b/apps/renderer/src/features/git-graph/rpc.ts
@@ -1,6 +1,8 @@
 import {
   GitCommitFilesRequest,
   GitCommitFilesResponse,
+  GitGithubIdentityRequest,
+  GitGithubIdentityResponse,
   GitLogRequest,
   GitLogResponse,
 } from "@gozd/proto";
@@ -12,3 +14,6 @@ export const rpcGitLog = (req: GitLogRequest) =>
 
 export const rpcGitCommitFiles = (req: GitCommitFilesRequest) =>
   rpc("/git/commitFiles", req, GitCommitFilesRequest, GitCommitFilesResponse);
+
+export const rpcGitGithubIdentity = (req: GitGithubIdentityRequest) =>
+  rpc("/git/githubIdentity", req, GitGithubIdentityRequest, GitGithubIdentityResponse);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,6 +96,26 @@ socket / launch dir / claude settings は `GOZD_DEV_PROJECT_ROOT` の有無で `
 
 永続データ（`~/.config/gozd/` 配下）は dev / stable で **共有** する。worktree 本体（`~/.local/share/gozd/worktrees/`）が共有なのと同じ扱い。
 
+## WebPage の navigation policy
+
+renderer 内の外部リンク (`<a target="_blank">` / `window.open`) を OS のデフォルトブラウザに渡すには `WebPage.NavigationDeciding` 準拠の `ExternalLinkNavigationDecider` (`apps/native/Sources/Gozd/ExternalLinkNavigationDecider.swift`) を `WebPage(configuration:navigationDecider:)` に差し込む必要がある（WWDC25「Meet WebKit for SwiftUI」公式パターン）。デフォルトでは main frame が外部 URL に置換されて renderer の UI 全体が消えるため、構造的に必要な防壁。
+
+判定軸は **scheme による 3 分岐** に統一する:
+
+- http(s) かつ dev mode の `$GOZD_DEV_VITE_URL` origin (scheme + host + port すべて一致) → 内部扱いで `.allow`
+- http(s) かつそれ以外 → 外部とみなして OS のデフォルトブラウザに渡し `.cancel`
+- それ以外の scheme（`gozd-rpc://` / `gozd-app://` / `about:` / `file:` 等）→ `.allow`
+
+`navigationType`（`linkActivated` / `formSubmitted` / `.reload` 等）や `action.target` の値には依存しない。renderer は単一 WebPage 上に Vue UI を構築する設計なので、main frame であれ subframe であれ http(s) への遷移は外部 host なら OS ブラウザで開くのが期待挙動であり、`<a href>` 以外の経路（form submit / window.open / meta refresh 等）でも構造的に外部送りで揃える。起動時の `page.load(http://localhost:5173/)` は dev origin allow 経路で透過する。
+
+dev mode で参照される `$GOZD_DEV_VITE_URL` は **origin 表現に限定** する（path なし / 空 / `/`）。path 付きの値が来た場合、起動時に nil 化して stderr にエラーを残す（`isInternalDevURL` は host:port 一致のみを見るため、path 付きを許すと path が違う external URL も internal allow に倒れる事故源になる）。
+
+外部 URL の launch 失敗（壊れた URL / 既定ブラウザが解決不能 等）は具体的な error 情報込みで stderr に残す（`[NavigationDecider] failed to open external URL: <url>: <error>` 形式、silent drop 禁止規律と整合）。
+
+renderer 側の `<a href>` には `target="_blank" rel="noopener noreferrer"` を付ける（defense in depth）。decider が `.cancel` する前の thin window で WebKit が referrer / opener を組み立てる可能性に備える保険であり、decider 経路と二重防御で揃える契約。`window.open` への迂回や `e.preventDefault()` での workaround は不要。
+
+副作用として、markdown preview ([preview.md](preview.md)) で render される `[text](https://...)` 由来の `<a href>` も同じ decider を経由するため、すべて外部ブラウザで開かれる。WebView 内で main frame を置換されるリスクが構造的に無くなる代わりに、「markdown 内のリンクは必ず外部ブラウザで開く」という挙動が決定的になる。
+
 ## 通信経路
 
 ### gozd-rpc:// URLSchemeHandler（renderer ↔ native）

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -149,6 +149,7 @@ desktop からの `fsChange` メッセージを購読し、選択中ファイル
 
 - `marked` で HTML に変換後、`DOMPurify.sanitize()` で XSS 対策
 - YAML frontmatter を `hooks.preprocess` でコードブロックに変換して表示
+- markdown 中の `[text](https://...)` 由来 `<a>` は、native の `ExternalLinkNavigationDecider`（[architecture.md](architecture.md) の「WebPage の navigation policy」参照）が拾って OS のデフォルトブラウザで開く。WebView 内で main frame が外部 URL に置換されることはない
 
 ### ImagePreview
 

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
@@ -585,6 +585,49 @@ public struct Gozd_V1_GitFetchRemotesResponse: Sendable {
   public init() {}
 }
 
+/// gitGithubIdentity: active worktree の origin remote から GitHub の (owner, repo) を返す。
+/// 内部実装は `GitHubOps.repoOwnerName` を **`gh pr list` 経路と共有** することで、
+/// 「git CLI への入力 / parser / host policy」すべてを 1 箇所に集約した SSOT 設計。
+/// `git remote get-url` ではなく `git config --get remote.origin.url` を使う (両経路を同一
+/// 入力に揃え、`~/.gitconfig` の `insteadOf` 解釈差で結果が乖離するのを防ぐ)。
+///
+/// host policy は **github.com 限定** (`gh` のデフォルト host と合わせる)。GitLab / Bitbucket /
+/// GitHub Enterprise 等の非 github.com remote、および remote 未設定 / parse 失敗はすべて
+/// owner / repo を空文字で返す。renderer 側はコミットメッセージ中の `#N` を
+/// `https://github.com/<owner>/<repo>/issues/<n>` にリンクするのに使い、空文字なら plain text。
+///
+/// wire format 上は失敗 3 経路 (remote 未設定 / 非 github.com / parser 拒否) を空文字 1 種類に
+/// 圧縮するが、native 側では `RepoIdentity` enum で区別し stderr に経路別ログを残す。
+/// 「あれ動かない」の切り分けが必要なときは `[handleGitGithubIdentity]` プレフィックスの
+/// stderr (および `gh pr list` 失敗時の GhError.detail) を参照する。
+public struct Gozd_V1_GitGithubIdentityRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var dir: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public struct Gozd_V1_GitGithubIdentityResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  /// GitHub repo の owner。非 github.com / remote 未設定 / parse 失敗では空文字
+  public var owner: String = String()
+
+  /// GitHub repo の repo。`.git` suffix は剥がされている。非 github.com / remote 未設定 / parse 失敗では空文字
+  public var repo: String = String()
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 /// gitDefaultBranch: `git worktree add -b <new> <abs> <ref>` の `<ref>` にそのまま渡せる
 /// 「default branch ref」を返す。新規 worktree 作成時の起点を一意に決めるために使う。
 /// 解決順序は二段 fallback:
@@ -1644,6 +1687,71 @@ extension Gozd_V1_GitFetchRemotesResponse: SwiftProtobuf.Message, SwiftProtobuf.
   public static func ==(lhs: Gozd_V1_GitFetchRemotesResponse, rhs: Gozd_V1_GitFetchRemotesResponse) -> Bool {
     if lhs.ok != rhs.ok {return false}
     if lhs.errorDetail != rhs.errorDetail {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Gozd_V1_GitGithubIdentityRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GitGithubIdentityRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}dir\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.dir) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.dir.isEmpty {
+      try visitor.visitSingularStringField(value: self.dir, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Gozd_V1_GitGithubIdentityRequest, rhs: Gozd_V1_GitGithubIdentityRequest) -> Bool {
+    if lhs.dir != rhs.dir {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Gozd_V1_GitGithubIdentityResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".GitGithubIdentityResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}owner\0\u{1}repo\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.owner) }()
+      case 2: try { try decoder.decodeSingularStringField(value: &self.repo) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.owner.isEmpty {
+      try visitor.visitSingularStringField(value: self.owner, fieldNumber: 1)
+    }
+    if !self.repo.isEmpty {
+      try visitor.visitSingularStringField(value: self.repo, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Gozd_V1_GitGithubIdentityResponse, rhs: Gozd_V1_GitGithubIdentityResponse) -> Bool {
+    if lhs.owner != rhs.owner {return false}
+    if lhs.repo != rhs.repo {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
@@ -340,6 +340,34 @@ export interface GitFetchRemotesResponse {
 }
 
 /**
+ * gitGithubIdentity: active worktree の origin remote から GitHub の (owner, repo) を返す。
+ * 内部実装は `GitHubOps.repoOwnerName` を **`gh pr list` 経路と共有** することで、
+ * 「git CLI への入力 / parser / host policy」すべてを 1 箇所に集約した SSOT 設計。
+ * `git remote get-url` ではなく `git config --get remote.origin.url` を使う (両経路を同一
+ * 入力に揃え、`~/.gitconfig` の `insteadOf` 解釈差で結果が乖離するのを防ぐ)。
+ *
+ * host policy は **github.com 限定** (`gh` のデフォルト host と合わせる)。GitLab / Bitbucket /
+ * GitHub Enterprise 等の非 github.com remote、および remote 未設定 / parse 失敗はすべて
+ * owner / repo を空文字で返す。renderer 側はコミットメッセージ中の `#N` を
+ * `https://github.com/<owner>/<repo>/issues/<n>` にリンクするのに使い、空文字なら plain text。
+ *
+ * wire format 上は失敗 3 経路 (remote 未設定 / 非 github.com / parser 拒否) を空文字 1 種類に
+ * 圧縮するが、native 側では `RepoIdentity` enum で区別し stderr に経路別ログを残す。
+ * 「あれ動かない」の切り分けが必要なときは `[handleGitGithubIdentity]` プレフィックスの
+ * stderr (および `gh pr list` 失敗時の GhError.detail) を参照する。
+ */
+export interface GitGithubIdentityRequest {
+  dir: string;
+}
+
+export interface GitGithubIdentityResponse {
+  /** GitHub repo の owner。非 github.com / remote 未設定 / parse 失敗では空文字 */
+  owner: string;
+  /** GitHub repo の repo。`.git` suffix は剥がされている。非 github.com / remote 未設定 / parse 失敗では空文字 */
+  repo: string;
+}
+
+/**
  * gitDefaultBranch: `git worktree add -b <new> <abs> <ref>` の `<ref>` にそのまま渡せる
  * 「default branch ref」を返す。新規 worktree 作成時の起点を一意に決めるために使う。
  * 解決順序は二段 fallback:
@@ -2616,6 +2644,140 @@ export const GitFetchRemotesResponse: MessageFns<GitFetchRemotesResponse> = {
     const message = createBaseGitFetchRemotesResponse();
     message.ok = object.ok ?? false;
     message.errorDetail = object.errorDetail ?? "";
+    return message;
+  },
+};
+
+function createBaseGitGithubIdentityRequest(): GitGithubIdentityRequest {
+  return { dir: "" };
+}
+
+export const GitGithubIdentityRequest: MessageFns<GitGithubIdentityRequest> = {
+  encode(message: GitGithubIdentityRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.dir !== "") {
+      writer.uint32(10).string(message.dir);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GitGithubIdentityRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGitGithubIdentityRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.dir = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GitGithubIdentityRequest {
+    return { dir: isSet(object.dir) ? globalThis.String(object.dir) : "" };
+  },
+
+  toJSON(message: GitGithubIdentityRequest): unknown {
+    const obj: any = {};
+    if (message.dir !== "") {
+      obj.dir = message.dir;
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<GitGithubIdentityRequest>): GitGithubIdentityRequest {
+    return GitGithubIdentityRequest.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<GitGithubIdentityRequest>): GitGithubIdentityRequest {
+    const message = createBaseGitGithubIdentityRequest();
+    message.dir = object.dir ?? "";
+    return message;
+  },
+};
+
+function createBaseGitGithubIdentityResponse(): GitGithubIdentityResponse {
+  return { owner: "", repo: "" };
+}
+
+export const GitGithubIdentityResponse: MessageFns<GitGithubIdentityResponse> = {
+  encode(message: GitGithubIdentityResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.owner !== "") {
+      writer.uint32(10).string(message.owner);
+    }
+    if (message.repo !== "") {
+      writer.uint32(18).string(message.repo);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): GitGithubIdentityResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseGitGithubIdentityResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.owner = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.repo = reader.string();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): GitGithubIdentityResponse {
+    return {
+      owner: isSet(object.owner) ? globalThis.String(object.owner) : "",
+      repo: isSet(object.repo) ? globalThis.String(object.repo) : "",
+    };
+  },
+
+  toJSON(message: GitGithubIdentityResponse): unknown {
+    const obj: any = {};
+    if (message.owner !== "") {
+      obj.owner = message.owner;
+    }
+    if (message.repo !== "") {
+      obj.repo = message.repo;
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<GitGithubIdentityResponse>): GitGithubIdentityResponse {
+    return GitGithubIdentityResponse.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<GitGithubIdentityResponse>): GitGithubIdentityResponse {
+    const message = createBaseGitGithubIdentityResponse();
+    message.owner = object.owner ?? "";
+    message.repo = object.repo ?? "";
     return message;
   },
 };

--- a/packages/proto-ts/src/index.ts
+++ b/packages/proto-ts/src/index.ts
@@ -96,6 +96,8 @@ export {
   GitDiffHunksResponse,
   GitFetchRemotesRequest,
   GitFetchRemotesResponse,
+  GitGithubIdentityRequest,
+  GitGithubIdentityResponse,
   GitIssueListRequest,
   GitIssueListResponse,
   GitLogRequest,

--- a/packages/proto/gozd/v1/git_ops.proto
+++ b/packages/proto/gozd/v1/git_ops.proto
@@ -217,6 +217,31 @@ message GitFetchRemotesResponse {
   string error_detail = 2;
 }
 
+// gitGithubIdentity: active worktree の origin remote から GitHub の (owner, repo) を返す。
+// 内部実装は `GitHubOps.repoOwnerName` を **`gh pr list` 経路と共有** することで、
+// 「git CLI への入力 / parser / host policy」すべてを 1 箇所に集約した SSOT 設計。
+// `git remote get-url` ではなく `git config --get remote.origin.url` を使う (両経路を同一
+// 入力に揃え、`~/.gitconfig` の `insteadOf` 解釈差で結果が乖離するのを防ぐ)。
+//
+// host policy は **github.com 限定** (`gh` のデフォルト host と合わせる)。GitLab / Bitbucket /
+// GitHub Enterprise 等の非 github.com remote、および remote 未設定 / parse 失敗はすべて
+// owner / repo を空文字で返す。renderer 側はコミットメッセージ中の `#N` を
+// `https://github.com/<owner>/<repo>/issues/<n>` にリンクするのに使い、空文字なら plain text。
+//
+// wire format 上は失敗 3 経路 (remote 未設定 / 非 github.com / parser 拒否) を空文字 1 種類に
+// 圧縮するが、native 側では `RepoIdentity` enum で区別し stderr に経路別ログを残す。
+// 「あれ動かない」の切り分けが必要なときは `[handleGitGithubIdentity]` プレフィックスの
+// stderr (および `gh pr list` 失敗時の GhError.detail) を参照する。
+message GitGithubIdentityRequest {
+  string dir = 1;
+}
+message GitGithubIdentityResponse {
+  // GitHub repo の owner。非 github.com / remote 未設定 / parse 失敗では空文字
+  string owner = 1;
+  // GitHub repo の repo。`.git` suffix は剥がされている。非 github.com / remote 未設定 / parse 失敗では空文字
+  string repo = 2;
+}
+
 // gitDefaultBranch: `git worktree add -b <new> <abs> <ref>` の `<ref>` にそのまま渡せる
 // 「default branch ref」を返す。新規 worktree 作成時の起点を一意に決めるために使う。
 // 解決順序は二段 fallback:


### PR DESCRIPTION
## 概要

Git Graph 上の PR 番号バッジとコミットメッセージの `#番号` を GitHub の PR / issue ページにリンクするようにする。あわせて WebPage 全体で外部リンク (`<a target="_blank">` / `window.open` 等) を OS のデフォルトブラウザに送る経路を整備する。

## 背景

Git Graph では各ブランチに対応する PR 番号バッジを表示しているが、これまではクリックしても遷移経路が無く、コミットメッセージ中の `#561` のような番号もプレーンテキストのままだった。Claude / ユーザーが worktree 並列で `gh pr create` する gozd の primary use case では「メッセージ中の参照番号から GitHub の議論にすぐ飛びたい」という需要が直接的に発生する。

実装中、当初は renderer 側で `window.open` 経路に倒す workaround を当てたが、これは「`<a target="_blank">` は WebPage で抑止される」という根拠なき推測に基づいたものだった。WWDC25 #231「Meet WebKit for SwiftUI」のトランスクリプトと `WebPage.NavigationDeciding` の公式ドキュメントを確認した結果、外部リンクの取り扱いは **native 側に `WebPage.NavigationDeciding` を実装するのが公式パターン** であることを確認したため、こちらに倒した。

## 変更内容

### `#番号` の linkify

- `apps/renderer/src/features/git-graph/linkifyCommitMessage.ts` 新規。`#\d+` を text / issue セグメントに分割するピュア関数と、git remote URL から GitHub repo base URL（`https://<host>/<owner>/<repo>`）を抽出する `deriveRepoBaseUrl` を提供。https / SSH (`git@host:owner/repo.git`) どちらの remote 形式にも対応し、`.git` suffix を剥がして正規化する。
- `CommitMessage.vue` 新規。セグメントを描画。issue セグメントは `<a href>` でリンク化し、`@click.stop` で行選択伝播を止める。preformatted な commit body 内に embed しても元 message の whitespace が壊れないよう template を 1 行記法で書く。
- GitHub は `/issues/<n>` も `/pull/<n>` も互いにリダイレクトするため、base から `/issues/<n>` で組み立てて issue / PR の判別を省略。
- `GitGraphPane.vue` で `deriveRepoBaseUrl(remoteUrl.value)` の computed を持ち、グラフ行と `CommitDetailPane` の subject / body 両方に渡す。

### Remote URL SSOT 化 (新規 RPC)

- `rpcGitRepoUrl` ではなく `rpcGitRemoteUrl` を新規 RPC として追加。`git remote get-url origin` を Swift 側で実行し、結果文字列（remote 未設定なら空文字）を返す。
- proto / Swift handler / TS rpc wrapper の 3 段で導線を作る。`GitGraphPane.vue` が worktree 切替時に 1 回だけ取得し、`remoteUrl` を SSOT として保持する。
- `#番号` のリンク化は PR list の有無に依存しなくなった（PR が 1 件もない repo でも `#番号` が linkify される）。

### PR 番号バッジのリンク化

- `RefBadge.vue` の PR バッジを `<span>` + `click` ハンドラから `<a href={pr.url}>` に変更。中ボタン / Cmd+Click / 右クリックメニュー (Copy Link) も自然に効く。

### WebPage の外部リンクハンドリング

- `apps/native/Sources/Gozd/ExternalLinkNavigationDecider.swift` 新規。`WebPage.NavigationDeciding` 準拠 struct。判定軸は **scheme による 3 分岐** に統一:
  - http(s) かつ dev mode の `$GOZD_DEV_VITE_URL` origin（scheme + host + port 一致）→ 内部扱いで `.allow`
  - http(s) かつそれ以外 → `.cancel` + `NSWorkspace.shared.open(url)` で OS のデフォルトブラウザに渡す
  - それ以外の scheme (`gozd-rpc://` / `gozd-app://` / `about:` / `file:` 等) → `.allow`
- `navigationType` (`linkActivated` / `formSubmitted` / `.reload` 等) や `action.target` の値には依存しない。`<form action=http://...>` submit / window.open / meta refresh でも外部 host への遷移は構造的に外部送りで揃える。
- `GozdApp.swift` の `WebPage` 生成を `WebPage(configuration:navigationDecider:)` 経路に切り替え。NavigationDecider 未設定では main frame が外部 URL に置換されて renderer の UI 全体が消えるため、構造的に必要な防壁。
- `NSWorkspace.shared.open` の Bool 戻り値 false (launch 失敗) は `[NavigationDecider] failed to open external URL: ...` で stderr に残す (silent drop 禁止規律と整合)。
- renderer 側は普通の `<a href="...">` で書ける。`target="_blank"` / `rel="noopener noreferrer"` / `window.open` への迂回は不要。

### ドキュメント

- `docs/architecture.md` に `## WebPage の navigation policy` セクションを新設。scheme 3 分岐の判定軸と「decider 未設定で UI が消える」根拠を残す。
- `docs/preview.md` の MarkdownPreview セクションに「markdown 内の `[text](https://...)` 由来 `<a>` も decider 経由で OS ブラウザに開く」副作用を追記。

## 確認事項

- [ ] PR バッジをクリック → デフォルトブラウザに該当 PR ページが開く
- [ ] コミットメッセージ中の `#561` をクリック → デフォルトブラウザに該当 issue / PR ページが開く（GitHub の自動リダイレクトで適切な側に飛ぶ）
- [ ] PR が 1 件もない repo でも `#番号` がリンク化される（`rpcGitRemoteUrl` の結果に依存）
- [ ] 行選択中に PR バッジ / `#番号` をクリックしても行選択が解除されない (`@click.stop` 動作)
- [ ] `pnpm dev` (Vite dev server) で `http://localhost:5173/...` 内の遷移は WebView 内で実行される（dev origin allow 経路）
- [ ] markdown preview 内の `[text](https://github.com/...)` 形式リンクをクリック → デフォルトブラウザで開く（main frame 置換にならない）
