### PR TITLE
chore(pty): resizeIsSafe flake の root cause 特定に向け trace 粒度を引き上げる

### DIFF
--- a/.github/workflows/code_validation.yml
+++ b/.github/workflows/code_validation.yml
@@ -124,12 +124,14 @@ jobs:
 
       - name: swift test
         working-directory: apps/native
-        # GOZD_PTY_TRACE: PTYRegistryTests.spawnAndExitDispatch が CI で稀に flaky に
-        # なる issue #450 の原因特定用。DEBUG build かつこの env=1 のときのみ
-        # PTYManager 内のライフサイクルイベント（drainPTY の集約結果、source
-        # eventHandler の発火順、waitpid の戻り値・errno、PTYFinishState の状態
-        # 遷移）を stderr に時系列出力する。再発時に CI ログから経路を逐語で復元
-        # するために残す。
+        # GOZD_PTY_TRACE: PTY ライフサイクル / テスト境界 trace を CI ログに残す
+        # ための観測 hook。issue #450 (PTYRegistryTests.spawnAndExitDispatch) と
+        # issue #556 (PTYManagerTests.resizeIsSafe) で再発した flake の root cause
+        # を一意特定するために維持する。DEBUG build かつこの env=1 のときのみ、
+        # PTYManager 内のライフサイクルイベント（drainPTY 集約結果、source
+        # eventHandler 発火順、waitpid 戻り値・errno、PTYFinishState 状態遷移、
+        # resize/kill/write の syscall 結果）と、テスト境界（test entry/exit、
+        # waitUntil tick 履歴、runner 環境 snapshot）を stderr に時系列出力する。
         env:
           GOZD_PTY_TRACE: "1"
         run: swift test

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -284,6 +284,7 @@ public final class PTYManager {
   /// `EWOULDBLOCK` は短い sleep で待つ。`EPIPE` 等の致命的 errno は諦める。
   /// state 経由で書き込むことで、close 後 race で EBADF / 別 fd 誤書き込みを防ぐ。
   public func write(_ data: Data) {
+    ptyTrace("api", pid: pid, "write called len=\(data.count) hasState=\(state != nil)")
     guard let state else { return }
     data.withUnsafeBytes { buffer in
       guard let base = buffer.baseAddress else { return }
@@ -313,13 +314,21 @@ public final class PTYManager {
 
   /// terminal サイズを子プロセスに通知する（xterm.js のリサイズ連動）。
   public func resize(rows: UInt16, cols: UInt16) {
+    ptyTrace(
+      "api", pid: pid,
+      "resize called rows=\(rows) cols=\(cols) hasState=\(state != nil)")
     state?.resize(rows: rows, cols: cols)
   }
 
   /// 子プロセスに SIGHUP を送る。SIGTERM は interactive zsh が無視するため不可。
   public func kill() {
-    guard pid > 0 else { return }
-    _ = Darwin.kill(pid, SIGHUP)
+    guard pid > 0 else {
+      ptyTrace("api", pid: pid, "kill called but pid=\(pid) ≤ 0 → no-op")
+      return
+    }
+    let ret = Darwin.kill(pid, SIGHUP)
+    let err: Int32 = ret == -1 ? errno : 0
+    ptyTrace("api", pid: pid, "kill(SIGHUP) ret=\(ret) errno=\(err)")
   }
 }
 
@@ -468,12 +477,24 @@ final class PTYFinishState: @unchecked Sendable {
   }
 
   /// terminal サイズ通知。close 済みなら no-op。
+  /// ioctl の戻り値・errno は trace に残す。「resize 呼び出しが届いたが ioctl が EBADF を返した」
+  /// 経路を後追いするには戻り値の観測が必須。silent 失敗だと CI ログから判別不能になる。
   func resize(rows: UInt16, cols: UInt16) {
     lock.lock()
-    defer { lock.unlock() }
-    if primaryClosed { return }
+    if primaryClosed {
+      lock.unlock()
+      ptyTrace(
+        "fin", pid: pid,
+        "resize rows=\(rows) cols=\(cols) primaryClosed → no-op")
+      return
+    }
     var ws = winsize(ws_row: rows, ws_col: cols, ws_xpixel: 0, ws_ypixel: 0)
-    _ = ioctl(primaryFd, TIOCSWINSZ, &ws)
+    let ret = ioctl(primaryFd, TIOCSWINSZ, &ws)
+    let err: Int32 = ret == -1 ? errno : 0
+    lock.unlock()
+    ptyTrace(
+      "fin", pid: pid,
+      "resize fd=\(primaryFd) rows=\(rows) cols=\(cols) ioctl ret=\(ret) errno=\(err)")
   }
 
   func markReadClosed(onComplete: (PTYExitReason) -> Void) {

--- a/apps/native/Sources/GozdCore/PTYTrace.swift
+++ b/apps/native/Sources/GozdCore/PTYTrace.swift
@@ -1,23 +1,30 @@
 import Foundation
 
-// PTYRegistryTests.spawnAndExitDispatch が CI 環境（macos-26 runner）で稀に flaky に
-// なる問題（issue #450）の原因特定用トレース。
+// PTY ライフサイクル / テスト境界の観測ログ。
 //
-// production の hot path（drainPTY のループ / setEventHandler コールバック）に呼び出しを
-// 仕込むため、二重 gate で release build には一切影響を出さない:
+// production の hot path（drainPTY のループ / setEventHandler コールバック / PTYManager の
+// public method）に呼び出しを仕込むため、二重 gate で release build には一切影響を出さない:
 //
-// 1. `#if DEBUG` で release build からは関数実体ごと除外
-// 2. DEBUG build でも環境変数 `GOZD_PTY_TRACE=1` が無ければ即座に return
+// - `#if DEBUG` で release build からは関数実体ごと除外
+// - DEBUG build でも環境変数 `GOZD_PTY_TRACE=1` が無ければ即座に return
 //
-// 出力先は GitHub Actions が capture するプロセスの stderr。swift-testing が
-// stderr をテスト出力に含めるかは保証外で、実質的には Actions 側のログ capture に依存する。
+// 出力先は GitHub Actions が capture するプロセスの stderr。
 //
 // 行単位の整合性（複数スレッドからの同時 write で 1 行が分断・混線しない）は
 // `FileHandle.standardError.write(contentsOf:)` 単独では保証されないため、自前の
-// NSLock で serialize する。lock の取得はマイクロ秒オーダーで、観測したい race
-// （EVFILT_READ / NOTE_EXIT の到着順）を潰す observer effect より、行が混線して
+// NSLock で serialize する。観測したい race を潰す observer effect より、行が混線して
 // 観測機構の信頼性が落ちる方が実害が大きいと判断した。
 // 行間の到着順は時刻と pid タグから事後復元できるため lock 内では保証しない。
+//
+// `[PTY-TRACE]` と `[TEST-TRACE]` の 2 系統を持つ:
+//
+// - `[PTY-TRACE]`: GozdCore 内の PTY ライフサイクルイベント。`ptyTrace` から発射。
+// - `[TEST-TRACE]`: テスト境界 / `waitUntil` の polling 推移。テスト target から
+//   `gozdTraceLine` で発射する。
+//
+// 両系統は `gozdTraceStart` 基準の同一 elapsed 時刻 + 同一 stderr lock を共有する。
+// PTY 内部状態とテスト経路の絶対時刻を 1 本のログ stream 上で突き合わせるのが目的。
+// 別 prefix にしているのは grep で分離可能にするためで、時系列分離の意図ではない。
 //
 // 再発時に確認したい情報:
 //
@@ -26,31 +33,45 @@ import Foundation
 // - waitpid の戻り値・status・errno・EINTR retry 回数
 // - fcntl の戻り値（O_NONBLOCK 設定の成否）
 // - PTYFinishState の状態遷移（markReadClosed / setExitReason / onComplete 発火）
+// - PTYManager.resize / kill / write の呼び出し境界、ioctl(TIOCSWINSZ) / kill(SIGHUP) の戻り値・errno
+// - waitUntil の tick ごとの condition 結果と timeout 時の polling history
 //
 // childPid を tag に入れることで PTYRegistryTests のように複数 PTY を並走させた
 // ケースでも時系列を分離できる。
 
 #if DEBUG
-  private let ptyTraceEnabled: Bool = {
+  /// 環境変数で trace を gate する。production の hot path で常に呼ばれることを想定。
+  let gozdTraceEnabled: Bool = {
     ProcessInfo.processInfo.environment["GOZD_PTY_TRACE"] == "1"
   }()
-  private let ptyTraceStart = ContinuousClock.now
-  private let ptyTraceLock = NSLock()
+  /// プロセス起動からの経過時間基準。`[PTY-TRACE]` / `[TEST-TRACE]` の elapsed 表記に共通利用する。
+  let gozdTraceStart = ContinuousClock.now
+  private let gozdTraceLock = NSLock()
+
+  /// 形成済みの 1 行を atomic に stderr へ流す。複数 thread からの同時呼び出しで行が
+  /// 分断・混線するのを防ぐ。改行は呼び出し側で含めること。
+  @inline(__always)
+  func gozdTraceLine(_ line: String) {
+    guard gozdTraceEnabled else { return }
+    guard let data = line.data(using: .utf8) else { return }
+    gozdTraceLock.lock()
+    defer { gozdTraceLock.unlock() }
+    try? FileHandle.standardError.write(contentsOf: data)
+  }
 
   @inline(__always)
   func ptyTrace(_ tag: String, pid: Int32 = 0, _ message: @autoclosure () -> String) {
-    guard ptyTraceEnabled else { return }
-    let elapsed = ContinuousClock.now - ptyTraceStart
+    guard gozdTraceEnabled else { return }
+    let elapsed = ContinuousClock.now - gozdTraceStart
     let pidPart = pid == 0 ? "" : " pid=\(pid)"
-    let line = "[PTY-TRACE +\(elapsed)\(pidPart) \(tag)] \(message())\n"
-    guard let data = line.data(using: .utf8) else { return }
-    ptyTraceLock.lock()
-    defer { ptyTraceLock.unlock() }
-    try? FileHandle.standardError.write(contentsOf: data)
+    gozdTraceLine("[PTY-TRACE +\(elapsed)\(pidPart) \(tag)] \(message())\n")
   }
 #else
   // release build でも関数定義自体は残るが、本体は空で `@inline(__always)` により
   // call site から完全に inline 展開・除去される（ABI 上のコストは無い）。
+  let gozdTraceEnabled: Bool = false
+  let gozdTraceStart = ContinuousClock.now
+  @inline(__always) func gozdTraceLine(_ line: String) {}
   @inline(__always)
   func ptyTrace(_ tag: String, pid: Int32 = 0, _ message: @autoclosure () -> String) {}
 #endif

--- a/apps/native/Sources/GozdCore/PTYTrace.swift
+++ b/apps/native/Sources/GozdCore/PTYTrace.swift
@@ -44,7 +44,12 @@ import Foundation
   let gozdTraceEnabled: Bool = {
     ProcessInfo.processInfo.environment["GOZD_PTY_TRACE"] == "1"
   }()
-  /// プロセス起動からの経過時間基準。`[PTY-TRACE]` / `[TEST-TRACE]` の elapsed 表記に共通利用する。
+  /// 「`gozdTraceStart` シンボルへの最初の参照時点」を基準にした相対時刻の起点。
+  /// Swift の global `let` は最初の参照時 lazy 初期化（言語仕様で thread-safe）。
+  /// 通常 `ptyTrace` / `testTrace` のいずれかから最初に触れた瞬間に初期化されるため、
+  /// 厳密には「プロセス起動からの elapsed」ではなく「最初の trace 呼び出しからの elapsed」。
+  /// `[PTY-TRACE]` / `[TEST-TRACE]` の elapsed は同一プロセス内なら同じ `let` を共有するため
+  /// 両系統の elapsed は相対比較可能。プロセス起動からの absolute は要求していない。
   let gozdTraceStart = ContinuousClock.now
   private let gozdTraceLock = NSLock()
 
@@ -69,8 +74,10 @@ import Foundation
 #else
   // release build でも関数定義自体は残るが、本体は空で `@inline(__always)` により
   // call site から完全に inline 展開・除去される（ABI 上のコストは無い）。
+  // `gozdTraceStart` は release build では宣言しない。test target は `@testable import GozdCore`
+  // 経由で参照するが、`@testable` は DEBUG build を要求するため #else 経路では到達不能。
+  // 不要な `ContinuousClock.now` evaluation が linker dead-strip 通過後に残る経路を塞ぐ。
   let gozdTraceEnabled: Bool = false
-  let gozdTraceStart = ContinuousClock.now
   @inline(__always) func gozdTraceLine(_ line: String) {}
   @inline(__always)
   func ptyTrace(_ tag: String, pid: Int32 = 0, _ message: @autoclosure () -> String) {}

--- a/apps/native/Sources/GozdCore/PTYTrace.swift
+++ b/apps/native/Sources/GozdCore/PTYTrace.swift
@@ -16,6 +16,13 @@ import Foundation
 // 観測機構の信頼性が落ちる方が実害が大きいと判断した。
 // 行間の到着順は時刻と pid タグから事後復元できるため lock 内では保証しない。
 //
+// 1 行のサイズ上限: 数百バイト以内を想定する。POSIX `write(2)` は `PIPE_BUF`
+// （macOS で 512 byte）を超えると atomic 保証外で、NSLock は同プロセス内の write 序列化
+// にしか効かないため、別 process が同 stderr に出す行と混じる可能性が残る。
+// 現状の trace message（drainPTY 集約結果、`waitUntil` の lastTicks=[…] 含め最長でも
+// 数百バイト）は問題なし。将来 history を 100 件に拡張したり長 message を足す PR で
+// この上限を超える場合は、message を圧縮するか 1 行を複数 trace に分割すること。
+//
 // `[PTY-TRACE]` と `[TEST-TRACE]` の 2 系統を持つ:
 //
 // - `[PTY-TRACE]`: GozdCore 内の PTY ライフサイクルイベント。`ptyTrace` から発射。

--- a/apps/native/Sources/GozdCore/PTYTrace.swift
+++ b/apps/native/Sources/GozdCore/PTYTrace.swift
@@ -74,8 +74,13 @@ import Foundation
 #else
   // release build でも関数定義自体は残るが、本体は空で `@inline(__always)` により
   // call site から完全に inline 展開・除去される（ABI 上のコストは無い）。
-  // `gozdTraceStart` は release build では宣言しない。test target は `@testable import GozdCore`
-  // 経由で参照するが、`@testable` は DEBUG build を要求するため #else 経路では到達不能。
+  //
+  // `gozdTraceStart` は release build では宣言しない。`@testable import GozdCore` は対象
+  // module の `-enable-testing` ビルドを要求し、本リポジトリの `apps/native/Package.swift`
+  // は GozdCore に明示的な `-enable-testing` を付けていないため、SwiftPM のデフォルト
+  // ( DEBUG build 時のみ enable ) に従う。よって現状の運用では release build で
+  // `@testable import GozdCore` が link 失敗し、#else 経路の gozdTraceStart 参照は到達不能。
+  // 将来 release build に `-enable-testing` を追加する場合は本宣言も対称化する必要がある。
   // 不要な `ContinuousClock.now` evaluation が linker dead-strip 通過後に残る経路を塞ぐ。
   let gozdTraceEnabled: Bool = false
   @inline(__always) func gozdTraceLine(_ line: String) {}

--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -7,11 +7,14 @@ import Testing
 // 同時刻に spawn され、CI trace 上で pid 多重化が起きる。`resizeIsSafe` のような
 // timeout 系 flake が再発した時、「どの pid を見ていたのか」をテスト失敗時刻と
 // 一致する spawn pid から目で突き合わせるしか手段が無くなる。
-// 本 suite は ~5s 規模で、直列化による性能劣化は許容範囲。
+// 本 suite は ローカル swift test 実測で 1 秒未満、CI macos-26 でも秒オーダー内に収まる
+// ことを想定。直列化による性能劣化は許容範囲。
 @Suite("PTYManager", .serialized)
 struct PTYManagerTests {
   @Test("子プロセスの stdout を受け取り、正常終了 (.exited(0)) を検知する")
   func receivesOutputAndExit() async throws {
+    testTrace("started")
+    defer { testTrace("ended") }
     let data = DataCollector()
     let exit = ExitCollector()
     let pty = PTYManager()
@@ -37,6 +40,8 @@ struct PTYManagerTests {
 
   @Test("write した内容を子プロセス経由で読み戻せる（cat エコー）")
   func writeRoundTrip() async throws {
+    testTrace("started")
+    defer { testTrace("ended") }
     let data = DataCollector()
     let exit = ExitCollector()
     let pty = PTYManager()
@@ -73,6 +78,8 @@ struct PTYManagerTests {
 
   @Test("resize は fd 確立前後で crash しない")
   func resizeIsSafe() async throws {
+    testTrace("started")
+    defer { testTrace("ended") }
     let pty = PTYManager()
     pty.resize(rows: 30, cols: 100)  // fd 未確立: no-op
     let data = DataCollector()
@@ -95,6 +102,8 @@ struct PTYManagerTests {
 
   @Test("0 byte 出力で正常終了する child (/usr/bin/true) でも onExit が発火する")
   func zeroByteOutput() async throws {
+    testTrace("started")
+    defer { testTrace("ended") }
     let data = DataCollector()
     let exit = ExitCollector()
     let pty = PTYManager()
@@ -119,6 +128,8 @@ struct PTYManagerTests {
 
   @Test("stderr のみに書く child の出力も master fd から読める")
   func stderrIsCapturedThroughSlave() async throws {
+    testTrace("started")
+    defer { testTrace("ended") }
     let data = DataCollector()
     let exit = ExitCollector()
     let pty = PTYManager()
@@ -145,6 +156,8 @@ struct PTYManagerTests {
 
   @Test("存在しない cwd を指定すると exited(code: 124) を返す (chdir 失敗)")
   func chdirFailureReportedAsExit124() async throws {
+    testTrace("started")
+    defer { testTrace("ended") }
     let data = DataCollector()
     let exit = ExitCollector()
     let pty = PTYManager()
@@ -174,6 +187,8 @@ struct PTYManagerTests {
 
   @Test("ディレクトリを executable に指定すると exited(code: 126) を返す (execve EACCES)")
   func execveEACCESReportedAsExit126() async throws {
+    testTrace("started")
+    defer { testTrace("ended") }
     let data = DataCollector()
     let exit = ExitCollector()
     let pty = PTYManager()
@@ -197,6 +212,8 @@ struct PTYManagerTests {
 
   @Test("実行できないパス (/path/does/not/exist) は exited(code: 127) を返す")
   func execveENOENTReportedAsExit127() async throws {
+    testTrace("started")
+    defer { testTrace("ended") }
     let data = DataCollector()
     let exit = ExitCollector()
     let pty = PTYManager()

--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -3,7 +3,12 @@ import Testing
 
 @testable import GozdCore
 
-@Suite("PTYManager")
+// `.serialized` で直列実行する（issue #556 観測項目 4）。並列実行下では複数の PTY が
+// 同時刻に spawn され、CI trace 上で pid 多重化が起きる。`resizeIsSafe` のような
+// timeout 系 flake が再発した時、「どの pid を見ていたのか」をテスト失敗時刻と
+// 一致する spawn pid から目で突き合わせるしか手段が無くなる。
+// 本 suite は ~5s 規模で、直列化による性能劣化は許容範囲。
+@Suite("PTYManager", .serialized)
 struct PTYManagerTests {
   @Test("子プロセスの stdout を受け取り、正常終了 (.exited(0)) を検知する")
   func receivesOutputAndExit() async throws {
@@ -216,24 +221,8 @@ struct PTYManagerTests {
 
 // MARK: - Helpers
 
-/// `condition()` が true を返すまで小さくポーリングで待つ。timeout 到達時に
-/// `Issue.record` で test を fail させる。silent return すると後段の `#expect` が
-/// 別の症状（exit が nil など）で間接 fail し、timeout だった事象を追跡できなくなる。
-private func waitUntil(
-  timeout: Duration,
-  description: String = "condition",
-  _ condition: @escaping @Sendable () -> Bool,
-  sourceLocation: SourceLocation = #_sourceLocation
-) async throws {
-  let deadline = ContinuousClock.now.advanced(by: timeout)
-  while ContinuousClock.now < deadline {
-    if condition() { return }
-    try await Task.sleep(for: .milliseconds(50))
-  }
-  Issue.record(
-    "waitUntil timed out after \(timeout) waiting for: \(description)",
-    sourceLocation: sourceLocation)
-}
+// `waitUntil` は `WaitUntil.swift` の共有実装を使う（issue #556 観測項目 3）。
+// tick polling 履歴を持ち、timeout 時に Issue.record の message に inline する。
 
 private final class DataCollector: @unchecked Sendable {
   private let lock = NSLock()

--- a/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
@@ -3,10 +3,16 @@ import Testing
 
 @testable import GozdCore
 
-@Suite("PTYRegistry")
+// `.serialized` で直列実行する（issue #556 観測項目 4）。
+// PTYManagerTests と同様、複数 PTY の並列 spawn を構造的に消すことで再発時の
+// trace 解析（pid と test の対応復元）を容易にする。
+// PTY を spawn する suite を跨いだ並列実行も避けるため、両 suite を揃って直列化する。
+@Suite("PTYRegistry", .serialized)
 struct PTYRegistryTests {
   @Test("spawn は連番の ptyId を返し、onText / onExit が ID 付きで配送される")
   func spawnAndExitDispatch() async throws {
+    testTrace("started")
+    defer { testTrace("ended") }
     let events = EventCollector()
     let registry = PTYRegistry(
       onText: { id, text in events.appendText(id: id, text: text) },
@@ -41,6 +47,8 @@ struct PTYRegistryTests {
 
   @Test("kill 後に PTY が registry から自動削除される")
   func cleanupOnKill() async throws {
+    testTrace("started")
+    defer { testTrace("ended") }
     let events = EventCollector()
     let registry = PTYRegistry(
       onText: { id, text in events.appendText(id: id, text: text) },
@@ -75,6 +83,8 @@ struct PTYRegistryTests {
 
   @Test("未知の ptyId への write / resize / kill は no-op")
   func unknownIdIsNoop() async throws {
+    testTrace("started")
+    defer { testTrace("ended") }
     let events = EventCollector()
     let registry = PTYRegistry(
       onText: { id, text in events.appendText(id: id, text: text) },
@@ -92,6 +102,8 @@ struct PTYRegistryTests {
 
   @Test("spawn 時 env[GOZD_RESUME_CLAUDE_SESSION] が expectedResumeSidById に保存される")
   func expectedResumeSidPopulatedFromEnv() async throws {
+    testTrace("started")
+    defer { testTrace("ended") }
     let events = EventCollector()
     let registry = PTYRegistry(
       onText: { id, text in events.appendText(id: id, text: text) },
@@ -115,6 +127,8 @@ struct PTYRegistryTests {
 
   @Test("consumeExpectedResumeSid は sid 関係なく必ず消費する (SessionStart 着弾の単一エントリポイント)")
   func consumeExpectedSidAlwaysConsumes() async throws {
+    testTrace("started")
+    defer { testTrace("ended") }
     let events = EventCollector()
     let registry = PTYRegistry(
       onText: { id, text in events.appendText(id: id, text: text) },
@@ -141,6 +155,8 @@ struct PTYRegistryTests {
 
   @Test("clearAssociations は expectedResumeSid を触らない (silent drop しない契約)")
   func clearAssociationsLeavesExpectedSid() async throws {
+    testTrace("started")
+    defer { testTrace("ended") }
     let events = EventCollector()
     let registry = PTYRegistry(
       onText: { id, text in events.appendText(id: id, text: text) },

--- a/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
@@ -164,24 +164,7 @@ struct PTYRegistryTests {
 
 // MARK: - Helpers
 
-/// `condition()` が true を返すまで小さくポーリングで待つ。timeout 到達時に
-/// `Issue.record` で test を fail させる。silent return すると後段の `#expect` が
-/// 別の症状（exit が nil など）で間接 fail し、timeout だった事象を追跡できなくなる。
-private func waitUntil(
-  timeout: Duration,
-  description: String = "condition",
-  _ condition: @escaping @Sendable () -> Bool,
-  sourceLocation: SourceLocation = #_sourceLocation
-) async throws {
-  let deadline = ContinuousClock.now.advanced(by: timeout)
-  while ContinuousClock.now < deadline {
-    if condition() { return }
-    try await Task.sleep(for: .milliseconds(50))
-  }
-  Issue.record(
-    "waitUntil timed out after \(timeout) waiting for: \(description)",
-    sourceLocation: sourceLocation)
-}
+// `waitUntil` は `WaitUntil.swift` の共有実装を使う（issue #556 観測項目 3）。
 
 private final class EventCollector: @unchecked Sendable {
   private let lock = NSLock()

--- a/apps/native/Tests/GozdCoreTests/SocketServerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/SocketServerTests.swift
@@ -8,6 +8,8 @@ import Testing
 struct SocketServerTests {
   @Test("単一の NDJSON 行を受信できる")
   func receivesSingleLine() async throws {
+    testTrace("started")
+    defer { testTrace("ended") }
     let path = makeSocketPath()
     defer { unlink(path) }
 
@@ -28,6 +30,8 @@ struct SocketServerTests {
 
   @Test("1 接続で複数行を順序通りに受信する")
   func receivesMultipleLines() async throws {
+    testTrace("started")
+    defer { testTrace("ended") }
     let path = makeSocketPath()
     defer { unlink(path) }
 
@@ -54,6 +58,8 @@ struct SocketServerTests {
 
   @Test("複数接続から並行受信できる")
   func receivesFromMultipleConnections() async throws {
+    testTrace("started")
+    defer { testTrace("ended") }
     let path = makeSocketPath()
     defer { unlink(path) }
 
@@ -95,16 +101,9 @@ private func fileExists(_ path: String) -> Bool {
   return stat(path, &st) == 0
 }
 
-private func waitUntil(
-  timeout: Duration,
-  _ condition: @escaping @Sendable () -> Bool
-) async throws {
-  let deadline = ContinuousClock.now.advanced(by: timeout)
-  while ContinuousClock.now < deadline {
-    if condition() { return }
-    try await Task.sleep(for: .milliseconds(30))
-  }
-}
+// `waitUntil` は `WaitUntil.swift` の共有実装を使う（issue #556 観測項目 3）。
+// 旧実装は silent return で、timeout 時に Issue.record を呼ばず後段の `#expect` が
+// 別症状で間接 fail していた。共有版は tick 履歴を Issue.record の message に inline する。
 
 enum SocketClientError: Error, CustomStringConvertible {
   case createSocket(errno: Int32)

--- a/apps/native/Tests/GozdCoreTests/TestTrace.swift
+++ b/apps/native/Tests/GozdCoreTests/TestTrace.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+
+@testable import GozdCore
+
+// テスト境界 trace。`[TEST-TRACE]` プレフィックスで `gozdTraceLine` に流す。
+// `gozdTraceStart` を共有することで `[PTY-TRACE]` と同じ elapsed 時刻になり、
+// PTY 内部状態とテスト経路を 1 本のログ stream 上で突き合わせ可能にする。
+//
+// test 名は `Test.current?.name`（swift-testing が test body 内で参照可能にする
+// task-local）から自動取得する。テスト本体に test_id 引数を増やさない設計。
+// test body 以外（static init / セットアップ前）から呼ばれた場合は `<no-test>` を出す。
+
+/// 最初の `testTrace` 呼び出し時に CI runner の OS / CPU / host を 1 度だけ log する。
+/// 再発時に「同じ runner で再現か / 別 runner か」を切り分ける材料。
+/// top-level `let` の初期化は Swift runtime が dispatch_once で thread-safe に行うため、
+/// 競合や二重発火は起きない。
+private let _logRunnerEnvironmentOnce: Void = {
+  guard gozdTraceEnabled else { return }
+  let info = ProcessInfo.processInfo
+  let osVersion = info.operatingSystemVersionString
+  let cpus = info.processorCount
+  let activeCpus = info.activeProcessorCount
+  let host = info.hostName
+  let elapsed = ContinuousClock.now - gozdTraceStart
+  gozdTraceLine(
+    "[TEST-TRACE +\(elapsed) test=<runner-env>] os=\(osVersion) cpus=\(cpus) activeCpus=\(activeCpus) host=\(host)\n"
+  )
+}()
+
+@inline(__always)
+func testTrace(_ message: @autoclosure () -> String) {
+  guard gozdTraceEnabled else { return }
+  _ = _logRunnerEnvironmentOnce
+  let testName = Test.current?.name ?? "<no-test>"
+  let elapsed = ContinuousClock.now - gozdTraceStart
+  gozdTraceLine("[TEST-TRACE +\(elapsed) test=\(testName)] \(message())\n")
+}

--- a/apps/native/Tests/GozdCoreTests/TestTrace.swift
+++ b/apps/native/Tests/GozdCoreTests/TestTrace.swift
@@ -33,8 +33,24 @@ private let _logRunnerEnvironmentOnce: Void = {
 /// ここで打った test name は trace ログ単独で pid と test を結びつける唯一の橋になる。
 /// `waitUntil` 内 polling やテスト経路途中で取りこぼしが起きても、entry / exit が出ていれば
 /// 「この pid を spawn した test はどれか」が直前直後の entry/exit から再構築可能。
-/// 使い方: 各 test の冒頭で `testTrace("started")` を呼び、
+///
+/// 使い方: 各 test の冒頭で `testTrace("started")` を呼び、その直後に
 /// `defer { testTrace("ended") }` を置く。
+///
+/// **trace key の予約語**: `"started"` / `"ended"` は test entry / exit を示す予約語として扱う。
+/// `[TEST-TRACE …] started` / `[TEST-TRACE …] ended` で grep するため、test 内で
+/// `testTrace("started …")` のような任意メッセージとしては使わない。
+///
+/// **defer LIFO 規約**: Swift の `defer` は LIFO で発火する。test 内に追加の `defer` を
+/// 書く場合、`defer { testTrace("ended") }` を **test の最初に登録する** ことを推奨する
+/// ( = LIFO で最後に発火 )。これにより `[TEST-TRACE … started]` と
+/// `[TEST-TRACE … ended]` の間に test 由来のすべての `[PTY-TRACE]` が収まり、解析者は
+/// 「started〜ended の区間に出た pid を test に紐付けるだけ」で経路復元が完結する。
+///
+/// 例外として `defer { Task { … } }` のような **detached cleanup** は test return 後の
+/// 非同期 task として走るため、defer 順序にかかわらず ended の trace に間に合わないこと
+/// がある。この場合 ended 後の `[PTY-TRACE]` 行は前 test の遅延 cleanup である可能性を
+/// 解析者が考慮する必要がある。
 @inline(__always)
 func testTrace(_ message: @autoclosure () -> String) {
   guard gozdTraceEnabled else { return }

--- a/apps/native/Tests/GozdCoreTests/TestTrace.swift
+++ b/apps/native/Tests/GozdCoreTests/TestTrace.swift
@@ -13,8 +13,8 @@ import Testing
 
 /// 最初の `testTrace` 呼び出し時に CI runner の OS / CPU / host を 1 度だけ log する。
 /// 再発時に「同じ runner で再現か / 別 runner か」を切り分ける材料。
-/// top-level `let` の初期化は Swift runtime が dispatch_once で thread-safe に行うため、
-/// 競合や二重発火は起きない。
+/// Swift の global `let` は言語仕様により最初の参照時に thread-safe な lazy 初期化が
+/// 1 度だけ走る（並行 access があっても初期化 closure の二重実行は起きない）。
 private let _logRunnerEnvironmentOnce: Void = {
   guard gozdTraceEnabled else { return }
   let info = ProcessInfo.processInfo
@@ -28,6 +28,13 @@ private let _logRunnerEnvironmentOnce: Void = {
   )
 }()
 
+/// テスト本体の最初と最後に呼び、`[TEST-TRACE]` に entry / exit を打つことを推奨する。
+/// `Test.current?.name` は test body の直系 thread / task では確実に解決されるため、
+/// ここで打った test name は trace ログ単独で pid と test を結びつける唯一の橋になる。
+/// `waitUntil` 内 polling やテスト経路途中で取りこぼしが起きても、entry / exit が出ていれば
+/// 「この pid を spawn した test はどれか」が直前直後の entry/exit から再構築可能。
+/// 使い方: 各 test の冒頭で `testTrace("started")` を呼び、
+/// `defer { testTrace("ended") }` を置く。
 @inline(__always)
 func testTrace(_ message: @autoclosure () -> String) {
   guard gozdTraceEnabled else { return }

--- a/apps/native/Tests/GozdCoreTests/TestTrace.swift
+++ b/apps/native/Tests/GozdCoreTests/TestTrace.swift
@@ -15,6 +15,13 @@ import Testing
 /// 再発時に「同じ runner で再現か / 別 runner か」を切り分ける材料。
 /// Swift の global `let` は言語仕様により最初の参照時に thread-safe な lazy 初期化が
 /// 1 度だけ走る（並行 access があっても初期化 closure の二重実行は起きない）。
+///
+/// 出力タイミングの注意: 「最初の `testTrace` 呼び出し時」に出るため、それ以前に
+/// `[PTY-TRACE]` が先に発射される経路（例: テストの `init` で PTYManager を生成する等）
+/// では `[TEST-TRACE … test=<runner-env>]` が `[PTY-TRACE]` 群の **後** に出る。
+/// issue ( #556 ) の用途（runner 識別の切り分け）では出力順序は意味を持たない。
+/// 「runner 環境変動と PTY 内部状態の絶対時刻相関」を見る用途が出た時は、
+/// `gozdTraceStart` 初期化と本 once の出力順序を保証する別経路が必要。
 private let _logRunnerEnvironmentOnce: Void = {
   guard gozdTraceEnabled else { return }
   let info = ProcessInfo.processInfo

--- a/apps/native/Tests/GozdCoreTests/WaitUntil.swift
+++ b/apps/native/Tests/GozdCoreTests/WaitUntil.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+
+// PTYManagerTests / PTYRegistryTests で共有する条件待機ヘルパー。
+//
+// 旧実装は各テストファイルに `private func waitUntil` を重複定義しており、
+// timeout 時に「いつから condition が false だったか」が分からなかった（issue #556 観測項目 3）。
+// 本実装は tick ごとの condition 結果を直近 10 件保持し、timeout 時に Issue.record の
+// failure メッセージに inline する。CI ログを遡らずに失敗メッセージから 2 秒分の polling
+// 推移が読めるようにするのが目的。
+//
+// 加えて `[TEST-TRACE]` で entry / tick / resolve / timeout を stderr に流すため、
+// 同じ ContinuousClock 基準を持つ `[PTY-TRACE]` と時系列を突き合わせ可能になる。
+
+/// `condition()` が true を返すまで小さくポーリングで待つ。timeout 到達時に
+/// `Issue.record` で test を fail させる。silent return すると後段の `#expect` が
+/// 別の症状（exit が nil など）で間接 fail し、timeout だった事象を追跡できなくなる。
+///
+/// - Parameters:
+///   - timeout: 待機の上限。超過時に Issue.record。
+///   - description: timeout 失敗メッセージに含める「何を待っていたか」の説明。
+///   - condition: 各 tick で評価する条件。`@Sendable` な capture のみ可。
+///
+/// trace 出力:
+///   - entry: `waitUntil entered timeout=... desc=...`
+///   - tick: `waitUntil tick=<n> elapsed=<dur> result=<bool>`
+///   - 成功: `waitUntil resolved tick=<n> elapsed=<dur>`
+///   - timeout: `waitUntil timeout tickCount=<n> elapsed=<dur> lastTicks=[...]`
+func waitUntil(
+  timeout: Duration,
+  description: String = "condition",
+  _ condition: @escaping @Sendable () -> Bool,
+  sourceLocation: SourceLocation = #_sourceLocation
+) async throws {
+  let started = ContinuousClock.now
+  let deadline = started.advanced(by: timeout)
+  testTrace("waitUntil entered timeout=\(timeout) desc=\(description)")
+  // 直近 N tick の polling 推移を保持。`N=10` は 50ms poll × 10 = 0.5s 分。
+  // 2 秒 timeout の場合「終端直前 0.5 秒の挙動」が再構築できれば
+  // 「開始直後から nil で固定」/「最後の数 tick だけ nil」の区別が付く。
+  let historyCap = 10
+  var tickHistory: [(elapsed: Duration, result: Bool)] = []
+  var tickCount = 0
+  while ContinuousClock.now < deadline {
+    let elapsed = ContinuousClock.now - started
+    let result = condition()
+    tickCount += 1
+    tickHistory.append((elapsed, result))
+    if tickHistory.count > historyCap {
+      tickHistory.removeFirst(tickHistory.count - historyCap)
+    }
+    testTrace("waitUntil tick=\(tickCount) elapsed=\(elapsed) result=\(result)")
+    if result {
+      testTrace("waitUntil resolved tick=\(tickCount) elapsed=\(elapsed)")
+      return
+    }
+    try await Task.sleep(for: .milliseconds(50))
+  }
+  let elapsed = ContinuousClock.now - started
+  let historyText = tickHistory
+    .map { "\($0.elapsed):\($0.result)" }
+    .joined(separator: ", ")
+  testTrace(
+    "waitUntil timeout tickCount=\(tickCount) elapsed=\(elapsed) lastTicks=[\(historyText)]")
+  Issue.record(
+    """
+    waitUntil timed out after \(timeout) waiting for: \(description). \
+    elapsed=\(elapsed) tickCount=\(tickCount). \
+    last \(tickHistory.count) ticks: [\(historyText)]
+    """,
+    sourceLocation: sourceLocation)
+}


### PR DESCRIPTION
## 概要

`PTYManagerTests / resizeIsSafe` の flake について、修正コードは加えず観測粒度のみを引き上げる。次回の再発で CI ログから root cause を一意特定できる trace を残すことを目的とする。

## 背景

`PTYManagerTests / resizeIsSafe` は macos-26 runner で flake 再発した ( issue ( #556 ) )。同テストは過去に「根治」を謳う PR が 2 件入っている:

- ( #545 ) `fix(pty): hold parent slave fd to defeat tty flush-on-close race`
- ( #550 ) `fix(pty): finish exit handler without waiting for master EOF event`

しかし両 PR とも CI ログから *推定* された race に対する対症療法で、本 PR の base ( `3044cee` ) には既に取り込まれた状態で再発している。これらの fix は flake を「減らした」だけで「根治していない」ことが確定している。

issue ( #556 ) の要旨は、現状の `[PTY-TRACE]` 系ログだけでは次の情報が **テスト経路と並列 PTY 識別の境界で欠落** している点:

- テスト境界とのひも付け不在: trace の `pid=` が「どのテストの spawn か」と結びつかない
- `PTYManager` の `resize` / `kill` / `write` の呼び出し境界 + ioctl(TIOCSWINSZ) / kill(SIGHUP) の戻り値・errno が出ない
- `waitUntil` の polling 履歴が無く、timeout 直前の condition 推移が分からない
- 並列実行下で複数 PTY の trace が pid 多重化されて経路復元が困難

本 PR ではこの観測ギャップを埋める。修正コード自体は **意図的に同梱しない** ( issue ( #556 ) の「TODO: 上記が入った状態で再発するまで CI を回し続け、再発したら trace から root cause を特定してから fix PR を出す」方針に従う )。

## 変更内容

### PTYManager public method 境界 trace

- `PTYManager.resize` / `kill` / `write` の entry で `[PTY-TRACE … api]` を出す
- `kill` は `Darwin.kill(pid, SIGHUP)` の戻り値・errno を trace に残す
- `PTYFinishState.resize` は `ioctl(TIOCSWINSZ)` の戻り値・errno を trace に残す。close 済みなら `primaryClosed → no-op` を区別して出す
- fd 未確立で resize が呼ばれた場合 ( `state == nil` ) は `hasState=false` を含めて trace を残し、`resizeIsSafe` の 1 回目 resize 経路が trace 単独で識別可能になる

### `[TEST-TRACE]` 系の新設と `[PTY-TRACE]` との timeline 共有

- `PTYTrace.swift` の `gozdTraceEnabled` / `gozdTraceStart` / `gozdTraceLine` を internal に昇格
- テスト target から `gozdTraceLine` 経由で `[TEST-TRACE]` を出す。両系統は同 elapsed 基準 ( = `gozdTraceStart` シンボル最初の参照時点 ) + 同 stderr lock を共有するため、PTY 内部状態とテスト経路を 1 本の timeline で突き合わせ可能
- `TestTrace.swift` を新設し、`Test.current?.name` で test_id を自動付与。テスト本体に test_id 引数を増やさない設計
- 最初の `testTrace` 呼び出し時に CI runner の OS / CPU / host を 1 度だけログ ( top-level `let` の Swift 言語仕様 lazy 初期化を利用 )

### 各 `@Test` の entry / exit trace

- PTY を spawn する全 test ( PTYManagerTests / PTYRegistryTests / SocketServerTests ) の冒頭に `testTrace("started")` + `defer { testTrace("ended") }` を入れ、`Test.current?.name` が確実に解決される test body 直系で test 名タグを必ず 1 度打つ
- `waitUntil` polling や teardown 経路で `Test.current` が `nil` になった場合でも、entry / exit 行が出ていれば pid と test の対応を直前直後から再構築可能
- defer LIFO の意味付け ( ended は test 内の他 defer より後に発火、detached Task は test return 後に走る ) を `TestTrace.swift` docstring に明示

### `waitUntil` の共通化と tick 履歴 inline

- 旧実装は `PTYManagerTests` / `PTYRegistryTests` / `SocketServerTests` に **3 つの別シグネチャ**で重複定義され、`SocketServerTests` 版は **silent return** で timeout 時に `Issue.record` を呼ばず後段の `#expect` が別症状で間接 fail していた
- `WaitUntil.swift` を新設し全 test 共有の SSOT として置く。tick ごとの `(elapsed, result)` を直近 10 件保持し、timeout 時に `Issue.record` の message に inline。CI ログを遡らずに失敗メッセージから直近 0.5 秒分の polling 推移が読める
- tick / entry / resolve / timeout を `[TEST-TRACE]` に出す

### PTY を spawn する全 suite の直列化

- `PTYManagerTests` / `PTYRegistryTests` に `@Suite(…, .serialized)` を適用。並列実行による pid 多重化を構造的に消す
- 旧 trace では同時刻に複数の `/bin/cat` spawn が走り「`resizeIsSafe` のどの pid を見ていたか」が trace 単独で復元不能だった。serial 化で発火順が一意になる
- ローカル swift test 実測で 1 秒未満、CI macos-26 でも秒オーダー内に収まる想定。性能劣化は許容範囲

### release build / 通常 CI への影響ゼロ

全 trace は `#if DEBUG` + `GOZD_PTY_TRACE=1` の二重 gate で gate される ( 既存設計を踏襲 ):

- release build では関数本体が空で `@inline(__always)` により call site から完全除去
- release build 側に `gozdTraceStart` 宣言を残さないことで、不要な `ContinuousClock.now` evaluation が linker dead-strip 通過後に残る経路を塞ぐ
- DEBUG build でも env 未設定では即 return

CI では既に `.github/workflows/code_validation.yml` で `GOZD_PTY_TRACE: "1"` が設定済み。コメントを issue ( #450 ) 単独参照から issue ( #556 ) 系列も対象に拡張した。

## 今回含めない点

- **今回は対応しない**: `PTYManagerTests / resizeIsSafe` flake の修正コード自体は出さない。issue ( #556 ) の「観測項目で root cause を特定する trace を残してから でないと、追加の修正 PR は出さない。trace を見ずに ( #545 ) / ( #550 ) と同じ系統の race だろうと推定して try するのを禁ずる」方針に従い、次の再発で本 PR の trace から経路を確定してから別 PR で fix する

## 確認事項

- [ ] `GOZD_PTY_TRACE=1 swift test --filter "PTYManagerTests|PTYRegistryTests|SocketServerTests"` で `[PTY-TRACE]` と `[TEST-TRACE]` が同一 elapsed 基準で interleave され、`resizeIsSafe` の fd 未確立 resize ( `pid=-1 hasState=false` ) と fd 確立後 resize ( `ioctl ret=0 errno=0` ) と `kill(SIGHUP) ret=0 errno=0` が trace に出ること
- [ ] `<no-test>` test name の `[TEST-TRACE]` 行が一切出ないこと ( `Test.current?.name` 取りこぼし経路の不在 )
- [ ] `[TEST-TRACE … test=<runner-env>] os=… cpus=… host=…` がプロセスあたり 1 回だけ出ること
- [ ] `[TEST-TRACE … test=resizeIsSafe started]` → `[PTY-TRACE …]` 群 → `[TEST-TRACE … test=resizeIsSafe ended]` の前後関係が想定通り並ぶこと ( defer LIFO 配置の確認 )
- [ ] release build ( `swift build -c release` ) で trace コードが dead code に inline 除去されること
- [ ] `PTYManagerTests` / `PTYRegistryTests` が `.serialized` により直列実行され、同時刻に複数 PTY pid が trace 内に並走しないこと
