### PR TITLE
chore(test-trace): dedicated NSThread の waitUntilThreaded で Task.sleep stall 経路を切り分ける

### DIFF
--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -31,9 +31,10 @@ struct PTYManagerTests {
     )
 
     // issue ( #566 ) 観測: 本 test は CI attempt 1 で tick=1 ( +0.124s ) → tick=2 ( +2.405s )
-    // と `Task.sleep(50ms)` が 2.28s stall した。GCD ベース版に切り替えて、SocketServer
-    // 並走テストと同じ stall window で GCD 経路も同様に止まるかを比較する。
-    try await waitUntilDispatch(timeout: .seconds(3)) { exit.snapshot() != nil }
+    // と `Task.sleep(50ms)` が 2.28s stall した。polling loop 全体を GCD thread 上で完結
+    // させる `waitUntilThreaded` に切り替えて、cooperative executor 外で tick が動くかを
+    // 観測する。
+    await waitUntilThreaded(timeout: .seconds(3)) { exit.snapshot() != nil }
 
     // pty (tty mode) は ONLCR で \n を \r\n に変換する。
     let text = String(decoding: data.snapshot(), as: UTF8.self)
@@ -241,8 +242,11 @@ struct PTYManagerTests {
 
 // MARK: - Helpers
 
-// `waitUntil` は `WaitUntil.swift` の共有実装を使う（issue #556 観測項目 3）。
+// `waitUntil` / `waitUntilThreaded` は `WaitUntil.swift` の共有実装を使う
+// （issue #556 観測項目 3 / issue #566 観測項目）。
 // tick polling 履歴を持ち、timeout 時に Issue.record の message に inline する。
+// `receivesOutputAndExit` のみ `waitUntilThreaded` ( GCD thread で polling loop 完結 ) を使い、
+// 他 test は `waitUntil` ( Task.sleep 経路 ) のまま並走させて同 stall window で経路を比較する。
 
 private final class DataCollector: @unchecked Sendable {
   private let lock = NSLock()

--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -30,7 +30,10 @@ struct PTYManagerTests {
       onExit: { exit.set($0) }
     )
 
-    try await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
+    // issue ( #566 ) 観測: 本 test は CI attempt 1 で tick=1 ( +0.124s ) → tick=2 ( +2.405s )
+    // と `Task.sleep(50ms)` が 2.28s stall した。GCD ベース版に切り替えて、SocketServer
+    // 並走テストと同じ stall window で GCD 経路も同様に止まるかを比較する。
+    try await waitUntilDispatch(timeout: .seconds(3)) { exit.snapshot() != nil }
 
     // pty (tty mode) は ONLCR で \n を \r\n に変換する。
     let text = String(decoding: data.snapshot(), as: UTF8.self)

--- a/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
@@ -37,7 +37,10 @@ struct PTYRegistryTests {
     )
     #expect(id2 == id1 + 1)
 
-    try await waitUntil(timeout: .seconds(3)) {
+    // issue ( #566 ) 観測: 本 test は CI attempt 1 で tick=1 ( +1.161s ) → tick=2 ( +2.534s )
+    // と `Task.sleep(50ms)` が 1.37s stall した ( SocketServer / receivesOutputAndExit と
+    // 同じ stall window )。GCD ベース版に切り替えて経路を分離する。
+    try await waitUntilDispatch(timeout: .seconds(3)) {
       events.exitedIds().contains(id1) && events.exitedIds().contains(id2)
     }
 

--- a/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
@@ -39,8 +39,9 @@ struct PTYRegistryTests {
 
     // issue ( #566 ) 観測: 本 test は CI attempt 1 で tick=1 ( +1.161s ) → tick=2 ( +2.534s )
     // と `Task.sleep(50ms)` が 1.37s stall した ( SocketServer / receivesOutputAndExit と
-    // 同じ stall window )。GCD ベース版に切り替えて経路を分離する。
-    try await waitUntilDispatch(timeout: .seconds(3)) {
+    // 同じ stall window )。polling loop 全体を GCD thread 上で完結させる
+    // `waitUntilThreaded` に切り替えて経路を完全分離する。
+    await waitUntilThreaded(timeout: .seconds(3)) {
       events.exitedIds().contains(id1) && events.exitedIds().contains(id2)
     }
 
@@ -183,7 +184,10 @@ struct PTYRegistryTests {
 
 // MARK: - Helpers
 
-// `waitUntil` は `WaitUntil.swift` の共有実装を使う（issue #556 観測項目 3）。
+// `waitUntil` / `waitUntilThreaded` は `WaitUntil.swift` の共有実装を使う
+// （issue #556 観測項目 3 / issue #566 観測項目）。
+// `spawnAndExitDispatch` のみ `waitUntilThreaded` ( GCD thread で polling loop 完結 ) を使い、
+// 他 test は `waitUntil` ( Task.sleep 経路 ) のまま並走させて同 stall window で経路を比較する。
 
 private final class EventCollector: @unchecked Sendable {
   private let lock = NSLock()

--- a/apps/native/Tests/GozdCoreTests/SocketServerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/SocketServerTests.swift
@@ -19,13 +19,19 @@ struct SocketServerTests {
     defer { server.stop() }
 
     // issue ( #566 ) 観測: SocketServer suite の `fileExists` polling は CI attempt 1 で
-    // `Task.sleep` 経路の stall を踏んだ。GCD ベースの `waitUntilDispatch` に置き換えて、
-    // 並列実行下でも tick が発火し続けるかを観測する。
-    try await waitUntilDispatch(timeout: .seconds(2)) { fileExists(path) }
+    // `Task.sleep` 経路の stall を踏んだ。polling loop 全体を GCD thread 上で完結させる
+    // `waitUntilThreaded` に置き換えて、cooperative executor 外で tick が発火し続けるか
+    // を観測する。先行版 `waitUntilDispatch` ( CI run 26029332080 attempt 1 で実証 ) は
+    // resume 経路が cooperative executor に hop して観測精度が不十分だった。
+    await waitUntilThreaded(timeout: .seconds(2)) { fileExists(path) }
 
     try sendOverUnixSocket(path: path, data: Data(#"{"type":"ping"}\#n"#.utf8))
 
-    try await waitUntilDispatch(timeout: .seconds(2)) { messages.snapshot().count == 1 }
+    // 後段 polling は attempt 1 で stall を踏んでいない ( fileExists 段で test が fail し
+    // ここまで到達しない )。同 test 内に Task.sleep 経路の比較対象を残すため waitUntil の
+    // ままにする。fileExists ( GCD ) と message-count ( Task ) が並走して、同 stall window
+    // でどちらが先に詰まるかを観測できる。
+    try await waitUntil(timeout: .seconds(2)) { messages.snapshot().count == 1 }
     let received = messages.snapshot()
     #expect(received.count == 1)
     #expect(String(decoding: received[0], as: UTF8.self) == #"{"type":"ping"}"#)
@@ -43,7 +49,7 @@ struct SocketServerTests {
     try server.start { data in messages.append(data) }
     defer { server.stop() }
 
-    try await waitUntilDispatch(timeout: .seconds(2)) { fileExists(path) }
+    await waitUntilThreaded(timeout: .seconds(2)) { fileExists(path) }
 
     let payload = Data(
       """
@@ -54,7 +60,8 @@ struct SocketServerTests {
       """.utf8)
     try sendOverUnixSocket(path: path, data: payload)
 
-    try await waitUntilDispatch(timeout: .seconds(2)) { messages.snapshot().count == 3 }
+    // 後段 polling は比較対象として waitUntil を残す ( receivesSingleLine と同設計 )。
+    try await waitUntil(timeout: .seconds(2)) { messages.snapshot().count == 3 }
     let received = messages.snapshot().map { String(decoding: $0, as: UTF8.self) }
     #expect(received == [#"{"i":1}"#, #"{"i":2}"#, #"{"i":3}"#])
   }
@@ -71,7 +78,7 @@ struct SocketServerTests {
     try server.start { data in messages.append(data) }
     defer { server.stop() }
 
-    try await waitUntilDispatch(timeout: .seconds(2)) { fileExists(path) }
+    await waitUntilThreaded(timeout: .seconds(2)) { fileExists(path) }
 
     try await withThrowingTaskGroup(of: Void.self) { group in
       for i in 0..<5 {
@@ -82,7 +89,8 @@ struct SocketServerTests {
       try await group.waitForAll()
     }
 
-    try await waitUntilDispatch(timeout: .seconds(3)) { messages.snapshot().count == 5 }
+    // 後段 polling は比較対象として waitUntil を残す ( receivesSingleLine と同設計 )。
+    try await waitUntil(timeout: .seconds(3)) { messages.snapshot().count == 5 }
     let received = Set(messages.snapshot().map { String(decoding: $0, as: UTF8.self) })
     let expected: Set<String> = (0..<5).map { #"{"i":\#($0)}"# }.reduce(into: Set()) {
       $0.insert($1)
@@ -104,9 +112,13 @@ private func fileExists(_ path: String) -> Bool {
   return stat(path, &st) == 0
 }
 
-// `waitUntil` は `WaitUntil.swift` の共有実装を使う（issue #556 観測項目 3）。
-// 旧実装は silent return で、timeout 時に Issue.record を呼ばず後段の `#expect` が
-// 別症状で間接 fail していた。共有版は tick 履歴を Issue.record の message に inline する。
+// `waitUntil` / `waitUntilThreaded` は `WaitUntil.swift` の共有実装を使う
+// （issue #556 観測項目 3 / issue #566 観測項目）。
+// 旧 silent return 版は timeout 時に Issue.record を呼ばず後段の `#expect` が別症状で
+// 間接 fail していた。共有版は tick 履歴を Issue.record の message に inline する。
+// 本 test は `fileExists` polling を `waitUntilThreaded` ( GCD thread 上で polling loop
+// 完結 )、後段 message-count polling を `waitUntil` ( Task.sleep 経路 ) に分けて、
+// 同 stall window で両経路の挙動を比較する。
 
 enum SocketClientError: Error, CustomStringConvertible {
   case createSocket(errno: Int32)

--- a/apps/native/Tests/GozdCoreTests/SocketServerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/SocketServerTests.swift
@@ -18,11 +18,14 @@ struct SocketServerTests {
     try server.start { data in messages.append(data) }
     defer { server.stop() }
 
-    try await waitUntil(timeout: .seconds(2)) { fileExists(path) }
+    // issue ( #566 ) 観測: SocketServer suite の `fileExists` polling は CI attempt 1 で
+    // `Task.sleep` 経路の stall を踏んだ。GCD ベースの `waitUntilDispatch` に置き換えて、
+    // 並列実行下でも tick が発火し続けるかを観測する。
+    try await waitUntilDispatch(timeout: .seconds(2)) { fileExists(path) }
 
     try sendOverUnixSocket(path: path, data: Data(#"{"type":"ping"}\#n"#.utf8))
 
-    try await waitUntil(timeout: .seconds(2)) { messages.snapshot().count == 1 }
+    try await waitUntilDispatch(timeout: .seconds(2)) { messages.snapshot().count == 1 }
     let received = messages.snapshot()
     #expect(received.count == 1)
     #expect(String(decoding: received[0], as: UTF8.self) == #"{"type":"ping"}"#)
@@ -40,7 +43,7 @@ struct SocketServerTests {
     try server.start { data in messages.append(data) }
     defer { server.stop() }
 
-    try await waitUntil(timeout: .seconds(2)) { fileExists(path) }
+    try await waitUntilDispatch(timeout: .seconds(2)) { fileExists(path) }
 
     let payload = Data(
       """
@@ -51,7 +54,7 @@ struct SocketServerTests {
       """.utf8)
     try sendOverUnixSocket(path: path, data: payload)
 
-    try await waitUntil(timeout: .seconds(2)) { messages.snapshot().count == 3 }
+    try await waitUntilDispatch(timeout: .seconds(2)) { messages.snapshot().count == 3 }
     let received = messages.snapshot().map { String(decoding: $0, as: UTF8.self) }
     #expect(received == [#"{"i":1}"#, #"{"i":2}"#, #"{"i":3}"#])
   }
@@ -68,7 +71,7 @@ struct SocketServerTests {
     try server.start { data in messages.append(data) }
     defer { server.stop() }
 
-    try await waitUntil(timeout: .seconds(2)) { fileExists(path) }
+    try await waitUntilDispatch(timeout: .seconds(2)) { fileExists(path) }
 
     try await withThrowingTaskGroup(of: Void.self) { group in
       for i in 0..<5 {
@@ -79,7 +82,7 @@ struct SocketServerTests {
       try await group.waitForAll()
     }
 
-    try await waitUntil(timeout: .seconds(3)) { messages.snapshot().count == 5 }
+    try await waitUntilDispatch(timeout: .seconds(3)) { messages.snapshot().count == 5 }
     let received = Set(messages.snapshot().map { String(decoding: $0, as: UTF8.self) })
     let expected: Set<String> = (0..<5).map { #"{"i":\#($0)}"# }.reduce(into: Set()) {
       $0.insert($1)

--- a/apps/native/Tests/GozdCoreTests/WaitUntil.swift
+++ b/apps/native/Tests/GozdCoreTests/WaitUntil.swift
@@ -27,7 +27,7 @@ import Testing
 //   これにより polling loop の実行 thread が Swift Concurrency の cooperative executor から
 //   完全に外れる。GCD pool も使わないため `Thread.sleep(forTimeInterval:)` の blocking が
 //   他 GCD 処理を阻害しない ( SocketServer 専用 queue 含め `DispatchQueue.global()` の
-//   worker pool に依存する全経路が無事 )。
+//   worker pool に依存する他 GCD 処理は worker 枯渇の間接影響を受けない )。
 //
 //   先行版の `waitUntilDispatch` ( CI run 26029332080 attempt 1 で実証 ) は `withCheckedContinuation`
 //   経由で sleep の wait phase だけを GCD に逃がし、resume 後の polling iteration が
@@ -113,8 +113,13 @@ func waitUntil(
 }
 
 /// `waitUntil` の **polling loop 全体を dedicated NSThread 上で完結** させる版。Swift
-/// Concurrency の cooperative executor 経路を完全に外し、`Task.sleep` 経路で詰まる stall
-/// ( CI run 26029332080 attempt 1 で観測 ) との切り分けに使う。
+/// Concurrency の cooperative executor 経路を完全に外し、`Task.sleep` 経路で詰まる
+/// 2 秒 stall ( PR #565 attempt 1 で初観測 ) との切り分けに使う。
+///
+/// 中間版 `waitUntilDispatch` ( GCD `asyncAfter` + `withCheckedContinuation` 経由、
+/// CI run 26029332080 attempt 1 で観測 ) も cooperative executor stall に巻き込まれ
+/// 観測無効と実証されたため、polling loop **全体** を Swift Concurrency runtime から
+/// 外す構造に到達した。
 ///
 /// 実装上の契約:
 ///

--- a/apps/native/Tests/GozdCoreTests/WaitUntil.swift
+++ b/apps/native/Tests/GozdCoreTests/WaitUntil.swift
@@ -21,10 +21,13 @@ import Testing
 //   を並列に記録し、稀な system clock 異常 ( NTP 巻き戻し / sleep wake 後の補正 ) と
 //   通常の単調進行を区別する保険として残す。(i)/(ii) 切り分けの主軸ではない。
 //
-// - `waitUntilThreaded` を追加する。`DispatchQueue.global().async` で polling loop **全体**
-//   ( condition 評価 / trace 出力 / sleep ) を GCD thread 上で完結させ、`withCheckedContinuation`
-//   の resume は polling 終了 ( resolved / timeout ) 時のみ呼ぶ。これにより polling loop の
-//   実行 thread が Swift Concurrency の cooperative executor から完全に外れる。
+// - `waitUntilThreaded` を追加する。`Thread { ... }.start()` で立てた dedicated NSThread で
+//   polling loop **全体** ( condition 評価 / trace 出力 / sleep ) を完結させ、
+//   `withCheckedContinuation` の resume は polling 終了 ( resolved / timeout ) 時のみ呼ぶ。
+//   これにより polling loop の実行 thread が Swift Concurrency の cooperative executor から
+//   完全に外れる。GCD pool も使わないため `Thread.sleep(forTimeInterval:)` の blocking が
+//   他 GCD 処理を阻害しない ( SocketServer 専用 queue 含め `DispatchQueue.global()` の
+//   worker pool に依存する全経路が無事 )。
 //
 //   先行版の `waitUntilDispatch` ( CI run 26029332080 attempt 1 で実証 ) は `withCheckedContinuation`
 //   経由で sleep の wait phase だけを GCD に逃がし、resume 後の polling iteration が
@@ -118,7 +121,8 @@ func waitUntil(
 /// - polling loop ( condition 評価 / trace 出力 / `Thread.sleep(forTimeInterval:)` ) は
 ///   `Thread { ... }.start()` で立てた **dedicated NSThread** 上で完結する。GCD worker
 ///   thread pool を使わないため、`Thread.sleep` の blocking で GCD pool を専有する経路は
-///   発生しない ( = 並走する `DispatchQueue.global()` ベースの test 用処理を阻害しない )。
+///   発生しない ( SocketServer 専用 queue 含め、`DispatchQueue.global()` の worker pool に
+///   依存する他 GCD 処理は worker 枯渇の間接影響を受けない )。
 ///   `withCheckedContinuation` の resume は polling 終了時 ( resolved / timeout ) の **1 回のみ**
 /// - `condition` は **同期的に評価できる predicate に限定** する ( `await` を含む condition は
 ///   渡してはいけない )。内部で async を呼ぶと再び cooperative executor に hop して観測精度が

--- a/apps/native/Tests/GozdCoreTests/WaitUntil.swift
+++ b/apps/native/Tests/GozdCoreTests/WaitUntil.swift
@@ -1,6 +1,8 @@
 import Foundation
 import Testing
 
+@testable import GozdCore
+
 // PTYManagerTests / PTYRegistryTests / SocketServerTests で共有する条件待機ヘルパー。
 //
 // 旧実装は各テストファイルに `private func waitUntil` を重複定義しており、
@@ -14,20 +16,35 @@ import Testing
 //
 // issue ( #566 ) 観測項目:
 //
-// - tick trace 行に `wall=<Date 秒>` を併記する。ContinuousClock (mach_continuous_time 基盤、
-//   suspend 中も進む) と Date (system clock、NTP 調整あり) を並列に記録し、CPU steal /
-//   VM freeze で両者が同時に止まる経路と、cooperative executor だけが止まる経路を区別する。
+// - tick trace 行に `wall=<Date 秒>` を併記する。`ContinuousClock`
+//   ( `mach_continuous_time` 基盤、suspend 中も進む ) と `Date` ( system clock、NTP 調整 )
+//   を並列に記録し、稀な system clock 異常 ( NTP 巻き戻し / sleep wake 後の補正 ) と
+//   通常の単調進行を区別する保険として残す。(i)/(ii) 切り分けの主軸ではない。
 //
-// - `waitUntilDispatch` を追加する。GCD `asyncAfter` ベースの polling で、Task / async-await
-//   経路ではなく DispatchQueue.global() の thread pool 上で再開する。`Task.sleep` 経由の
-//   `waitUntil` と並走させた結果、片方だけが stall するか / 両方同時に stall するかで、
-//   stall の経路が (i) Swift Concurrency runtime 固有か (ii) OS scheduler 全体停止か
-//   を切り分ける。同 elapsed 基準 / 同 stderr lock を共有する `[TEST-TRACE-DISPATCH]`
-//   prefix で出すため、grep で 2 系統に分離可能。
+// - `waitUntilThreaded` を追加する。`DispatchQueue.global().async` で polling loop **全体**
+//   ( condition 評価 / trace 出力 / sleep ) を GCD thread 上で完結させ、`withCheckedContinuation`
+//   の resume は polling 終了 ( resolved / timeout ) 時のみ呼ぶ。これにより polling loop の
+//   実行 thread が Swift Concurrency の cooperative executor から完全に外れる。
+//
+//   先行版の `waitUntilDispatch` ( CI run 26029332080 attempt 1 で実証 ) は `withCheckedContinuation`
+//   経由で sleep の wait phase だけを GCD に逃がし、resume 後の polling iteration が
+//   cooperative executor に hop して戻る構造だった。結果 `Task.sleep` 経路と同じ stall
+//   window で詰まり、(i) cooperative executor 固有 stall / (ii) OS scheduler 全体停止 の
+//   切り分けに不十分だった。`waitUntilThreaded` はこの設計欠陥を構造的に解消する版。
+//
+//   期待される観測:
+//   - (i) cooperative executor 固有が真: `waitUntilThreaded` の tick は stall window 中も
+//     50ms 間隔で発火、同 window で `waitUntil` ( Task.sleep 経路 ) だけが詰まる
+//   - (ii) OS scheduler 全体停止が真: `waitUntilThreaded` も同 window で詰まる
+//
+// 重複の意図: `waitUntil` と `waitUntilThreaded` は polling loop の構造がほぼ同一だが、
+// 観測 PR の独立性 ( 片方を変更しても他方が影響を受けない保証 ) を保つため敢えて重複させる。
+// 観測終了後の fix PR で一本化するかは別判断。
 
-/// `condition()` が true を返すまで小さくポーリングで待つ。timeout 到達時に
-/// `Issue.record` で test を fail させる。silent return すると後段の `#expect` が
-/// 別の症状（exit が nil など）で間接 fail し、timeout だった事象を追跡できなくなる。
+/// `condition()` が true を返すまで小さくポーリングで待つ ( `Task.sleep` 経路 )。
+/// timeout 到達時に `Issue.record` で test を fail させる。silent return すると後段の
+/// `#expect` が別の症状（exit が nil など）で間接 fail し、timeout だった事象を追跡
+/// できなくなる。
 ///
 /// - Parameters:
 ///   - timeout: 待機の上限。超過時に Issue.record。
@@ -68,7 +85,9 @@ func waitUntil(
       testTrace("waitUntil resolved tick=\(tickCount) elapsed=\(elapsed)")
       return
     }
+    testTrace("waitUntil before-sleep tick=\(tickCount)")
     try await Task.sleep(for: .milliseconds(50))
+    testTrace("waitUntil after-sleep tick=\(tickCount)")
   }
   let elapsed = ContinuousClock.now - started
   let historyText = tickHistory
@@ -85,79 +104,93 @@ func waitUntil(
     sourceLocation: sourceLocation)
 }
 
-/// `waitUntil` の GCD ( `DispatchQueue.global().asyncAfter` ) ベース版。
+/// `waitUntil` の **polling loop 全体を GCD thread 上で完結** させる版。Swift Concurrency
+/// の cooperative executor 経路を完全に外し、`Task.sleep` 経路で詰まる stall ( CI run
+/// 26029332080 attempt 1 で観測 ) との切り分けに使う。
 ///
-/// 観測目的: issue ( #566 ) の stall window ( CI attempt 1 で `+0.002s〜+2.04s` の間
-/// `Task.sleep(50ms)` が一度も resume しなかった ) が、cooperative executor 固有か
-/// OS scheduler 全体停止かを切り分ける。本関数は `Task.sleep` を経由せず GCD の
-/// `asyncAfter` で next tick を schedule するため:
+/// 実装上の契約:
 ///
-/// - (i) Swift Concurrency runtime / cooperative executor 固有の stall なら、本関数の
-///   tick は stall window 中も発火し続ける ( = `waitUntil` だけが詰まり、本関数は通常通り )
-/// - (ii) OS scheduler 全体停止 ( CPU steal / VM freeze ) なら、GCD thread pool も
-///   同じ OS scheduler に依存するため、本関数も同時刻に stall する
+/// - polling loop ( condition 評価 / trace 出力 / `Thread.sleep` ) は `DispatchQueue.global().async`
+///   の closure 内で 1 つの GCD worker thread 上に閉じる。`withCheckedContinuation` の
+///   resume は polling 終了時 ( resolved / timeout ) の **1 回のみ**
+/// - `condition` は **同期的に評価できる predicate に限定** する ( `await` を含む condition は
+///   渡してはいけない )。内部で async を呼ぶと再び cooperative executor に hop して観測精度が
+///   失われる。本 PR 対象 5 test の condition ( `fileExists` / `MessageCollector.snapshot()` /
+///   `ExitCollector.snapshot()` / `events.exitedIds()` ) はすべて同期完結する NSLock ベースで
+///   契約を満たす
+/// - `Issue.record` は cooperative executor / GCD どちらの thread からも呼べる
 ///
-/// trace prefix は `[TEST-TRACE]` のままで、内容に `waitUntilDispatch` を含めることで
-/// grep で `waitUntil` と分離可能にする。
-///
-/// 失敗時 ( timeout 到達 / condition が `await` を必要とする等 ) の規律は `waitUntil` と
-/// 同一: silent return せず `Issue.record` で test を fail させる。
-func waitUntilDispatch(
+/// trace 出力は `[TEST-TRACE]` 共有 + 行内 `waitUntilThreaded` で grep 分離可能。
+/// `waitUntil` と同じ tick / before-sleep / after-sleep の粒度で出す。
+func waitUntilThreaded(
   timeout: Duration,
   description: String = "condition",
   _ condition: @escaping @Sendable () -> Bool,
   sourceLocation: SourceLocation = #_sourceLocation
-) async throws {
-  let started = ContinuousClock.now
-  let deadline = started.advanced(by: timeout)
-  testTrace("waitUntilDispatch entered timeout=\(timeout) desc=\(description)")
-  let historyCap = 10
-  var tickHistory: [(elapsed: Duration, result: Bool)] = []
-  var tickCount = 0
-  while ContinuousClock.now < deadline {
-    let elapsed = ContinuousClock.now - started
-    let wall = Date().timeIntervalSinceReferenceDate
-    let result = condition()
-    tickCount += 1
-    tickHistory.append((elapsed, result))
-    if tickHistory.count > historyCap {
-      tickHistory.removeFirst(tickHistory.count - historyCap)
+) async {
+  testTrace("waitUntilThreaded entered timeout=\(timeout) desc=\(description)")
+  let result: ThreadedWaitResult = await withCheckedContinuation { continuation in
+    DispatchQueue.global().async {
+      let started = ContinuousClock.now
+      let deadline = started.advanced(by: timeout)
+      let historyCap = 10
+      var tickHistory: [(elapsed: Duration, result: Bool)] = []
+      var tickCount = 0
+      while ContinuousClock.now < deadline {
+        let elapsed = ContinuousClock.now - started
+        let wall = Date().timeIntervalSinceReferenceDate
+        let condResult = condition()
+        tickCount += 1
+        tickHistory.append((elapsed, condResult))
+        if tickHistory.count > historyCap {
+          tickHistory.removeFirst(tickHistory.count - historyCap)
+        }
+        threadedTrace(
+          "tick=\(tickCount) elapsed=\(elapsed) wall=\(wall) result=\(condResult)")
+        if condResult {
+          threadedTrace("resolved tick=\(tickCount) elapsed=\(elapsed)")
+          continuation.resume(returning: .resolved)
+          return
+        }
+        threadedTrace("before-sleep tick=\(tickCount)")
+        Thread.sleep(forTimeInterval: 0.050)
+        threadedTrace("after-sleep tick=\(tickCount)")
+      }
+      let finalElapsed = ContinuousClock.now - started
+      let historyText = tickHistory
+        .map { "\($0.elapsed):\($0.result)" }
+        .joined(separator: ", ")
+      threadedTrace(
+        "timeout tickCount=\(tickCount) elapsed=\(finalElapsed) lastTicks=[\(historyText)]")
+      continuation.resume(
+        returning: .timeout(elapsed: finalElapsed, tickCount: tickCount, history: historyText))
     }
-    testTrace(
-      "waitUntilDispatch tick=\(tickCount) elapsed=\(elapsed) wall=\(wall) result=\(result)")
-    if result {
-      testTrace("waitUntilDispatch resolved tick=\(tickCount) elapsed=\(elapsed)")
-      return
-    }
-    try await dispatchSleep(milliseconds: 50)
   }
-  let elapsed = ContinuousClock.now - started
-  let historyText = tickHistory
-    .map { "\($0.elapsed):\($0.result)" }
-    .joined(separator: ", ")
-  testTrace(
-    "waitUntilDispatch timeout tickCount=\(tickCount) elapsed=\(elapsed) lastTicks=[\(historyText)]"
-  )
-  Issue.record(
-    """
-    waitUntilDispatch timed out after \(timeout) waiting for: \(description). \
-    elapsed=\(elapsed) tickCount=\(tickCount). \
-    last \(tickHistory.count) ticks: [\(historyText)]
-    """,
-    sourceLocation: sourceLocation)
+  switch result {
+  case .resolved:
+    return
+  case .timeout(let elapsed, let tickCount, let history):
+    Issue.record(
+      """
+      waitUntilThreaded timed out after \(timeout) waiting for: \(description). \
+      elapsed=\(elapsed) tickCount=\(tickCount). \
+      last ticks: [\(history)]
+      """,
+      sourceLocation: sourceLocation)
+  }
 }
 
-/// `DispatchQueue.global().asyncAfter` で `milliseconds` 後に resume する。
-/// `Task.sleep` は cooperative executor 経路で sleep するが、本関数は GCD thread pool
-/// 上で resume する。issue ( #566 ) の stall 経路切り分けに使う。
-///
-/// `withCheckedContinuation` で continuation の resume を GCD に委譲する。
-/// continuation の race は GCD `asyncAfter` が単一発火を保証するため起きない。
-private func dispatchSleep(milliseconds: Int) async throws {
-  try Task.checkCancellation()
-  await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-    DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(milliseconds)) {
-      continuation.resume()
-    }
-  }
+/// `waitUntilThreaded` 内 GCD thread からの trace は `Test.current` が解決できる保証が
+/// 無いため、`testTrace` ではなく `gozdTraceLine` を直接呼んで `<no-test>` 経由ではなく
+/// `<threaded>` タグで吐く。GCD thread と `Test.current` の TaskLocal の関係は未保証。
+private func threadedTrace(_ message: String) {
+  guard gozdTraceEnabled else { return }
+  let elapsed = ContinuousClock.now - gozdTraceStart
+  let testName = Test.current?.name ?? "<threaded>"
+  gozdTraceLine("[TEST-TRACE +\(elapsed) test=\(testName)] waitUntilThreaded \(message)\n")
+}
+
+private enum ThreadedWaitResult {
+  case resolved
+  case timeout(elapsed: Duration, tickCount: Int, history: String)
 }

--- a/apps/native/Tests/GozdCoreTests/WaitUntil.swift
+++ b/apps/native/Tests/GozdCoreTests/WaitUntil.swift
@@ -46,6 +46,11 @@ import Testing
 /// `#expect` が別の症状（exit が nil など）で間接 fail し、timeout だった事象を追跡
 /// できなくなる。
 ///
+/// **cancel 経路**: `try await Task.sleep(for:)` を使うため、外側 Task が cancel されると
+/// `CancellationError` を throw する。これは `waitUntilThreaded` ( cancel 非対応 ) との
+/// 意図的な非対称設計。observation PR では Task.sleep 経路と完全独立 thread 経路を
+/// 並走させて挙動を比較するのが目的で、cancel 経路まで揃える必要はない。
+///
 /// - Parameters:
 ///   - timeout: 待機の上限。超過時に Issue.record。
 ///   - description: timeout 失敗メッセージに含める「何を待っていたか」の説明。
@@ -104,21 +109,28 @@ func waitUntil(
     sourceLocation: sourceLocation)
 }
 
-/// `waitUntil` の **polling loop 全体を GCD thread 上で完結** させる版。Swift Concurrency
-/// の cooperative executor 経路を完全に外し、`Task.sleep` 経路で詰まる stall ( CI run
-/// 26029332080 attempt 1 で観測 ) との切り分けに使う。
+/// `waitUntil` の **polling loop 全体を dedicated NSThread 上で完結** させる版。Swift
+/// Concurrency の cooperative executor 経路を完全に外し、`Task.sleep` 経路で詰まる stall
+/// ( CI run 26029332080 attempt 1 で観測 ) との切り分けに使う。
 ///
 /// 実装上の契約:
 ///
-/// - polling loop ( condition 評価 / trace 出力 / `Thread.sleep` ) は `DispatchQueue.global().async`
-///   の closure 内で 1 つの GCD worker thread 上に閉じる。`withCheckedContinuation` の
-///   resume は polling 終了時 ( resolved / timeout ) の **1 回のみ**
+/// - polling loop ( condition 評価 / trace 出力 / `Thread.sleep(forTimeInterval:)` ) は
+///   `Thread { ... }.start()` で立てた **dedicated NSThread** 上で完結する。GCD worker
+///   thread pool を使わないため、`Thread.sleep` の blocking で GCD pool を専有する経路は
+///   発生しない ( = 並走する `DispatchQueue.global()` ベースの test 用処理を阻害しない )。
+///   `withCheckedContinuation` の resume は polling 終了時 ( resolved / timeout ) の **1 回のみ**
 /// - `condition` は **同期的に評価できる predicate に限定** する ( `await` を含む condition は
 ///   渡してはいけない )。内部で async を呼ぶと再び cooperative executor に hop して観測精度が
 ///   失われる。本 PR 対象 5 test の condition ( `fileExists` / `MessageCollector.snapshot()` /
 ///   `ExitCollector.snapshot()` / `events.exitedIds()` ) はすべて同期完結する NSLock ベースで
 ///   契約を満たす
-/// - `Issue.record` は cooperative executor / GCD どちらの thread からも呼べる
+/// - `Issue.record` は cooperative executor / GCD / NSThread どこから呼んでも safe
+///
+/// **cancel 経路**: 本関数は cancel に応答しない設計 ( `throws` を返さない、`Task.checkCancellation`
+/// を呼ばない )。NSThread を `cancel()` で止める経路は条件分岐コストが trace に乗るので
+/// 観測 PR では採用しない。外側 Task が cancel されても polling は timeout まで継続する。
+/// `waitUntil` ( cancel あり ) との意図的な非対称設計で、両経路の挙動を独立に観測する目的。
 ///
 /// trace 出力は `[TEST-TRACE]` 共有 + 行内 `waitUntilThreaded` で grep 分離可能。
 /// `waitUntil` と同じ tick / before-sleep / after-sleep の粒度で出す。
@@ -130,7 +142,7 @@ func waitUntilThreaded(
 ) async {
   testTrace("waitUntilThreaded entered timeout=\(timeout) desc=\(description)")
   let result: ThreadedWaitResult = await withCheckedContinuation { continuation in
-    DispatchQueue.global().async {
+    let thread = Thread {
       let started = ContinuousClock.now
       let deadline = started.advanced(by: timeout)
       let historyCap = 10
@@ -165,6 +177,8 @@ func waitUntilThreaded(
       continuation.resume(
         returning: .timeout(elapsed: finalElapsed, tickCount: tickCount, history: historyText))
     }
+    thread.name = "WaitUntilThreaded"
+    thread.start()
   }
   switch result {
   case .resolved:
@@ -180,9 +194,12 @@ func waitUntilThreaded(
   }
 }
 
-/// `waitUntilThreaded` 内 GCD thread からの trace は `Test.current` が解決できる保証が
-/// 無いため、`testTrace` ではなく `gozdTraceLine` を直接呼んで `<no-test>` 経由ではなく
-/// `<threaded>` タグで吐く。GCD thread と `Test.current` の TaskLocal の関係は未保証。
+/// `waitUntilThreaded` 内 dedicated NSThread からの trace は `Test.current` が解決できる
+/// 保証が無いため、`testTrace` ではなく `gozdTraceLine` を直接呼んで `<no-test>` 経由ではなく
+/// `<threaded>` タグで吐く。NSThread と `Test.current` の TaskLocal の関係は未保証
+/// ( TaskLocal は Swift Concurrency の Task に紐づく storage で、NSThread closure は
+/// Task の outside で実行されるため、TaskLocal は伝播せず `Test.current` は nil になる
+/// のが期待動作。実観測は CI run の trace で `<threaded>` が出ることで確認する )。
 private func threadedTrace(_ message: String) {
   guard gozdTraceEnabled else { return }
   let elapsed = ContinuousClock.now - gozdTraceStart

--- a/apps/native/Tests/GozdCoreTests/WaitUntil.swift
+++ b/apps/native/Tests/GozdCoreTests/WaitUntil.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Testing
 
-// PTYManagerTests / PTYRegistryTests で共有する条件待機ヘルパー。
+// PTYManagerTests / PTYRegistryTests / SocketServerTests で共有する条件待機ヘルパー。
 //
 // 旧実装は各テストファイルに `private func waitUntil` を重複定義しており、
 // timeout 時に「いつから condition が false だったか」が分からなかった（issue #556 観測項目 3）。
@@ -11,6 +11,19 @@ import Testing
 //
 // 加えて `[TEST-TRACE]` で entry / tick / resolve / timeout を stderr に流すため、
 // 同じ ContinuousClock 基準を持つ `[PTY-TRACE]` と時系列を突き合わせ可能になる。
+//
+// issue ( #566 ) 観測項目:
+//
+// - tick trace 行に `wall=<Date 秒>` を併記する。ContinuousClock (mach_continuous_time 基盤、
+//   suspend 中も進む) と Date (system clock、NTP 調整あり) を並列に記録し、CPU steal /
+//   VM freeze で両者が同時に止まる経路と、cooperative executor だけが止まる経路を区別する。
+//
+// - `waitUntilDispatch` を追加する。GCD `asyncAfter` ベースの polling で、Task / async-await
+//   経路ではなく DispatchQueue.global() の thread pool 上で再開する。`Task.sleep` 経由の
+//   `waitUntil` と並走させた結果、片方だけが stall するか / 両方同時に stall するかで、
+//   stall の経路が (i) Swift Concurrency runtime 固有か (ii) OS scheduler 全体停止か
+//   を切り分ける。同 elapsed 基準 / 同 stderr lock を共有する `[TEST-TRACE-DISPATCH]`
+//   prefix で出すため、grep で 2 系統に分離可能。
 
 /// `condition()` が true を返すまで小さくポーリングで待つ。timeout 到達時に
 /// `Issue.record` で test を fail させる。silent return すると後段の `#expect` が
@@ -23,7 +36,7 @@ import Testing
 ///
 /// trace 出力:
 ///   - entry: `waitUntil entered timeout=... desc=...`
-///   - tick: `waitUntil tick=<n> elapsed=<dur> result=<bool>`
+///   - tick: `waitUntil tick=<n> elapsed=<dur> wall=<sec> result=<bool>`
 ///   - 成功: `waitUntil resolved tick=<n> elapsed=<dur>`
 ///   - timeout: `waitUntil timeout tickCount=<n> elapsed=<dur> lastTicks=[...]`
 func waitUntil(
@@ -43,13 +56,14 @@ func waitUntil(
   var tickCount = 0
   while ContinuousClock.now < deadline {
     let elapsed = ContinuousClock.now - started
+    let wall = Date().timeIntervalSinceReferenceDate
     let result = condition()
     tickCount += 1
     tickHistory.append((elapsed, result))
     if tickHistory.count > historyCap {
       tickHistory.removeFirst(tickHistory.count - historyCap)
     }
-    testTrace("waitUntil tick=\(tickCount) elapsed=\(elapsed) result=\(result)")
+    testTrace("waitUntil tick=\(tickCount) elapsed=\(elapsed) wall=\(wall) result=\(result)")
     if result {
       testTrace("waitUntil resolved tick=\(tickCount) elapsed=\(elapsed)")
       return
@@ -69,4 +83,81 @@ func waitUntil(
     last \(tickHistory.count) ticks: [\(historyText)]
     """,
     sourceLocation: sourceLocation)
+}
+
+/// `waitUntil` の GCD ( `DispatchQueue.global().asyncAfter` ) ベース版。
+///
+/// 観測目的: issue ( #566 ) の stall window ( CI attempt 1 で `+0.002s〜+2.04s` の間
+/// `Task.sleep(50ms)` が一度も resume しなかった ) が、cooperative executor 固有か
+/// OS scheduler 全体停止かを切り分ける。本関数は `Task.sleep` を経由せず GCD の
+/// `asyncAfter` で next tick を schedule するため:
+///
+/// - (i) Swift Concurrency runtime / cooperative executor 固有の stall なら、本関数の
+///   tick は stall window 中も発火し続ける ( = `waitUntil` だけが詰まり、本関数は通常通り )
+/// - (ii) OS scheduler 全体停止 ( CPU steal / VM freeze ) なら、GCD thread pool も
+///   同じ OS scheduler に依存するため、本関数も同時刻に stall する
+///
+/// trace prefix は `[TEST-TRACE]` のままで、内容に `waitUntilDispatch` を含めることで
+/// grep で `waitUntil` と分離可能にする。
+///
+/// 失敗時 ( timeout 到達 / condition が `await` を必要とする等 ) の規律は `waitUntil` と
+/// 同一: silent return せず `Issue.record` で test を fail させる。
+func waitUntilDispatch(
+  timeout: Duration,
+  description: String = "condition",
+  _ condition: @escaping @Sendable () -> Bool,
+  sourceLocation: SourceLocation = #_sourceLocation
+) async throws {
+  let started = ContinuousClock.now
+  let deadline = started.advanced(by: timeout)
+  testTrace("waitUntilDispatch entered timeout=\(timeout) desc=\(description)")
+  let historyCap = 10
+  var tickHistory: [(elapsed: Duration, result: Bool)] = []
+  var tickCount = 0
+  while ContinuousClock.now < deadline {
+    let elapsed = ContinuousClock.now - started
+    let wall = Date().timeIntervalSinceReferenceDate
+    let result = condition()
+    tickCount += 1
+    tickHistory.append((elapsed, result))
+    if tickHistory.count > historyCap {
+      tickHistory.removeFirst(tickHistory.count - historyCap)
+    }
+    testTrace(
+      "waitUntilDispatch tick=\(tickCount) elapsed=\(elapsed) wall=\(wall) result=\(result)")
+    if result {
+      testTrace("waitUntilDispatch resolved tick=\(tickCount) elapsed=\(elapsed)")
+      return
+    }
+    try await dispatchSleep(milliseconds: 50)
+  }
+  let elapsed = ContinuousClock.now - started
+  let historyText = tickHistory
+    .map { "\($0.elapsed):\($0.result)" }
+    .joined(separator: ", ")
+  testTrace(
+    "waitUntilDispatch timeout tickCount=\(tickCount) elapsed=\(elapsed) lastTicks=[\(historyText)]"
+  )
+  Issue.record(
+    """
+    waitUntilDispatch timed out after \(timeout) waiting for: \(description). \
+    elapsed=\(elapsed) tickCount=\(tickCount). \
+    last \(tickHistory.count) ticks: [\(historyText)]
+    """,
+    sourceLocation: sourceLocation)
+}
+
+/// `DispatchQueue.global().asyncAfter` で `milliseconds` 後に resume する。
+/// `Task.sleep` は cooperative executor 経路で sleep するが、本関数は GCD thread pool
+/// 上で resume する。issue ( #566 ) の stall 経路切り分けに使う。
+///
+/// `withCheckedContinuation` で continuation の resume を GCD に委譲する。
+/// continuation の race は GCD `asyncAfter` が単一発火を保証するため起きない。
+private func dispatchSleep(milliseconds: Int) async throws {
+  try Task.checkCancellation()
+  await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+    DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(milliseconds)) {
+      continuation.resume()
+    }
+  }
 }

--- a/apps/native/scripts/analyze-stall.sh
+++ b/apps/native/scripts/analyze-stall.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# CI log の `[TEST-TRACE]` waitUntil tick 行を test 横断で時系列ソートし、
+# 「同時刻 stall window」を集計する。
+#
+# issue ( #566 ) で観測した stall は SocketServer / PTYManager / PTYRegistry の
+# 並列 test が同一 window ( +0s〜+2.04s ) で `Task.sleep(50ms)` が全停止する pattern
+# だった。本スクリプトは「どの test の tick がどの時刻に発火したか」「stall window
+# の幅 ( tick 間 gap が閾値を超える区間 ) はどれか」を 1 view で出す。
+#
+# 入力: CI log を stdin に流すか、第 1 引数に log file path を渡す。
+# 出力:
+#   - timeline section: 全 waitUntil / waitUntilDispatch tick を `+elapsed [test] tick=N
+#     result=B` の 1 行で時系列出力 (Task / Dispatch 経路は kind 列で区別される)
+#   - stall section: 連続 tick 間の gap が `STALL_THRESHOLD` ( default 0.5s ) を
+#     超える window を `gap=Δs from=+a to=+b` で列挙
+#
+# 使い方:
+#   ./apps/native/scripts/analyze-stall.sh ci-log.txt
+#   gh api repos/OWNER/REPO/actions/jobs/JOB_ID/logs | ./apps/native/scripts/analyze-stall.sh
+#   STALL_THRESHOLD=0.2 ./apps/native/scripts/analyze-stall.sh ci-log.txt
+#
+# 移植性: macOS default の BWK awk と Linux の gawk 両方で動くよう、GNU awk 固有の
+# `match($0, /re/, arr)` array 引数や RSTART/RLENGTH に依存しない。perl の正規表現で
+# 抽出してから sort する。
+
+set -euo pipefail
+
+STALL_THRESHOLD="${STALL_THRESHOLD:-0.5}"
+
+input="${1:-/dev/stdin}"
+
+# tick 行を `elapsed<TAB>test<TAB>kind<TAB>tick<TAB>result` に正規化する。
+# trace 行例:
+#   2026-05-18T09:40:24.2295220Z [TEST-TRACE +0.004299333 seconds test=receivesMultipleLines()] waitUntil tick=1 elapsed=2.3875e-05 seconds result=false
+extract() {
+  perl -ne '
+    next unless /\[TEST-TRACE \+([0-9.eE+\-]+) seconds test=(\S+?)\] (waitUntilDispatch|waitUntil) tick=(\d+) elapsed=\S+ seconds (?:wall=\S+ )?result=(true|false)/;
+    print join("\t", $1, $2, $3, $4, $5), "\n";
+  ' "$1" | sort -n -k1,1
+}
+
+print_timeline() {
+  printf 'timeline:\n'
+  while IFS=$'\t' read -r elapsed name kind tick result; do
+    printf '  +%s [%s] %s tick=%s result=%s\n' "$elapsed" "$name" "$kind" "$tick" "$result"
+  done
+}
+
+print_stall_windows() {
+  local prev=-1 prev_label=""
+  local elapsed name kind tick result
+  while IFS=$'\t' read -r elapsed name kind tick result; do
+    if [[ "$prev" != "-1" ]]; then
+      local gap
+      gap=$(awk -v a="$elapsed" -v b="$prev" 'BEGIN { printf "%.4f", a - b }')
+      local over
+      over=$(awk -v g="$gap" -v t="$STALL_THRESHOLD" 'BEGIN { print (g > t) ? "1" : "0" }')
+      if [[ "$over" == "1" ]]; then
+        printf '  gap=%ss from=+%s to=+%s prev=[%s] cur=[%s %s tick=%s result=%s]\n' \
+          "$gap" "$prev" "$elapsed" "$prev_label" "$name" "$kind" "$tick" "$result"
+      fi
+    fi
+    prev="$elapsed"
+    prev_label="$name $kind tick=$tick result=$result"
+  done
+}
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+extract "$input" > "$tmp"
+
+print_timeline < "$tmp"
+printf '\nstall windows (gap > %ss):\n' "$STALL_THRESHOLD"
+print_stall_windows < "$tmp"

--- a/apps/native/scripts/analyze-stall.sh
+++ b/apps/native/scripts/analyze-stall.sh
@@ -8,12 +8,15 @@
 # だった。本スクリプトは「どの test の tick がどの時刻に発火したか」「stall window
 # の幅 ( tick 間 gap が閾値を超える区間 ) はどれか」を 1 view で出す。
 #
+# 対応 helper: `waitUntil` ( Task.sleep 経路 ) / `waitUntilDispatch` ( 旧版、観測無効と
+# 判明 ) / `waitUntilThreaded` ( polling loop 全体を GCD thread 上で完結 )。kind 列で区別。
+#
 # 入力: CI log を stdin に流すか、第 1 引数に log file path を渡す。
 # 出力:
-#   - timeline section: 全 waitUntil / waitUntilDispatch tick を `+elapsed [test] tick=N
-#     result=B` の 1 行で時系列出力 (Task / Dispatch 経路は kind 列で区別される)
-#   - stall section: 連続 tick 間の gap が `STALL_THRESHOLD` ( default 0.5s ) を
-#     超える window を `gap=Δs from=+a to=+b` で列挙
+#   - timeline section: 全 tick を `+elapsed wall=<sec> [test] <kind> tick=N result=B` で
+#     時系列出力。wall 列は ContinuousClock と乖離があった場合のみ意味を持つ保険記録
+#   - stall windows section: 連続 tick 間の global gap が `STALL_THRESHOLD` ( default 0.5s )
+#     を超える window を `gap=Δs from=+a to=+b prev=[...] cur=[...]` で列挙
 #
 # 使い方:
 #   ./apps/native/scripts/analyze-stall.sh ci-log.txt
@@ -30,27 +33,37 @@ STALL_THRESHOLD="${STALL_THRESHOLD:-0.5}"
 
 input="${1:-/dev/stdin}"
 
-# tick 行を `elapsed<TAB>test<TAB>kind<TAB>tick<TAB>result` に正規化する。
-# trace 行例:
-#   2026-05-18T09:40:24.2295220Z [TEST-TRACE +0.004299333 seconds test=receivesMultipleLines()] waitUntil tick=1 elapsed=2.3875e-05 seconds result=false
+# tick 行を `elapsed<TAB>wall<TAB>test<TAB>kind<TAB>tick<TAB>result` に正規化する。
+# trace 行例 ( wall= は新版で付く。旧 trace との互換のためオプショナル ):
+#   2026-05-18T09:40:24.2295220Z [TEST-TRACE +0.004299333 seconds test=receivesMultipleLines()] waitUntil tick=1 elapsed=2.3875e-05 seconds wall=800792337.6 result=false
 extract() {
   perl -ne '
-    next unless /\[TEST-TRACE \+([0-9.eE+\-]+) seconds test=(\S+?)\] (waitUntilDispatch|waitUntil) tick=(\d+) elapsed=\S+ seconds (?:wall=\S+ )?result=(true|false)/;
-    print join("\t", $1, $2, $3, $4, $5), "\n";
+    next unless /\[TEST-TRACE \+([0-9.eE+\-]+) seconds test=(\S+?)\] (waitUntilThreaded|waitUntilDispatch|waitUntil) tick=(\d+) elapsed=\S+ seconds (?:wall=(\S+) )?result=(true|false)/;
+    my $elapsed = $1;
+    my $name    = $2;
+    my $kind    = $3;
+    my $tick    = $4;
+    my $wall    = defined($5) ? $5 : "";
+    my $result  = $6;
+    print join("\t", $elapsed, $wall, $name, $kind, $tick, $result), "\n";
   ' "$1" | sort -n -k1,1
 }
 
 print_timeline() {
   printf 'timeline:\n'
-  while IFS=$'\t' read -r elapsed name kind tick result; do
-    printf '  +%s [%s] %s tick=%s result=%s\n' "$elapsed" "$name" "$kind" "$tick" "$result"
+  while IFS=$'\t' read -r elapsed wall name kind tick result; do
+    if [[ -n "$wall" ]]; then
+      printf '  +%s wall=%s [%s] %s tick=%s result=%s\n' "$elapsed" "$wall" "$name" "$kind" "$tick" "$result"
+    else
+      printf '  +%s [%s] %s tick=%s result=%s\n' "$elapsed" "$name" "$kind" "$tick" "$result"
+    fi
   done
 }
 
 print_stall_windows() {
   local prev=-1 prev_label=""
-  local elapsed name kind tick result
-  while IFS=$'\t' read -r elapsed name kind tick result; do
+  local elapsed wall name kind tick result
+  while IFS=$'\t' read -r elapsed wall name kind tick result; do
     if [[ "$prev" != "-1" ]]; then
       local gap
       gap=$(awk -v a="$elapsed" -v b="$prev" 'BEGIN { printf "%.4f", a - b }')


### PR DESCRIPTION
## 概要

issue ( #566 ) で観測された `Task.sleep(50ms)` 2 秒 stall を「観測」のみで切り分けるための test infrastructure を追加する。fix は次フェーズ。本 PR は production コードには触らない。

CI run 26029332080 attempt 1 ( PR #567 初版 `waitUntilDispatch` ) で **GCD 経路でも cooperative executor stall に巻き込まれた** ため、polling loop **全体** を **dedicated NSThread** に閉じる `waitUntilThreaded` に切り替えた経緯がある。本 PR の差分は最終形態であり、観測 PR の本体。

## 背景

PR ( #565 ) の attempt 1 ( failure ) log で次の事実が確定している:

- `SocketServerTests` 3 test ( receivesSingleLine / receivesMultipleLines / receivesFromMultipleConnections ) が `+0.002s` で `waitUntil tick=1 result=false` を打った後、**2 秒間 1 度も tick が発火せず** `+2.04s` で timeout
- 同 attempt 1 の **並列実行 window 内** で、別 suite の `PTYManagerTests.receivesOutputAndExit` も tick=1 ( +0.124s ) → tick=2 ( +2.405s ) と **2.28 秒** stall。`PTYRegistryTests.spawnAndExitDispatch` も tick=1 ( +1.161s ) → tick=2 ( +2.534s ) と 1.37 秒 stall
- timeout 後の再 `waitUntil` は即 `result=true` を返す → socket bind / message 受信は早期に完了済み、`Task.sleep(50ms)` が executor 上で resume できなかったことを示すデータ

原因仮説は次の二択に絞られる:

- (i) Swift Concurrency runtime / cooperative executor 固有の stall ( `Task.sleep` 経路のみ詰まる )
- (ii) OS scheduler 全体停止 ( CPU steal / VM freeze で別経路も同時 stall )

(i)/(ii) を確定させないまま fix PR を書くと、効いたように見えて他 flake で再発する。issue ( #566 ) の「`やらないこと`: 当てずっぽうの『根治』PR を出さない」と整合する形で観測 PR を先行させる。

### 初版 (17ff6c5) の `waitUntilDispatch` ( GCD `asyncAfter` 経由 ) 実装の廃止経緯

初版 ( commit `17ff6c5` ) では `DispatchQueue.global().asyncAfter` + `withCheckedContinuation` ベースの `waitUntilDispatch` で sleep の wait phase を GCD に逃がす実装だった。CI run 26029332080 attempt 1 で `waitUntilDispatch` 化した 5 test 全部が **tickCount=1 / elapsed=3.0s+** で timeout した:

```text
receivesOutputAndExit            waitUntilDispatch timeout tickCount=1 elapsed=3.136s
receivesSingleLine               waitUntilDispatch timeout tickCount=1 elapsed=3.125s
receivesMultipleLines            waitUntilDispatch timeout tickCount=1 elapsed=3.081s
receivesFromMultipleConnections  waitUntilDispatch timeout tickCount=1 elapsed=3.086s
spawnAndExitDispatch             waitUntilDispatch timeout tickCount=1 elapsed=3.082s
```

`withCheckedContinuation` の resume 経路が cooperative executor に hop して polling loop が結局 Swift Concurrency runtime に戻る構造になっていたことが分かった ( = `asyncAfter` の closure は GCD で発火していたが、`await` から戻る次の polling iteration / `condition()` 評価 / trace 出力 / `while` ループはすべて cooperative executor 上 )。

### 中間版 (942c2a5) の `DispatchQueue.global().async` ( GCD pool 専有 ) 実装の廃止経緯

中間版 ( commit `942c2a5` ) では polling loop **全体** を `DispatchQueue.global().async` の closure に閉じる構造に変更した ( `waitUntilDispatch` → `waitUntilThreaded` 改名 + cooperative executor 経路の排除 )。ただし `Thread.sleep(forTimeInterval:)` で blocking 中に GCD pool の worker thread を専有する経路があり、並走する `DispatchQueue.global()` 利用処理 ( `SocketServer` 専用 queue 含め、pool worker を借りる全経路 ) を阻害するリスクがあった。

最終版 ( commit `6289d1e` ) で `Thread { ... }.start()` ベースの **dedicated NSThread** に変更し、GCD pool 経路を一切踏まない構造に整理した。`thread.name = "WaitUntilThreaded"` で Instruments / Activity Monitor からも識別可能。

## 変更内容

### `WaitUntil.swift`

- 既存 `waitUntil` の tick trace 行に `wall=<Date.timeIntervalSinceReferenceDate>` を併記。`ContinuousClock` ( `mach_continuous_time` 基盤、suspend 中も進む ) と `Date` ( system clock、NTP 調整あり ) を並列に記録し、稀な system clock 異常 ( NTP 巻き戻し / sleep wake 後の補正 ) の検知用に保険として残す。(i)/(ii) 切り分けの主軸ではない
- `waitUntil` 内に `before-sleep` / `after-sleep` の trace を追加。`Task.sleep(50ms)` の前後で trace を出し「sleep 開始時刻 → 再開時刻」を直接観測可能にする
- `waitUntilThreaded` を新規追加。`Thread { ... }.start()` で立てた **dedicated NSThread** で polling loop **全体** ( `condition()` 評価 / trace 出力 / `Thread.sleep(forTimeInterval:)` ) を完結させ、`withCheckedContinuation` の resume は polling 終了 ( resolved / timeout ) 時のみ呼ぶ。GCD pool を使わないため、`Thread.sleep` の blocking が他 GCD 処理 ( `SocketServer` 専用 queue 等 ) を阻害しない
- `condition` は **同期的に評価できる predicate に限定** する契約。`await` を含む condition を渡すと再び cooperative executor に hop して観測精度が失われる。本 PR 対象 5 test の condition ( `fileExists` / `MessageCollector.snapshot()` / `ExitCollector.snapshot()` / `events.exitedIds()` ) はすべて NSLock ベースで同期完結
- trace prefix は `[TEST-TRACE]` 共有、行内に `waitUntilThreaded` を含めて grep 分離。NSThread 上の polling では `Test.current?.name` が TaskLocal 不伝播で nil になるため `<threaded>` tag を fallback で出す
- `waitUntil` / `waitUntilThreaded` の cancel 経路は **意図的に非対称** に設計。`waitUntil` は `try await Task.sleep` で `CancellationError` を throw、`waitUntilThreaded` は cancel 非応答 ( timeout まで継続 )。両経路の独立性を保ち、観測条件に cancel 差分を持ち込まないため
- `waitUntil` / `waitUntilThreaded` の polling loop 構造はほぼ同一だが、観測 PR の独立性 ( 片方を変更しても他方が影響を受けない保証 ) を保つため敢えて重複させている

### 対象 test の置き換え ( 5 箇所のみ )

attempt 1 で実際に 1 秒以上 stall を踏んだ 5 箇所のみを `waitUntilThreaded` に置換する。SocketServer 後段の message-count polling 3 箇所と、その他の `waitUntil` 利用 test は既存 `waitUntil` のまま並列実行で並走させ、両経路を同 run 内で比較可能にする。

- `SocketServerTests`: `fileExists` polling × 3 ( receivesSingleLine / receivesMultipleLines / receivesFromMultipleConnections の 1 箇所ずつ )
- `PTYManagerTests.receivesOutputAndExit`: 2.28s stall を踏んだ箇所
- `PTYRegistryTests.spawnAndExitDispatch`: 1.37s stall を踏んだ箇所

### `apps/native/scripts/analyze-stall.sh`

CI log を入れると全 `waitUntil` / `waitUntilThreaded` ( および履歴のための `waitUntilDispatch` ) tick を test 横断で時系列ソートし、`gap > STALL_THRESHOLD` ( default 0.5s ) の global stall window を列挙するシェル。perl の named regex で抽出してから `sort -n` に流すことで macOS BWK awk / Linux gawk 両方で動く portable 実装。timeline 出力に `wall=` 列を併記し、stall window 出力に prev / cur の test / kind 情報を含める。

## 期待される CI 観測

- (i) cooperative executor 固有が真: `waitUntilThreaded` 化した 5 test は stall window 中も `before-sleep`/`after-sleep` 込みで tick が ~50ms 間隔で発火、`waitUntil` のままの他 test だけが秒級 stall を踏む
- (ii) OS scheduler 全体停止が真: `waitUntilThreaded` 化した 5 test も同 window で停止し、`waitUntil` 群と並んで tick gap が秒級に伸びる

CI 1 回で (i)/(ii) が決まる前提だが、stall 自体が flaky なので 1 回緑になったら attempt 1 / 2 / ... を rerun して再現させる方針。

## 今回含めない点

- **別 PR で対応**: `WaitUntil` 本体を `Task.sleep` 非依存に書き換える fix PR。本 PR の CI 結果で (i) と確定してから出す。(ii) が真と判定された場合は runner config 変更 ( macOS runner バージョン切替 / job 分割 ) の論点に切り上がる
- **別 PR で対応**: `SocketServer.start` を `NWListener .ready` 完了同期 API に変更する production 改善。test 側の `fileExists` polling を消す方向の構造改善だが、PTY 側 stall は残るため flake 解消単独の手段としては不十分。観測完了後に独立 PR で出す

## 確認事項

- [ ] CI swift-test job が 1 回緑になっても rerun して attempt 1 で stall が出るかを確認する
- [ ] stall 観測が出たら `apps/native/scripts/analyze-stall.sh` を CI log に流して timeline と stall window を確認する
- [ ] `waitUntilThreaded` と `waitUntil` の tick 発火 pattern を比較し (i)/(ii) を判定する
- [ ] NSThread closure 内 trace に `<threaded>` tag が実際に出るか CI log で確認する ( `Test.current` の TaskLocal 不伝播仮説の実証 )
