### PR TITLE
fix(renderer): restore <dialog> centering broken by Tailwind v4 preflight

### DIFF
--- a/apps/renderer/src/assets/main.css
+++ b/apps/renderer/src/assets/main.css
@@ -5,6 +5,11 @@ button {
   cursor: pointer;
 }
 
+/* Tailwind v4 preflight が `<dialog>` の margin: auto を意図的にリセットする (tailwindlabs/tailwindcss issue 16372) ため、UA 標準の中央配置を復元する */
+dialog {
+  margin: auto;
+}
+
 /* 細いオーバーレイスクロールバー */
 ::-webkit-scrollbar {
   width: 6px;

--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -260,7 +260,7 @@ const activeRootWorktree = computed(() => {
     <!-- 確認ダイアログ -->
     <dialog
       ref="confirmRef"
-      class="backdrop:bg-black/50"
+      class="m-auto backdrop:bg-black/50"
       @click="$event.target === confirmRef && closeConfirm()"
     >
       <div class="space-y-4 rounded-lg border border-zinc-700 bg-zinc-900 p-4 text-white">

--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -260,7 +260,7 @@ const activeRootWorktree = computed(() => {
     <!-- 確認ダイアログ -->
     <dialog
       ref="confirmRef"
-      class="m-auto backdrop:bg-black/50"
+      class="backdrop:bg-black/50"
       @click="$event.target === confirmRef && closeConfirm()"
     >
       <div class="space-y-4 rounded-lg border border-zinc-700 bg-zinc-900 p-4 text-white">

--- a/apps/renderer/src/features/sidebar/useDialogs.ts
+++ b/apps/renderer/src/features/sidebar/useDialogs.ts
@@ -10,13 +10,21 @@ export function useDialogs() {
   const confirmAction = ref<(() => Promise<void>) | undefined>();
 
   function showConfirm(message: string, action: () => Promise<void>) {
+    const dialog = confirmRef.value;
+    if (dialog === undefined) {
+      throw new Error("confirmRef is not mounted");
+    }
     confirmMessage.value = message;
     confirmAction.value = action;
-    confirmRef.value?.showModal();
+    dialog.showModal();
   }
 
   function closeConfirm() {
-    confirmRef.value?.close();
+    const dialog = confirmRef.value;
+    if (dialog === undefined) {
+      throw new Error("confirmRef is not mounted");
+    }
+    dialog.close();
     confirmAction.value = undefined;
   }
 

--- a/apps/renderer/src/features/sidebar/useDialogs.ts
+++ b/apps/renderer/src/features/sidebar/useDialogs.ts
@@ -1,10 +1,12 @@
 import { ref } from "vue";
+import { useNotificationStore } from "../../shared/notification";
 
 /**
  * 確認ダイアログの状態管理。
  * テンプレート側の dialog 要素に ref をバインドして使う。
  */
 export function useDialogs() {
+  const notify = useNotificationStore();
   const confirmRef = ref<HTMLDialogElement>();
   const confirmMessage = ref("");
   const confirmAction = ref<(() => Promise<void>) | undefined>();
@@ -12,7 +14,8 @@ export function useDialogs() {
   function showConfirm(message: string, action: () => Promise<void>) {
     const dialog = confirmRef.value;
     if (dialog === undefined) {
-      throw new Error("confirmRef is not mounted");
+      notify.error("Confirmation dialog not mounted", new Error("confirmRef is undefined"));
+      return;
     }
     confirmMessage.value = message;
     confirmAction.value = action;
@@ -22,7 +25,8 @@ export function useDialogs() {
   function closeConfirm() {
     const dialog = confirmRef.value;
     if (dialog === undefined) {
-      throw new Error("confirmRef is not mounted");
+      notify.error("Confirmation dialog not mounted", new Error("confirmRef is undefined"));
+      return;
     }
     dialog.close();
     confirmAction.value = undefined;


### PR DESCRIPTION
## 概要

サイドバーで worktree を強制削除する際の確認ダイアログがビューポート左上に張り付いていたのを、本来の中央配置に戻す。原因が Tailwind v4 preflight の `<dialog>` margin リセットだったため、base layer で 1 度だけ復元する形に修正する。あわせて確認ダイアログ実装の silent fallback も renderer の規律に揃える。

## 背景

worktree の通常削除に失敗した時に `Force remove?` の確認ダイアログを `<dialog>.showModal()` で開いている (`SidebarPane.vue`)。`<dialog>` は UA stylesheet の `position: fixed; inset: 0; margin: auto` で中央配置されるのが標準仕様だが、実際は左上に固定されていた。

調査の結果、Tailwind v4 の preflight が `* { margin: 0 }` 相当のルールで `<dialog>` の `margin: auto` を意図的にリセットする破壊的変更を入れていることが判明した ( tailwindlabs/tailwindcss issue 16372、v4 upgrade guide にも記載 )。

このプロジェクトの他の dialog ( `CommandPalette.vue` `IssuePickerDialog.vue` `PrPickerDialog.vue` `SettingsModal.vue` ) はそれぞれ scoped CSS で `margin: 15vh auto 0` を個別に当てて位置復元している。今回の confirm dialog だけ復元処理が漏れていた構造であり、各 dialog で個別 workaround を持っている状態自体が SSOT 違反である。レビューを経て、症状消しの個別パッチではなく base layer で一度だけ復元する方針に切り替えた。

加えて `useDialogs.ts` の `confirmRef.value?.showModal()` / `?.close()` が optional chaining で silent に no-op に倒れる構造になっていた点も、本 PR の近傍 silent fallback として renderer の規律 ( `useNotificationStore.error` 経由でトースト通知 / silent return 禁止 ) に揃える形に修正する。

## 変更内容

### Renderer base styles

- `assets/main.css` の base に `dialog { margin: auto }` を 1 度だけ追加し、Tailwind v4 preflight が奪った UA 標準の中央配置を復元
- preflight は `@import "tailwindcss"` で `layer(base)` 内に置かれるため、unlayered の `dialog { margin: auto }` は cascade layer 順で勝つ。既存 dialog の scoped CSS `margin: 15vh auto 0` は specificity と unlayered 優位の二重で勝つため上部中央の意図は維持される

### Sidebar

- `useDialogs.ts` の `showConfirm` / `closeConfirm` で `confirmRef.value` の undefined ガードを追加し、未マウント時は `useNotificationStore.error` でトースト通知 + early return する形に変更
- `executeConfirm` は dialog 表示後の OK クリックでのみ走るため `confirmRef.value` は必ず存在し、early return が `await action()` 到達経路にならない

## 確認事項

- [ ] サイドバーで worktree を強制削除する操作（通常 remove 失敗 → 確認ダイアログ）を行い、ダイアログがビューポート中央に表示されること
- [ ] backdrop クリックと Cancel ボタンで dialog が閉じること
- [ ] OK ボタンで `--force` が走り対象 worktree が削除されること
- [ ] CommandPalette / IssuePickerDialog / PrPickerDialog / SettingsModal の 4 つの dialog が従来通り上部中央に表示されること（base 追加の副次影響確認）
