### PR TITLE
fix(terminal-link,preview): open worktree-external paths via shift+click with traversal-safe markdown links

### DIFF
--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -481,6 +481,9 @@ function buildFileServerUrl(
   gitOriginal = false,
 ): string | undefined {
   if (!fileServerBaseUrl.value) return undefined;
+  // 絶対パス（worktree 外）は file server 経路で扱えない（worktree 相対のみ提供する経路）。
+  // 画像/SVG は fsReadFileAbsolute 経由の binary 表示にフォールバックする。
+  if (relPath.startsWith("/")) return undefined;
   const base = fileServerBaseUrl.value.endsWith("/")
     ? fileServerBaseUrl.value
     : `${fileServerBaseUrl.value}/`;

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -122,6 +122,9 @@ const fileType = computed<FileType>(() => {
   return detectFileType(selectedPath.value);
 });
 
+/** 選択中パスが worktree 外の絶対パスか（terminal link から worktree 外を開いた場合） */
+const isExternalPath = computed(() => selectedPath.value?.startsWith("/") ?? false);
+
 /** 画像プレビュー表示中か（diff 不可のため モード制限に使用） */
 const isImagePreview = computed(() => {
   const ft = fileType.value;
@@ -508,6 +511,11 @@ const imageUrl = computed(() => {
 /** preview チェックボックスを表示するか（diff モードでは非表示） */
 const showPreviewCheckbox = computed(() => {
   if (activeMode.value === "diff") return false;
+  // 絶対パス（worktree 外）の image / svg は file server 経由で読めないため Preview トグルを出さない。
+  // markdown はテキスト経路で読めるためトグル対象を維持する。
+  if (isExternalPath.value && (fileType.value === "image" || fileType.value === "svg")) {
+    return false;
+  }
   return hasRenderedView(fileType.value);
 });
 
@@ -748,6 +756,14 @@ watch(
 
         <!-- 画像プレビュー（バイナリ画像 + SVG preview モード） -->
         <ImagePreview v-else-if="imageUrl" :src="imageUrl" />
+
+        <!-- worktree 外の絶対パス image / svg は file server 経由で読めないため未対応を明示する -->
+        <div
+          v-else-if="(fileType === 'image' || fileType === 'svg') && isExternalPath"
+          class="p-4 text-sm text-zinc-500"
+        >
+          Image preview is not available for paths outside the worktree
+        </div>
 
         <!-- バイナリ（画像以外） -->
         <div v-else-if="displayIsBinary" class="p-4 text-sm text-zinc-500">

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -438,7 +438,10 @@ watch(
     }
 
     const isCommitMode = selectedHash !== UNCOMMITTED_HASH || compareHash !== null;
-    if (isCommitMode) {
+    // 絶対パス（worktree 外）は git 履歴を持たず rpcFsReadFile は worktree 境界外で
+    // FSError.outsideDir を返すため、commit mode 中でも fsReadFileAbsolute 経路に倒す。
+    const isAbsolute = path.startsWith("/");
+    if (isCommitMode && !isAbsolute) {
       await fetchCommitContent(path);
     } else {
       activeMode.value = defaultMode(gitChange);

--- a/apps/renderer/src/features/preview/resolveMarkdownLink.test.ts
+++ b/apps/renderer/src/features/preview/resolveMarkdownLink.test.ts
@@ -346,5 +346,35 @@ describe("resolveMarkdownLink", () => {
       // ./ → normalize で /Users/me/elsewhere に解決 → basePath dir 自身は配下とみなさず invalid
       expect(resolve("./", "/Users/me/elsewhere/README.md").kind).toBe("invalid");
     });
+
+    describe("root 直下の絶対 basePath (`/foo.md` 等の退化ケース)", () => {
+      const rootBase = "/foo.md";
+
+      test("sibling 参照 (`./bar.md`) は `/bar.md` として internal", () => {
+        expect(resolve("./bar.md", rootBase)).toEqual({
+          kind: "internal",
+          path: "/bar.md",
+          lineNumber: undefined,
+          droppedAnchor: false,
+        });
+      });
+
+      test("root 直下の絶対パス (`/bar.md`) も internal", () => {
+        expect(resolve("/bar.md", rootBase)).toEqual({
+          kind: "internal",
+          path: "/bar.md",
+          lineNumber: undefined,
+          droppedAnchor: false,
+        });
+      });
+
+      test("root 直下に居ても `/etc/passwd` 等 sub-dir 配下は invalid (bypass 防止)", () => {
+        expect(resolve("/etc/passwd", rootBase).kind).toBe("invalid");
+      });
+
+      test("root 直下に居ても `./foo/bar.md` のような子 dir 経路は invalid", () => {
+        expect(resolve("./foo/bar.md", rootBase).kind).toBe("invalid");
+      });
+    });
   });
 });

--- a/apps/renderer/src/features/preview/resolveMarkdownLink.test.ts
+++ b/apps/renderer/src/features/preview/resolveMarkdownLink.test.ts
@@ -294,7 +294,7 @@ describe("resolveMarkdownLink", () => {
   });
 
   describe("absolute basePath (worktree 外 markdown を terminal link から開いた経路)", () => {
-    test("相対リンクは絶対 basePath dir を起点に絶対パスとして解決する", () => {
+    test("相対リンクは絶対 basePath dir 内に絶対パスとして解決する", () => {
       expect(resolve("./image.png", "/Users/me/elsewhere/README.md")).toEqual({
         kind: "internal",
         path: "/Users/me/elsewhere/image.png",
@@ -303,22 +303,19 @@ describe("resolveMarkdownLink", () => {
       });
     });
 
-    test("`../` も絶対 basePath で正しく resolve され invalid にならない", () => {
-      expect(resolve("../sibling.md", "/Users/me/elsewhere/docs/README.md")).toEqual({
+    test("子ディレクトリへの相対リンクは internal", () => {
+      expect(resolve("./images/x.png", "/Users/me/elsewhere/README.md")).toEqual({
         kind: "internal",
-        path: "/Users/me/elsewhere/sibling.md",
+        path: "/Users/me/elsewhere/images/x.png",
         lineNumber: undefined,
         droppedAnchor: false,
       });
     });
 
-    test("`/` 始まりは absolute base のもとでは絶対パスとして扱う", () => {
-      expect(resolve("/Users/me/other/foo.md", "/Users/me/elsewhere/README.md")).toEqual({
-        kind: "internal",
-        path: "/Users/me/other/foo.md",
-        lineNumber: undefined,
-        droppedAnchor: false,
-      });
+    test("`../` で basePath dir を抜けるリンクは invalid (信頼境界縮小)", () => {
+      // basePath dir `/Users/me/elsewhere/docs` を抜ける `../sibling.md` は invalid。
+      // 同じドキュメントツリー扱いせず、絶対 basePath では「source file の dir 配下のみ」を信頼境界とする。
+      expect(resolve("../sibling.md", "/Users/me/elsewhere/docs/README.md").kind).toBe("invalid");
     });
 
     test("行番号 fragment も absolute base 経路で抽出される", () => {
@@ -328,6 +325,26 @@ describe("resolveMarkdownLink", () => {
         lineNumber: 42,
         droppedAnchor: false,
       });
+    });
+
+    test("`/` 始まりの絶対パスは basePath dir 配下でない限り invalid (path traversal block)", () => {
+      // basePath dir = `/Users/me/elsewhere`。/Users/me/other/foo.md は配下でないため invalid
+      expect(resolve("/Users/me/other/foo.md", "/Users/me/elsewhere/README.md").kind).toBe(
+        "invalid",
+      );
+    });
+
+    test("`/etc/passwd` 系の絶対パスは basePath dir を抜けるため invalid", () => {
+      expect(resolve("/etc/passwd", "/Users/me/elsewhere/README.md").kind).toBe("invalid");
+    });
+
+    test("`../../etc/passwd` 系の相対 traversal も basePath dir を抜けると invalid", () => {
+      expect(resolve("../../etc/passwd", "/Users/me/elsewhere/README.md").kind).toBe("invalid");
+    });
+
+    test("basePath dir そのもの (末尾 `/`) を指すリンクは invalid (ディレクトリ参照)", () => {
+      // ./ → normalize で /Users/me/elsewhere に解決 → basePath dir 自身は配下とみなさず invalid
+      expect(resolve("./", "/Users/me/elsewhere/README.md").kind).toBe("invalid");
     });
   });
 });

--- a/apps/renderer/src/features/preview/resolveMarkdownLink.test.ts
+++ b/apps/renderer/src/features/preview/resolveMarkdownLink.test.ts
@@ -29,7 +29,7 @@ function fakeNormalizePath(path: string): string {
   const startIdx = isTilde ? 1 : 0;
 
   for (let i = startIdx; i < segments.length; i++) {
-    const seg = segments[i]!;
+    const seg = segments[i];
     if (seg === ".") continue;
     if (seg === "..") {
       if (result.length > 0 && result[result.length - 1] !== "..") {

--- a/apps/renderer/src/features/preview/resolveMarkdownLink.test.ts
+++ b/apps/renderer/src/features/preview/resolveMarkdownLink.test.ts
@@ -292,4 +292,42 @@ describe("resolveMarkdownLink", () => {
       expect(resolve("../../../etc/passwd", "docs/preview.md").kind).toBe("invalid");
     });
   });
+
+  describe("absolute basePath (worktree 外 markdown を terminal link から開いた経路)", () => {
+    test("相対リンクは絶対 basePath dir を起点に絶対パスとして解決する", () => {
+      expect(resolve("./image.png", "/Users/me/elsewhere/README.md")).toEqual({
+        kind: "internal",
+        path: "/Users/me/elsewhere/image.png",
+        lineNumber: undefined,
+        droppedAnchor: false,
+      });
+    });
+
+    test("`../` も絶対 basePath で正しく resolve され invalid にならない", () => {
+      expect(resolve("../sibling.md", "/Users/me/elsewhere/docs/README.md")).toEqual({
+        kind: "internal",
+        path: "/Users/me/elsewhere/sibling.md",
+        lineNumber: undefined,
+        droppedAnchor: false,
+      });
+    });
+
+    test("`/` 始まりは absolute base のもとでは絶対パスとして扱う", () => {
+      expect(resolve("/Users/me/other/foo.md", "/Users/me/elsewhere/README.md")).toEqual({
+        kind: "internal",
+        path: "/Users/me/other/foo.md",
+        lineNumber: undefined,
+        droppedAnchor: false,
+      });
+    });
+
+    test("行番号 fragment も absolute base 経路で抽出される", () => {
+      expect(resolve("./foo.ts#L42", "/Users/me/elsewhere/README.md")).toEqual({
+        kind: "internal",
+        path: "/Users/me/elsewhere/foo.ts",
+        lineNumber: 42,
+        droppedAnchor: false,
+      });
+    });
+  });
 });

--- a/apps/renderer/src/features/preview/resolveMarkdownLink.ts
+++ b/apps/renderer/src/features/preview/resolveMarkdownLink.ts
@@ -112,12 +112,23 @@ function resolveMarkdownLink({
   // markdown 内 link の信頼境界をできるだけ狭く取る方針を選択した。
   const isAbsoluteBase = basePath !== undefined && basePath.startsWith("/");
 
+  // 絶対 basePath 用に親 dir を導出する。relDirOf は worktree 相対パス契約のため絶対パスに
+  // 流用すると `/foo.md` で空文字を返し信頼境界が破綻する。root 直下のファイル
+  // (lastIndexOf("/") === 0) では baseDir を "/" で表現する。
+  const absoluteBaseDir = (path: string): string => {
+    const lastSlash = path.lastIndexOf("/");
+    return lastSlash <= 0 ? "/" : path.substring(0, lastSlash);
+  };
+
   // `/` 始まり:
   // - 相対 basePath: worktree root 相対として `/` を剥がす
-  // - 絶対 basePath: そのまま絶対パス（直後に basePath dir 内チェックで絞り込む）
+  // - 絶対 basePath: そのまま絶対パス（後で basePath dir 内チェックで絞り込む）
   let combined: string;
   if (decodedPath.startsWith("/")) {
     combined = isAbsoluteBase ? decodedPath : decodedPath.substring(1);
+  } else if (isAbsoluteBase) {
+    const baseDir = absoluteBaseDir(basePath!);
+    combined = baseDir === "/" ? `/${decodedPath}` : `${baseDir}/${decodedPath}`;
   } else {
     const dir = basePath === undefined ? "" : relDirOf(basePath);
     combined = dir === "" ? decodedPath : `${dir}/${decodedPath}`;
@@ -126,9 +137,15 @@ function resolveMarkdownLink({
   const normalized = normalizePath(combined);
 
   if (isAbsoluteBase) {
-    const baseDir = relDirOf(basePath!);
-    const baseDirPrefix = baseDir.endsWith("/") ? baseDir : `${baseDir}/`;
-    if (!normalized.startsWith(baseDirPrefix) || normalized === baseDir) {
+    const baseDir = absoluteBaseDir(basePath!);
+    const isAllowed =
+      baseDir === "/"
+        ? // root 直下: `/<name>` (slash が 1 つだけ) のみ許可。`/etc/passwd` は invalid。
+          normalized.startsWith("/") && normalized.length > 1 && normalized.indexOf("/", 1) === -1
+        : // 通常: baseDir 配下のみ許可（baseDir 自身への参照は不可）
+          normalized.startsWith(`${baseDir}/`);
+
+    if (!isAllowed) {
       return {
         kind: "invalid",
         reason: `Link target is outside the source file directory: ${href}`,

--- a/apps/renderer/src/features/preview/resolveMarkdownLink.ts
+++ b/apps/renderer/src/features/preview/resolveMarkdownLink.ts
@@ -108,51 +108,65 @@ function resolveMarkdownLink({
   // 「normalized が basePath の dir prefix で始まる」ことを唯一の通過条件にする。これにより
   // `/etc/passwd` のような system path への直接 jump と、`../../etc/passwd` のような相対 traversal、
   // および `/Users/<user>/.ssh/id_rsa` のような sibling 領域参照を一律 invalid に倒す。
-  // 「同じドキュメントツリー」までを信頼するか「同じ dir」までで止めるかは設計判断で、
-  // markdown 内 link の信頼境界をできるだけ狭く取る方針を選択した。
-  const isAbsoluteBase = basePath !== undefined && basePath.startsWith("/");
-
-  // 絶対 basePath 用に親 dir を導出する。relDirOf は worktree 相対パス契約のため絶対パスに
-  // 流用すると `/foo.md` で空文字を返し信頼境界が破綻する。root 直下のファイル
-  // (lastIndexOf("/") === 0) では baseDir を "/" で表現する。
-  const absoluteBaseDir = (path: string): string => {
-    const lastSlash = path.lastIndexOf("/");
-    return lastSlash <= 0 ? "/" : path.substring(0, lastSlash);
-  };
-
-  // `/` 始まり:
-  // - 相対 basePath: worktree root 相対として `/` を剥がす
-  // - 絶対 basePath: そのまま絶対パス（後で basePath dir 内チェックで絞り込む）
-  let combined: string;
-  if (decodedPath.startsWith("/")) {
-    combined = isAbsoluteBase ? decodedPath : decodedPath.substring(1);
-  } else if (isAbsoluteBase) {
-    const baseDir = absoluteBaseDir(basePath!);
-    combined = baseDir === "/" ? `/${decodedPath}` : `${baseDir}/${decodedPath}`;
-  } else {
-    const dir = basePath === undefined ? "" : relDirOf(basePath);
-    combined = dir === "" ? decodedPath : `${dir}/${decodedPath}`;
+  // 絶対 basePath の処理は別関数に分離し、control flow narrowing で basePath: string が効くため
+  // non-null assertion (`!`) を使わない構造にする。
+  if (basePath !== undefined && basePath.startsWith("/")) {
+    return resolveWithAbsoluteBase(basePath, decodedPath, rawFragment, href, normalizePath);
   }
+
+  // 相対 basePath 経路（active worktree 内のファイルを起点とする従来挙動）
+  // `/` 始まり: worktree root 相対として `/` を剥がす / それ以外: basePath dir 相対
+  const dir = basePath === undefined ? "" : relDirOf(basePath);
+  const combined = decodedPath.startsWith("/")
+    ? decodedPath.substring(1)
+    : dir === ""
+      ? decodedPath
+      : `${dir}/${decodedPath}`;
 
   const normalized = normalizePath(combined);
 
-  if (isAbsoluteBase) {
-    const baseDir = absoluteBaseDir(basePath!);
-    const isAllowed =
-      baseDir === "/"
-        ? // root 直下: `/<name>` (slash が 1 つだけ) のみ許可。`/etc/passwd` は invalid。
-          normalized.startsWith("/") && normalized.length > 1 && normalized.indexOf("/", 1) === -1
-        : // 通常: baseDir 配下のみ許可（baseDir 自身への参照は不可）
-          normalized.startsWith(`${baseDir}/`);
-
-    if (!isAllowed) {
-      return {
-        kind: "invalid",
-        reason: `Link target is outside the source file directory: ${href}`,
-      };
-    }
-  } else if (escapesWorktree(normalized)) {
+  if (escapesWorktree(normalized)) {
     return { kind: "invalid", reason: `Link target is outside the worktree: ${href}` };
+  }
+
+  const { lineNumber, droppedAnchor } = parseAnchor(rawFragment);
+  return { kind: "internal", path: normalized, lineNumber, droppedAnchor };
+}
+
+/**
+ * 絶対 basePath 起点の link 解決。relDirOf は worktree 相対契約のため絶対パスでは使わず、
+ * 内部で親 dir を抽出する。root 直下のファイル (lastIndexOf("/") === 0) では baseDir を "/" で表現する。
+ */
+function resolveWithAbsoluteBase(
+  basePath: string,
+  decodedPath: string,
+  rawFragment: string,
+  href: string,
+  normalizePath: (path: string) => string,
+): ResolvedLink {
+  const lastSlash = basePath.lastIndexOf("/");
+  const baseDir = lastSlash <= 0 ? "/" : basePath.substring(0, lastSlash);
+
+  const combined = decodedPath.startsWith("/")
+    ? decodedPath
+    : baseDir === "/"
+      ? `/${decodedPath}`
+      : `${baseDir}/${decodedPath}`;
+
+  const normalized = normalizePath(combined);
+
+  const isAllowed =
+    baseDir === "/"
+      ? // root 直下: `/<name>` (slash が 1 つだけ) のみ許可。`/etc/passwd` は invalid。
+        normalized.startsWith("/") && normalized.length > 1 && normalized.indexOf("/", 1) === -1
+      : // 通常: baseDir 配下のみ許可（baseDir 自身への参照は不可）
+        normalized.startsWith(`${baseDir}/`);
+
+  if (!isAllowed) {
+    return {
+      kind: "invalid",
+      reason: `Link target is outside the source file directory: ${href}`,
+    };
   }
 
   const { lineNumber, droppedAnchor } = parseAnchor(rawFragment);

--- a/apps/renderer/src/features/preview/resolveMarkdownLink.ts
+++ b/apps/renderer/src/features/preview/resolveMarkdownLink.ts
@@ -103,10 +103,17 @@ function resolveMarkdownLink({
   }
   const decodedPath = decoded.value;
 
-  // `/` 始まり: worktree ルート相対として扱う / それ以外: selectedPath dir 相対
+  // basePath が worktree 外の絶対パスのとき、相対リンクは絶対 basePath dir を起点に解決し、
+  // 結果も絶対パスのまま返す（escapesWorktree 判定は無意味なのでスキップ）。
+  // terminal link 経由で worktree 外 markdown を開いた際、内部の相対リンクが全部
+  // invalid に倒れて操作不能になる症状を避ける。
+  const isAbsoluteBase = basePath !== undefined && basePath.startsWith("/");
+
+  // `/` 始まり: worktree 内 basePath なら worktree root 相対、絶対 basePath なら絶対パスそのまま
+  // それ以外: basePath dir 相対
   let combined: string;
   if (decodedPath.startsWith("/")) {
-    combined = decodedPath.substring(1);
+    combined = isAbsoluteBase ? decodedPath : decodedPath.substring(1);
   } else {
     const dir = basePath === undefined ? "" : relDirOf(basePath);
     combined = dir === "" ? decodedPath : `${dir}/${decodedPath}`;
@@ -114,7 +121,7 @@ function resolveMarkdownLink({
 
   const normalized = normalizePath(combined);
 
-  if (escapesWorktree(normalized)) {
+  if (!isAbsoluteBase && escapesWorktree(normalized)) {
     return { kind: "invalid", reason: `Link target is outside the worktree: ${href}` };
   }
 

--- a/apps/renderer/src/features/preview/resolveMarkdownLink.ts
+++ b/apps/renderer/src/features/preview/resolveMarkdownLink.ts
@@ -46,7 +46,7 @@ function parseAnchor(fragment: string): { lineNumber: number | undefined; droppe
   const text = decoded.ok ? decoded.value : fragment;
   const match = LINE_FRAGMENT_RE.exec(text);
   if (match === null) return { lineNumber: undefined, droppedAnchor: true };
-  const parsed = Number.parseInt(match[1]!, 10);
+  const parsed = Number.parseInt(match[1], 10);
   if (Number.isNaN(parsed) || parsed <= 0) {
     return { lineNumber: undefined, droppedAnchor: true };
   }

--- a/apps/renderer/src/features/preview/resolveMarkdownLink.ts
+++ b/apps/renderer/src/features/preview/resolveMarkdownLink.ts
@@ -103,14 +103,18 @@ function resolveMarkdownLink({
   }
   const decodedPath = decoded.value;
 
-  // basePath が worktree 外の絶対パスのとき、相対リンクは絶対 basePath dir を起点に解決し、
-  // 結果も絶対パスのまま返す（escapesWorktree 判定は無意味なのでスキップ）。
-  // terminal link 経由で worktree 外 markdown を開いた際、内部の相対リンクが全部
-  // invalid に倒れて操作不能になる症状を避ける。
+  // basePath が worktree 外の絶対パスのとき、信頼境界を「source file が居る dir 配下」に縮小する。
+  // escapesWorktree（worktree root 基準）は意味を成さない代わりに、
+  // 「normalized が basePath の dir prefix で始まる」ことを唯一の通過条件にする。これにより
+  // `/etc/passwd` のような system path への直接 jump と、`../../etc/passwd` のような相対 traversal、
+  // および `/Users/<user>/.ssh/id_rsa` のような sibling 領域参照を一律 invalid に倒す。
+  // 「同じドキュメントツリー」までを信頼するか「同じ dir」までで止めるかは設計判断で、
+  // markdown 内 link の信頼境界をできるだけ狭く取る方針を選択した。
   const isAbsoluteBase = basePath !== undefined && basePath.startsWith("/");
 
-  // `/` 始まり: worktree 内 basePath なら worktree root 相対、絶対 basePath なら絶対パスそのまま
-  // それ以外: basePath dir 相対
+  // `/` 始まり:
+  // - 相対 basePath: worktree root 相対として `/` を剥がす
+  // - 絶対 basePath: そのまま絶対パス（直後に basePath dir 内チェックで絞り込む）
   let combined: string;
   if (decodedPath.startsWith("/")) {
     combined = isAbsoluteBase ? decodedPath : decodedPath.substring(1);
@@ -121,7 +125,16 @@ function resolveMarkdownLink({
 
   const normalized = normalizePath(combined);
 
-  if (!isAbsoluteBase && escapesWorktree(normalized)) {
+  if (isAbsoluteBase) {
+    const baseDir = relDirOf(basePath!);
+    const baseDirPrefix = baseDir.endsWith("/") ? baseDir : `${baseDir}/`;
+    if (!normalized.startsWith(baseDirPrefix) || normalized === baseDir) {
+      return {
+        kind: "invalid",
+        reason: `Link target is outside the source file directory: ${href}`,
+      };
+    }
+  } else if (escapesWorktree(normalized)) {
     return { kind: "invalid", reason: `Link target is outside the worktree: ${href}` };
   }
 

--- a/apps/renderer/src/features/terminal/findAbsolutePathMatches.ts
+++ b/apps/renderer/src/features/terminal/findAbsolutePathMatches.ts
@@ -15,7 +15,7 @@ const WORD_CHAR = /[A-Za-z0-9_]/;
 /** prefix が単語境界の直後で始まっているか（URL の path 部分のような連続 token 内では拾わない） */
 function hasBoundaryBefore(text: string, idx: number): boolean {
   if (idx === 0) return true;
-  return !WORD_CHAR.test(text[idx - 1]!);
+  return !WORD_CHAR.test(text[idx - 1]);
 }
 
 /** boundary が立っている prefix の出現位置を search start から探す */
@@ -42,7 +42,7 @@ export interface AbsolutePathMatch {
 /** パスの末尾位置を探す（区切り文字 or 行末まで） */
 function findPathEnd(text: string, from: number): number {
   let end = from;
-  while (end < text.length && !PATH_TERMINATORS.test(text[end]!)) {
+  while (end < text.length && !PATH_TERMINATORS.test(text[end])) {
     end++;
   }
   return end;
@@ -55,7 +55,7 @@ function findPathEnd(text: string, from: number): number {
  */
 export function resolveHomeDir(dirPrefix: string): string {
   const match = dirPrefix.match(/^(\/Users\/[^/]+)\//);
-  return match ? match[1]! : "";
+  return match ? match[1] : "";
 }
 
 /**
@@ -104,7 +104,7 @@ export function findAbsolutePathMatches(
 
     // idx 昇順、同 idx なら prefixLen 降順（dir > home > tilde）
     candidates.sort((a, b) => a.idx - b.idx || b.prefixLen - a.prefixLen);
-    const { idx, prefixLen, expandTilde } = candidates[0]!;
+    const { idx, prefixLen, expandTilde } = candidates[0];
 
     const pathEnd = findPathEnd(text, idx + prefixLen);
     const fullPath = expandTilde

--- a/apps/renderer/src/features/terminal/findAbsolutePathMatches.ts
+++ b/apps/renderer/src/features/terminal/findAbsolutePathMatches.ts
@@ -84,10 +84,19 @@ export function findAbsolutePathMatches(
       ? `${homeDir}/${text.slice(idx + prefixLen, pathEnd)}`
       : text.slice(idx, pathEnd);
 
-    // パス直後に `:行番号` が続くか
+    // パス直後に `:行番号` が続くか。判定規律は resolveMarkdownLink.parseAnchor に揃える:
+    // 1-based の正整数 (Number.isSafeInteger 内) のみ採用し、`:0` や `:99999999999999999999` 等は
+    // suffix は consume するが lineNumber は undefined にする (下流に 0 や精度損失値を流さない)。
     const lineMatch = LINE_NUMBER_SUFFIX.exec(text.slice(pathEnd));
-    const lineNumber = lineMatch ? Number(lineMatch[1]) : undefined;
-    const totalEnd = lineMatch ? pathEnd + lineMatch[0].length : pathEnd;
+    let lineNumber: number | undefined;
+    let totalEnd: number;
+    if (lineMatch) {
+      const parsed = Number.parseInt(lineMatch[1]!, 10);
+      lineNumber = Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+      totalEnd = pathEnd + lineMatch[0].length;
+    } else {
+      totalEnd = pathEnd;
+    }
 
     const selectPath = fullPath.startsWith(dirPrefix) ? fullPath.slice(dirPrefix.length) : fullPath;
 

--- a/apps/renderer/src/features/terminal/findAbsolutePathMatches.ts
+++ b/apps/renderer/src/features/terminal/findAbsolutePathMatches.ts
@@ -1,0 +1,102 @@
+/** パスの末尾区切り文字 */
+const PATH_TERMINATORS = /[\s()}\]>'",:;]/;
+
+/** パスの直後に `:行番号` が続くかを検出する正規表現 */
+const LINE_NUMBER_SUFFIX = /^:(\d+)/;
+
+export interface AbsolutePathMatch {
+  /** マッチ全体の開始位置（行番号サフィックスも含む） */
+  idx: number;
+  /** マッチ全体の終了位置（行番号サフィックスも含む） */
+  totalEnd: number;
+  /** worktree 内なら相対パス、worktree 外なら絶対パス */
+  selectPath: string;
+  /** パス直後の `:N` から取り出した 1-based 行番号 */
+  lineNumber?: number;
+}
+
+/** パスの末尾位置を探す（区切り文字 or 行末まで） */
+function findPathEnd(text: string, from: number): number {
+  let end = from;
+  while (end < text.length && !PATH_TERMINATORS.test(text[end]!)) {
+    end++;
+  }
+  return end;
+}
+
+/**
+ * `~/` プレフィックスを展開するために、dirPrefix からホームディレクトリを推定する。
+ * dirPrefix が `/Users/miyaoka/...` のような形式なら `/Users/miyaoka` を返す。
+ * gozd は macOS 専用のため `/Users/<user>` のみ対象とする。
+ */
+export function resolveHomeDir(dirPrefix: string): string {
+  const match = dirPrefix.match(/^(\/Users\/[^/]+)\//);
+  return match ? match[1]! : "";
+}
+
+/**
+ * テキストから絶対パスマッチを収集する純粋関数。
+ * dirPrefix / homePrefix / `~/` の 3 つを indexOf で並列に探し、最も手前のマッチを採用する。
+ *
+ * dirPrefix は homePrefix を内包しうる（dirPrefix が `/Users/<user>/` 配下なら、文字列として
+ * 部分一致する）。同 idx 衝突時は prefixLen の長い方を採用することで「dir-prefix 相対化を
+ * 優先する」規律を明示する（Array.prototype.sort の stability に依存しない）。
+ *
+ * dirPrefix が `/tmp/...` のように homeDir 外のケースもあるため、dirPrefix も独立に検索する。
+ *
+ * prefix 部分は走査対象から除外する（`idx + prefixLen` から findPathEnd を開始）。worktree
+ * dir 名に空白や括弧などが入っていてもパスが prefix 途中で切れない。
+ */
+export function findAbsolutePathMatches(
+  text: string,
+  dirPrefix: string,
+  homeDir: string,
+): AbsolutePathMatch[] {
+  const homePrefix = homeDir ? `${homeDir}/` : "";
+  const matches: AbsolutePathMatch[] = [];
+  let searchStart = 0;
+
+  while (searchStart < text.length) {
+    const candidates: Array<{ idx: number; prefixLen: number; expandTilde: boolean }> = [];
+    const dirIdx = text.indexOf(dirPrefix, searchStart);
+    if (dirIdx !== -1) {
+      candidates.push({ idx: dirIdx, prefixLen: dirPrefix.length, expandTilde: false });
+    }
+    if (homePrefix) {
+      const homeIdx = text.indexOf(homePrefix, searchStart);
+      if (homeIdx !== -1) {
+        candidates.push({ idx: homeIdx, prefixLen: homePrefix.length, expandTilde: false });
+      }
+      const tildeIdx = text.indexOf("~/", searchStart);
+      if (tildeIdx !== -1) {
+        candidates.push({ idx: tildeIdx, prefixLen: 2, expandTilde: true });
+      }
+    }
+
+    if (candidates.length === 0) break;
+
+    // idx 昇順、同 idx なら prefixLen 降順（dir > home > tilde）
+    candidates.sort((a, b) => a.idx - b.idx || b.prefixLen - a.prefixLen);
+    const { idx, prefixLen, expandTilde } = candidates[0]!;
+
+    const pathEnd = findPathEnd(text, idx + prefixLen);
+    const fullPath = expandTilde
+      ? `${homeDir}/${text.slice(idx + prefixLen, pathEnd)}`
+      : text.slice(idx, pathEnd);
+
+    // パス直後に `:行番号` が続くか
+    const lineMatch = LINE_NUMBER_SUFFIX.exec(text.slice(pathEnd));
+    const lineNumber = lineMatch ? Number(lineMatch[1]) : undefined;
+    const totalEnd = lineMatch ? pathEnd + lineMatch[0].length : pathEnd;
+
+    const selectPath = fullPath.startsWith(dirPrefix) ? fullPath.slice(dirPrefix.length) : fullPath;
+
+    if (selectPath.length > 0) {
+      matches.push({ idx, totalEnd, selectPath, lineNumber });
+    }
+
+    searchStart = totalEnd;
+  }
+
+  return matches;
+}

--- a/apps/renderer/src/features/terminal/findAbsolutePathMatches.ts
+++ b/apps/renderer/src/features/terminal/findAbsolutePathMatches.ts
@@ -1,8 +1,26 @@
+import { parseLineNumberSuffix } from "./parseLineNumberSuffix";
+
 /** パスの末尾区切り文字 */
 const PATH_TERMINATORS = /[\s()}\]>'",:;]/;
 
 /** パスの直後に `:行番号` が続くかを検出する正規表現 */
 const LINE_NUMBER_SUFFIX = /^:(\d+)/;
+
+/** prefix が単語境界の直後で始まっているか（URL の path 部分のような連続 token 内では拾わない） */
+function hasBoundaryBefore(text: string, idx: number): boolean {
+  if (idx === 0) return true;
+  return PATH_TERMINATORS.test(text[idx - 1]!);
+}
+
+/** boundary が立っている prefix の出現位置を search start から探す */
+function indexOfWithBoundary(text: string, prefix: string, start: number): number {
+  let idx = text.indexOf(prefix, start);
+  while (idx !== -1) {
+    if (hasBoundaryBefore(text, idx)) return idx;
+    idx = text.indexOf(prefix, idx + 1);
+  }
+  return -1;
+}
 
 export interface AbsolutePathMatch {
   /** マッチ全体の開始位置（行番号サフィックスも含む） */
@@ -57,17 +75,20 @@ export function findAbsolutePathMatches(
   let searchStart = 0;
 
   while (searchStart < text.length) {
+    // 単語境界の直後（行頭 / 区切り文字直後）でのみ拾う。これにより
+    // `https://example.com/Users/<user>/foo` の `/Users/...` 部分のような URL 内 path を
+    // 絶対パスとして誤検出しない。
     const candidates: Array<{ idx: number; prefixLen: number; expandTilde: boolean }> = [];
-    const dirIdx = text.indexOf(dirPrefix, searchStart);
+    const dirIdx = indexOfWithBoundary(text, dirPrefix, searchStart);
     if (dirIdx !== -1) {
       candidates.push({ idx: dirIdx, prefixLen: dirPrefix.length, expandTilde: false });
     }
     if (homePrefix) {
-      const homeIdx = text.indexOf(homePrefix, searchStart);
+      const homeIdx = indexOfWithBoundary(text, homePrefix, searchStart);
       if (homeIdx !== -1) {
         candidates.push({ idx: homeIdx, prefixLen: homePrefix.length, expandTilde: false });
       }
-      const tildeIdx = text.indexOf("~/", searchStart);
+      const tildeIdx = indexOfWithBoundary(text, "~/", searchStart);
       if (tildeIdx !== -1) {
         candidates.push({ idx: tildeIdx, prefixLen: 2, expandTilde: true });
       }
@@ -84,19 +105,11 @@ export function findAbsolutePathMatches(
       ? `${homeDir}/${text.slice(idx + prefixLen, pathEnd)}`
       : text.slice(idx, pathEnd);
 
-    // パス直後に `:行番号` が続くか。判定規律は resolveMarkdownLink.parseAnchor に揃える:
-    // 1-based の正整数 (Number.isSafeInteger 内) のみ採用し、`:0` や `:99999999999999999999` 等は
-    // suffix は consume するが lineNumber は undefined にする (下流に 0 や精度損失値を流さない)。
+    // パス直後の `:行番号` を SSOT 関数 (parseLineNumberSuffix) で validate する。
+    // `:0` や Number.isSafeInteger 外は suffix は consume するが lineNumber は undefined。
     const lineMatch = LINE_NUMBER_SUFFIX.exec(text.slice(pathEnd));
-    let lineNumber: number | undefined;
-    let totalEnd: number;
-    if (lineMatch) {
-      const parsed = Number.parseInt(lineMatch[1]!, 10);
-      lineNumber = Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
-      totalEnd = pathEnd + lineMatch[0].length;
-    } else {
-      totalEnd = pathEnd;
-    }
+    const lineNumber = lineMatch ? parseLineNumberSuffix(lineMatch[1]) : undefined;
+    const totalEnd = lineMatch ? pathEnd + lineMatch[0].length : pathEnd;
 
     const selectPath = fullPath.startsWith(dirPrefix) ? fullPath.slice(dirPrefix.length) : fullPath;
 

--- a/apps/renderer/src/features/terminal/findAbsolutePathMatches.ts
+++ b/apps/renderer/src/features/terminal/findAbsolutePathMatches.ts
@@ -6,10 +6,16 @@ const PATH_TERMINATORS = /[\s()}\]>'",:;]/;
 /** パスの直後に `:行番号` が続くかを検出する正規表現 */
 const LINE_NUMBER_SUFFIX = /^:(\d+)/;
 
+/** path 内に出現しない区切り側の文字。word char 否定で書くことで、
+ *  `[`、`{`、`<`、`(`、`'`、`"` のような括弧/引用符類が boundary として認められる。
+ *  PATH_TERMINATORS（パス末尾の切れ目）とは責務が違う: あちらは「path 内に登場しない」が中心、
+ *  こちらは「直前にあれば token 境界が立つ」が中心。 */
+const WORD_CHAR = /[A-Za-z0-9_]/;
+
 /** prefix が単語境界の直後で始まっているか（URL の path 部分のような連続 token 内では拾わない） */
 function hasBoundaryBefore(text: string, idx: number): boolean {
   if (idx === 0) return true;
-  return PATH_TERMINATORS.test(text[idx - 1]!);
+  return !WORD_CHAR.test(text[idx - 1]!);
 }
 
 /** boundary が立っている prefix の出現位置を search start から探す */

--- a/apps/renderer/src/features/terminal/findRelativePaths.ts
+++ b/apps/renderer/src/features/terminal/findRelativePaths.ts
@@ -1,8 +1,10 @@
+import { parseLineNumberSuffix } from "./parseLineNumberSuffix";
+
 interface RelativePathMatch {
   path: string;
   startIdx: number;
   endIdx: number;
-  /** `:行番号` が付与されていた場合の行番号（1-based） */
+  /** `:行番号` が付与されていた場合の 1-based 行番号（safe integer のみ） */
   lineNumber?: number;
 }
 
@@ -10,7 +12,7 @@ interface RelativePathMatch {
  * テキストから相対パスの候補を検出する。
  * ワード文字で始まり、`/` 区切りで2セグメント以上あり、最後のセグメントにファイル拡張子を持つパターン。
  * 複数ドットの拡張子（`.test.ts`, `.d.ts` 等）にも対応する。
- * パスの直後に `:行番号` が続く場合は行番号も抽出する。
+ * パスの直後に `:行番号` が続く場合は行番号も抽出する（規律は parseLineNumberSuffix の SSOT）。
  */
 export function findRelativePaths(text: string): RelativePathMatch[] {
   const regex = /([\w@.-]+(?:\/[\w@.-]+)*\/[\w@-]+(?:\.[\w]+)+)(?::(\d+))?/g;
@@ -19,12 +21,12 @@ export function findRelativePaths(text: string): RelativePathMatch[] {
 
   while ((match = regex.exec(text)) !== null) {
     const startIdx = match.index;
-    const lineNumberStr = match[2];
+    const lineNumber = parseLineNumberSuffix(match[2]);
     results.push({
       path: match[1]!,
       startIdx,
       endIdx: startIdx + match[0]!.length,
-      ...(lineNumberStr !== undefined ? { lineNumber: Number(lineNumberStr) } : {}),
+      ...(lineNumber !== undefined ? { lineNumber } : {}),
     });
   }
 

--- a/apps/renderer/src/features/terminal/findRelativePaths.ts
+++ b/apps/renderer/src/features/terminal/findRelativePaths.ts
@@ -23,9 +23,9 @@ export function findRelativePaths(text: string): RelativePathMatch[] {
     const startIdx = match.index;
     const lineNumber = parseLineNumberSuffix(match[2]);
     results.push({
-      path: match[1]!,
+      path: match[1],
       startIdx,
-      endIdx: startIdx + match[0]!.length,
+      endIdx: startIdx + match[0].length,
       ...(lineNumber !== undefined ? { lineNumber } : {}),
     });
   }

--- a/apps/renderer/src/features/terminal/parseLineNumberSuffix.ts
+++ b/apps/renderer/src/features/terminal/parseLineNumberSuffix.ts
@@ -1,0 +1,8 @@
+/** `:行番号` を読み取り、1-based の safe integer のみ採用する SSOT 関数。
+ *  `:0` / `Number.isSafeInteger` 外は undefined を返す（呼び出し側で `:N` 自体は consume する想定）。
+ *  resolveMarkdownLink.parseAnchor の line fragment 判定と同じ規律。 */
+export function parseLineNumberSuffix(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}

--- a/apps/renderer/src/features/terminal/useFilePathLinkProvider.test.ts
+++ b/apps/renderer/src/features/terminal/useFilePathLinkProvider.test.ts
@@ -56,6 +56,16 @@ describe("findRelativePaths", () => {
     expect(result?.lineNumber).toBeUndefined();
   });
 
+  test("行番号 `:0` は SSOT (parseLineNumberSuffix) で undefined に倒す", () => {
+    const [result] = findRelativePaths("src/main.ts:0");
+    expect(result?.lineNumber).toBeUndefined();
+  });
+
+  test("Number.MAX_SAFE_INTEGER を超える行番号も undefined", () => {
+    const [result] = findRelativePaths("src/main.ts:99999999999999999999");
+    expect(result?.lineNumber).toBeUndefined();
+  });
+
   test("テキスト中の行番号付きパスを検出する", () => {
     const results = findRelativePaths("error at src/app.vue:25 and src/main.ts:100");
     expect(results).toEqual([
@@ -167,6 +177,32 @@ describe("findAbsolutePathMatches", () => {
       const matches = findAbsolutePathMatches("~/:42", dirPrefix, homeDir);
       expect(matches[0]?.selectPath).toBe("/Users/me/");
       expect(matches[0]?.lineNumber).toBe(42);
+    });
+  });
+
+  describe("token boundary", () => {
+    test("URL の path 部分にある `/Users/<user>/...` は誤検出しない", () => {
+      // homePrefix `/Users/me/` の直前が `m` (word char) なので boundary が立たず skip される
+      const matches = findAbsolutePathMatches(
+        "see https://example.com/Users/me/foo.ts for details",
+        dirPrefix,
+        homeDir,
+      );
+      expect(matches).toEqual([]);
+    });
+
+    test("行頭の絶対パスは boundary 成立で検出される", () => {
+      const matches = findAbsolutePathMatches("/Users/me/elsewhere/x.ts", dirPrefix, homeDir);
+      expect(matches[0]?.selectPath).toBe("/Users/me/elsewhere/x.ts");
+    });
+
+    test("空白直後の絶対パスも boundary 成立で検出される", () => {
+      const matches = findAbsolutePathMatches(
+        "open /Users/me/elsewhere/x.ts now",
+        dirPrefix,
+        homeDir,
+      );
+      expect(matches[0]?.selectPath).toBe("/Users/me/elsewhere/x.ts");
     });
   });
 });

--- a/apps/renderer/src/features/terminal/useFilePathLinkProvider.test.ts
+++ b/apps/renderer/src/features/terminal/useFilePathLinkProvider.test.ts
@@ -136,18 +136,29 @@ describe("findAbsolutePathMatches", () => {
       expect(matches).toEqual([]);
     });
 
-    test("行番号 `:0` も lineNumber=0 として返す（呼び出し側で 1-based 検証する想定）", () => {
+    test("行番号 `:0` は consume するが lineNumber は undefined", () => {
       const matches = findAbsolutePathMatches("/Users/me/proj/a.ts:0", dirPrefix, homeDir);
-      expect(matches[0]?.lineNumber).toBe(0);
+      expect(matches[0]?.lineNumber).toBeUndefined();
+      // `:0` も totalEnd に含めて consume する（後続の indexOf 再走査で重複検出させない）
+      expect(matches[0]?.totalEnd).toBe("/Users/me/proj/a.ts:0".length);
     });
 
-    test("巨大な行番号もそのまま Number で返す", () => {
+    test("safe integer 内の大きな行番号はそのまま返す", () => {
       const matches = findAbsolutePathMatches(
         "/Users/me/proj/a.ts:99999999999",
         dirPrefix,
         homeDir,
       );
       expect(matches[0]?.lineNumber).toBe(99999999999);
+    });
+
+    test("Number.MAX_SAFE_INTEGER を超える行番号は精度損失するため undefined", () => {
+      const matches = findAbsolutePathMatches(
+        "/Users/me/proj/a.ts:99999999999999999999",
+        dirPrefix,
+        homeDir,
+      );
+      expect(matches[0]?.lineNumber).toBeUndefined();
     });
 
     test("`~/:42` のように tilde 直後が PATH_TERMINATORS の場合、homeDir 自体を絶対パスとして返す", () => {

--- a/apps/renderer/src/features/terminal/useFilePathLinkProvider.test.ts
+++ b/apps/renderer/src/features/terminal/useFilePathLinkProvider.test.ts
@@ -204,5 +204,21 @@ describe("findAbsolutePathMatches", () => {
       );
       expect(matches[0]?.selectPath).toBe("/Users/me/elsewhere/x.ts");
     });
+
+    test("`[/path]` のような bracket 始まりも boundary が立って検出される", () => {
+      // `[` は word char ではないため boundary 成立
+      const matches = findAbsolutePathMatches("[/Users/me/elsewhere/foo.ts]", dirPrefix, homeDir);
+      expect(matches[0]?.selectPath).toBe("/Users/me/elsewhere/foo.ts");
+    });
+
+    test("`{/path}` のような curly 始まりも検出される", () => {
+      const matches = findAbsolutePathMatches("{/Users/me/elsewhere/foo.ts}", dirPrefix, homeDir);
+      expect(matches[0]?.selectPath).toBe("/Users/me/elsewhere/foo.ts");
+    });
+
+    test("`</path>` のような angle bracket 始まりも検出される", () => {
+      const matches = findAbsolutePathMatches("</Users/me/elsewhere/foo.ts>", dirPrefix, homeDir);
+      expect(matches[0]?.selectPath).toBe("/Users/me/elsewhere/foo.ts");
+    });
   });
 });

--- a/apps/renderer/src/features/terminal/useFilePathLinkProvider.test.ts
+++ b/apps/renderer/src/features/terminal/useFilePathLinkProvider.test.ts
@@ -129,4 +129,33 @@ describe("findAbsolutePathMatches", () => {
     const matches = findAbsolutePathMatches("~/foo.ts and /Users/me/bar.ts", "/tmp/proj/", "");
     expect(matches).toEqual([]);
   });
+
+  describe("境界条件", () => {
+    test("dirPrefix 単独 (末尾 / のみ) は selectPath が空になり結果から落ちる", () => {
+      const matches = findAbsolutePathMatches("/Users/me/proj/", dirPrefix, homeDir);
+      expect(matches).toEqual([]);
+    });
+
+    test("行番号 `:0` も lineNumber=0 として返す（呼び出し側で 1-based 検証する想定）", () => {
+      const matches = findAbsolutePathMatches("/Users/me/proj/a.ts:0", dirPrefix, homeDir);
+      expect(matches[0]?.lineNumber).toBe(0);
+    });
+
+    test("巨大な行番号もそのまま Number で返す", () => {
+      const matches = findAbsolutePathMatches(
+        "/Users/me/proj/a.ts:99999999999",
+        dirPrefix,
+        homeDir,
+      );
+      expect(matches[0]?.lineNumber).toBe(99999999999);
+    });
+
+    test("`~/:42` のように tilde 直後が PATH_TERMINATORS の場合、homeDir 自体を絶対パスとして返す", () => {
+      // homeDir + "/" がそのまま絶対パスとして返り、`:行番号` も読まれる。
+      // 呼び出し側 (PreviewPane) でディレクトリ判定 (`isDirectory`) を受け取る挙動に依存する。
+      const matches = findAbsolutePathMatches("~/:42", dirPrefix, homeDir);
+      expect(matches[0]?.selectPath).toBe("/Users/me/");
+      expect(matches[0]?.lineNumber).toBe(42);
+    });
+  });
 });

--- a/apps/renderer/src/features/terminal/useFilePathLinkProvider.test.ts
+++ b/apps/renderer/src/features/terminal/useFilePathLinkProvider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { findAbsolutePathMatches } from "./findAbsolutePathMatches";
 import { findRelativePaths } from "./findRelativePaths";
 
 describe("findRelativePaths", () => {
@@ -61,5 +62,71 @@ describe("findRelativePaths", () => {
       { path: "src/app.vue", startIdx: 9, endIdx: 23, lineNumber: 25 },
       { path: "src/main.ts", startIdx: 28, endIdx: 43, lineNumber: 100 },
     ]);
+  });
+});
+
+describe("findAbsolutePathMatches", () => {
+  const dirPrefix = "/Users/me/proj/";
+  const homeDir = "/Users/me";
+
+  test("worktree 内パスは dirPrefix を剥がした相対パスで返す", () => {
+    const matches = findAbsolutePathMatches("/Users/me/proj/src/a.ts", dirPrefix, homeDir);
+    expect(matches).toEqual([
+      { idx: 0, totalEnd: 23, selectPath: "src/a.ts", lineNumber: undefined },
+    ]);
+  });
+
+  test("worktree 外の絶対パスは絶対パスのまま返す", () => {
+    const matches = findAbsolutePathMatches("/Users/me/elsewhere/b.ts", dirPrefix, homeDir);
+    expect(matches[0]?.selectPath).toBe("/Users/me/elsewhere/b.ts");
+  });
+
+  test("`~/` はホームディレクトリに展開した絶対パスで返す", () => {
+    const matches = findAbsolutePathMatches("~/elsewhere/c.ts", dirPrefix, homeDir);
+    expect(matches[0]?.selectPath).toBe("/Users/me/elsewhere/c.ts");
+  });
+
+  test("パス末尾の `:行番号` を読み取る", () => {
+    const matches = findAbsolutePathMatches("/Users/me/elsewhere/d.ts:42", dirPrefix, homeDir);
+    expect(matches[0]?.lineNumber).toBe(42);
+    expect(matches[0]?.totalEnd).toBe("/Users/me/elsewhere/d.ts:42".length);
+  });
+
+  test("dir 名に空白を含んでも prefix 内で切れない", () => {
+    // homeDir 外の dir なので homePrefix では拾わない
+    const dir = "/tmp/My Project/repo/";
+    const matches = findAbsolutePathMatches("build at /tmp/My Project/repo/src/x.ts done", dir, "");
+    expect(matches[0]?.selectPath).toBe("src/x.ts");
+  });
+
+  test("dir 名に括弧を含んでも prefix 内で切れない", () => {
+    const dir = "/tmp/foo(bar)/repo/";
+    const matches = findAbsolutePathMatches("/tmp/foo(bar)/repo/src/y.ts", dir, "");
+    expect(matches[0]?.selectPath).toBe("src/y.ts");
+  });
+
+  test("同 idx で dir/home が衝突した場合 dir 相対化を優先する", () => {
+    // dirPrefix === homePrefix のとき、両方が idx=0 で match する。
+    // prefixLen 降順 tie-break により dir が勝ち、selectPath は相対化される。
+    const matches = findAbsolutePathMatches("/Users/me/src/z.ts", "/Users/me/", "/Users/me");
+    expect(matches[0]?.selectPath).toBe("src/z.ts");
+  });
+
+  test("home prefix の境界をまたぐ別ユーザー名は誤検出しない", () => {
+    // homePrefix は `/Users/me/`。`/Users/me_other/...` は match しない
+    const matches = findAbsolutePathMatches("/Users/me_other/x.ts", dirPrefix, homeDir);
+    expect(matches).toEqual([]);
+  });
+
+  test("テキスト中の複数の絶対パスを順に検出する", () => {
+    const text = "see /Users/me/proj/src/a.ts and /Users/me/elsewhere/b.ts";
+    const matches = findAbsolutePathMatches(text, dirPrefix, homeDir);
+    expect(matches.map((m) => m.selectPath)).toEqual(["src/a.ts", "/Users/me/elsewhere/b.ts"]);
+  });
+
+  test("homeDir が空なら `~/` も homePrefix も検出しない", () => {
+    // resolveHomeDir が `/Users/<user>` を抽出できないケース（dirPrefix が `/tmp/...` 等）
+    const matches = findAbsolutePathMatches("~/foo.ts and /Users/me/bar.ts", "/tmp/proj/", "");
+    expect(matches).toEqual([]);
   });
 });

--- a/apps/renderer/src/features/terminal/useFilePathLinkProvider.ts
+++ b/apps/renderer/src/features/terminal/useFilePathLinkProvider.ts
@@ -1,18 +1,15 @@
 import type { IBuffer, IBufferLine, ILink, ILinkProvider, Terminal } from "@xterm/xterm";
 import { useWorktreeStore } from "../worktree";
+import { findAbsolutePathMatches, resolveHomeDir } from "./findAbsolutePathMatches";
 import { findRelativePaths } from "./findRelativePaths";
-
-/** パスの末尾区切り文字 */
-const PATH_TERMINATORS = /[\s()}\]>'",:;]/;
-
-/** パスの直後に `:行番号` が続くかを検出する正規表現 */
-const LINE_NUMBER_SUFFIX = /^:(\d+)/;
 
 /**
  * ターミナル出力中のファイルパスを検出し、クリックでファイラー/プレビューに反映する LinkProvider を作成する。
- * - ワークスペース内のパス → 相対パスで selectPath
- * - ワークスペース外の絶対パス（`/Users/<user>/...` / `~/...`）→ 絶対パスで selectPath
- *   （プレビューが fsReadFileAbsolute で読む）
+ * - active worktree 内のパス → 相対パスで selectPath（Preview で内容表示、FilerPane で reveal）
+ * - worktree 外の絶対パス（`/Users/<user>/...` / `~/...`）→ 絶対パスで selectPath
+ *   - Preview は fsReadFileAbsolute で内容表示する
+ *   - FilerPane のツリーは active worktree 配下しか持たないため reveal 対象外
+ *     （ツリー上で選択ハイライトされない契約）
  * - Claude Code が明示的改行+インデントで折り返した長いパスも結合して検出
  */
 export function createFilePathLinkProvider(terminal: Terminal): ILinkProvider {
@@ -63,16 +60,6 @@ export function createFilePathLinkProvider(terminal: Terminal): ILinkProvider {
       callback(links.length > 0 ? links : undefined);
     },
   };
-}
-
-/**
- * `~/` プレフィックスを展開するために、dirPrefix からホームディレクトリを推定する。
- * dirPrefix が `/Users/miyaoka/...` のような形式なら `/Users/miyaoka` を返す。
- */
-function resolveHomeDir(dirPrefix: string): string {
-  const match = dirPrefix.match(/^(\/(?:Users|home)\/[^/]+)\//);
-  if (match) return match[1]!;
-  return "";
 }
 
 /**
@@ -150,7 +137,7 @@ function getLineOffset(buf: IBuffer, topLineIdx: number, targetLineIdx: number):
 }
 
 /**
- * 結合テキストから絶対パス（`/...` および `~/...`）を検出してリンクを作成する。
+ * 結合テキストから絶対パスを検出してリンクを作成する。
  * currentLineOffset/currentLineLength で現在行の範囲を指定し、
  * パスが現在行に重なる場合のみリンク化する。
  */
@@ -166,72 +153,26 @@ function findAbsolutePathLinks(
   links: ILink[],
 ): void {
   const currentLineEnd = currentLineOffset + currentLineLength;
-  const homePrefix = homeDir ? `${homeDir}/` : "";
-  let searchStart = 0;
+  const matches = findAbsolutePathMatches(joinedText, dirPrefix, homeDir);
 
-  while (searchStart < joinedText.length) {
-    // dirPrefix / homePrefix / `~/` のうち最も手前のものを採用する。
-    // homePrefix は dirPrefix を内包しうるが、dirPrefix が homeDir 外（例: `/tmp/...`）の
-    // ケースもあるため両方を探す。
-    const candidates: Array<{ idx: number; kind: "dir" | "home" | "tilde" }> = [];
-    const dirIdx = joinedText.indexOf(dirPrefix, searchStart);
-    if (dirIdx !== -1) candidates.push({ idx: dirIdx, kind: "dir" });
-    if (homePrefix) {
-      const homeIdx = joinedText.indexOf(homePrefix, searchStart);
-      if (homeIdx !== -1) candidates.push({ idx: homeIdx, kind: "home" });
-      const tildeIdx = joinedText.indexOf("~/", searchStart);
-      if (tildeIdx !== -1) candidates.push({ idx: tildeIdx, kind: "tilde" });
-    }
+  for (const { idx, totalEnd, selectPath, lineNumber: lineNum } of matches) {
+    if (idx >= currentLineEnd || totalEnd <= currentLineOffset) continue;
 
-    if (candidates.length === 0) break;
+    const linkStart = Math.max(idx, currentLineOffset) - currentLineOffset;
+    const linkEnd = Math.min(totalEnd, currentLineEnd) - currentLineOffset;
 
-    candidates.sort((a, b) => a.idx - b.idx);
-    const { idx, kind } = candidates[0]!;
-
-    let fullPath: string;
-    let pathEnd: number;
-
-    if (kind === "tilde") {
-      const afterTilde = idx + 2;
-      pathEnd = findPathEnd(joinedText, afterTilde);
-      fullPath = `${homeDir}/${joinedText.slice(afterTilde, pathEnd)}`;
-    } else {
-      pathEnd = findPathEnd(joinedText, idx);
-      fullPath = joinedText.slice(idx, pathEnd);
-    }
-
-    // パスの直後に `:行番号` が続くか検出
-    const lineMatch = LINE_NUMBER_SUFFIX.exec(joinedText.slice(pathEnd));
-    const lineNumber_ = lineMatch ? Number(lineMatch[1]) : undefined;
-    const totalEnd = lineMatch ? pathEnd + lineMatch[0].length : pathEnd;
-
-    // パスが現在行と重なるかチェック
-    if (idx < currentLineEnd && totalEnd > currentLineOffset) {
-      const selectPath = fullPath.startsWith(dirPrefix)
-        ? fullPath.slice(dirPrefix.length)
-        : fullPath;
-
-      if (selectPath.length > 0) {
-        // 現在行内のリンク範囲を算出（行番号サフィックスも含む）
-        const linkStart = Math.max(idx, currentLineOffset) - currentLineOffset;
-        const linkEnd = Math.min(totalEnd, currentLineEnd) - currentLineOffset;
-
-        pushLink(
-          bufLine,
-          lineNumber,
-          linkStart,
-          linkEnd,
-          selectPath,
-          (event) => {
-            if (!event.shiftKey) return;
-            worktreeStore.selectPath(selectPath, lineNumber_);
-          },
-          links,
-        );
-      }
-    }
-
-    searchStart = totalEnd;
+    pushLink(
+      bufLine,
+      lineNumber,
+      linkStart,
+      linkEnd,
+      selectPath,
+      (event) => {
+        if (!event.shiftKey) return;
+        worktreeStore.selectPath(selectPath, lineNum);
+      },
+      links,
+    );
   }
 }
 
@@ -302,15 +243,6 @@ function overlapsRange(link: ILink, startIdx: number, endIdx: number, lineNumber
   const { start, end } = link.range;
   if (start.y !== lineNumber || end.y !== lineNumber) return false;
   return startIdx < end.x && endIdx > start.x - 1;
-}
-
-/** パスの末尾位置を探す（区切り文字 or 行末まで） */
-function findPathEnd(text: string, from: number): number {
-  let end = from;
-  while (end < text.length && !PATH_TERMINATORS.test(text[end]!)) {
-    end++;
-  }
-  return end;
 }
 
 /**

--- a/apps/renderer/src/features/terminal/useFilePathLinkProvider.ts
+++ b/apps/renderer/src/features/terminal/useFilePathLinkProvider.ts
@@ -11,7 +11,8 @@ const LINE_NUMBER_SUFFIX = /^:(\d+)/;
 /**
  * ターミナル出力中のファイルパスを検出し、クリックでファイラー/プレビューに反映する LinkProvider を作成する。
  * - ワークスペース内のパス → 相対パスで selectPath
- * - ワークスペース外のパス（`~/...` 含む）→ 絶対パスで selectPath（プレビューが fsReadFileAbsolute で読む）
+ * - ワークスペース外の絶対パス（`/Users/<user>/...` / `~/...`）→ 絶対パスで selectPath
+ *   （プレビューが fsReadFileAbsolute で読む）
  * - Claude Code が明示的改行+インデントで折り返した長いパスも結合して検出
  */
 export function createFilePathLinkProvider(terminal: Terminal): ILinkProvider {
@@ -165,26 +166,37 @@ function findAbsolutePathLinks(
   links: ILink[],
 ): void {
   const currentLineEnd = currentLineOffset + currentLineLength;
+  const homePrefix = homeDir ? `${homeDir}/` : "";
   let searchStart = 0;
 
   while (searchStart < joinedText.length) {
-    const directIdx = joinedText.indexOf(dirPrefix, searchStart);
-    const tildeIdx = homeDir ? joinedText.indexOf("~/", searchStart) : -1;
+    // dirPrefix / homePrefix / `~/` のうち最も手前のものを採用する。
+    // homePrefix は dirPrefix を内包しうるが、dirPrefix が homeDir 外（例: `/tmp/...`）の
+    // ケースもあるため両方を探す。
+    const candidates: Array<{ idx: number; kind: "dir" | "home" | "tilde" }> = [];
+    const dirIdx = joinedText.indexOf(dirPrefix, searchStart);
+    if (dirIdx !== -1) candidates.push({ idx: dirIdx, kind: "dir" });
+    if (homePrefix) {
+      const homeIdx = joinedText.indexOf(homePrefix, searchStart);
+      if (homeIdx !== -1) candidates.push({ idx: homeIdx, kind: "home" });
+      const tildeIdx = joinedText.indexOf("~/", searchStart);
+      if (tildeIdx !== -1) candidates.push({ idx: tildeIdx, kind: "tilde" });
+    }
 
-    if (directIdx === -1 && tildeIdx === -1) break;
+    if (candidates.length === 0) break;
 
-    const useTilde = tildeIdx !== -1 && (directIdx === -1 || tildeIdx < directIdx);
-    const idx = useTilde ? tildeIdx : directIdx;
+    candidates.sort((a, b) => a.idx - b.idx);
+    const { idx, kind } = candidates[0]!;
 
     let fullPath: string;
     let pathEnd: number;
 
-    if (useTilde) {
+    if (kind === "tilde") {
       const afterTilde = idx + 2;
       pathEnd = findPathEnd(joinedText, afterTilde);
       fullPath = `${homeDir}/${joinedText.slice(afterTilde, pathEnd)}`;
     } else {
-      pathEnd = findPathEnd(joinedText, idx + dirPrefix.length);
+      pathEnd = findPathEnd(joinedText, idx);
       fullPath = joinedText.slice(idx, pathEnd);
     }
 
@@ -195,10 +207,9 @@ function findAbsolutePathLinks(
 
     // パスが現在行と重なるかチェック
     if (idx < currentLineEnd && totalEnd > currentLineOffset) {
-      const resolvedPath = useTilde ? fullPath : fullPath;
-      const selectPath = resolvedPath.startsWith(dirPrefix)
-        ? resolvedPath.slice(dirPrefix.length)
-        : resolvedPath;
+      const selectPath = fullPath.startsWith(dirPrefix)
+        ? fullPath.slice(dirPrefix.length)
+        : fullPath;
 
       if (selectPath.length > 0) {
         // 現在行内のリンク範囲を算出（行番号サフィックスも含む）

--- a/apps/renderer/src/features/worktree/pathUtils.ts
+++ b/apps/renderer/src/features/worktree/pathUtils.ts
@@ -13,7 +13,7 @@ function normalizePath(path: string): string {
   const startIdx = isTilde ? 1 : 0;
 
   for (let i = startIdx; i < segments.length; i++) {
-    const seg = segments[i]!;
+    const seg = segments[i];
     if (seg === ".") continue;
     if (seg === "..") {
       if (result.length > 0 && result[result.length - 1] !== "..") {

--- a/apps/renderer/src/features/worktree/useWorktreeStore.ts
+++ b/apps/renderer/src/features/worktree/useWorktreeStore.ts
@@ -15,7 +15,21 @@ export const useWorktreeStore = defineStore("worktree", () => {
   const repoStore = useRepoStore();
   const fileServerBaseUrl = ref<string>();
 
-  /** プレビュー対象の選択状態。worktree 横断で 1 つだけ保持し、dir が変わるたびにクリアする */
+  /**
+   * プレビュー対象の選択状態。worktree 横断で 1 つだけ保持し、dir が変わるたびにクリアする。
+   *
+   * **path の形式契約**:
+   * - active worktree 内のファイル: 相対パス（例: `src/foo.ts`）
+   * - worktree 外のファイル: 絶対パス（例: `/Users/<user>/ghq/.../README.md`）。
+   *   terminal link から worktree 外パスを Shift+クリックした場合に渡される。
+   *
+   * 購読側は path が絶対パスを取りうる前提で分岐する:
+   * - PreviewPane: `path.startsWith("/")` で fsReadFile / fsReadFileAbsolute を切り替え
+   * - FilerPane reveal: ツリーは active worktree 配下しか持たないため、絶対パスは
+   *   reveal 対象外（ハイライトされない契約）
+   * - resolveFileGitChange: gitStatuses record の lookup に失敗して `undefined` を返す
+   *   （worktree 外パスは git status に存在しないため挙動として整合）
+   */
   const selection = ref<Selection>();
 
   /**
@@ -35,7 +49,10 @@ export const useWorktreeStore = defineStore("worktree", () => {
   /** 現在 UI で選択中の dir。repoStore.selectedDir の薄いエイリアス */
   const dir = computed(() => repoStore.selectedDir);
 
-  /** 選択中のパス（相対パス）。worktree 切替で undefined にリセットされる */
+  /**
+   * 選択中のパス。形式は `selection` の契約に従い、相対パスまたは絶対パスを取る。
+   * worktree 切替で undefined にリセットされる
+   */
   const selectedPath = computed(() => selection.value?.path);
 
   /** リンクから指定された行番号（1-based）。スクロール・ハイライトに使用 */


### PR DESCRIPTION
## 概要

ターミナル出力中に表示される worktree 外の絶対パス（例: `/Users/miyaoka/ghq/github.com/shikijs/shiki/docs/guide/index.md`）を Shift+クリックしてテキストプレビューに渡せるようにする。terminal link provider の絶対パス検出を `homeDir` 配下の絶対パスにも拡張し、Preview 経路・markdown link 解決経路で派生する silent breakage と path traversal を同時に閉じる。

## 背景

ターミナル上のファイルパスは xterm の LinkProvider 経由で検出してプレビューに渡している。現状の検出は次の 2 種類しか拾っていなかった。

- `dirPrefix`（active worktree のパス）始まり
- `~/` 始まり

実際のターミナル出力（`ls` / `cat` / 各種ツール / MCP の応答）は、シェルが展開した後の `/Users/<user>/...` 形式が大半で、`~/` 形式で出ることはほぼない。そのため worktree 外のパスは事実上クリックでプレビューできなかった。

調査の中で次のことも判明した。

- `useFilePathLinkProvider.ts` のヘッダコメントには「ワークスペース外のパス（`~/...` 含む）→ 絶対パスで selectPath」と書かれており、実装意図としては worktree 外も対応する設計だった。実装側だけが追いついていなかった
- Preview 側（`PreviewPane.vue`）と RPC 側（`/fs/readFileAbsolute` → Swift `FSOps.readFileAbsolute`）は元から絶対パスを読み取れる実装になっており、front 側のリンク検出を広げれば貫通する経路ができていた

レビュー過程で次の派生問題も顕在化したため同 PR で潰している。

- worktree 外 README を開いた瞬間、内部の相対リンクが `escapesWorktree` で全部 invalid に倒れて操作不能になる症状
- worktree 外画像/SVG が file server URL を相対パス前提で組むため 404 する症状
- 絶対 basePath 経路で `escapesWorktree` をスキップした副作用として `/etc/passwd` などへの path traversal が internal kind で通る穴
- root 直下 basePath（`/foo.md`）で `relDirOf` の契約外使用により上記 path traversal 防壁が bypass される穴
- ターミナル出力中の URL の path 部分（`https://example.com/Users/me/...` 等）が誤検出される問題
- `[/path]` / `{/path}` / `</path>` 始まりの絶対パスが false negative になる boundary 判定の誤り
- commit mode 中に worktree 外パスを開くと `rpcFsReadFile` が `FSError.outsideDir` で失敗する経路
- `findAbsolutePathMatches` / `findRelativePaths` で `:行番号` validation 規律が揃っていなかった SSOT 違反

## 変更内容

### terminal link provider

- `findAbsolutePathMatches.ts` をコアロジックの純粋関数として独立モジュール化（vue/pinia/rpc を import chain から切り、bun test から直接呼べる）
- 検出プレフィックスを `dirPrefix` / `homePrefix`（例: `/Users/miyaoka/`）/ `~/` の 3 種類に拡張し、`{idx, prefixLen, expandTilde}` の単一構造体配列に集約
- 候補は idx 昇順、同 idx は prefixLen 降順（dir > home > tilde）で tie-break して `Array.prototype.sort` の stability に依存しない
- prefix 部分を走査対象から除外（`idx + prefixLen` から `findPathEnd` を開始）。dir 名に空白や括弧を含んでも prefix 内で path が切れない
- `indexOfWithBoundary` を追加し、prefix の直前が word char (`/[A-Za-z0-9_]/`) のときは候補から落とす。`[`、`{`、`<`、空白などは boundary として認める。URL の path 部分にある `/Users/...` は誤検出しない一方、bracket / curly / angle 囲みの絶対パスは正しく検出される

### Markdown link 解決

- `resolveMarkdownLink` で basePath が絶対パスのとき、相対リンクを「source file の dir 配下」に限定して解決する信頼境界を導入
- `escapesWorktree`（worktree root 基準）は意味を成さないため絶対 basePath 経路ではスキップし、代わりに「`normalized` が `${baseDir}/` で始まる」ことを唯一の通過条件にする
- root 直下 basePath（`/foo.md`）専用の `absoluteBaseDir` helper を内部に置き、`relDirOf` の契約外使用を排除。`/foo.md` 起点では `/<name>` のみ許可、`/etc/passwd` / `./foo/bar.md` のような sub-dir 経路は invalid
- 絶対 basePath 経路を `resolveWithAbsoluteBase` 関数に分離し、control flow narrowing で `basePath: string` を効かせる構造に変更（non-null assertion を排除）
- 既存 worktree 内 basePath の挙動（`escapesWorktree` 経路）は変更なし

### Preview

- `PreviewPane.buildFileServerUrl` で relPath が `/` 始まりのとき undefined を返す。file server は worktree 相対のみ提供する経路のため、絶対パスで壊れた URL を作らない
- 絶対パス時の image / svg は Preview トグルを gate し、テンプレートに「Image preview is not available for paths outside the worktree」分岐を明示
- 絶対パスのとき commit mode フラグを bypass して `fetchContent` (`fsReadFileAbsolute` 経由) に倒す。git 履歴を持たないパスに `rpcFsReadFile` の worktree 境界制約を踏ませない
- text 系 (`.md` raw / `.ts` / `.json` 等) の絶対パスプレビューは fsReadFileAbsolute 経由で正常動作

### Line number SSOT

- `parseLineNumberSuffix.ts` を新設し、`Number.isSafeInteger` 内かつ正整数のみ採用、`:0` / 巨大値は consume するが undefined に倒す
- `findAbsolutePathMatches` と `findRelativePaths` の両方で同 helper を参照

### Selection 型の契約明文化

- `useWorktreeStore.selection` の jsdoc に「path は active worktree 内なら相対パス、worktree 外なら絶対パス」「購読側は path 形式に応じて分岐する」契約を invariant として書き下した
- 購読側の挙動も列挙（PreviewPane 分岐、FilerPane reveal 対象外、resolveFileGitChange は lookup miss で undefined）

### 規律整備

- `findAbsolutePathMatches.ts` / `findRelativePaths.ts` / `resolveMarkdownLink.ts` / `pathUtils.ts` / 関連 test で残っていた non-null assertion (`!`) を全削除。`noUncheckedIndexedAccess` 未有効プロジェクトでは `text[i]` / `match[N]` / `candidates[0]` などが `string` に narrow されるため `!` は冗長な escape hatch。本 PR スコープ内で規律「`!` は使わない」を完徹

### テスト

- `findAbsolutePathMatches`: worktree 内/外、`~/`、空白/括弧 dir 名、同 idx tie-break、home 境界誤検出、複数検出、URL token boundary、bracket / curly / angle 囲み、`:0` / safe integer 外 / 巨大値、`~/:42` 等
- `findRelativePaths`: `:0` / 巨大値の SSOT 揃え
- `resolveMarkdownLink`: 絶対 basePath の正常系・path traversal 防御・root 直下 bypass 防止

## 今回含めない点

レビュー過程で派生して上がった次の構造改修は別 issue に切り出して別 PR で扱う。本 PR は「worktree 外パスのテキストプレビューを動かす + その実装で露見した silent breakage / traversal 穴の封止 + 関連 SSOT 揃え」までを責務とする。

- **#589**: `Selection.path` を `{ kind: "worktreeRelative"; relPath } | { kind: "absolute"; absPath }` の discriminated union に書き換える根本対応。本 PR では各購読側の `path.startsWith("/")` 分岐の漏れを潰すことで本 PR 起因の bug 経路は塞いだが、string sniff 自体の排除には Selection 型 + 購読側 8 箇所 + 集約 helper の同時改修が必要
- **#590**: worktree 外 image / svg を実際にレンダリングする経路（file server の絶対パス対応 or `fsReadFileAbsolute` の戻り値を Blob URL 化）。本 PR では明示的に「未対応」を画面表示することで silent breakage を防ぐにとどめる

## 確認事項

- [ ] worktree 内パス（相対 / 絶対）が従来通り Shift+クリックでプレビューに渡る
- [ ] worktree 外の `/Users/<user>/...` 形式の絶対パスが Shift+クリックでテキストプレビューに渡る
- [ ] `~/...` 形式のパスも従来通り展開されてプレビューに渡る
- [ ] パス末尾の `:行番号` サフィックスが行ジャンプとして反映される（`:0` / 巨大値は行ジャンプなしで開く）
- [ ] 複数行に折り返した長い絶対パスも結合して認識される
- [ ] ターミナル出力中の URL に含まれる `/Users/...` 部分がリンク化されない
- [ ] `[/path]` / `{/path}` / `</path>` 囲みの絶対パスもリンク化される
- [ ] worktree 外 markdown を開いたとき、内部の `./foo.md` / `./images/x.png` などの sibling 参照が動く
- [ ] 同 markdown 内の `/etc/passwd` / `../../etc/passwd` / 親方向 traversal が「Link target is outside the source file directory」として弾かれる
- [ ] git-graph で過去 commit を選択中の状態でも、ターミナル出力中の worktree 外絶対パスを Shift+クリックでテキストプレビューに渡る（`FSError.outsideDir` エラートーストが出ない）
- [ ] worktree 外の画像/SVG は「Image preview is not available for paths outside the worktree」が表示される（silent に空白にならない）
