### PR TITLE
fix(filer): propagate isIgnored to nested entries

### DIFF
--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -138,11 +138,11 @@ async function loadChildren() {
 function mergeWithGitStatus(entries: FileEntry[]): FileEntry[] {
   const existingNames = new Set(entries.map((e) => e.name));
 
-  const withGitChange = entries.map((entry) => {
+  const withGitChange = entries.map((entry): FileEntry => {
     const filePath = `${props.path}/${entry.name}`;
     const statusCode = props.gitStatuses[filePath];
     if (statusCode) {
-      return { ...entry, gitChange: resolveGitChangeKind(statusCode) } as FileEntry;
+      return { ...entry, gitChange: resolveGitChangeKind(statusCode) };
     }
     return entry;
   });

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -26,7 +26,7 @@ import {
   useWorktreeStore,
 } from "../worktree";
 import type { GitChangeKind } from "../worktree";
-import { getDeletedEntries, sortEntries } from "./filerUtils";
+import { getDeletedEntries, sortEntries, toFileEntries } from "./filerUtils";
 import type { FileEntry } from "./filerUtils";
 import { rpcFsReadDir } from "./rpc";
 import { getFileIconUrl, getFolderIconUrl } from "./useFileIcon";
@@ -130,12 +130,7 @@ async function loadChildren() {
     loading.value = false;
     return;
   }
-  const entries = result.value.entries.map((e) => ({
-    name: e.name,
-    isDirectory: e.type === "directory",
-    isIgnored: false,
-  }));
-  children.value = mergeWithGitStatus(entries);
+  children.value = mergeWithGitStatus(toFileEntries(result.value.entries));
   loading.value = false;
 }
 

--- a/apps/renderer/src/features/filer/FilerPane.vue
+++ b/apps/renderer/src/features/filer/FilerPane.vue
@@ -52,11 +52,11 @@ function mergeWithGitStatus(entries: FileEntry[], dirPath: string): FileEntry[] 
   const existingNames = new Set(entries.map((e) => e.name));
 
   // 既存エントリに git 変更種別を付与
-  const withGitChange = entries.map((entry) => {
+  const withGitChange = entries.map((entry): FileEntry => {
     const filePath = dirPath === "" ? entry.name : `${dirPath}/${entry.name}`;
     const statusCode = gitStatuses.value[filePath];
     if (statusCode) {
-      return { ...entry, gitChange: resolveGitChangeKind(statusCode) } as FileEntry;
+      return { ...entry, gitChange: resolveGitChangeKind(statusCode) };
     }
     return entry;
   });

--- a/apps/renderer/src/features/filer/FilerPane.vue
+++ b/apps/renderer/src/features/filer/FilerPane.vue
@@ -17,7 +17,7 @@ import { useNotificationStore } from "../../shared/notification";
 import { onMessage } from "../../shared/rpc";
 import { resolveGitChangeKind, useGitStatusStore, useWorktreeStore } from "../worktree";
 import type { GitStatusChangePayload } from "../worktree";
-import { getDeletedEntries, sortEntries } from "./filerUtils";
+import { getDeletedEntries, sortEntries, toFileEntries } from "./filerUtils";
 import type { FileEntry } from "./filerUtils";
 import FileTreeItem from "./FileTreeItem.vue";
 import { rpcFsReadDir } from "./rpc";
@@ -46,15 +46,6 @@ let loadRootSeq = 0;
  * 世代軸と互いに干渉しない SSOT として機能する。
  */
 let gitStatusChangeSeq = 0;
-
-/** proto の FsReadDirEntry を FileEntry に変換する */
-function toFileEntries(entries: { name: string; type: string; isIgnored: boolean }[]): FileEntry[] {
-  return entries.map((e) => ({
-    name: e.name,
-    isDirectory: e.type === "directory",
-    isIgnored: e.isIgnored,
-  }));
-}
 
 /** readDir の結果に git 変更情報と削除ファイルをマージする */
 function mergeWithGitStatus(entries: FileEntry[], dirPath: string): FileEntry[] {

--- a/apps/renderer/src/features/filer/filerUtils.test.ts
+++ b/apps/renderer/src/features/filer/filerUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { dirName, sortEntries, type FileEntry } from "./filerUtils";
+import { dirName, sortEntries, toFileEntries, type FileEntry } from "./filerUtils";
 
 describe("dirName", () => {
   test("パスの末尾をディレクトリ名として返す", () => {
@@ -47,5 +47,41 @@ describe("sortEntries", () => {
 
   test("空配列を処理できる", () => {
     expect(sortEntries([])).toEqual([]);
+  });
+});
+
+describe("toFileEntries", () => {
+  test("isIgnored: true を伝搬する", () => {
+    const result = toFileEntries([{ name: "node_modules", type: "directory", isIgnored: true }]);
+    expect(result[0]?.isIgnored).toBe(true);
+  });
+
+  test("isIgnored: false を伝搬する", () => {
+    const result = toFileEntries([{ name: "src", type: "directory", isIgnored: false }]);
+    expect(result[0]?.isIgnored).toBe(false);
+  });
+
+  test("type === 'directory' は isDirectory: true になる", () => {
+    const result = toFileEntries([{ name: "src", type: "directory", isIgnored: false }]);
+    expect(result[0]?.isDirectory).toBe(true);
+  });
+
+  test("type === 'file' は isDirectory: false になる", () => {
+    const result = toFileEntries([{ name: "a.txt", type: "file", isIgnored: false }]);
+    expect(result[0]?.isDirectory).toBe(false);
+  });
+
+  test("type === 'symlink' は isDirectory: false になる", () => {
+    const result = toFileEntries([{ name: "link", type: "symlink", isIgnored: false }]);
+    expect(result[0]?.isDirectory).toBe(false);
+  });
+
+  test("type === 'other' は isDirectory: false になる", () => {
+    const result = toFileEntries([{ name: "fifo", type: "other", isIgnored: false }]);
+    expect(result[0]?.isDirectory).toBe(false);
+  });
+
+  test("空配列を処理できる", () => {
+    expect(toFileEntries([])).toEqual([]);
   });
 });

--- a/apps/renderer/src/features/filer/filerUtils.ts
+++ b/apps/renderer/src/features/filer/filerUtils.ts
@@ -45,6 +45,15 @@ function getDeletedEntries(dirPath: string, gitStatuses: Record<string, string>)
   }));
 }
 
+/** proto の FsReadDirEntry を FileEntry に変換する */
+function toFileEntries(entries: { name: string; type: string; isIgnored: boolean }[]): FileEntry[] {
+  return entries.map((e) => ({
+    name: e.name,
+    isDirectory: e.type === "directory",
+    isIgnored: e.isIgnored,
+  }));
+}
+
 /** ディレクトリパスの末尾から表示名を抽出 */
 function dirName(dirPath: string): string {
   const parts = dirPath.split("/");
@@ -61,5 +70,5 @@ function sortEntries(entries: FileEntry[]): FileEntry[] {
   });
 }
 
-export { dirName, getDeletedEntries, sortEntries };
+export { dirName, getDeletedEntries, sortEntries, toFileEntries };
 export type { FileEntry };

--- a/apps/renderer/src/features/filer/filerUtils.ts
+++ b/apps/renderer/src/features/filer/filerUtils.ts
@@ -1,3 +1,4 @@
+import type { FsReadDirEntry } from "@gozd/proto";
 import type { GitChangeKind } from "../worktree";
 
 interface FileEntry {
@@ -46,7 +47,7 @@ function getDeletedEntries(dirPath: string, gitStatuses: Record<string, string>)
 }
 
 /** proto の FsReadDirEntry を FileEntry に変換する */
-function toFileEntries(entries: { name: string; type: string; isIgnored: boolean }[]): FileEntry[] {
+function toFileEntries(entries: FsReadDirEntry[]): FileEntry[] {
   return entries.map((e) => ({
     name: e.name,
     isDirectory: e.type === "directory",


### PR DESCRIPTION
## 概要

filer のネスト階層で git ignored 表示が反映されないバグを修正する。トップ階層では `.gitignore` 配下の `node_modules` などが text-zinc-500 でグレーアウト表示されるが、ディレクトリを展開して取得した子エントリでは ignored 情報が落ちており通常色で表示されていた。

合わせて、これを引き起こした「proto → FileEntry 変換ロジックの二重定義」を解消し、変換ヘルパーの引数型を proto 型に紐付けて proto schema 進化を compile error として顕在化させる。

## 背景

`FsReadDirEntry` の `isIgnored` フィールドは native 側 `FSOps.readDir` で `git check-ignore --stdin -z` を worktree root に対して呼び出して計算しており、ネストパスでも正しい判定値が返ってきている（`node_modules/` パターンは gitignore 仕様上どの階層でも一致する）。

しかし renderer 側で proto → `FileEntry` への変換が次の 2 箇所に重複していた:

- `FilerPane.vue` のローカル `toFileEntries`（ルート読み込み用、`e.isIgnored` を正しく伝搬）
- `FileTreeItem.vue` の `loadChildren` 内インライン変換（子読み込み用、`isIgnored: false` でハードコード）

`isIgnored` フィールドが追加された際に前者だけが更新され、後者は古い実装が残ったまま `false` で潰す挙動になっていたのが直接原因。同じロジックが分散しているとフィールド追加時に片側だけ反映漏れする再発リスクが残るため、最小修正ではなく SSOT 化する形で潰す。さらに変換ヘルパー側も手書き構造型で受けていると proto schema 進化（フィールド rename / 削除 / enum 化）が compile 時に検知できず、同類のバグが再発しうるため proto 型を直接受ける形に強化する。

## 変更内容

### filer

- `filerUtils.ts` に `toFileEntries(entries)` を追加し、proto エントリ → `FileEntry` 変換を SSOT 化
- `toFileEntries` の引数型を `@gozd/proto` の `FsReadDirEntry[]` に紐付け、proto schema 進化が renderer 側の変換実装に compile error として波及するようにする
- `FilerPane.vue`: 同名のローカル関数を削除して `filerUtils` 経由に差し替え
- `FileTreeItem.vue`: `loadChildren` 内のインライン変換を `toFileEntries` 呼び出しに置換し、`isIgnored: false` のハードコードを撤去
- `FilerPane.vue` / `FileTreeItem.vue` の `mergeWithGitStatus` 内に残っていた `as FileEntry` キャストを `map` コールバックの戻り値型注釈（`(entry): FileEntry => ...`）に置き換え、`...entry` のシェイプ欠落が将来 silent に通らないようにする

### filer tests

- `toFileEntries` の境界テストを追加: `isIgnored: true` / `false` の伝搬、`"directory"` / `"file"` / `"symlink"` / `"other"` 各 type 値の `isDirectory` 派生、空配列入力

## 確認事項

- [ ] worktree root 直下の `node_modules` が text-zinc-500 でグレーアウト表示される（既存挙動）
- [ ] `packages/*/node_modules` などネストされた gitignored ディレクトリもグレーアウト表示される（修正後の挙動）
- [ ] ネスト階層の `.DS_Store` 等 gitignored ファイルもグレーアウト表示される
- [ ] ignored ではない通常ファイル / ディレクトリの色合いが変わっていない
- [ ] 削除ファイル（仮想エントリ）の表示・git 変更色（modified / added / renamed）が壊れていない
