### PR TITLE
fix(lockfile): align shiki-lang-map importer with oxlint-tsgolint 0.23.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,10 +283,10 @@ importers:
         version: 0.50.0
       oxlint:
         specifier: 'catalog:'
-        version: 1.65.0(oxlint-tsgolint@0.22.1)
+        version: 1.65.0(oxlint-tsgolint@0.23.0)
       oxlint-tsgolint:
         specifier: 'catalog:'
-        version: 0.22.1
+        version: 0.23.0
       shiki:
         specifier: 4.0.2
         version: 4.0.2


### PR DESCRIPTION
## 概要

`pnpm install` を走らせるたびに `pnpm-lock.yaml` の `packages/shiki-lang-map` importer セクションだけが catalog の `oxlint-tsgolint@0.23.0` と整合せず 2 行の差分を吐き続けていたのを、catalog 真値に揃えて根絶する。

## 背景

`pnpm install` がコード変更なしに lockfile を 2 行書き換える挙動を観測したことが起点。

調査の結果、main 上で 2 系統の作業が並走していたのが原因と判明:

- `07b1d3d8` 〜 `cfaae776` で新 importer `packages/shiki-lang-map` を追加。このとき catalog は `oxlint-tsgolint: 0.22.1` だったため、lockfile の同 importer セクションには `oxlint@1.65.0(oxlint-tsgolint@0.22.1)` / `oxlint-tsgolint: 0.22.1` が刻まれた
- Renovate PR ( #587 ) は `oxlint-tsgolint` を `0.22.1 → 0.23.0` に上げたが、PR の base には `packages/shiki-lang-map` importer がまだ存在しなかったため、その importer セクションは書き換え対象に含まれなかった
- マージ時、git の 3-way textual merge では「Renovate 側に存在しない・main 側にのみ存在するセクション」として素通り → `packages/shiki-lang-map` の `oxlint-tsgolint` peer 参照だけ `0.22.1` のまま残った
- `pnpm install` は catalog の真値 (`0.23.0`) と lockfile を照合して都度書き換えるため、毎回 2 行の差分が発生していた

pnpm-lock.yaml は importer ごとに peer dependency 解決の context (`oxlint@1.65.0(oxlint-tsgolint@X.Y.Z)` の形) を独立に書く構造のため、catalog バージョン更新 PR と新 importer 追加 PR が並走すると、この種の zonbie 参照が原理的に残りうる。

## 変更内容

### lockfile

- `packages/shiki-lang-map` importer の `oxlint` peer context と `oxlint-tsgolint` 直接参照を `0.22.1` → `0.23.0` に揃える ( `pnpm install` の出力をそのまま採用)

## 今回含めない点

- **再発防止策は別途検討**: Renovate の `rebaseWhen` / `lockMaintenance` 設定の見直しで catalog 更新 PR を他 PR マージ後に自動 rebase させる方向が王道だが、本 PR は観測された差分の即時解消に scope を絞る

## 確認事項

- [ ] `pnpm install` を実行しても `pnpm-lock.yaml` に差分が出ないこと
- [ ] `pnpm lint:all` / `pnpm typecheck:all` が通ること (oxlint-tsgolint の整合性確認)
