### PR TITLE
refactor(filer): unify tree management under a single root FileTreeItem

### DIFF
--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -11,7 +11,8 @@
 
 - `path === ""` を worktree 自体を指す値として扱う（Swift `relDir` SSOT と整合）。`isRootPath()` で 1 か所判定
 - ボタン非表示、初期 `expanded = true`、`onMounted` で `loadChildren()` を起動
-- ルートでは表示要素由来の computed（`textColorClass` / `effectiveGitChange` / `iconUrl`）を呼ばない
+- 表示要素由来の computed（`textColorClass` / `effectiveGitChange` / `iconUrl`）はテンプレートが `<button v-if="!isRoot">` でガードしているため、root では lazy 評価により実行されない。ルート専用の早期 return は持たない（v-if を唯一の防壁とする）
+- `depth` の意味は「自身のインデント階層」。root には FilerPane が sentinel `-1` を渡し、root 自身は描画されないので depth は使われない。子に渡す depth は通常通り `depth + 1` で、root 直下の子は `-1 + 1 = 0` から始まる
 
 ## レース対策
 
@@ -70,7 +71,11 @@ const props = defineProps<{
   gitChange?: GitChangeKind;
   /** git status マップ全体（ディレクトリの変更種別推論に使用） */
   gitStatuses: Record<string, string>;
-  /** 自身のインデント階層。子に渡す depth は `childDepth` computed で算出する */
+  /**
+   * 自身のインデント階層。worktree 不可視ルートには FilerPane が sentinel `-1` を渡す
+   * （root は描画されないので負値の paddingLeft は実体に到達しない）。
+   * 子は通常通り `depth + 1` を受け取る。root 直下は `-1 + 1 = 0` から始まる。
+   */
   depth: number;
   selectedRelPath?: string;
 }>();
@@ -98,11 +103,12 @@ const loading = ref(false);
  */
 let loadSeq = 0;
 
-/** ルート不可視ノードは表示要素を描画しないので、関連 computed は早期 return で無駄計算を避ける */
+// 以下の表示要素由来 computed はテンプレートの `<button v-if="!isRoot">` 配下でしか参照されない。
+// Vue の computed は lazy 評価のため、root では実体が走らない。早期 return ガードは持たない
+// （v-if が唯一の防壁）。
 
 /** gitStatuses マップからリアルタイムに変更種別を算出する */
 const effectiveGitChange = computed<GitChangeKind | undefined>(() => {
-  if (isRoot.value) return undefined;
   // 削除エントリ（打ち消し線）は親から渡された gitChange をそのまま使う
   if (props.gitChange === "deleted") return "deleted";
   if (props.isDirectory) {
@@ -112,7 +118,6 @@ const effectiveGitChange = computed<GitChangeKind | undefined>(() => {
 });
 
 const textColorClass = computed(() => {
-  if (isRoot.value) return "";
   if (effectiveGitChange.value) return GIT_CHANGE_COLOR_MAP[effectiveGitChange.value];
   if (props.isIgnored) return "text-zinc-500";
   if (props.selectedRelPath === props.path) return "text-white";
@@ -124,18 +129,11 @@ const isDeleted = computed(() => props.gitChange === "deleted");
 
 /** material-icon-theme のアイコン URL */
 const iconUrl = computed(() => {
-  if (isRoot.value) return "";
   if (props.isDirectory) {
     return getFolderIconUrl(props.name, expanded.value);
   }
   return getFileIconUrl(props.name);
 });
-
-/**
- * 子に渡す depth。ルート不可視ノードは描画されないので、ルートの直下を depth 0 から始める。
- * `depth` prop の意味を「自身のインデント階層」と一貫させるための変換を 1 か所に閉じる。
- */
-const childDepth = computed(() => (isRoot.value ? 0 : props.depth + 1));
 
 async function toggle() {
   if (!props.isDirectory) {
@@ -337,7 +335,7 @@ function onChildSelect(childPath: string) {
         :is-ignored="child.isIgnored"
         :git-change="child.gitChange"
         :git-statuses="gitStatuses"
-        :depth="childDepth"
+        :depth="depth + 1"
         :selected-rel-path="selectedRelPath"
         @select="onChildSelect"
       />

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -7,6 +7,11 @@
 - material-icon-theme のアイコンを表示
 - git status に応じた色分け（modified=黄、added=緑、deleted=赤、renamed=青）と削除ファイルの打ち消し線
 
+## ルートノード
+
+- `isRoot` を渡すと worktree 自体を表す不可視ノードとして振る舞う（ボタン非表示、常時 expanded、初期マウントで子を読み込み）
+- `path === ""` が worktree 直下を表す。子の `path` 組み立てと git status マッチには `joinPath` を経由する
+
 ## 更新（イベント駆動）
 
 - filer event store の fsChange を watch して自分の path 該当時に再読み込み
@@ -17,7 +22,7 @@
 
 <script setup lang="ts">
 import { tryCatch } from "@gozd/shared";
-import { computed, ref, useTemplateRef, watch } from "vue";
+import { computed, onMounted, ref, useTemplateRef, watch } from "vue";
 import { useNotificationStore } from "../../shared/notification";
 import {
   resolveDirectoryGitChange,
@@ -26,7 +31,7 @@ import {
   useWorktreeStore,
 } from "../worktree";
 import type { GitChangeKind } from "../worktree";
-import { getDeletedEntries, sortEntries, toFileEntries } from "./filerUtils";
+import { getDeletedEntries, joinPath, sortEntries, toFileEntries } from "./filerUtils";
 import type { FileEntry } from "./filerUtils";
 import { rpcFsReadDir } from "./rpc";
 import { getFileIconUrl, getFolderIconUrl } from "./useFileIcon";
@@ -42,7 +47,7 @@ const GIT_CHANGE_COLOR_MAP: Record<GitChangeKind, string> = {
 
 const props = defineProps<{
   name: string;
-  /** ルートからの相対パス */
+  /** worktree からの相対パス。worktree 直下（ルートノード）は `""` */
   path: string;
   isDirectory: boolean;
   isIgnored: boolean;
@@ -52,6 +57,8 @@ const props = defineProps<{
   gitStatuses: Record<string, string>;
   depth: number;
   selectedRelPath?: string;
+  /** worktree 自体を表す不可視ルートノード。ボタンを描画せず、初期マウントで子を読み込む */
+  isRoot?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -63,7 +70,7 @@ const worktreeStore = useWorktreeStore();
 const filerEventStore = useFilerEventStore();
 
 const buttonRef = useTemplateRef<HTMLButtonElement>("button");
-const expanded = ref(false);
+const expanded = ref(props.isRoot ?? false);
 const children = ref<FileEntry[]>();
 const loading = ref(false);
 
@@ -117,7 +124,10 @@ async function loadChildren() {
     loading.value = false;
     return;
   }
-  const result = await tryCatch(rpcFsReadDir({ dir, path: props.path }));
+  // native 側 `URL(fileURLWithPath:)` は空文字列を未定義扱いするため、worktree 直下は `.` で投げる。
+  // 結果は dir からの相対 entries で返るので、children 側の path 組み立て (joinPath) は影響を受けない。
+  const rpcPath = props.path === "" ? "." : props.path;
+  const result = await tryCatch(rpcFsReadDir({ dir, path: rpcPath }));
   if (!result.ok) {
     // 削除ディレクトリの場合、readDir は失敗するので削除エントリのみ表示
     const deletedEntries = getDeletedEntries(props.path, props.gitStatuses);
@@ -139,7 +149,7 @@ function mergeWithGitStatus(entries: FileEntry[]): FileEntry[] {
   const existingNames = new Set(entries.map((e) => e.name));
 
   const withGitChange = entries.map((entry): FileEntry => {
-    const filePath = `${props.path}/${entry.name}`;
+    const filePath = joinPath(props.path, entry.name);
     const statusCode = props.gitStatuses[filePath];
     if (statusCode) {
       return { ...entry, gitChange: resolveGitChangeKind(statusCode) };
@@ -154,8 +164,15 @@ function mergeWithGitStatus(entries: FileEntry[]): FileEntry[] {
   return sortEntries([...withGitChange, ...deletedEntries]);
 }
 
+// ルートノードは worktree 自体を表すため、マウント時点で子（ルート直下のエントリ）を読み込む。
+// 通常ノードは初回展開時に loadChildren が走るが、ルートは常時 expanded なので初期 mount にフックする。
+onMounted(() => {
+  if (props.isRoot) void loadChildren();
+});
+
 // fsChange を購読し、自分の path が変更対象なら再読み込み（折りたたみ中はキャッシュ破棄）。
 // 自分の path 配下のノードは独立に同じ store を watch しているため、再帰伝播は不要。
+// ルートノード（path === ""）は worktree 直下の fsChange（relDir === ""）にマッチする。
 watch(
   () => filerEventStore.fsChangeEvent,
   (event) => {
@@ -191,6 +208,8 @@ watch(
  * 祖先の場合は展開するだけ。子は v-for でマウント後に自分の revealVersion watch (immediate)
  * で target を処理する再帰チェーン。
  *
+ * ルートノード（path === ""）はあらゆる target の祖先扱い（target が worktree 内なら自身配下にある）。
+ *
  * absolute 選択中 (worktree 外) は selectedRelPath が undefined になり reveal は no-op。
  * ツリーが持っていないパスをマッチさせる経路を型レベルで排除する。
  */
@@ -210,7 +229,8 @@ async function handleReveal() {
   }
   // ディレクトリでないか、ターゲットが自身の配下でない場合は何もしない
   if (!props.isDirectory) return;
-  if (!targetPath.startsWith(props.path + "/")) return;
+  const prefix = props.path === "" ? "" : props.path + "/";
+  if (!targetPath.startsWith(prefix)) return;
   // 自身の配下に target がある場合、自分は展開するだけ（target そのものへの scroll は
   // 子の watch が処理する）。子は v-for で children を読み込むとマウントされ、
   // immediate watch が現在の revealVersion で発火する
@@ -238,6 +258,7 @@ function onChildSelect(childPath: string) {
 <template>
   <div>
     <button
+      v-if="!isRoot"
       ref="button"
       class="flex w-full items-center gap-1 rounded-sm px-1 py-0.5 text-left text-sm hover:bg-zinc-700"
       :class="[
@@ -274,7 +295,7 @@ function onChildSelect(childPath: string) {
         v-for="child in children"
         :key="`${child.name}-${child.isDirectory}`"
         :name="child.name"
-        :path="`${path}/${child.name}`"
+        :path="joinPath(path, child.name)"
         :is-directory="child.isDirectory"
         :is-ignored="child.isIgnored"
         :git-change="child.gitChange"

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -7,10 +7,17 @@
 - material-icon-theme のアイコンを表示
 - git status に応じた色分け（modified=黄、added=緑、deleted=赤、renamed=青）と削除ファイルの打ち消し線
 
-## ルートノード
+## ルートノード（worktree 自体を表す不可視ノード）
 
-- `isRoot` を渡すと worktree 自体を表す不可視ノードとして振る舞う（ボタン非表示、常時 expanded、初期マウントで子を読み込み）
-- `path === ""` が worktree 直下を表す。子の `path` 組み立てと git status マッチには `joinPath` を経由する
+- `path === ""` を worktree 自体を指す値として扱う（Swift `relDir` SSOT と整合）。`isRootPath()` で 1 か所判定
+- ボタン非表示、初期 `expanded = true`、`onMounted` で `loadChildren()` を起動
+- ルートでは表示要素由来の computed（`textColorClass` / `effectiveGitChange` / `iconUrl`）を呼ばない
+
+## レース対策
+
+- `loadChildren` は per-instance 世代カウンタで保護。await 後に「自分が最新の呼び出し」でなければ
+  結果を破棄する。同一 dir 内で `fsChange` / `gitStatusChange` が連発した時に古い `rpcFsReadDir`
+  レスポンスが新しい entries を踏み潰すのを防ぐ（FilerPane 側にあったルート専用ガードを SSOT 化）
 
 ## 更新（イベント駆動）
 
@@ -31,7 +38,15 @@ import {
   useWorktreeStore,
 } from "../worktree";
 import type { GitChangeKind } from "../worktree";
-import { getDeletedEntries, joinPath, sortEntries, toFileEntries } from "./filerUtils";
+import {
+  getDeletedEntries,
+  isDescendantOf,
+  isRootPath,
+  joinPath,
+  pathForNativeRpc,
+  sortEntries,
+  toFileEntries,
+} from "./filerUtils";
 import type { FileEntry } from "./filerUtils";
 import { rpcFsReadDir } from "./rpc";
 import { getFileIconUrl, getFolderIconUrl } from "./useFileIcon";
@@ -47,7 +62,7 @@ const GIT_CHANGE_COLOR_MAP: Record<GitChangeKind, string> = {
 
 const props = defineProps<{
   name: string;
-  /** worktree からの相対パス。worktree 直下（ルートノード）は `""` */
+  /** worktree からの相対パス。worktree 直下（不可視ルート）は `""` */
   path: string;
   isDirectory: boolean;
   isIgnored: boolean;
@@ -55,10 +70,9 @@ const props = defineProps<{
   gitChange?: GitChangeKind;
   /** git status マップ全体（ディレクトリの変更種別推論に使用） */
   gitStatuses: Record<string, string>;
+  /** 自身のインデント階層。子に渡す depth は `childDepth` computed で算出する */
   depth: number;
   selectedRelPath?: string;
-  /** worktree 自体を表す不可視ルートノード。ボタンを描画せず、初期マウントで子を読み込む */
-  isRoot?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -69,13 +83,26 @@ const notify = useNotificationStore();
 const worktreeStore = useWorktreeStore();
 const filerEventStore = useFilerEventStore();
 
+const isRoot = computed(() => isRootPath(props.path));
+
 const buttonRef = useTemplateRef<HTMLButtonElement>("button");
-const expanded = ref(props.isRoot ?? false);
+const expanded = ref(isRoot.value);
 const children = ref<FileEntry[]>();
 const loading = ref(false);
 
+/**
+ * loadChildren の呼び出し世代カウンタ。`fsChange` / `gitStatusChange` の連続発火で
+ * `rpcFsReadDir` レスポンス順序が逆転して古い entries が新しい entries を踏み潰す race を防ぐ。
+ * 旧 FilerPane の `loadRootSeq` / `gitStatusChangeSeq` が担っていたルート専用ガードを、
+ * 全ノードの共通ガードとして FileTreeItem に内製化したもの。
+ */
+let loadSeq = 0;
+
+/** ルート不可視ノードは表示要素を描画しないので、関連 computed は早期 return で無駄計算を避ける */
+
 /** gitStatuses マップからリアルタイムに変更種別を算出する */
 const effectiveGitChange = computed<GitChangeKind | undefined>(() => {
+  if (isRoot.value) return undefined;
   // 削除エントリ（打ち消し線）は親から渡された gitChange をそのまま使う
   if (props.gitChange === "deleted") return "deleted";
   if (props.isDirectory) {
@@ -85,6 +112,7 @@ const effectiveGitChange = computed<GitChangeKind | undefined>(() => {
 });
 
 const textColorClass = computed(() => {
+  if (isRoot.value) return "";
   if (effectiveGitChange.value) return GIT_CHANGE_COLOR_MAP[effectiveGitChange.value];
   if (props.isIgnored) return "text-zinc-500";
   if (props.selectedRelPath === props.path) return "text-white";
@@ -96,11 +124,18 @@ const isDeleted = computed(() => props.gitChange === "deleted");
 
 /** material-icon-theme のアイコン URL */
 const iconUrl = computed(() => {
+  if (isRoot.value) return "";
   if (props.isDirectory) {
     return getFolderIconUrl(props.name, expanded.value);
   }
   return getFileIconUrl(props.name);
 });
+
+/**
+ * 子に渡す depth。ルート不可視ノードは描画されないので、ルートの直下を depth 0 から始める。
+ * `depth` prop の意味を「自身のインデント階層」と一貫させるための変換を 1 か所に閉じる。
+ */
+const childDepth = computed(() => (isRoot.value ? 0 : props.depth + 1));
 
 async function toggle() {
   if (!props.isDirectory) {
@@ -117,24 +152,27 @@ async function toggle() {
 }
 
 async function loadChildren() {
+  const mySeq = ++loadSeq;
   loading.value = true;
   const dir = worktreeStore.dir;
   if (dir === undefined) {
-    children.value = [];
-    loading.value = false;
+    if (mySeq === loadSeq) {
+      children.value = [];
+      loading.value = false;
+    }
     return;
   }
-  // native 側 `URL(fileURLWithPath:)` は空文字列を未定義扱いするため、worktree 直下は `.` で投げる。
-  // 結果は dir からの相対 entries で返るので、children 側の path 組み立て (joinPath) は影響を受けない。
-  const rpcPath = props.path === "" ? "." : props.path;
-  const result = await tryCatch(rpcFsReadDir({ dir, path: rpcPath }));
+  const result = await tryCatch(rpcFsReadDir({ dir, path: pathForNativeRpc(props.path) }));
+  // await 中に loadChildren が再度呼ばれた場合、この呼び出しの結果は破棄する
+  if (mySeq !== loadSeq) return;
   if (!result.ok) {
     // 削除ディレクトリの場合、readDir は失敗するので削除エントリのみ表示
     const deletedEntries = getDeletedEntries(props.path, props.gitStatuses);
     if (deletedEntries.length > 0) {
       children.value = sortEntries(deletedEntries);
     } else {
-      notify.error(`Failed to read directory: ${props.path}`, result.error);
+      const label = isRoot.value ? "(worktree root)" : props.path;
+      notify.error(`Failed to read directory: ${label}`, result.error);
       children.value = [];
     }
     loading.value = false;
@@ -167,7 +205,7 @@ function mergeWithGitStatus(entries: FileEntry[]): FileEntry[] {
 // ルートノードは worktree 自体を表すため、マウント時点で子（ルート直下のエントリ）を読み込む。
 // 通常ノードは初回展開時に loadChildren が走るが、ルートは常時 expanded なので初期 mount にフックする。
 onMounted(() => {
-  if (props.isRoot) void loadChildren();
+  if (isRoot.value) void loadChildren();
 });
 
 // fsChange を購読し、自分の path が変更対象なら再読み込み（折りたたみ中はキャッシュ破棄）。
@@ -208,7 +246,7 @@ watch(
  * 祖先の場合は展開するだけ。子は v-for でマウント後に自分の revealVersion watch (immediate)
  * で target を処理する再帰チェーン。
  *
- * ルートノード（path === ""）はあらゆる target の祖先扱い（target が worktree 内なら自身配下にある）。
+ * ルートノード（path === ""）は `isDescendantOf` で worktree 内の任意 target の祖先扱い。
  *
  * absolute 選択中 (worktree 外) は selectedRelPath が undefined になり reveal は no-op。
  * ツリーが持っていないパスをマッチさせる経路を型レベルで排除する。
@@ -229,8 +267,7 @@ async function handleReveal() {
   }
   // ディレクトリでないか、ターゲットが自身の配下でない場合は何もしない
   if (!props.isDirectory) return;
-  const prefix = props.path === "" ? "" : props.path + "/";
-  if (!targetPath.startsWith(prefix)) return;
+  if (!isDescendantOf(targetPath, props.path)) return;
   // 自身の配下に target がある場合、自分は展開するだけ（target そのものへの scroll は
   // 子の watch が処理する）。子は v-for で children を読み込むとマウントされ、
   // immediate watch が現在の revealVersion で発火する
@@ -300,7 +337,7 @@ function onChildSelect(childPath: string) {
         :is-ignored="child.isIgnored"
         :git-change="child.gitChange"
         :git-statuses="gitStatuses"
-        :depth="depth + 1"
+        :depth="childDepth"
         :selected-rel-path="selectedRelPath"
         @select="onChildSelect"
       />

--- a/apps/renderer/src/features/filer/FilerPane.vue
+++ b/apps/renderer/src/features/filer/FilerPane.vue
@@ -5,16 +5,19 @@
 
 - worktree の dir が設定されると、worktree 自体を表す不可視ルート FileTreeItem を 1 個描画する
 - ツリー全体（ルート直下を含む）の管理は FileTreeItem 側に再帰委譲する
-- fsChange / gitStatusChange の RPC メッセージを購読し、filer event store 経由で各 FileTreeItem に通知する
 - dir 切替時は `:key="dir"` でルート FileTreeItem を再マウントする（旧 dir の in-flight loadChildren を構造的に破棄）
+
+## gitStatus / fsChange の購読
+
+- `fsChange` push は `dir` フィルタを通して `filerEventStore.emitFsChange(relDir)` に流す
+- `gitStatuses` は `useGitStatusStore` の computed（`repoStore` 派生）で、初回 `loadGitStatus()` 完了 / `gitStatusChange` push の両経路で更新される。これを `watch` して `filerEventStore.emitGitStatusChange()` を発火することで、両経路を 1 本のトリガに揃える（初回マウント直後に削除仮想エントリが取りこぼされる race を解消）
 </doc>
 
 <script setup lang="ts">
 import { storeToRefs } from "pinia";
-import { onUnmounted } from "vue";
+import { onUnmounted, watch } from "vue";
 import { onMessage } from "../../shared/rpc";
 import { useGitStatusStore, useWorktreeStore } from "../worktree";
-import type { GitStatusChangePayload } from "../worktree";
 import FileTreeItem from "./FileTreeItem.vue";
 import type { FsChangePayload } from "./rpc";
 import { useFilerEventStore } from "./useFilerEventStore";
@@ -38,23 +41,21 @@ function handleFsChange(eventDir: string, relDir: string) {
   filerEventStore.emitFsChange(relDir);
 }
 
-function handleGitStatusChange(eventDir: string) {
-  // useFsWatchSync は全 worktree を watch するため、別 worktree の gitStatusChange も
-  // 到達する。active worktree dir 以外は無視して空打ちの再 merge を防ぐ。
-  if (eventDir !== dir.value) return;
+// gitStatuses は useGitStatusStore の computed で、初回 loadGitStatus() 完了と
+// gitStatusChange push の両方が同じ ref を更新する SSOT。ここを watch することで、
+// 両経路の更新を 1 本のトリガ（emitGitStatusChange）に揃える。
+// dir 切替時にも computed の値は変わるが、ルート FileTreeItem は `:key="dir"` で
+// 再マウントされるため、世代カウンタによる race ガード（FileTreeItem.loadChildren）と
+// 重複しても挙動は最終的に整合する。
+watch(gitStatuses, () => {
   filerEventStore.emitGitStatusChange();
-}
+});
 
 const unsubscribeFsChange = onMessage<FsChangePayload>("fsChange", ({ dir: eventDir, relDir }) =>
   handleFsChange(eventDir, relDir),
 );
-const unsubscribeGitStatus = onMessage<GitStatusChangePayload>(
-  "gitStatusChange",
-  ({ dir: eventDir }) => handleGitStatusChange(eventDir),
-);
 onUnmounted(() => {
   unsubscribeFsChange();
-  unsubscribeGitStatus();
 });
 </script>
 
@@ -73,9 +74,8 @@ onUnmounted(() => {
         :is-directory="true"
         :is-ignored="false"
         :git-statuses="gitStatuses"
-        :depth="-1"
+        :depth="0"
         :selected-rel-path="selectedRelPath"
-        :is-root="true"
         @select="onSelect"
       />
     </div>

--- a/apps/renderer/src/features/filer/FilerPane.vue
+++ b/apps/renderer/src/features/filer/FilerPane.vue
@@ -47,6 +47,12 @@ function handleFsChange(eventDir: string, relDir: string) {
 // dir 切替時にも computed の値は変わるが、ルート FileTreeItem は `:key="dir"` で
 // 再マウントされるため、世代カウンタによる race ガード（FileTreeItem.loadChildren）と
 // 重複しても挙動は最終的に整合する。
+//
+// 暗黙契約: `useRepoStore.setWorktreeGitStatuses` が呼ばれるたびに worktree object と
+// gitStatuses の reference を新規生成すること。両 push / 初回 RPC ともに deserialize 由来の
+// 新規オブジェクトを渡すので reference 同一性は保たれる。同 reference を渡す最適化が将来
+// 入る場合は、shared 層で書き込み version ref を持たせて filer がそれを watch する経路に
+// 切り替える必要がある。
 watch(gitStatuses, () => {
   filerEventStore.emitGitStatusChange();
 });
@@ -74,7 +80,7 @@ onUnmounted(() => {
         :is-directory="true"
         :is-ignored="false"
         :git-statuses="gitStatuses"
-        :depth="0"
+        :depth="-1"
         :selected-rel-path="selectedRelPath"
         @select="onSelect"
       />

--- a/apps/renderer/src/features/filer/FilerPane.vue
+++ b/apps/renderer/src/features/filer/FilerPane.vue
@@ -3,24 +3,19 @@
 
 ## 動作
 
-- ワークスペースのディレクトリが設定されるとルートエントリを読み込み、FileTreeItem を再帰的にレンダリング
-- fsChange / gitStatusChange の RPC メッセージを購読し、ルート再構築 + filer event store 経由で子に通知
-- git 削除ファイルは仮想エントリとしてツリーに挿入
-- 各 FileTreeItem は filer event store + worktreeStore.revealVersion を自律的に watch する設計
+- worktree の dir が設定されると、worktree 自体を表す不可視ルート FileTreeItem を 1 個描画する
+- ツリー全体（ルート直下を含む）の管理は FileTreeItem 側に再帰委譲する
+- fsChange / gitStatusChange の RPC メッセージを購読し、filer event store 経由で各 FileTreeItem に通知する
+- dir 切替時は `:key="dir"` でルート FileTreeItem を再マウントする（旧 dir の in-flight loadChildren を構造的に破棄）
 </doc>
 
 <script setup lang="ts">
-import { tryCatch } from "@gozd/shared";
 import { storeToRefs } from "pinia";
-import { onUnmounted, ref, watch } from "vue";
-import { useNotificationStore } from "../../shared/notification";
+import { onUnmounted } from "vue";
 import { onMessage } from "../../shared/rpc";
-import { resolveGitChangeKind, useGitStatusStore, useWorktreeStore } from "../worktree";
+import { useGitStatusStore, useWorktreeStore } from "../worktree";
 import type { GitStatusChangePayload } from "../worktree";
-import { getDeletedEntries, sortEntries, toFileEntries } from "./filerUtils";
-import type { FileEntry } from "./filerUtils";
 import FileTreeItem from "./FileTreeItem.vue";
-import { rpcFsReadDir } from "./rpc";
 import type { FsChangePayload } from "./rpc";
 import { useFilerEventStore } from "./useFilerEventStore";
 
@@ -28,79 +23,7 @@ const worktreeStore = useWorktreeStore();
 const { dir, selectedRelPath } = storeToRefs(worktreeStore);
 const gitStatusStore = useGitStatusStore();
 const { gitStatuses } = storeToRefs(gitStatusStore);
-const notify = useNotificationStore();
 const filerEventStore = useFilerEventStore();
-
-const rootEntries = ref<FileEntry[]>();
-const loading = ref(false);
-/**
- * loadRoot の呼び出し世代カウンタ。await 境界で旧呼び出しが新呼び出しの結果を上書きしないよう、
- * 各呼び出しが自身の世代を保持して mismatch なら早期 return する。
- * dir 比較だけだと A → B → A のとき同じ dir 値で旧呼び出しと新呼び出しを区別できないため使う。
- */
-let loadRootSeq = 0;
-/**
- * handleGitStatusChange 専用の世代カウンタ。同一 dir 内で gitStatusChange push が
- * 連続発火した場合、`rpcFsReadDir` レスポンス順序が逆転して古い entries が新しい
- * entries を踏み潰す race を防ぐ。`loadRootSeq` と独立に持つことで、loadRoot の
- * 世代軸と互いに干渉しない SSOT として機能する。
- */
-let gitStatusChangeSeq = 0;
-
-/** readDir の結果に git 変更情報と削除ファイルをマージする */
-function mergeWithGitStatus(entries: FileEntry[], dirPath: string): FileEntry[] {
-  const existingNames = new Set(entries.map((e) => e.name));
-
-  // 既存エントリに git 変更種別を付与
-  const withGitChange = entries.map((entry): FileEntry => {
-    const filePath = dirPath === "" ? entry.name : `${dirPath}/${entry.name}`;
-    const statusCode = gitStatuses.value[filePath];
-    if (statusCode) {
-      return { ...entry, gitChange: resolveGitChangeKind(statusCode) };
-    }
-    return entry;
-  });
-
-  // 削除ファイルを追加（既存エントリと重複しないもののみ）
-  const deletedEntries = getDeletedEntries(dirPath, gitStatuses.value).filter(
-    (e) => !existingNames.has(e.name),
-  );
-
-  return sortEntries([...withGitChange, ...deletedEntries]);
-}
-
-async function loadRoot() {
-  const mySeq = ++loadRootSeq;
-  loading.value = true;
-  const dirPath = dir.value;
-  if (dirPath === undefined) {
-    if (mySeq === loadRootSeq) {
-      loading.value = false;
-      rootEntries.value = [];
-    }
-    return;
-  }
-  // rpcFsReadDir と loadGitStatus を並列で投げ、readDir 失敗時のみエラー通知する。
-  // loadGitStatus 側のエラーは store 内で個別に通知済み（cause を握り潰さない）。
-  const [readResult] = await Promise.all([
-    tryCatch(rpcFsReadDir({ dir: dirPath, path: "." })),
-    gitStatusStore.loadGitStatus(),
-  ]);
-  // await 中に loadRoot が再度呼ばれた場合、この呼び出しの結果は破棄する。
-  // 旧呼び出しが新 dir 用の rootEntries を上書きするのを防ぐ。
-  if (mySeq !== loadRootSeq) return;
-  if (!readResult.ok) {
-    notify.error("Failed to read root directory", readResult.error);
-    rootEntries.value = [];
-    // 世代チェック (上の `if (mySeq !== loadRootSeq) return;`) を通過した時点で
-    // `mySeq === loadRootSeq` は確定だが、将来この早期 return の位置が変わった場合に
-    // 備えて重複ガードを置く。N+1 の `loading = true` を誤って消さない防御。
-    if (mySeq === loadRootSeq) loading.value = false;
-    return;
-  }
-  rootEntries.value = mergeWithGitStatus(toFileEntries(readResult.value.entries), "");
-  if (mySeq === loadRootSeq) loading.value = false;
-}
 
 function onSelect(path: string) {
   worktreeStore.selectRelPath(path);
@@ -110,56 +33,17 @@ function handleFsChange(eventDir: string, relDir: string) {
   // useFsWatchSync は全 worktree を watch するため、別 repo / 別 worktree の
   // fsChange も到達する。active worktree dir 以外は無視する。
   if (eventDir !== dir.value) return;
-  // worktree 直下の変更は loadRoot で全件再構築。relDir 表現は Swift
-  // `FSWatchRegistry.relativeDir()` の SSOT に従い、直下は常に `""`。
-  if (relDir === "") {
-    void loadRoot();
-    return;
-  }
-  // 子ディレクトリの変更は filer event store 経由で各 FileTreeItem に通知
+  // ルート（relDir === ""）も子も filer event store 経由で対応 FileTreeItem に通知する。
+  // ルートノードは props.path === "" で同 relDir を購読しているため特別分岐は不要。
   filerEventStore.emitFsChange(relDir);
 }
 
-async function handleGitStatusChange(eventDir: string) {
+function handleGitStatusChange(eventDir: string) {
   // useFsWatchSync は全 worktree を watch するため、別 worktree の gitStatusChange も
-  // 到達する。active worktree dir 以外は無視して空打ちの rpcFsReadDir を防ぐ。
+  // 到達する。active worktree dir 以外は無視して空打ちの再 merge を防ぐ。
   if (eventDir !== dir.value) return;
-  // 子 FileTreeItem は store を watch して自分の path 配下のキャッシュを破棄/再読み込みする
   filerEventStore.emitGitStatusChange();
-  // ルート rootEntries の再構築は FilerPane の責務として残す（gitStatuses 反映 + 削除エントリ）
-  const dirPath = dir.value;
-  if (dirPath === undefined) return;
-  // dir 切替 race と同一 dir 内連続発火 race の両方を世代でガード。
-  // 専用カウンタ gitStatusChangeSeq + loadRootSeq + dir.value の 3 軸チェックで
-  // 「自分が投げた呼び出しの後により新しいものが来ていない」ことを構造的に保証する。
-  const myGitStatusSeq = ++gitStatusChangeSeq;
-  const myLoadSeq = loadRootSeq;
-  const result = await tryCatch(rpcFsReadDir({ dir: dirPath, path: "." }));
-  if (myGitStatusSeq !== gitStatusChangeSeq || myLoadSeq !== loadRootSeq || dir.value !== dirPath) {
-    return;
-  }
-  if (!result.ok) {
-    notify.error("Failed to rebuild root entries", result.error);
-    return;
-  }
-  rootEntries.value = mergeWithGitStatus(toFileEntries(result.value.entries), "");
 }
-
-// dir watch は `flush: 'sync'` を指定して、setOpen({ selection }) で dir 変化と
-// revealVersion ++ が同 tick で起きたとき必ず先に発火させる。
-// （各 FileTreeItem の revealVersion watch はデフォルトの async flush なので、sync watch の後に走る）
-// これにより「dir watch が rootEntries を初期化して loadRoot を起動 → 子マウント後の
-// revealVersion watch (immediate) が target を処理」の順序が flush ステージで構造的に保証される。
-watch(
-  dir,
-  (newDir) => {
-    if (newDir) {
-      rootEntries.value = undefined;
-      void loadRoot();
-    }
-  },
-  { immediate: true, flush: "sync" },
-);
 
 const unsubscribeFsChange = onMessage<FsChangePayload>("fsChange", ({ dir: eventDir, relDir }) =>
   handleFsChange(eventDir, relDir),
@@ -181,24 +65,19 @@ onUnmounted(() => {
       <div v-if="!dir" class="px-2 py-4 text-center text-sm text-zinc-500">
         waiting for open command...
       </div>
-      <div v-else-if="loading && !rootEntries" class="px-2 py-4 text-center text-sm text-zinc-500">
-        Loading...
-      </div>
-      <template v-else>
-        <FileTreeItem
-          v-for="entry in rootEntries"
-          :key="`${entry.name}-${entry.isDirectory}`"
-          :name="entry.name"
-          :path="entry.name"
-          :is-directory="entry.isDirectory"
-          :is-ignored="entry.isIgnored"
-          :git-change="entry.gitChange"
-          :git-statuses="gitStatuses"
-          :depth="0"
-          :selected-rel-path="selectedRelPath"
-          @select="onSelect"
-        />
-      </template>
+      <FileTreeItem
+        v-else
+        :key="dir"
+        name=""
+        path=""
+        :is-directory="true"
+        :is-ignored="false"
+        :git-statuses="gitStatuses"
+        :depth="-1"
+        :selected-rel-path="selectedRelPath"
+        :is-root="true"
+        @select="onSelect"
+      />
     </div>
   </div>
 </template>

--- a/apps/renderer/src/features/filer/filerUtils.test.ts
+++ b/apps/renderer/src/features/filer/filerUtils.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { dirName, sortEntries, toFileEntries, type FileEntry } from "./filerUtils";
+import {
+  dirName,
+  isDescendantOf,
+  isRootPath,
+  joinPath,
+  pathForNativeRpc,
+  sortEntries,
+  toFileEntries,
+  type FileEntry,
+} from "./filerUtils";
 
 describe("dirName", () => {
   test("パスの末尾をディレクトリ名として返す", () => {
@@ -47,6 +56,70 @@ describe("sortEntries", () => {
 
   test("空配列を処理できる", () => {
     expect(sortEntries([])).toEqual([]);
+  });
+});
+
+describe("joinPath", () => {
+  test("worktree 直下の親は先頭スラッシュなし", () => {
+    expect(joinPath("", "name")).toBe("name");
+  });
+
+  test("通常の親は / で連結する", () => {
+    expect(joinPath("dir", "name")).toBe("dir/name");
+  });
+
+  test("ネストした親も / で連結する", () => {
+    expect(joinPath("a/b", "c")).toBe("a/b/c");
+  });
+
+  test("name が空文字でも先頭スラッシュは付かない", () => {
+    expect(joinPath("", "")).toBe("");
+  });
+});
+
+describe("isRootPath", () => {
+  test("空文字列は root", () => {
+    expect(isRootPath("")).toBe(true);
+  });
+
+  test("通常の relPath は root ではない", () => {
+    expect(isRootPath("src")).toBe(false);
+    expect(isRootPath("a/b")).toBe(false);
+  });
+
+  test(". は root ではない（Swift relDir SSOT に従い root は空文字のみ）", () => {
+    expect(isRootPath(".")).toBe(false);
+  });
+});
+
+describe("pathForNativeRpc", () => {
+  test("root は . に置き換わる", () => {
+    expect(pathForNativeRpc("")).toBe(".");
+  });
+
+  test("通常の relPath はそのまま", () => {
+    expect(pathForNativeRpc("src")).toBe("src");
+    expect(pathForNativeRpc("a/b")).toBe("a/b");
+  });
+});
+
+describe("isDescendantOf", () => {
+  test("root はあらゆる relPath の祖先扱い", () => {
+    expect(isDescendantOf("src/foo.ts", "")).toBe(true);
+    expect(isDescendantOf("a", "")).toBe(true);
+  });
+
+  test("ディレクトリ配下の relPath は配下扱い", () => {
+    expect(isDescendantOf("src/foo.ts", "src")).toBe(true);
+    expect(isDescendantOf("src/a/b.ts", "src/a")).toBe(true);
+  });
+
+  test("自分自身は配下扱いではない（厳密配下）", () => {
+    expect(isDescendantOf("src", "src")).toBe(false);
+  });
+
+  test("prefix のみ一致する別 dir は配下扱いではない（/foo が /foobar の prefix にならない）", () => {
+    expect(isDescendantOf("srcbar/foo.ts", "src")).toBe(false);
   });
 });
 

--- a/apps/renderer/src/features/filer/filerUtils.test.ts
+++ b/apps/renderer/src/features/filer/filerUtils.test.ts
@@ -104,7 +104,7 @@ describe("pathForNativeRpc", () => {
 });
 
 describe("isDescendantOf", () => {
-  test("root はあらゆる relPath の祖先扱い", () => {
+  test("root はあらゆる非ルート relPath の祖先扱い", () => {
     expect(isDescendantOf("src/foo.ts", "")).toBe(true);
     expect(isDescendantOf("a", "")).toBe(true);
   });
@@ -116,6 +116,10 @@ describe("isDescendantOf", () => {
 
   test("自分自身は配下扱いではない（厳密配下）", () => {
     expect(isDescendantOf("src", "src")).toBe(false);
+  });
+
+  test("root × root も厳密配下に従って自分自身扱い（false）", () => {
+    expect(isDescendantOf("", "")).toBe(false);
   });
 
   test("prefix のみ一致する別 dir は配下扱いではない（/foo が /foobar の prefix にならない）", () => {

--- a/apps/renderer/src/features/filer/filerUtils.ts
+++ b/apps/renderer/src/features/filer/filerUtils.ts
@@ -61,6 +61,14 @@ function dirName(dirPath: string): string {
   return parts[parts.length - 1] ?? dirPath;
 }
 
+/**
+ * worktree 相対パスの親 + 子名を連結する。worktree 直下のパスを表現する `""` を
+ * 親として渡すと先頭 `/` が付かない。`getDeletedEntries` の `prefix` 算出と同じ規律。
+ */
+function joinPath(parent: string, name: string): string {
+  return parent === "" ? name : `${parent}/${name}`;
+}
+
 /** ディレクトリ優先 → 名前順 */
 function sortEntries(entries: FileEntry[]): FileEntry[] {
   return [...entries].sort((a, b) => {
@@ -71,5 +79,5 @@ function sortEntries(entries: FileEntry[]): FileEntry[] {
   });
 }
 
-export { dirName, getDeletedEntries, sortEntries, toFileEntries };
+export { dirName, getDeletedEntries, joinPath, sortEntries, toFileEntries };
 export type { FileEntry };

--- a/apps/renderer/src/features/filer/filerUtils.ts
+++ b/apps/renderer/src/features/filer/filerUtils.ts
@@ -69,6 +69,32 @@ function joinPath(parent: string, name: string): string {
   return parent === "" ? name : `${parent}/${name}`;
 }
 
+/**
+ * worktree 自体（不可視ルート）を表す path 値かどうか。Swift の `relDir` SSOT に合わせ、
+ * worktree 直下を `""` で表現する規約に依存する全分岐の根拠を 1 か所に集約する。
+ */
+function isRootPath(path: string): boolean {
+  return path === "";
+}
+
+/**
+ * native の `URL(fileURLWithPath:)` は空文字を未定義扱いするため、worktree 直下を
+ * RPC で指す時だけ `.` に置き換える。entries は dir からの相対で返るため、結果側の
+ * パス組み立て（`joinPath`）は影響を受けない。
+ */
+function pathForNativeRpc(path: string): string {
+  return isRootPath(path) ? "." : path;
+}
+
+/**
+ * `targetPath` が `ancestorPath` の配下にあるか判定する。worktree ルート
+ * （`ancestorPath === ""`）はあらゆる relPath の祖先扱い。
+ */
+function isDescendantOf(targetPath: string, ancestorPath: string): boolean {
+  if (isRootPath(ancestorPath)) return true;
+  return targetPath.startsWith(ancestorPath + "/");
+}
+
 /** ディレクトリ優先 → 名前順 */
 function sortEntries(entries: FileEntry[]): FileEntry[] {
   return [...entries].sort((a, b) => {
@@ -79,5 +105,14 @@ function sortEntries(entries: FileEntry[]): FileEntry[] {
   });
 }
 
-export { dirName, getDeletedEntries, joinPath, sortEntries, toFileEntries };
+export {
+  dirName,
+  getDeletedEntries,
+  isDescendantOf,
+  isRootPath,
+  joinPath,
+  pathForNativeRpc,
+  sortEntries,
+  toFileEntries,
+};
 export type { FileEntry };

--- a/apps/renderer/src/features/filer/filerUtils.ts
+++ b/apps/renderer/src/features/filer/filerUtils.ts
@@ -87,11 +87,12 @@ function pathForNativeRpc(path: string): string {
 }
 
 /**
- * `targetPath` が `ancestorPath` の配下にあるか判定する。worktree ルート
- * （`ancestorPath === ""`）はあらゆる relPath の祖先扱い。
+ * `targetPath` が `ancestorPath` の **厳密配下** にあるか判定する（自分自身は配下扱いではない）。
+ * worktree ルート（`ancestorPath === ""`）はあらゆる非ルート relPath の祖先扱い。
+ * root × root のケースは「祖先 != 自分自身」の規律に従って false を返す。
  */
 function isDescendantOf(targetPath: string, ancestorPath: string): boolean {
-  if (isRootPath(ancestorPath)) return true;
+  if (isRootPath(ancestorPath)) return !isRootPath(targetPath);
   return targetPath.startsWith(ancestorPath + "/");
 }
 

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -245,6 +245,12 @@ export const useRepoStore = defineStore("repo", () => {
    * dir に該当する worktree が見つからなければ no-op。
    * 書き込み毎に per-dir 世代を進め、in-flight な loadGitStatus / fetchRepo の
    * 古いレスポンスがこの値を上書きできないようにする。
+   *
+   * **不変条件**: 呼び出しごとに `worktree` と上位 `repo` を新規オブジェクトに置き換える
+   * （shallow copy）。`useGitStatusStore.gitStatuses` computed の reference 同一性を変化させ、
+   * FilerPane の `watch(gitStatuses)` を確実に発火させるための SSOT。「同じ statuses なら
+   * no-op で skip する」最適化を入れる場合は、watch 側を reference ベースから書き込み
+   * version ref ベースに切り替える必要がある。
    */
   function setWorktreeGitStatuses(dir: string, patch: WorktreeStatusPatch) {
     const repo = findRepoOwning(dir);


### PR DESCRIPTION
## 概要

filer のツリー管理を `FileTreeItem` の再帰だけで完結させるリファクタ。`FilerPane` がルート専用に持っていた `rootEntries` / `loadRoot` / `mergeWithGitStatus` / 世代カウンタ群を撤廃し、worktree 自体を表す不可視ルート `FileTreeItem` を 1 個描画する構成に統一する。

## 背景

issue ( #125 ) で指摘された通り、`FilerPane` と `FileTreeItem` でツリー管理が二重構造になっていた。具体的には:

- `mergeWithGitStatus` がほぼ同じ実装で `FilerPane.vue` と `FileTreeItem.vue` に存在
- `handleFsChange` がルートディレクトリ（`relDir === ""`）の特別分岐を持つ
- ルート専用に `loadRootSeq` / `gitStatusChangeSeq` の 2 軸 race ガードが必要
- `:key` パターンや「Loading...」表示が両コンポーネントに重複

ルートだけが特別な race ガードを持っている事実が、二重構造の歪みを示していた。ツリー全体を `FileTreeItem` の再帰として扱えば、ガードもパス処理も 1 か所に集約できる。

## 変更内容

### `FileTreeItem.vue` をツリー管理の SSOT に

- worktree 自体を表す不可視ルートは `path === ""` で表現（Swift `relDir` SSOT と整合）。判定は `isRootPath()` ヘルパに集約
- ボタン非表示・初期 `expanded = true`・`onMounted` での `loadChildren()` 起動・depth 計算・エラーメッセージのラベル分岐をすべて `isRootPath(path)` 経由で吸収。`isRoot` prop は廃止
- ルート不可視ノードでは表示要素由来の computed（`textColorClass` / `effectiveGitChange` / `iconUrl`）を冒頭で短絡し、不要計算を避ける
- `loadChildren` に per-instance 世代カウンタ `loadSeq` を導入。await 後に `mySeq !== loadSeq` なら結果を破棄する。旧 FilerPane のルート専用ガードを全ノードの SSOT に格上げし、同一 dir 内で `fsChange` / `gitStatusChange` push が連続発火しても古い `rpcFsReadDir` レスポンスが新しい entries を踏み潰さない
- `handleReveal` の祖先判定は `isDescendantOf(target, ancestor)` ヘルパ経由（ルートは任意 relPath の祖先扱い）

### `FilerPane.vue` をコンテナだけに簡素化

- `rootEntries` / `loadRoot` / `mergeWithGitStatus` / `loadRootSeq` / `gitStatusChangeSeq` / `dir` の sync watch を全削除
- dir 切替の race ガードは `:key="dir"` による FileTreeItem の unmount/mount に置き換え。in-flight な `loadChildren` は破棄済みコンポーネントの ref に書き込むだけで構造的に無効化される
- `handleFsChange` のルート分岐（`relDir === ""`）を削除。ルート FileTreeItem が `props.path === ""` の relDir を購読する
- `gitStatusChange` の購読を `onMessage` から `watch(gitStatuses)` に切り替え。`useGitStatusStore.gitStatuses` は `repoStore` 派生 computed で、初回 `loadGitStatus()` 完了 / `gitStatusChange` push の両経路で同じ ref を更新する。これを 1 本のトリガにすることで、初回マウント直後の数 ms 間だけ削除仮想エントリの merge が空になる regression を解消した

### `filerUtils.ts` に SSOT helper を追加

- `joinPath(parent, name)`: 親 `""` のとき先頭 `/` を付けない
- `isRootPath(path)`: worktree 自体（不可視ルート）の判定
- `pathForNativeRpc(path)`: native `URL(fileURLWithPath:)` が空文字を未定義扱いする件を吸収（`""` → `"."`）
- `isDescendantOf(target, ancestor)`: ルートは任意 relPath の祖先扱い、`/foo` が `/foobar` の prefix にならない厳密配下判定
- すべてに境界値テストを追加

## 確認事項

- [ ] worktree を開いたときルート直下のファイル一覧が表示される
- [ ] 削除ファイル（仮想エントリ）は **初回表示時点から** ツリーに見える（後続の fsChange を待たない）
- [ ] サブディレクトリを展開して中身が読み込まれる
- [ ] worktree を切り替えるとツリーが入れ替わる（in-flight load の race なし）
- [ ] ファイルを編集 / 削除 / 作成すると git status の色付けと削除エントリが反映される
- [ ] `git checkout -b` 等で gitStatus が変わったときツリーが追従する
- [ ] reveal（terminal でファイルパスをクリック等）でツリーが展開・スクロールする
