### PR TITLE
fix(pty): PTYError サブ case を dispatcher log と 500 response に届ける

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,15 @@ macOS 26 Tahoe 以降専用（`WebPage` API は macOS 26 で追加された Swif
 - `tryCatch(() => ...)` で同期処理、`tryCatch(promise)` で非同期処理をラップ
 - 結果は `result.ok` で判定し、`result.value` / `result.error` でアクセスする
 
+### 観察ログ (stderr) の書式
+
+dispatcher / store / hook ハンドラなどから `FileHandle.standardError.write` で出す観察ログは以下の SSOT に揃える:
+
+- **素埋め込み**（`"\(value)"` 直書き）を採用する。`String(reflecting:)` などで path / executable / 任意フィールドを quote 化しない。stderr log 全体の書式統一を維持するため、1 箇所だけ quote 化する変更は入れない
+- prefix は handler 関数名 (`[handlePtySpawn]`) または store 名 (`[ClaudeSessionStore]`) を使う。grep で経路を絞れるよう一貫させる
+- 改行 / 制御文字を含み得るフィールドは log に乗せる前に source 側で sanitize する（例: `PTYError.errnoText` の control-char gate）。log フォーマット側で escape しない
+- 仮に path quoting が必要になった場合は本セクションを改定して全箇所を統一する。一部箇所だけの差分は入れない
+
 ## Swift
 
 ### 型システム / safety 機構の無効化・回避は厳禁

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,9 @@ dispatcher / store / hook ハンドラなどから `FileHandle.standardError.wri
 
 対象外:
 
-- **trace 系統** (`PTYTrace.swift` の `[PTY-TRACE +elapsed pid tag]` / `[TEST-TRACE]`): 専用の prefix フォーマット (elapsed timestamp + pid + tag) を持ち、デバッグトレース用途として別系統で運用する。handler 名 prefix 規約の対象外
+- **trace 系統**: 専用の prefix フォーマットを持ち、デバッグトレース用途として別系統で運用する。handler 名 prefix 規約の対象外
+  - `[PTY-TRACE +elapsed pid=N tag]` (`PTYTrace.swift`): GozdCore 内の PTY ライフサイクルイベント。pid を含む
+  - `[TEST-TRACE +elapsed test=NAME]` (`TestTrace.swift`): test ハーネス側のトレース。pid は含まない
 - print/NSLog 経由のログは対象外（gozd では使わない方針）
 
 ## Swift

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,12 +162,17 @@ macOS 26 Tahoe 以降専用（`WebPage` API は macOS 26 で追加された Swif
 
 ### 観察ログ (stderr) の書式
 
-dispatcher / store / hook ハンドラなどから `FileHandle.standardError.write` で出す観察ログは以下の SSOT に揃える:
+dispatcher / store / hook ハンドラなどから `FileHandle.standardError.write` で出す **ad-hoc な観察ログ** は以下の SSOT に揃える:
 
 - **素埋め込み**（`"\(value)"` 直書き）を採用する。`String(reflecting:)` などで path / executable / 任意フィールドを quote 化しない。stderr log 全体の書式統一を維持するため、1 箇所だけ quote 化する変更は入れない
 - prefix は handler 関数名 (`[handlePtySpawn]`) または store 名 (`[ClaudeSessionStore]`) を使う。grep で経路を絞れるよう一貫させる
 - 改行 / 制御文字を含み得るフィールドは log に乗せる前に source 側で sanitize する（例: `PTYError.errnoText` の control-char gate）。log フォーマット側で escape しない
 - 仮に path quoting が必要になった場合は本セクションを改定して全箇所を統一する。一部箇所だけの差分は入れない
+
+対象外:
+
+- **trace 系統** (`PTYTrace.swift` の `[PTY-TRACE +elapsed pid tag]` / `[TEST-TRACE]`): 専用の prefix フォーマット (elapsed timestamp + pid + tag) を持ち、デバッグトレース用途として別系統で運用する。handler 名 prefix 規約の対象外
+- print/NSLog 経由のログは対象外（gozd では使わない方針）
 
 ## Swift
 

--- a/apps/native/Sources/Gozd/GozdApp.swift
+++ b/apps/native/Sources/Gozd/GozdApp.swift
@@ -657,6 +657,13 @@ struct RpcSchemeHandler: URLSchemeHandler {
         } catch RpcError.unknownPath(let p) {
           yield(continuation: continuation, status: 404, url: url, message: "unknown RPC: \(p)")
         } catch {
+          // 500 response の body は `"\(error)"` （= `String(describing:)`）で組み立てる。
+          // Swift は `CustomStringConvertible` 準拠を優先するため、dispatcher から
+          // throw する Error 型は `CustomStringConvertible` で人間可読な identifier
+          // を提供する契約とする（例: `PTYError` の case 名 + errno + strerror）。
+          // この経路は renderer 側で `Error(\`RPC ${path} failed: ${res.status} ${text}\`)`
+          // として再 raise されるため、Error の `description` 品質が renderer 通知の
+          // 識別性を決定する。
           yield(continuation: continuation, status: 500, url: url, message: "\(error)")
         }
         continuation.finish()

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -384,11 +384,21 @@ extension PTYError: CustomStringConvertible {
   /// strerror 出力（観察ログ品質）を諦めることになる。よって rc は信用せず
   /// buffer を返す。
   ///
-  /// ただし POSIX 文面の最悪ケース（rc != 0 時の buffer 中間に部分的ゴミ）に
-  /// 備え、buffer 内容が「印字可能 ASCII (0x20–0x7E) のみ」であることを構造的に
-  /// 検証する。観察ログに制御文字 / 非 ASCII バイトが漏れると Console.app の
-  /// 1 行性が崩れる / grep 経路が壊れるため、印字可能性を満たさない buffer は
-  /// 自前 fallback に倒す。NUL のみ（空 buffer）も同経路で fallback。
+  /// ただし POSIX 文面の最悪ケース（rc != 0 時の buffer 中間に部分的ゴミ）と
+  /// 観察ログの 1 行性に備え、buffer 内容に制御文字（0x00-0x1F / 0x7F）が含まれない
+  /// ことを構造的に検証する。
+  ///
+  /// 非 ASCII バイト（0x80-0xFF）は **許容する**: `strerror_r` は `LC_MESSAGES`
+  /// ロケール依存（POSIX 仕様）で、`LANG=ja_JP.UTF-8` 等の環境では valid errno に
+  /// 対しても multi-byte UTF-8 シーケンスが buffer に書かれる。これらは観察ログの
+  /// 1 行性を破壊しない（multi-byte の構成バイトは 0x80-0xFF で制御文字に重ならない）
+  /// ため信頼する。これで stderr の 1 行性と renderer に届く identifier 品質の双方を
+  /// 同時に満たせる。
+  ///
+  /// gate に倒れる条件:
+  ///   - buffer が空（NUL のみ）
+  ///   - buffer に制御文字（CR/LF/TAB/NUL 等の 0x00-0x1F、DEL 0x7F）が含まれる
+  /// 上記いずれかなら自前 fallback `"unknown errno N"` を返す。
   ///
   /// `PTYError` / `PTYExitReason` 両方の `description` から共有するため `internal`。
   static func errnoText(_ code: Int32) -> String {
@@ -399,14 +409,14 @@ extension PTYError: CustomStringConvertible {
     if slice.isEmpty {
       return "unknown errno \(code)"
     }
-    // 印字可能 ASCII (space 0x20 〜 tilde 0x7E) のみで構成されることを確認。
-    // 制御文字 (CR/LF/TAB 含む)、DEL (0x7F)、非 ASCII (0x80–0xFF) を含む buffer は
-    // 観察可能性を毀損するため信用しない。CChar (Int8) → UInt8 bitPattern で評価。
-    let isPrintableAscii = slice.allSatisfy { c in
+    // 制御文字 (0x00-0x1F, 0x7F) を含む buffer は観察ログの 1 行性を破壊するため
+    // 信用しない。CChar (Int8) を UInt8 bitPattern で評価。multi-byte UTF-8 の
+    // 構成バイト (0x80-0xFF) は許容して非英語 locale の strerror を保持する。
+    let hasControlChar = slice.contains { c in
       let u = UInt8(bitPattern: c)
-      return u >= 0x20 && u <= 0x7E
+      return u < 0x20 || u == 0x7F
     }
-    if !isPrintableAscii {
+    if hasControlChar {
       return "unknown errno \(code)"
     }
     return String(decoding: slice.lazy.map { UInt8(bitPattern: $0) }, as: UTF8.self)

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -360,7 +360,7 @@ extension PTYError: CustomStringConvertible {
   /// errno → 人間可読文字列。`PTYError` / `PTYExitReason` 両方の `description`
   /// から共有するため `internal`。
   ///
-  /// # API 選択
+  /// ## API 選択
   ///
   /// - `strerror(3)` は POSIX 文面上 thread-safe ではない（同一スレッド内で次回呼び出し
   ///   まで有効、別スレッドが同時に呼ぶと buffer が上書きされる）。よって thread-safe な
@@ -373,7 +373,7 @@ extension PTYError: CustomStringConvertible {
   ///   deprecated（deprecation message: "after truncating the null termination"）。
   ///   `CChar` (Int8) → `UInt8` の bitPattern reinterpret で UTF-8 バイト列とみなす
   ///
-  /// # buffer / rc の扱い
+  /// ## buffer / rc の扱い
   ///
   /// `strerror_r` の rc 値は捨てて buffer を返す。
   ///
@@ -392,7 +392,7 @@ extension PTYError: CustomStringConvertible {
   /// 1 行性を破壊しない（制御文字に重ならない）ため信頼する。これで stderr の 1 行性と
   /// renderer に届く identifier 品質の双方を同時に満たせる。
   ///
-  /// # 防御的 gate
+  /// ## 防御的 gate
   ///
   /// Darwin 保証は POSIX 未定義領域 (`rc != 0` 時 buffer 未定義) に依存しているため、
   /// 将来 version の挙動変化 / OS 内部状態の異常で「制御文字混入 buffer」が返る
@@ -406,7 +406,7 @@ extension PTYError: CustomStringConvertible {
   ///
   /// gate のコストは spawn 失敗ごとの低頻度経路で無視できる。
   ///
-  /// # invalid UTF-8 sequence
+  /// ## invalid UTF-8 sequence
   ///
   /// `String(decoding:as: UTF8.self)` は不正バイト列を U+FFFD (Unicode replacement
   /// character) に置換する。Darwin 保証範囲外の最悪ケース（制御文字を含まない

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -400,6 +400,14 @@ extension PTYError: CustomStringConvertible {
   ///   - buffer に制御文字（CR/LF/TAB/NUL 等の 0x00-0x1F、DEL 0x7F）が含まれる
   /// 上記いずれかなら自前 fallback `"unknown errno N"` を返す。
   ///
+  /// invalid UTF-8 sequence の扱い: `String(decoding:as: UTF8.self)` は不正な
+  /// バイト列を U+FFFD (Unicode replacement character) に置換する。POSIX 文面の
+  /// 最悪ケース（rc != 0 時に buffer が部分的に corrupt しているケース）で、
+  /// 制御文字を含まない non-ASCII gibberish が U+FFFD 混じりで description に
+  /// 乗る可能性がある。これは invalid errno 経路の現実離れした最悪ケースに限り
+  /// 発現する副作用で、観察ログとしては「errno N に対し何らかの非標準応答が
+  /// あった」識別子として acceptable と判定し、追加の gate は入れない。
+  ///
   /// `PTYError` / `PTYExitReason` 両方の `description` から共有するため `internal`。
   static func errnoText(_ code: Int32) -> String {
     var buf = [CChar](repeating: 0, count: 256)

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -349,17 +349,41 @@ extension PTYError: CustomStringConvertible {
   public var description: String {
     switch self {
     case .openptyFailed(let errno):
-      return "PTYError.openptyFailed(errno=\(errno) \(errnoText(errno)))"
+      return "PTYError.openptyFailed(errno=\(errno) \(Self.errnoText(errno)))"
     case .forkFailed(let errno):
-      return "PTYError.forkFailed(errno=\(errno) \(errnoText(errno)))"
+      return "PTYError.forkFailed(errno=\(errno) \(Self.errnoText(errno)))"
     case .preforkAllocFailed(let errno):
-      return "PTYError.preforkAllocFailed(errno=\(errno) \(errnoText(errno)))"
+      return "PTYError.preforkAllocFailed(errno=\(errno) \(Self.errnoText(errno)))"
     }
   }
-}
 
-private func errnoText(_ errno: Int32) -> String {
-  String(cString: strerror(errno))
+  /// errno → 人間可読文字列。`strerror(3)` は POSIX 文面上 thread-safe ではない
+  /// （同一スレッド内で次回呼び出しまで有効、別スレッドが同時に呼ぶと buffer が
+  /// 上書きされる可能性がある）。`String(cString:)` のコピーは API 仕様上の race
+  /// window を閉じる根拠にならないため、thread-safe な `strerror_r(3)` (POSIX 版、
+  /// `int` 戻り) を使う。
+  ///
+  /// `swift-system` の `Errno.description` は内部で `strerror` (thread-unsafe) を
+  /// 使っており ( apple/swift-system #156 ) 採用しない。`Foundation.POSIXError` も
+  /// NSError bridge 経由で内部実装は同根のため不採用。errno → text の thread-safe
+  /// 経路は現状 `strerror_r` 直叩きが業界推奨に残っている。
+  ///
+  /// 文字列化は SE-0405 の公式 deprecation 方針に従い、`String(cString: [CChar])`
+  /// （Swift 6 で deprecated）を避けて `String(decoding: slice, as: UTF8.self)` を
+  /// 使う。`firstIndex(of: 0)` で NUL 終端まで truncate するイディオムが公式推奨
+  /// （deprecation message: "after truncating the null termination"）。errno text は
+  /// ASCII 範囲のため `CChar` (Int8) → `UInt8` の bitPattern reinterpret で UTF-8 と等価。
+  ///
+  /// `PTYError` / `PTYExitReason` 両方の `description` から共有するため `internal`。
+  static func errnoText(_ code: Int32) -> String {
+    var buf = [CChar](repeating: 0, count: 256)
+    let rc = strerror_r(code, &buf, buf.count)
+    if rc != 0 {
+      return "unknown errno \(code)"
+    }
+    let nul = buf.firstIndex(of: 0) ?? buf.endIndex
+    return String(decoding: buf[..<nul].lazy.map { UInt8(bitPattern: $0) }, as: UTF8.self)
+  }
 }
 
 public enum PTYExitReason: Sendable, Equatable {
@@ -383,6 +407,24 @@ public enum PTYExitReason: Sendable, Equatable {
       return .stopped
     }
     return .signaled(signal: lower, coreDumped: (status & 0x80) != 0)
+  }
+}
+
+extension PTYExitReason: CustomStringConvertible {
+  /// `PTYError` と同じく、`"\(reason)"` / `String(describing:)` 経由で case 名 +
+  /// 付随情報が必ず stderr / log に残るようにする。`waitpidFailed` は errno を
+  /// 持つため `strerror_r(3)` 経由で人間可読化する。
+  public var description: String {
+    switch self {
+    case .exited(let code):
+      return "PTYExitReason.exited(code=\(code))"
+    case .signaled(let signal, let coreDumped):
+      return "PTYExitReason.signaled(signal=\(signal) coreDumped=\(coreDumped))"
+    case .stopped:
+      return "PTYExitReason.stopped"
+    case .waitpidFailed(let errno):
+      return "PTYExitReason.waitpidFailed(errno=\(errno) \(PTYError.errnoText(errno)))"
+    }
   }
 }
 

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -357,66 +357,69 @@ extension PTYError: CustomStringConvertible {
     }
   }
 
-  /// errno → 人間可読文字列。`strerror(3)` は POSIX 文面上 thread-safe ではない
-  /// （同一スレッド内で次回呼び出しまで有効、別スレッドが同時に呼ぶと buffer が
-  /// 上書きされる可能性がある）。`String(cString:)` のコピーは API 仕様上の race
-  /// window を閉じる根拠にならないため、thread-safe な `strerror_r(3)` (POSIX 版、
-  /// `int` 戻り) を使う。
+  /// errno → 人間可読文字列。`PTYError` / `PTYExitReason` 両方の `description`
+  /// から共有するため `internal`。
   ///
-  /// `swift-system` の `Errno.description` は内部で `strerror` (thread-unsafe) を
-  /// 使っており ( apple/swift-system #156 ) 採用しない。`Foundation.POSIXError` も
-  /// NSError bridge 経由で内部実装は同根のため不採用。errno → text の thread-safe
-  /// 経路は現状 `strerror_r` 直叩きが業界推奨に残っている。
+  /// # API 選択
   ///
-  /// 文字列化は SE-0405 の公式 deprecation 方針に従い、`String(cString: [CChar])`
-  /// （Swift 6 で deprecated）を避けて `String(decoding: slice, as: UTF8.self)` を
-  /// 使う。`firstIndex(of: 0)` で NUL 終端まで truncate するイディオムが公式推奨
-  /// （deprecation message: "after truncating the null termination"）。errno text は
-  /// ASCII 範囲のため `CChar` (Int8) → `UInt8` の bitPattern reinterpret で UTF-8 と等価。
+  /// - `strerror(3)` は POSIX 文面上 thread-safe ではない（同一スレッド内で次回呼び出し
+  ///   まで有効、別スレッドが同時に呼ぶと buffer が上書きされる）。よって thread-safe な
+  ///   `strerror_r(3)` (POSIX 版、`int` 戻り) を使う
+  /// - `swift-system` の `Errno.description` は内部で `strerror` を呼ぶ + 未解決の
+  ///   thread-safety bug ( apple/swift-system #156 ) のため不採用
+  /// - `Foundation.POSIXError` も NSError bridge 経由で内部実装は同根のため不採用
+  /// - 文字列化は SE-0405 (`String(decoding:as: UTF8.self)` + `firstIndex(of: 0)` で
+  ///   NUL truncate) の公式イディオムに従う。`String(cString: [CChar])` は Swift 6 で
+  ///   deprecated（deprecation message: "after truncating the null termination"）。
+  ///   `CChar` (Int8) → `UInt8` の bitPattern reinterpret で UTF-8 バイト列とみなす
   ///
-  /// **主根拠 (Darwin manpage 保証)**: macOS Darwin の strerror_r(3) manpage は
-  /// "If the error number is not recognized, these functions return EINVAL ...
-  /// The strerror_r() function ... copies an error message string into the
-  /// buffer ..." と明記しており、**invalid errno (EINVAL を返す経路) でも
-  /// buffer に readable な error message string を埋める** ことを保証する。
-  /// gozd は macOS 26 Tahoe 専用 (CLAUDE.md「対応プラットフォーム」) のため、
-  /// Darwin 保証の範囲で実用上の挙動は閉じる。よって rc 値は捨てて buffer を
-  /// そのまま返す方針が観察可能性（renderer に届く identifier 品質、Console.app
-  /// 観察ログの人間可読性）を最大化する。Linux glibc も同等挙動を示すと観察済み。
+  /// # buffer / rc の扱い
   ///
-  /// **防御的多重化として gate を入れる**: 上記 Darwin 保証は POSIX 文面では
-  /// 未定義領域 (`rc != 0` 時 buffer 未定義) に依存している。Darwin 将来 version
-  /// で挙動が変わる / OS 内部状態の異常 / マルチスレッド境界の不整合 等の
-  /// 想定外シナリオで「control char 混入 buffer」が返る可能性をゼロとは断言
-  /// できない。観察ログの 1 行性 (Console.app の grep 経路 / event 分離) は
-  /// 構造的に守りたいので、buffer に制御文字 (0x00-0x1F / 0x7F) が含まれる場合
-  /// のみ自前 fallback に倒す gate を入れる。`PTYError` / `PTYExitReason` の
-  /// `description` は spawn 失敗ごとの低頻度経路なので gate のコストは無視できる。
+  /// `strerror_r` の rc 値は捨てて buffer を返す。
   ///
-  /// 非 ASCII バイト（0x80-0xFF）は **許容する**: `strerror_r` は `LC_MESSAGES`
-  /// ロケール依存（POSIX 仕様）で、`LANG=ja_JP.UTF-8` 等の環境では valid errno に
-  /// 対しても multi-byte UTF-8 シーケンスが buffer に書かれる。これらは観察ログの
-  /// 1 行性を破壊しない（multi-byte の構成バイトは 0x80-0xFF で制御文字に重ならない）
-  /// ため信頼する。これで stderr の 1 行性と renderer に届く identifier 品質の双方を
-  /// 同時に満たせる。
+  /// Darwin manpage strerror_r(3) は "If the error number is not recognized, these
+  /// functions return EINVAL ... The strerror_r() function ... copies an error
+  /// message string into the buffer ..." と明記しており、**invalid errno (EINVAL を
+  /// 返す経路) でも buffer に readable な error message string を埋める** ことを
+  /// 保証する。gozd は macOS 26 Tahoe 専用 (CLAUDE.md「対応プラットフォーム」) のため、
+  /// Darwin 保証の範囲で挙動が閉じる。rc != 0 を理由に buffer を捨てると本物の
+  /// strerror 出力 (renderer に届く identifier 品質、Console.app の人間可読性) を
+  /// 失うため、buffer を信用する方針が観察可能性を最大化する。
   ///
-  /// gate に倒れる条件:
-  ///   - buffer が空（NUL のみ）
-  ///   - buffer に制御文字（CR/LF/TAB/NUL 等の 0x00-0x1F、DEL 0x7F）が含まれる
-  /// 上記いずれかなら自前 fallback `"unknown errno N"` を返す。
+  /// 非 ASCII バイト（0x80-0xFF）は許容する。`strerror_r` は `LC_MESSAGES` ロケール
+  /// 依存（POSIX 仕様）で、`LANG=ja_JP.UTF-8` 等の環境では valid errno に対しても
+  /// multi-byte UTF-8 シーケンスが buffer に書かれる。非 ASCII 構成バイトは観察ログの
+  /// 1 行性を破壊しない（制御文字に重ならない）ため信頼する。これで stderr の 1 行性と
+  /// renderer に届く identifier 品質の双方を同時に満たせる。
   ///
-  /// invalid UTF-8 sequence の扱い: `String(decoding:as: UTF8.self)` は不正な
-  /// バイト列を U+FFFD (Unicode replacement character) に置換する。Darwin 保証の
-  /// 範囲外で非標準的な non-ASCII gibberish が返った場合、それが U+FFFD 混じりで
-  /// description に乗る可能性がある。観察ログとしては「errno N に対し何らかの
-  /// 非標準応答があった」識別子として acceptable と判定し、追加の UTF-8 validity
-  /// gate は入れない。validity gate を入れると BCP-47 locale の合法な multi-byte
-  /// sequence で edge case を起こすリスクがあり、locale 依存性を考慮した上で
-  /// U+FFFD 許容が最も観察可能性を維持する判断。
+  /// # 防御的 gate
   ///
-  /// `PTYError` / `PTYExitReason` 両方の `description` から共有するため `internal`。
+  /// Darwin 保証は POSIX 未定義領域 (`rc != 0` 時 buffer 未定義) に依存しているため、
+  /// 将来 version の挙動変化 / OS 内部状態の異常で「制御文字混入 buffer」が返る
+  /// 可能性をゼロにできない（マルチスレッド race は `strerror_r` の POSIX 版が
+  /// thread-safe なため脅威モデルから除外）。観察ログの 1 行性 (Console.app の grep
+  /// 経路 / event 分離) を構造的に守るため、以下の条件で自前 fallback
+  /// `"unknown errno N"` に倒す:
+  ///
+  /// - buffer が空（NUL のみ）
+  /// - buffer に制御文字（CR/LF/TAB/NUL 等の 0x00-0x1F、DEL 0x7F）が含まれる
+  ///
+  /// gate のコストは spawn 失敗ごとの低頻度経路で無視できる。
+  ///
+  /// # invalid UTF-8 sequence
+  ///
+  /// `String(decoding:as: UTF8.self)` は不正バイト列を U+FFFD (Unicode replacement
+  /// character) に置換する。Darwin 保証範囲外の最悪ケース（制御文字を含まない
+  /// 非 ASCII gibberish）で description に U+FFFD 混じりの文字列が乗る可能性がある。
+  /// 観察ログ識別子として「errno N に対し非標準応答があった」として acceptable と
+  /// 判定し、UTF-8 validity gate は入れない。
+  ///
+  /// validity gate を入れない理由は、非 UTF-8 ロケール（ISO-8859-1 / Shift_JIS 等の
+  /// レガシー単 byte / non-UTF-8 multi-byte ロケール）で `strerror_r` が返す非 UTF-8
+  /// 文字列を取りこぼす副作用を避けるため。現代 macOS の主要ロケール (UTF-8 ベース)
+  /// では理論上の懸念だが、locale 依存性と観察可能性のバランスで U+FFFD 許容を選んだ。
   static func errnoText(_ code: Int32) -> String {
-    var buf = [CChar](repeating: 0, count: 256)
+    var buf = [CChar](repeating: 0, count: errnoTextBufferSize)
     _ = strerror_r(code, &buf, buf.count)
     let nul = buf.firstIndex(of: 0) ?? buf.endIndex
     let slice = buf[..<nul]
@@ -435,6 +438,15 @@ extension PTYError: CustomStringConvertible {
     }
     return String(decoding: slice.lazy.map { UInt8(bitPattern: $0) }, as: UTF8.self)
   }
+
+  /// `strerror_r` に渡す buffer のサイズ。実機の strerror 出力は Linux glibc で
+  /// 100 byte 未満 / macOS Darwin でも 80 byte 程度に収まる。256 は将来の長文 errno
+  /// (e.g. Darwin の "Cross-device link" 系) に対しても十分な余裕がある選択。
+  /// ロケール依存の multi-byte UTF-8 では 1 文字あたり 1-4 バイトを消費するため
+  /// ASCII 想定より緩衝が必要だが、256 はそれでも 2 倍以上のヘッドルームを確保する。
+  /// test 側 mirror (`expectedErrnoText`) から参照するため `internal` で公開する
+  /// (構造定数で運用 API としての副作用は無い)。
+  internal static let errnoTextBufferSize = 256
 }
 
 public enum PTYExitReason: Sendable, Equatable {

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -342,6 +342,26 @@ public enum PTYError: Error, Equatable {
   case preforkAllocFailed(errno: Int32)
 }
 
+extension PTYError: CustomStringConvertible {
+  /// 上位 catch が `"\(error)"` や `String(describing:)` で文字列化したときに case 名と
+  /// errno + strerror(3) が必ず残るようにする。Console.app log (stderr) と
+  /// `RpcSchemeHandler` の 500 response payload の双方に同じ文字列が届く。
+  public var description: String {
+    switch self {
+    case .openptyFailed(let errno):
+      return "PTYError.openptyFailed(errno=\(errno) \(errnoText(errno)))"
+    case .forkFailed(let errno):
+      return "PTYError.forkFailed(errno=\(errno) \(errnoText(errno)))"
+    case .preforkAllocFailed(let errno):
+      return "PTYError.preforkAllocFailed(errno=\(errno) \(errnoText(errno)))"
+    }
+  }
+}
+
+private func errnoText(_ errno: Int32) -> String {
+  String(cString: strerror(errno))
+}
+
 public enum PTYExitReason: Sendable, Equatable {
   case exited(code: Int32)
   case signaled(signal: Int32, coreDumped: Bool)

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -374,14 +374,21 @@ extension PTYError: CustomStringConvertible {
   /// （deprecation message: "after truncating the null termination"）。errno text は
   /// ASCII 範囲のため `CChar` (Int8) → `UInt8` の bitPattern reinterpret で UTF-8 と等価。
   ///
+  /// rc 値は捨てる。POSIX 文面では `rc != 0` 時の buffer 内容は未定義だが、
+  /// macOS Darwin / Linux glibc 双方の実機では invalid errno でも buffer に
+  /// "Unknown error: N" / "Undefined error: N" 相当の readable な文字列を書く。
+  /// rc != 0 を理由に buffer を捨てて自前 fallback 文字列に倒すと、本物の
+  /// strerror 出力（観察ログ品質）を諦めることになる。よって rc は信用せず
+  /// buffer を返し、空 buffer（NUL のみ）のときだけ自前 fallback に倒す。
+  ///
   /// `PTYError` / `PTYExitReason` 両方の `description` から共有するため `internal`。
   static func errnoText(_ code: Int32) -> String {
     var buf = [CChar](repeating: 0, count: 256)
-    let rc = strerror_r(code, &buf, buf.count)
-    if rc != 0 {
+    _ = strerror_r(code, &buf, buf.count)
+    let nul = buf.firstIndex(of: 0) ?? buf.endIndex
+    if nul == buf.startIndex {
       return "unknown errno \(code)"
     }
-    let nul = buf.firstIndex(of: 0) ?? buf.endIndex
     return String(decoding: buf[..<nul].lazy.map { UInt8(bitPattern: $0) }, as: UTF8.self)
   }
 }

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -374,19 +374,24 @@ extension PTYError: CustomStringConvertible {
   /// （deprecation message: "after truncating the null termination"）。errno text は
   /// ASCII 範囲のため `CChar` (Int8) → `UInt8` の bitPattern reinterpret で UTF-8 と等価。
   ///
-  /// rc 値は捨てる。POSIX 文面では `rc != 0` 時の buffer 内容は未定義だが、
-  /// macOS Darwin / Linux glibc 双方の実機では invalid errno でも buffer に
-  /// "Unknown error: N" / "Undefined error: N" 相当の readable な文字列を書く
-  /// （Darwin manpage strerror_r(3): "If the error number is not recognized,
-  /// these functions return EINVAL ... The strerror_r() function ... copies an
-  /// error message string into the buffer ..." — EINVAL でも buffer は埋まる）。
-  /// rc != 0 を理由に buffer を捨てて自前 fallback 文字列に倒すと、本物の
-  /// strerror 出力（観察ログ品質）を諦めることになる。よって rc は信用せず
-  /// buffer を返す。
+  /// **主根拠 (Darwin manpage 保証)**: macOS Darwin の strerror_r(3) manpage は
+  /// "If the error number is not recognized, these functions return EINVAL ...
+  /// The strerror_r() function ... copies an error message string into the
+  /// buffer ..." と明記しており、**invalid errno (EINVAL を返す経路) でも
+  /// buffer に readable な error message string を埋める** ことを保証する。
+  /// gozd は macOS 26 Tahoe 専用 (CLAUDE.md「対応プラットフォーム」) のため、
+  /// Darwin 保証の範囲で実用上の挙動は閉じる。よって rc 値は捨てて buffer を
+  /// そのまま返す方針が観察可能性（renderer に届く identifier 品質、Console.app
+  /// 観察ログの人間可読性）を最大化する。Linux glibc も同等挙動を示すと観察済み。
   ///
-  /// ただし POSIX 文面の最悪ケース（rc != 0 時の buffer 中間に部分的ゴミ）と
-  /// 観察ログの 1 行性に備え、buffer 内容に制御文字（0x00-0x1F / 0x7F）が含まれない
-  /// ことを構造的に検証する。
+  /// **防御的多重化として gate を入れる**: 上記 Darwin 保証は POSIX 文面では
+  /// 未定義領域 (`rc != 0` 時 buffer 未定義) に依存している。Darwin 将来 version
+  /// で挙動が変わる / OS 内部状態の異常 / マルチスレッド境界の不整合 等の
+  /// 想定外シナリオで「control char 混入 buffer」が返る可能性をゼロとは断言
+  /// できない。観察ログの 1 行性 (Console.app の grep 経路 / event 分離) は
+  /// 構造的に守りたいので、buffer に制御文字 (0x00-0x1F / 0x7F) が含まれる場合
+  /// のみ自前 fallback に倒す gate を入れる。`PTYError` / `PTYExitReason` の
+  /// `description` は spawn 失敗ごとの低頻度経路なので gate のコストは無視できる。
   ///
   /// 非 ASCII バイト（0x80-0xFF）は **許容する**: `strerror_r` は `LC_MESSAGES`
   /// ロケール依存（POSIX 仕様）で、`LANG=ja_JP.UTF-8` 等の環境では valid errno に
@@ -401,12 +406,13 @@ extension PTYError: CustomStringConvertible {
   /// 上記いずれかなら自前 fallback `"unknown errno N"` を返す。
   ///
   /// invalid UTF-8 sequence の扱い: `String(decoding:as: UTF8.self)` は不正な
-  /// バイト列を U+FFFD (Unicode replacement character) に置換する。POSIX 文面の
-  /// 最悪ケース（rc != 0 時に buffer が部分的に corrupt しているケース）で、
-  /// 制御文字を含まない non-ASCII gibberish が U+FFFD 混じりで description に
-  /// 乗る可能性がある。これは invalid errno 経路の現実離れした最悪ケースに限り
-  /// 発現する副作用で、観察ログとしては「errno N に対し何らかの非標準応答が
-  /// あった」識別子として acceptable と判定し、追加の gate は入れない。
+  /// バイト列を U+FFFD (Unicode replacement character) に置換する。Darwin 保証の
+  /// 範囲外で非標準的な non-ASCII gibberish が返った場合、それが U+FFFD 混じりで
+  /// description に乗る可能性がある。観察ログとしては「errno N に対し何らかの
+  /// 非標準応答があった」識別子として acceptable と判定し、追加の UTF-8 validity
+  /// gate は入れない。validity gate を入れると BCP-47 locale の合法な multi-byte
+  /// sequence で edge case を起こすリスクがあり、locale 依存性を考慮した上で
+  /// U+FFFD 許容が最も観察可能性を維持する判断。
   ///
   /// `PTYError` / `PTYExitReason` 両方の `description` から共有するため `internal`。
   static func errnoText(_ code: Int32) -> String {

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -376,20 +376,40 @@ extension PTYError: CustomStringConvertible {
   ///
   /// rc 値は捨てる。POSIX 文面では `rc != 0` 時の buffer 内容は未定義だが、
   /// macOS Darwin / Linux glibc 双方の実機では invalid errno でも buffer に
-  /// "Unknown error: N" / "Undefined error: N" 相当の readable な文字列を書く。
+  /// "Unknown error: N" / "Undefined error: N" 相当の readable な文字列を書く
+  /// （Darwin manpage strerror_r(3): "If the error number is not recognized,
+  /// these functions return EINVAL ... The strerror_r() function ... copies an
+  /// error message string into the buffer ..." — EINVAL でも buffer は埋まる）。
   /// rc != 0 を理由に buffer を捨てて自前 fallback 文字列に倒すと、本物の
   /// strerror 出力（観察ログ品質）を諦めることになる。よって rc は信用せず
-  /// buffer を返し、空 buffer（NUL のみ）のときだけ自前 fallback に倒す。
+  /// buffer を返す。
+  ///
+  /// ただし POSIX 文面の最悪ケース（rc != 0 時の buffer 中間に部分的ゴミ）に
+  /// 備え、buffer 内容が「印字可能 ASCII (0x20–0x7E) のみ」であることを構造的に
+  /// 検証する。観察ログに制御文字 / 非 ASCII バイトが漏れると Console.app の
+  /// 1 行性が崩れる / grep 経路が壊れるため、印字可能性を満たさない buffer は
+  /// 自前 fallback に倒す。NUL のみ（空 buffer）も同経路で fallback。
   ///
   /// `PTYError` / `PTYExitReason` 両方の `description` から共有するため `internal`。
   static func errnoText(_ code: Int32) -> String {
     var buf = [CChar](repeating: 0, count: 256)
     _ = strerror_r(code, &buf, buf.count)
     let nul = buf.firstIndex(of: 0) ?? buf.endIndex
-    if nul == buf.startIndex {
+    let slice = buf[..<nul]
+    if slice.isEmpty {
       return "unknown errno \(code)"
     }
-    return String(decoding: buf[..<nul].lazy.map { UInt8(bitPattern: $0) }, as: UTF8.self)
+    // 印字可能 ASCII (space 0x20 〜 tilde 0x7E) のみで構成されることを確認。
+    // 制御文字 (CR/LF/TAB 含む)、DEL (0x7F)、非 ASCII (0x80–0xFF) を含む buffer は
+    // 観察可能性を毀損するため信用しない。CChar (Int8) → UInt8 bitPattern で評価。
+    let isPrintableAscii = slice.allSatisfy { c in
+      let u = UInt8(bitPattern: c)
+      return u >= 0x20 && u <= 0x7E
+    }
+    if !isPrintableAscii {
+      return "unknown errno \(code)"
+    }
+    return String(decoding: slice.lazy.map { UInt8(bitPattern: $0) }, as: UTF8.self)
   }
 }
 

--- a/apps/native/Sources/GozdCore/PTYRegistry.swift
+++ b/apps/native/Sources/GozdCore/PTYRegistry.swift
@@ -87,8 +87,12 @@ public actor PTYRegistry {
   private var expectedResumeSidById: [UInt32: String] = [:]
   // 削除 RPC で clearAssociations された ptyId 集合。late session-start hook が
   // 到達したとき、「明示削除後の late hook」と「そもそも未登録 PTY」を区別して
-  // 観察ログを出すために使う（applyClaudeSessionHook 側で参照）。ptyId は
-  // 単調増加で再利用されないので、PTY exit 後も残しておいて問題ない。
+  // 観察ログを出すために使う（applyClaudeSessionHook 側で参照）。
+  // 不変条件: spawn が成功した ptyId は単調増加で再利用されない（`nextId += 1` は
+  // spawn 成功後にのみ走るため成功 id は決して衝突しない）。一方 spawn が throw した
+  // id は再利用され得るが、その id は ptys に登録されておらず `clearAssociations` も
+  // 呼ばれないため、本集合に入る経路がない。よって本集合内では再利用は起きず、
+  // PTY exit 後も残しておいて問題ない。
   private var explicitlyRemovedPtyIds: Set<UInt32> = []
   private var nextId: UInt32 = 1
 
@@ -197,6 +201,13 @@ public actor PTYRegistry {
   /// hook 受信側が ptyId から worktreePath を逆引きするための accessor。
   public func worktreePath(for id: UInt32) -> String? {
     return worktreePathById[id]
+  }
+
+  /// 次に spawn が成功した時に割り当てられる ptyId を返す。
+  /// 「spawn 失敗時に id を消費しない」契約をテストから観察するための seam。
+  /// 直接の運用経路では使わない。
+  internal func peekNextId() -> UInt32 {
+    return nextId
   }
 
   /// 削除 RPC / hook ハンドラが ptyId から直近 sessionId を逆引きするための accessor。

--- a/apps/native/Sources/GozdCore/PTYRegistry.swift
+++ b/apps/native/Sources/GozdCore/PTYRegistry.swift
@@ -113,8 +113,11 @@ public actor PTYRegistry {
     cols: UInt16,
     worktreePath: String = ""
   ) throws -> UInt32 {
+    // `nextId` は spawn 成功後に進める。spawn が throw した場合に id を消費せず
+    // 次の試行で同じ id を再利用できる（PTY は生成されていないため id 衝突は無い）。
+    // 先に進めると失敗時に id が穴開きで上昇し、ptys / worktreePathById マップに
+    // 紐付かない「観測不能な id」が累積する。
     let id = nextId
-    nextId += 1
 
     let (stream, continuation) = AsyncStream<PTYEvent>.makeStream()
 
@@ -139,6 +142,7 @@ public actor PTYRegistry {
         continuation.finish()
       }
     )
+    nextId += 1
     ptys[id] = pty
     if !worktreePath.isEmpty {
       worktreePathById[id] = worktreePath

--- a/apps/native/Sources/GozdCore/PTYRegistry.swift
+++ b/apps/native/Sources/GozdCore/PTYRegistry.swift
@@ -203,13 +203,6 @@ public actor PTYRegistry {
     return worktreePathById[id]
   }
 
-  /// 次に spawn が成功した時に割り当てられる ptyId を返す。
-  /// 「spawn 失敗時に id を消費しない」契約をテストから観察するための seam。
-  /// 直接の運用経路では使わない。
-  internal func peekNextId() -> UInt32 {
-    return nextId
-  }
-
   /// 削除 RPC / hook ハンドラが ptyId から直近 sessionId を逆引きするための accessor。
   /// 未観測なら nil。
   public func sessionId(for id: UInt32) -> String? {

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -489,9 +489,13 @@ public actor RpcDispatcher {
       // よって本 handler 側で stderr に書かなければ Console.app には spawn 失敗の
       // 痕跡が残らない。PTYError のサブ case（openptyFailed / forkFailed /
       // preforkAllocFailed）に加え、再現に必要な executable / cwd も併記する。
+      // executable / cwd は `String(reflecting:)` で quote + escape する。macOS の
+      // path には改行 (`\n`) や制御文字を含めることが構造的に可能で、quote 化
+      // しないと log 1 行が分断され、Console.app での grep / 後段 parser での
+      // event 分離が壊れる。
       FileHandle.standardError.write(
         Data(
-          "[handlePtySpawn] pty.spawn failed: \(error) executable=\(req.executable) cwd=\(req.dir)\n"
+          "[handlePtySpawn] pty.spawn failed: \(error) executable=\(String(reflecting: req.executable)) cwd=\(String(reflecting: req.dir))\n"
             .utf8
         )
       )

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -488,14 +488,17 @@ public actor RpcDispatcher {
       // は 500 response の body に文字列を載せるだけで stderr には書き出さない。
       // よって本 handler 側で stderr に書かなければ Console.app には spawn 失敗の
       // 痕跡が残らない。PTYError のサブ case（openptyFailed / forkFailed /
-      // preforkAllocFailed）に加え、再現に必要な executable / cwd も併記する。
-      // executable / cwd は `String(reflecting:)` で quote + escape する。macOS の
-      // path には改行 (`\n`) や制御文字を含めることが構造的に可能で、quote 化
-      // しないと log 1 行が分断され、Console.app での grep / 後段 parser での
-      // event 分離が壊れる。
+      // preforkAllocFailed）に加え、再現に必要な executable / cwd / worktreePath を
+      // 併記する。worktreePath は cwd と独立で、複数 worktree が並列に Claude を
+      // 起動する gozd の primary use case で「どの worktree の spawn か」を識別する
+      // ために必要（cwd はユーザーが任意に cd した path で worktree とは限らない）。
+      // path quoting は本 PR では入れない: 他の dispatcher stderr log（handleGitGithubIdentity,
+      // TaskStore, GitHubOps 等）は素埋め込みのまま運用されており、ここ 1 箇所だけ
+      // quote 化すると stderr log の書式 SSOT が分裂する。系として揃えるなら全箇所を
+      // 統一する必要があり、本 PR スコープを越える。
       FileHandle.standardError.write(
         Data(
-          "[handlePtySpawn] pty.spawn failed: \(error) executable=\(String(reflecting: req.executable)) cwd=\(String(reflecting: req.dir))\n"
+          "[handlePtySpawn] pty.spawn failed: \(error) executable=\(req.executable) cwd=\(req.dir) worktreePath=\(req.worktreePath)\n"
             .utf8
         )
       )

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -472,15 +472,29 @@ public actor RpcDispatcher {
 
   private func handlePtySpawn(_ body: Data) async throws -> Data {
     let req = try Gozd_V1_PtySpawnRequest(jsonUTF8Data: body)
-    let id = try await pty.spawn(
-      executable: req.executable,
-      args: req.args,
-      env: req.env,
-      cwd: req.dir,
-      rows: UInt16(req.rows),
-      cols: UInt16(req.cols),
-      worktreePath: req.worktreePath
-    )
+    let id: UInt32
+    do {
+      id = try await pty.spawn(
+        executable: req.executable,
+        args: req.args,
+        env: req.env,
+        cwd: req.dir,
+        rows: UInt16(req.rows),
+        cols: UInt16(req.cols),
+        worktreePath: req.worktreePath
+      )
+    } catch let error as PTYError {
+      // PTYError のサブ case（openptyFailed / forkFailed / preforkAllocFailed）を
+      // 構造化 log に書き残す。包括 catch まで bubble させると Console.app には
+      // case 名 + errno が残るが、失敗した executable / cwd が落ちて再現困難になる。
+      FileHandle.standardError.write(
+        Data(
+          "[RpcDispatcher] pty.spawn failed: \(error) executable=\(req.executable) cwd=\(req.dir)\n"
+            .utf8
+        )
+      )
+      throw error
+    }
     var resp = Gozd_V1_PtySpawnResponse()
     resp.ptyID = id
     return try resp.jsonUTF8Data()

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -484,12 +484,14 @@ public actor RpcDispatcher {
         worktreePath: req.worktreePath
       )
     } catch let error as PTYError {
-      // PTYError のサブ case（openptyFailed / forkFailed / preforkAllocFailed）を
-      // 構造化 log に書き残す。包括 catch まで bubble させると Console.app には
-      // case 名 + errno が残るが、失敗した executable / cwd が落ちて再現困難になる。
+      // `RpcSchemeHandler` の包括 catch (`GozdApp.swift` 内 `RpcSchemeHandler.reply`)
+      // は 500 response の body に文字列を載せるだけで stderr には書き出さない。
+      // よって本 handler 側で stderr に書かなければ Console.app には spawn 失敗の
+      // 痕跡が残らない。PTYError のサブ case（openptyFailed / forkFailed /
+      // preforkAllocFailed）に加え、再現に必要な executable / cwd も併記する。
       FileHandle.standardError.write(
         Data(
-          "[RpcDispatcher] pty.spawn failed: \(error) executable=\(req.executable) cwd=\(req.dir)\n"
+          "[handlePtySpawn] pty.spawn failed: \(error) executable=\(req.executable) cwd=\(req.dir)\n"
             .utf8
         )
       )

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -492,10 +492,13 @@ public actor RpcDispatcher {
       // 併記する。worktreePath は cwd と独立で、複数 worktree が並列に Claude を
       // 起動する gozd の primary use case で「どの worktree の spawn か」を識別する
       // ために必要（cwd はユーザーが任意に cd した path で worktree とは限らない）。
-      // path quoting は本 PR では入れない: 他の dispatcher stderr log（handleGitGithubIdentity,
-      // TaskStore, GitHubOps 等）は素埋め込みのまま運用されており、ここ 1 箇所だけ
-      // quote 化すると stderr log の書式 SSOT が分裂する。系として揃えるなら全箇所を
-      // 統一する必要があり、本 PR スコープを越える。
+      // path quoting は採用しない: 他の dispatcher stderr log（handleGitGithubIdentity,
+      // TaskStore, GitHubOps 等）も素埋め込みのまま運用されており、stderr log の書式は
+      // 「素埋め込み」を SSOT として揃える。`worktreePath` / `cwd` には git / 一般的な
+      // 開発フローで改行 / 制御文字を含むパスが入る現実的経路は無く、ここで quote 化
+      // する積極理由は乏しい。仮に必要になった場合はプロジェクト全体の stderr log 衛生
+      // ポリシーとして CLAUDE.md / docs/ に明文化した上で全箇所を統一する。
+      // 「次の PR で潰す」のような追跡されない先送りは避ける。
       FileHandle.standardError.write(
         Data(
           "[handlePtySpawn] pty.spawn failed: \(error) executable=\(req.executable) cwd=\(req.dir) worktreePath=\(req.worktreePath)\n"

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -492,13 +492,8 @@ public actor RpcDispatcher {
       // 併記する。worktreePath は cwd と独立で、複数 worktree が並列に Claude を
       // 起動する gozd の primary use case で「どの worktree の spawn か」を識別する
       // ために必要（cwd はユーザーが任意に cd した path で worktree とは限らない）。
-      // path quoting は採用しない: 他の dispatcher stderr log（handleGitGithubIdentity,
-      // TaskStore, GitHubOps 等）も素埋め込みのまま運用されており、stderr log の書式は
-      // 「素埋め込み」を SSOT として揃える。`worktreePath` / `cwd` には git / 一般的な
-      // 開発フローで改行 / 制御文字を含むパスが入る現実的経路は無く、ここで quote 化
-      // する積極理由は乏しい。仮に必要になった場合はプロジェクト全体の stderr log 衛生
-      // ポリシーとして CLAUDE.md / docs/ に明文化した上で全箇所を統一する。
-      // 「次の PR で潰す」のような追跡されない先送りは避ける。
+      // stderr log の書式は CLAUDE.md「観察ログ (stderr) の書式」の SSOT に従い、
+      // 素埋め込みで書く（quote 化しない）。
       FileHandle.standardError.write(
         Data(
           "[handlePtySpawn] pty.spawn failed: \(error) executable=\(req.executable) cwd=\(req.dir) worktreePath=\(req.worktreePath)\n"

--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -279,12 +279,43 @@ struct PTYManagerTests {
     #expect(waitFail.description == "PTYExitReason.waitpidFailed(errno=\(ECHILD) \(expectedErrnoText(ECHILD)))")
     #expect("\(waitFail)" == waitFail.description)
   }
+
+  @Test("errnoText は無効 errno (rc != 0 経路) で `unknown errno N` に倒れる")
+  func errnoTextFallsBackOnInvalidErrno() {
+    // POSIX 文面では `strerror_r` の `rc != 0` 時の buffer 内容は未定義。本実装は
+    // この未定義領域を信じず明示的 fallback 文字列 `"unknown errno N"` を返す契約。
+    // 9999 は POSIX で定義されていない invalid errno の代表値（Linux / macOS で
+    // EINVAL を返す）。本契約が壊れると、観察ログに macOS バージョン依存の Darwin
+    // 文字列が漏れ出して観察可能性が分散する。
+    let invalid = PTYError.openptyFailed(errno: 9999)
+    #expect(invalid.description == "PTYError.openptyFailed(errno=9999 unknown errno 9999)")
+    #expect("\(invalid)" == invalid.description)
+
+    // PTYExitReason 側も同じ fallback 経路を踏むことを確認。`errnoText` の SSOT が
+    // 2 enum で共有されていることの構造的検証も兼ねる。
+    let waitFail = PTYExitReason.waitpidFailed(errno: 9999)
+    #expect(waitFail.description == "PTYExitReason.waitpidFailed(errno=9999 unknown errno 9999)")
+  }
 }
 
-/// 本 SUT (`PTYError.errnoText`) と同じく `strerror_r(3)` + SE-0405 イディオムで
-/// 期待値を構築する。`strerror(3)` ベースで期待値を作ると本実装と独立にならず
-/// (POSIX 文面の thread-safety 議論で本実装を `strerror_r` にしている動機が消える)、
-/// `String(cString: [CChar])` で組むと本実装と非対称になるため避ける。
+/// 本 SUT (`PTYError.errnoText`) と同じ実装を **意図的に** 再現した mirror。
+///
+/// 構造的 SSOT 重複に見えるが、これは形式契約 test の道具立てとして妥当な
+/// パターン:
+///   - test の目的は「`description` が `PTYError.<case>(errno=<n> <strerror>)`
+///     形式に厳密に従う」契約を完全一致で固定すること
+///   - macOS の strerror_r 出力文字列はバージョン依存（"Cannot allocate memory" /
+///     "Resource temporarily unavailable" 等）で test に直書きすると CI で壊れる
+///   - そのため期待値も同じ `strerror_r` API から組み立てる必要がある
+///
+/// 別案として正規表現 / prefix+suffix での形式検査も検討したが、それでは前回
+/// 強化した「完全一致で形式を fix する」契約が弱まる。SUT と mirror が同じ
+/// イディオムを使うこと自体が形式契約の test 対象になっている。SUT 側
+/// `errnoText` のイディオムを変える時は本 helper も同時に同期更新する。
+///
+/// rc != 0 (無効 errno) 経路は SUT 側で `"unknown errno N"` に倒すが、本 helper は
+/// rc を捨てて buffer の中身を文字列化する。両者の差異は `errnoTextFallsBackOnInvalidErrno`
+/// test で SUT 側の文字列形式に対する完全一致として固定する（本 helper は呼ばれない）。
 private func expectedErrnoText(_ code: Int32) -> String {
   var buf = [CChar](repeating: 0, count: 256)
   _ = strerror_r(code, &buf, buf.count)

--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -280,21 +280,34 @@ struct PTYManagerTests {
     #expect("\(waitFail)" == waitFail.description)
   }
 
-  @Test("errnoText は無効 errno (rc != 0 経路) で `unknown errno N` に倒れる")
-  func errnoTextFallsBackOnInvalidErrno() {
-    // POSIX 文面では `strerror_r` の `rc != 0` 時の buffer 内容は未定義。本実装は
-    // この未定義領域を信じず明示的 fallback 文字列 `"unknown errno N"` を返す契約。
-    // 9999 は POSIX で定義されていない invalid errno の代表値（Linux / macOS で
-    // EINVAL を返す）。本契約が壊れると、観察ログに macOS バージョン依存の Darwin
-    // 文字列が漏れ出して観察可能性が分散する。
+  @Test("errnoText は無効 errno でも description 形式 (errno 値 + 閉じ括弧) を保つ")
+  func errnoTextHandlesInvalidErrnoSafely() {
+    // 9999 は POSIX で定義されていない invalid errno。Darwin の `strerror_r` は
+    // 現状 rc != 0 を返し、SUT は `unknown errno N` fallback に倒れるが、POSIX 文面
+    // は invalid errno で:
+    //   (a) rc != 0 で buffer 内容未定義
+    //   (b) rc == 0 で buffer に "Unknown error: N" を書く（Linux glibc 経路）
+    // のどちらも合法としている。よって完全一致 test を組むと Darwin 実装変更で
+    // CI が壊れるリスクがある。
+    //
+    // ここでは「Darwin 実装に依存せず保証される不変条件」のみを固定する:
+    //   - description は `"PTYError.<case>(errno=9999 "` で始まる
+    //   - 末尾は `")"` で閉じる
+    //   - errno 数値が必ず embed される
+    // これにより、前回完全一致を強化した動機（他 case 名混入 / 無関係文言の混入 /
+    // 形式の崩れ）は依然として捕捉される一方、`strerror_r` の rc != 0 / "Unknown
+    // error: N" の Darwin 実装差では壊れない。有効 errno 3 case
+    // (`ptyErrorDescriptionMatchesContractFormat`) では完全一致を維持する。
     let invalid = PTYError.openptyFailed(errno: 9999)
-    #expect(invalid.description == "PTYError.openptyFailed(errno=9999 unknown errno 9999)")
+    #expect(invalid.description.hasPrefix("PTYError.openptyFailed(errno=9999 "))
+    #expect(invalid.description.hasSuffix(")"))
     #expect("\(invalid)" == invalid.description)
 
-    // PTYExitReason 側も同じ fallback 経路を踏むことを確認。`errnoText` の SSOT が
-    // 2 enum で共有されていることの構造的検証も兼ねる。
+    // PTYExitReason 側も同じ Darwin 非依存契約。`errnoText` の SSOT が 2 enum で
+    // 共有されていることの構造的検証も兼ねる。
     let waitFail = PTYExitReason.waitpidFailed(errno: 9999)
-    #expect(waitFail.description == "PTYExitReason.waitpidFailed(errno=9999 unknown errno 9999)")
+    #expect(waitFail.description.hasPrefix("PTYExitReason.waitpidFailed(errno=9999 "))
+    #expect(waitFail.description.hasSuffix(")"))
   }
 }
 

--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -280,38 +280,43 @@ struct PTYManagerTests {
     #expect("\(waitFail)" == waitFail.description)
   }
 
-  @Test("errnoText は無効 errno でも description 形式 (errno 値 + 閉じ括弧) を保つ")
-  func errnoTextHandlesInvalidErrnoSafely() {
-    // 9999 は POSIX で定義されていない invalid errno。Darwin の `strerror_r` は
-    // 現状 rc != 0 を返し、SUT は `unknown errno N` fallback に倒れるが、POSIX 文面
-    // は invalid errno で:
-    //   (a) rc != 0 で buffer 内容未定義
-    //   (b) rc == 0 で buffer に "Unknown error: N" を書く（Linux glibc 経路）
-    // のどちらも合法としている。よって完全一致 test を組むと Darwin 実装変更で
-    // CI が壊れるリスクがある。
+  @Test("errnoText は invalid / sentinel errno でも description 形式 (errno 値 + 閉じ括弧) を保つ")
+  func errnoTextHandlesBoundaryErrnoSafely() {
+    // 境界 errno をまとめて検査する:
+    //   - 9999: POSIX で未定義の invalid errno
+    //   - 0:    "エラー無し" sentinel（waitpidFailed で渡されることは構造的に想定外だが
+    //          Int32 型で構造的に渡せるため境界として cover する）
+    //   - -1:   負の errno（Int32 で渡せる構造的境界）
     //
-    // ここでは「Darwin 実装に依存せず保証される不変条件」のみを固定する:
-    //   - description は `"PTYError.<case>(errno=9999 "` で始まる
+    // SUT (`errnoText`) は rc を信用せず buffer を返す方針のため、Darwin / Linux glibc
+    // 双方で invalid / sentinel errno に対しても buffer に readable な文字列が書かれる
+    // 実機挙動を尊重する。ただしその文字列内容 (`"Unknown error: 9999"` / `"Undefined
+    // error: 0"` 等) は OS バージョン依存で test に直書きできない。
+    //
+    // よってここでは「OS 実装に依存せず保証される不変条件」のみを固定する:
+    //   - description は `"PTYError.<case>(errno=N "` で始まる
     //   - 末尾は `")"` で閉じる
     //   - errno 数値が必ず embed される
-    // これにより、前回完全一致を強化した動機（他 case 名混入 / 無関係文言の混入 /
-    // 形式の崩れ）は依然として捕捉される一方、`strerror_r` の rc != 0 / "Unknown
-    // error: N" の Darwin 実装差では壊れない。有効 errno 3 case
-    // (`ptyErrorDescriptionMatchesContractFormat`) では完全一致を維持する。
-    let invalid = PTYError.openptyFailed(errno: 9999)
-    #expect(invalid.description.hasPrefix("PTYError.openptyFailed(errno=9999 "))
-    #expect(invalid.description.hasSuffix(")"))
-    #expect("\(invalid)" == invalid.description)
+    // 完全一致が必要な valid errno 3 case (`ptyErrorDescriptionMatchesContractFormat`)
+    // とは責務を分ける: 完全一致は SSOT mirror で組み立てた expected と等価性を主張、
+    // 本 test は OS 実装差を吸収する形式契約。
+    for code: Int32 in [9999, 0, -1] {
+      let openpty = PTYError.openptyFailed(errno: code)
+      #expect(openpty.description.hasPrefix("PTYError.openptyFailed(errno=\(code) "))
+      #expect(openpty.description.hasSuffix(")"))
+      #expect("\(openpty)" == openpty.description)
 
-    // PTYExitReason 側も同じ Darwin 非依存契約。`errnoText` の SSOT が 2 enum で
-    // 共有されていることの構造的検証も兼ねる。
-    let waitFail = PTYExitReason.waitpidFailed(errno: 9999)
-    #expect(waitFail.description.hasPrefix("PTYExitReason.waitpidFailed(errno=9999 "))
-    #expect(waitFail.description.hasSuffix(")"))
+      let waitFail = PTYExitReason.waitpidFailed(errno: code)
+      #expect(waitFail.description.hasPrefix("PTYExitReason.waitpidFailed(errno=\(code) "))
+      #expect(waitFail.description.hasSuffix(")"))
+    }
   }
 }
 
 /// 本 SUT (`PTYError.errnoText`) と同じ実装を **意図的に** 再現した mirror。
+/// `ptyErrorDescriptionMatchesContractFormat` / `ptyExitReasonDescriptionMatchesContractFormat`
+/// から呼ばれ、valid errno (ENOMEM / EAGAIN / ECHILD / SIGHUP 等) に対して
+/// SUT が生成する `description` の完全一致 expected を組み立てる。
 ///
 /// 構造的 SSOT 重複に見えるが、これは形式契約 test の道具立てとして妥当な
 /// パターン:
@@ -321,14 +326,14 @@ struct PTYManagerTests {
 ///     "Resource temporarily unavailable" 等）で test に直書きすると CI で壊れる
 ///   - そのため期待値も同じ `strerror_r` API から組み立てる必要がある
 ///
-/// 別案として正規表現 / prefix+suffix での形式検査も検討したが、それでは前回
-/// 強化した「完全一致で形式を fix する」契約が弱まる。SUT と mirror が同じ
+/// 別案として正規表現 / prefix+suffix での形式検査も検討したが、valid errno に
+/// 対しては「完全一致で形式を fix する」契約が望ましい。SUT と mirror が同じ
 /// イディオムを使うこと自体が形式契約の test 対象になっている。SUT 側
 /// `errnoText` のイディオムを変える時は本 helper も同時に同期更新する。
 ///
-/// rc != 0 (無効 errno) 経路は SUT 側で `"unknown errno N"` に倒すが、本 helper は
-/// rc を捨てて buffer の中身を文字列化する。両者の差異は `errnoTextFallsBackOnInvalidErrno`
-/// test で SUT 側の文字列形式に対する完全一致として固定する（本 helper は呼ばれない）。
+/// boundary errno (9999 / 0 / -1) に対する OS 実装差吸収は別 test
+/// (`errnoTextHandlesBoundaryErrnoSafely`) で prefix/suffix の不変条件のみを
+/// 主張する形に分離している。本 helper は boundary 経路では呼ばれない。
 private func expectedErrnoText(_ code: Int32) -> String {
   var buf = [CChar](repeating: 0, count: 256)
   _ = strerror_r(code, &buf, buf.count)

--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -317,20 +317,21 @@ struct PTYManagerTests {
     }
   }
 
-  @Test("errnoText の strerror 出力部分は印字可能 ASCII / 非空 / 単一行 (SUT 単独不変条件)")
-  func errnoTextStrerrorOutputIsAsciiPrintableSingleLine() {
+  @Test("errnoText の strerror 出力は制御文字 / 改行を含まず非空 (SUT 単独不変条件)")
+  func errnoTextStrerrorOutputIsControlCharFreeAndNonEmpty() {
     // `ptyErrorDescriptionMatchesContractFormat` は SUT と同根の `expectedErrnoText`
     // mirror で完全一致を主張するため、SUT と mirror が同じバグを抱えると pass して
-    // しまう（reviewer 指摘 E）。これを補強するため、SUT 単独で観察可能な strerror
-    // 出力の最低限の品質を assert する。
+    // しまう。これを補強するため、SUT 単独で観察可能な strerror 出力の最低限の品質を
+    // assert する。
     //
     // mirror に依存せず、description 文字列から `errnoText` 出力部分を抽出して
     // 検証する。`errnoText` の出力品質契約:
     //   - 非空
-    //   - 印字可能 ASCII (0x20–0x7E) のみで構成される（SUT 側の防御と一致）
-    //   - 改行 / TAB / 制御文字を含まない
-    // 具体的な文字列内容（"Cannot allocate memory" 等）は macOS バージョン依存
-    // なので主張しない。あくまで「観察ログを壊さない品質」を fix する。
+    //   - 制御文字 (0x00-0x1F, 0x7F) を含まない（CR/LF/TAB/NUL/DEL すべて排除）
+    //   - 上記の帰結として単一行（CR/LF が含まれない）
+    // 具体的な文字列内容（"Cannot allocate memory" 等）や ASCII/非 ASCII の区別は
+    // macOS バージョン / locale 依存なので主張しない。あくまで「観察ログを壊さない
+    // 品質」を fix する。multi-byte UTF-8 (0x80-0xFF) は構造的に許容される。
     for code: Int32 in [ENOMEM, EAGAIN, ECHILD, EINTR, EFAULT, 0, -1, 9999] {
       let desc = PTYError.openptyFailed(errno: code).description
       // 形式: "PTYError.openptyFailed(errno=N <strerror>)" から <strerror> を抽出
@@ -341,9 +342,17 @@ struct PTYManagerTests {
       let strerrorEnd = desc.index(before: desc.endIndex)
       let strerrorText = desc[strerrorStart..<strerrorEnd]
       #expect(!strerrorText.isEmpty, "errno=\(code) produced empty strerror text")
+      // 改行を直接検査（単一行性の明示的 assertion）
+      #expect(!strerrorText.contains("\n"), "errno=\(code) contains LF: \(strerrorText.debugDescription)")
+      #expect(!strerrorText.contains("\r"), "errno=\(code) contains CR: \(strerrorText.debugDescription)")
+      // 全制御文字を unicodeScalars 経由で網羅検査
+      let hasControl = strerrorText.unicodeScalars.contains { scalar in
+        let v = scalar.value
+        return v < 0x20 || v == 0x7F
+      }
       #expect(
-        strerrorText.unicodeScalars.allSatisfy { $0.value >= 0x20 && $0.value <= 0x7E },
-        "errno=\(code) strerror text contains non-printable-ASCII: \(strerrorText.debugDescription)"
+        !hasControl,
+        "errno=\(code) strerror text contains control char: \(strerrorText.debugDescription)"
       )
     }
   }

--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -300,7 +300,12 @@ struct PTYManagerTests {
     // 完全一致が必要な valid errno 3 case (`ptyErrorDescriptionMatchesContractFormat`)
     // とは責務を分ける: 完全一致は SSOT mirror で組み立てた expected と等価性を主張、
     // 本 test は OS 実装差を吸収する形式契約。
-    for code: Int32 in [9999, 0, -1] {
+    // Int32 の真の境界 (max / min) も含む。`PTYError.openptyFailed(errno:)` 等の
+    // associated value は `Int32` で受けるため構造的に渡せる入力域全体を境界として
+    // 扱う。`strerror_r` の第 1 引数 (`int` = `Int32`) は POSIX 文面では errno 値域
+    // 外のときに EINVAL を返すが、これは指摘 A の printable-ASCII チェック経路で
+    // safely fallback に倒れる契約。
+    for code: Int32 in [Int32.max, Int32.min, 9999, 0, -1] {
       let openpty = PTYError.openptyFailed(errno: code)
       #expect(openpty.description.hasPrefix("PTYError.openptyFailed(errno=\(code) "))
       #expect(openpty.description.hasSuffix(")"))
@@ -309,6 +314,37 @@ struct PTYManagerTests {
       let waitFail = PTYExitReason.waitpidFailed(errno: code)
       #expect(waitFail.description.hasPrefix("PTYExitReason.waitpidFailed(errno=\(code) "))
       #expect(waitFail.description.hasSuffix(")"))
+    }
+  }
+
+  @Test("errnoText の strerror 出力部分は印字可能 ASCII / 非空 / 単一行 (SUT 単独不変条件)")
+  func errnoTextStrerrorOutputIsAsciiPrintableSingleLine() {
+    // `ptyErrorDescriptionMatchesContractFormat` は SUT と同根の `expectedErrnoText`
+    // mirror で完全一致を主張するため、SUT と mirror が同じバグを抱えると pass して
+    // しまう（reviewer 指摘 E）。これを補強するため、SUT 単独で観察可能な strerror
+    // 出力の最低限の品質を assert する。
+    //
+    // mirror に依存せず、description 文字列から `errnoText` 出力部分を抽出して
+    // 検証する。`errnoText` の出力品質契約:
+    //   - 非空
+    //   - 印字可能 ASCII (0x20–0x7E) のみで構成される（SUT 側の防御と一致）
+    //   - 改行 / TAB / 制御文字を含まない
+    // 具体的な文字列内容（"Cannot allocate memory" 等）は macOS バージョン依存
+    // なので主張しない。あくまで「観察ログを壊さない品質」を fix する。
+    for code: Int32 in [ENOMEM, EAGAIN, ECHILD, EINTR, EFAULT, 0, -1, 9999] {
+      let desc = PTYError.openptyFailed(errno: code).description
+      // 形式: "PTYError.openptyFailed(errno=N <strerror>)" から <strerror> を抽出
+      let prefix = "PTYError.openptyFailed(errno=\(code) "
+      #expect(desc.hasPrefix(prefix))
+      #expect(desc.hasSuffix(")"))
+      let strerrorStart = desc.index(desc.startIndex, offsetBy: prefix.count)
+      let strerrorEnd = desc.index(before: desc.endIndex)
+      let strerrorText = desc[strerrorStart..<strerrorEnd]
+      #expect(!strerrorText.isEmpty, "errno=\(code) produced empty strerror text")
+      #expect(
+        strerrorText.unicodeScalars.allSatisfy { $0.value >= 0x20 && $0.value <= 0x7E },
+        "errno=\(code) strerror text contains non-printable-ASCII: \(strerrorText.debugDescription)"
+      )
     }
   }
 }
@@ -331,8 +367,14 @@ struct PTYManagerTests {
 /// イディオムを使うこと自体が形式契約の test 対象になっている。SUT 側
 /// `errnoText` のイディオムを変える時は本 helper も同時に同期更新する。
 ///
-/// boundary errno (9999 / 0 / -1) に対する OS 実装差吸収は別 test
-/// (`errnoTextHandlesBoundaryErrnoSafely`) で prefix/suffix の不変条件のみを
+/// 限界: 本 helper と SUT が同じイディオムで実装されているため、両者に同じバグが
+/// 入った場合 (例: UTF-8 解釈ミス、buffer サイズ不足、bitPattern reinterpret 誤り)
+/// この test 経路では検出できない。この相互救済を断つため、SUT 単独の strerror 出力
+/// 品質 test (`errnoTextStrerrorOutputIsAsciiPrintableSingleLine`) を別途置き、
+/// mirror に依存しない不変条件（印字可能 ASCII / 非空 / 単一行）も assert している。
+///
+/// boundary errno (Int32.max / Int32.min / 9999 / 0 / -1) に対する OS 実装差吸収は
+/// 別 test (`errnoTextHandlesBoundaryErrnoSafely`) で prefix/suffix の不変条件のみを
 /// 主張する形に分離している。本 helper は boundary 経路では呼ばれない。
 private func expectedErrnoText(_ code: Int32) -> String {
   var buf = [CChar](repeating: 0, count: 256)

--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -379,8 +379,13 @@ struct PTYManagerTests {
 /// 限界: 本 helper と SUT が同じイディオムで実装されているため、両者に同じバグが
 /// 入った場合 (例: UTF-8 解釈ミス、buffer サイズ不足、bitPattern reinterpret 誤り)
 /// この test 経路では検出できない。この相互救済を断つため、SUT 単独の strerror 出力
-/// 品質 test (`errnoTextStrerrorOutputIsAsciiPrintableSingleLine`) を別途置き、
-/// mirror に依存しない不変条件（印字可能 ASCII / 非空 / 単一行）も assert している。
+/// 品質 test (`errnoTextStrerrorOutputIsControlCharFreeAndNonEmpty`) を別途置き、
+/// mirror に依存しない不変条件（制御文字 / 改行を含まない / 非空）も assert している。
+///
+/// SUT と完全同期するため、空 buffer fallback と control-char gate も mirror に持たせる
+/// （SUT 側 `errnoText` の実装を参照）。valid errno (ENOMEM / EAGAIN / ECHILD / SIGHUP 等)
+/// では実機の strerror_r が制御文字を返さないため gate は通過し、SUT と同じ文字列を返す。
+/// 将来 SUT 側の gate 条件を変えた場合、本 helper も同時に同期更新する。
 ///
 /// boundary errno (Int32.max / Int32.min / 9999 / 0 / -1) に対する OS 実装差吸収は
 /// 別 test (`errnoTextHandlesBoundaryErrnoSafely`) で prefix/suffix の不変条件のみを
@@ -389,7 +394,18 @@ private func expectedErrnoText(_ code: Int32) -> String {
   var buf = [CChar](repeating: 0, count: 256)
   _ = strerror_r(code, &buf, buf.count)
   let nul = buf.firstIndex(of: 0) ?? buf.endIndex
-  return String(decoding: buf[..<nul].lazy.map { UInt8(bitPattern: $0) }, as: UTF8.self)
+  let slice = buf[..<nul]
+  if slice.isEmpty {
+    return "unknown errno \(code)"
+  }
+  let hasControlChar = slice.contains { c in
+    let u = UInt8(bitPattern: c)
+    return u < 0x20 || u == 0x7F
+  }
+  if hasControlChar {
+    return "unknown errno \(code)"
+  }
+  return String(decoding: slice.lazy.map { UInt8(bitPattern: $0) }, as: UTF8.self)
 }
 
 // MARK: - Helpers

--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -238,6 +238,29 @@ struct PTYManagerTests {
     // POSIX shell 慣例 / CPty.c の child で execve ENOENT → _exit(127)。
     #expect(exit.snapshot() == .exited(code: 127))
   }
+
+  @Test("PTYError の description は case 名 + errno + strerror を含む (issue #493)")
+  func ptyErrorDescriptionIncludesCaseAndErrno() {
+    // RpcSchemeHandler が `"\(error)"` で 500 response payload を作るため、
+    // CustomStringConvertible に乗った description が renderer まで届く文字列となる。
+    // case 名・errno 数値・strerror の 3 点を必ず含むことを契約として固定する。
+    let openpty = PTYError.openptyFailed(errno: ENOMEM)
+    #expect(openpty.description.contains("openptyFailed"))
+    #expect(openpty.description.contains("\(ENOMEM)"))
+    #expect(openpty.description.contains(String(cString: strerror(ENOMEM))))
+
+    let fork = PTYError.forkFailed(errno: EAGAIN)
+    #expect(fork.description.contains("forkFailed"))
+    #expect(fork.description.contains("\(EAGAIN)"))
+    #expect(fork.description.contains(String(cString: strerror(EAGAIN))))
+
+    let prealloc = PTYError.preforkAllocFailed(errno: ENOMEM)
+    #expect(prealloc.description.contains("preforkAllocFailed"))
+    #expect(prealloc.description.contains("\(ENOMEM)"))
+
+    // `"\(error)"` 経路でも同じ description が出ること（String(describing:) との一致）。
+    #expect("\(openpty)" == openpty.description)
+  }
 }
 
 // MARK: - Helpers

--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -391,7 +391,7 @@ struct PTYManagerTests {
 /// 別 test (`errnoTextHandlesBoundaryErrnoSafely`) で prefix/suffix の不変条件のみを
 /// 主張する形に分離している。本 helper は boundary 経路では呼ばれない。
 private func expectedErrnoText(_ code: Int32) -> String {
-  var buf = [CChar](repeating: 0, count: 256)
+  var buf = [CChar](repeating: 0, count: PTYError.errnoTextBufferSize)
   _ = strerror_r(code, &buf, buf.count)
   let nul = buf.firstIndex(of: 0) ?? buf.endIndex
   let slice = buf[..<nul]

--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -239,28 +239,57 @@ struct PTYManagerTests {
     #expect(exit.snapshot() == .exited(code: 127))
   }
 
-  @Test("PTYError の description は case 名 + errno + strerror を含む (issue #493)")
-  func ptyErrorDescriptionIncludesCaseAndErrno() {
+  @Test("PTYError の description は `PTYError.<case>(errno=<n> <strerror>)` 形式で完全一致する")
+  func ptyErrorDescriptionMatchesContractFormat() {
     // RpcSchemeHandler が `"\(error)"` で 500 response payload を作るため、
     // CustomStringConvertible に乗った description が renderer まで届く文字列となる。
-    // case 名・errno 数値・strerror の 3 点を必ず含むことを契約として固定する。
+    // PR 本文と doc コメントで宣言した形式を **完全一致** で固定する。substring
+    // 検査では「無関係文言が混ざっても pass する」「他 case 名が混入しても pass する」
+    // を許してしまうため契約として弱い。
     let openpty = PTYError.openptyFailed(errno: ENOMEM)
-    #expect(openpty.description.contains("openptyFailed"))
-    #expect(openpty.description.contains("\(ENOMEM)"))
-    #expect(openpty.description.contains(String(cString: strerror(ENOMEM))))
+    #expect(openpty.description == "PTYError.openptyFailed(errno=\(ENOMEM) \(expectedErrnoText(ENOMEM)))")
+    #expect("\(openpty)" == openpty.description)
 
     let fork = PTYError.forkFailed(errno: EAGAIN)
-    #expect(fork.description.contains("forkFailed"))
-    #expect(fork.description.contains("\(EAGAIN)"))
-    #expect(fork.description.contains(String(cString: strerror(EAGAIN))))
+    #expect(fork.description == "PTYError.forkFailed(errno=\(EAGAIN) \(expectedErrnoText(EAGAIN)))")
+    #expect("\(fork)" == fork.description)
 
     let prealloc = PTYError.preforkAllocFailed(errno: ENOMEM)
-    #expect(prealloc.description.contains("preforkAllocFailed"))
-    #expect(prealloc.description.contains("\(ENOMEM)"))
-
-    // `"\(error)"` 経路でも同じ description が出ること（String(describing:) との一致）。
-    #expect("\(openpty)" == openpty.description)
+    #expect(prealloc.description == "PTYError.preforkAllocFailed(errno=\(ENOMEM) \(expectedErrnoText(ENOMEM)))")
+    #expect("\(prealloc)" == prealloc.description)
   }
+
+  @Test("PTYExitReason の description は case ごとに付随情報を含む形式で完全一致する")
+  func ptyExitReasonDescriptionMatchesContractFormat() {
+    // `PTYError` と対称に、`PTYExitReason` も `"\(reason)"` で stderr / log に
+    // 残す経路で case 名 + 付随情報が確実に出ることを契約として固定する。
+    let exited = PTYExitReason.exited(code: 42)
+    #expect(exited.description == "PTYExitReason.exited(code=42)")
+    #expect("\(exited)" == exited.description)
+
+    let signaled = PTYExitReason.signaled(signal: SIGHUP, coreDumped: false)
+    #expect(signaled.description == "PTYExitReason.signaled(signal=\(SIGHUP) coreDumped=false)")
+    #expect("\(signaled)" == signaled.description)
+
+    let stopped = PTYExitReason.stopped
+    #expect(stopped.description == "PTYExitReason.stopped")
+    #expect("\(stopped)" == stopped.description)
+
+    let waitFail = PTYExitReason.waitpidFailed(errno: ECHILD)
+    #expect(waitFail.description == "PTYExitReason.waitpidFailed(errno=\(ECHILD) \(expectedErrnoText(ECHILD)))")
+    #expect("\(waitFail)" == waitFail.description)
+  }
+}
+
+/// 本 SUT (`PTYError.errnoText`) と同じく `strerror_r(3)` + SE-0405 イディオムで
+/// 期待値を構築する。`strerror(3)` ベースで期待値を作ると本実装と独立にならず
+/// (POSIX 文面の thread-safety 議論で本実装を `strerror_r` にしている動機が消える)、
+/// `String(cString: [CChar])` で組むと本実装と非対称になるため避ける。
+private func expectedErrnoText(_ code: Int32) -> String {
+  var buf = [CChar](repeating: 0, count: 256)
+  _ = strerror_r(code, &buf, buf.count)
+  let nul = buf.firstIndex(of: 0) ?? buf.endIndex
+  return String(decoding: buf[..<nul].lazy.map { UInt8(bitPattern: $0) }, as: UTF8.self)
 }
 
 // MARK: - Helpers

--- a/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
@@ -35,6 +35,10 @@ struct PTYRegistryTests {
       rows: 24,
       cols: 80
     )
+    // ptyId 採番の不変条件「成功 spawn 時に nextId は +1 だけ進む」をここで担保する。
+    // `peekNextId()` 専用 seam を test 用に公開する案を以前持っていたが、
+    // module API に test-only accessor を漏らすコストを避けるため撤去し、配送機構
+    // test である本 test の副次 assertion に統合した（PR #597 review feedback）。
     #expect(id2 == id1 + 1)
 
     // issue ( #566 ) 観測: 本 test は CI attempt 1 で tick=1 ( +1.161s ) → tick=2 ( +2.534s )

--- a/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
@@ -180,41 +180,6 @@ struct PTYRegistryTests {
     let stillThere = await registry.consumeExpectedResumeSid(for: id)
     #expect(stillThere == "expected-sid-X")
   }
-
-  @Test("spawn 成功時に nextId は +1 だけ進む（spawn 失敗時の id 消費の構造的観察）")
-  func spawnAdvancesNextIdByOneOnSuccess() async throws {
-    testTrace("started")
-    defer { testTrace("ended") }
-    let events = EventCollector()
-    let registry = PTYRegistry(
-      onText: { id, text in events.appendText(id: id, text: text) },
-      onExit: { id, reason in events.appendExit(id: id, reason: reason) }
-    )
-
-    // spawn 失敗を実環境で確実に発火させる手段は無い（preforkAllocFailed /
-    // openptyFailed / forkFailed は OOM やリソース枯渇でしか起きない）。
-    // そのため「spawn 失敗時に nextId が消費されない」契約を直接 test は出来ないが、
-    // 構造的に観察可能な不変条件として「成功時の前後で nextId が ちょうど +1 だけ
-    // 進む」を fix する。これにより `nextId += 1` の位置が変わって余分に進むような
-    // 退行（例: spawn の前後 2 回 += 1 する diff、失敗経路でも += 1 する diff）が
-    // CI で即座に検出される。
-    let beforeFirst = await registry.peekNextId()
-    let id1 = try await registry.spawn(
-      executable: "/bin/echo", args: ["echo", "x"], env: ProcessInfo.processInfo.environment,
-      cwd: "/tmp", rows: 24, cols: 80
-    )
-    let afterFirst = await registry.peekNextId()
-    #expect(id1 == beforeFirst)
-    #expect(afterFirst == beforeFirst + 1)
-
-    let id2 = try await registry.spawn(
-      executable: "/bin/echo", args: ["echo", "y"], env: ProcessInfo.processInfo.environment,
-      cwd: "/tmp", rows: 24, cols: 80
-    )
-    let afterSecond = await registry.peekNextId()
-    #expect(id2 == afterFirst)
-    #expect(afterSecond == afterFirst + 1)
-  }
 }
 
 // MARK: - Helpers

--- a/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
@@ -180,6 +180,41 @@ struct PTYRegistryTests {
     let stillThere = await registry.consumeExpectedResumeSid(for: id)
     #expect(stillThere == "expected-sid-X")
   }
+
+  @Test("spawn 成功時に nextId は +1 だけ進む（spawn 失敗時の id 消費の構造的観察）")
+  func spawnAdvancesNextIdByOneOnSuccess() async throws {
+    testTrace("started")
+    defer { testTrace("ended") }
+    let events = EventCollector()
+    let registry = PTYRegistry(
+      onText: { id, text in events.appendText(id: id, text: text) },
+      onExit: { id, reason in events.appendExit(id: id, reason: reason) }
+    )
+
+    // spawn 失敗を実環境で確実に発火させる手段は無い（preforkAllocFailed /
+    // openptyFailed / forkFailed は OOM やリソース枯渇でしか起きない）。
+    // そのため「spawn 失敗時に nextId が消費されない」契約を直接 test は出来ないが、
+    // 構造的に観察可能な不変条件として「成功時の前後で nextId が ちょうど +1 だけ
+    // 進む」を fix する。これにより `nextId += 1` の位置が変わって余分に進むような
+    // 退行（例: spawn の前後 2 回 += 1 する diff、失敗経路でも += 1 する diff）が
+    // CI で即座に検出される。
+    let beforeFirst = await registry.peekNextId()
+    let id1 = try await registry.spawn(
+      executable: "/bin/echo", args: ["echo", "x"], env: ProcessInfo.processInfo.environment,
+      cwd: "/tmp", rows: 24, cols: 80
+    )
+    let afterFirst = await registry.peekNextId()
+    #expect(id1 == beforeFirst)
+    #expect(afterFirst == beforeFirst + 1)
+
+    let id2 = try await registry.spawn(
+      executable: "/bin/echo", args: ["echo", "y"], env: ProcessInfo.processInfo.environment,
+      cwd: "/tmp", rows: 24, cols: 80
+    )
+    let afterSecond = await registry.peekNextId()
+    #expect(id2 == afterFirst)
+    #expect(afterSecond == afterFirst + 1)
+  }
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
## 概要

`PTYError` のサブ case（`openptyFailed` / `forkFailed` / `preforkAllocFailed`）を Console.app log（stderr）と renderer 向けエラー応答の双方で identifiable にする。

## 背景

issue ( #493 ) で「`PTYError` を type 付きで catch している箇所がリポジトリ内に 1 箇所も無く、上位の包括 catch では `Error.localizedDescription` 経由で文字列化されるため失敗 syscall を区別できない」と指摘されていた。

`PR ( #491 )` のレビュー過程で `PTYError.preforkAllocFailed(errno:)` を新設し「失敗 syscall を取り違える」既存挙動を直したものの、`PTYManager.spawn` 呼び出し元（`PTYRegistry.swift` / `RpcDispatcher.swift`）も `PTYError` を型として扱っておらず、case を分けた効果（`forkFailed` vs `preforkAllocFailed` vs `openptyFailed` の意味分離）が観察可能性に届いていない状態だった。

加えて `GitError` 側は `commandFailed(_, stderr)` / `launchFailed(let message)` 形式で handler レベルの type 付き catch が既に存在しており（`RpcDispatcher.swift:925` ほか）、`PTYError` だけが downstream 統合から取り残された格好になっていた。

## 変更内容

### PTYManager (`apps/native/Sources/GozdCore/PTYManager.swift`)

- `PTYError` に `CustomStringConvertible` 適合を extension で追加
- `description` は `PTYError.<case>(errno=<n> <strerror テキスト>)` 形式
- `"\(error)"` / `String(describing:)` / `print(error)` すべてがこの `description` を使うため、文字列化箇所を 1 つ整えるだけで stderr log と RPC 500 response payload の双方をカバーできる
- enum 宣言と既存 `Error, Equatable` 適合は無変更（extension のみ追加）

### RpcDispatcher (`apps/native/Sources/GozdCore/RpcDispatcher.swift`)

- `handlePtySpawn` で `catch let error as PTYError` を追加
- stderr に `[RpcDispatcher] pty.spawn failed: <PTYError description> executable=<exe> cwd=<dir>` の形式で構造化 log を書いて rethrow
- rethrow した error は既存の `RpcSchemeHandler.swift:660` の `"\(error)"` 経路で 500 response の body として renderer に届く
- `GitError.commandFailed` を `handleGitFetchRemotes` 等で handler レベルで処理しているのと対称

### テスト (`apps/native/Tests/GozdCoreTests/PTYManagerTests.swift`)

- 新規 test `ptyErrorDescriptionIncludesCaseAndErrno` を追加
- 3 case すべてで `description` が case 名・errno 数値・strerror テキストを含むことを契約として固定
- `"\(error)"` が `description` と一致することも検証（CustomStringConvertible 経路の保険）

## 今回含めない点

- **PTYRegistry 側の type 付き catch は追加しない**: `PTYRegistry.spawn` は `try pty.spawn` で throws をそのまま流す薄い rethrow ラッパで、type discrimination はディスパッチ層 1 箇所にあれば十分。重複させると `GitError` 系統と対称な「handler レベルで catch」という SSOT が崩れる
- **`GitError` の Console / renderer 統合**: issue ( #493 ) 内で「`launchFailed(String)` は文字列で原因保持しているので Console 経由では届く」と既に評価されており、本 PR のスコープ外

## 確認事項

- [ ] `swift build` 成功
- [ ] `swift test --filter PTYManager` で新規 test を含む 9 件すべて pass
- [ ] `pnpm -r typecheck` 全 workspace 通過
- [ ] `LocalizedError` を採用しなかった判断（Cocoa 由来の user-facing 文言粒度で開発者向け syscall 識別に合わない、を `description` 一択にする方が SSOT になりやすい）が妥当か
- [ ] `strerror(3)` を `String(cString:)` 経由で即時コピーする扱い（thread-safe ではないが本経路ではコピー直後に文字列が完成するため race の影響を受けない）の評価
