### PR TITLE
chore(pnpm-config): pnpm 11.1.3 で修正済みの minimumReleaseAgeStrict workaround を解除

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,12 +184,6 @@ macOS 26 Tahoe 以降専用（`WebPage` API は macOS 26 で追加された Swif
 
 `pnpm-workspace.yaml` の `packageExtensions` で upstream の依存宣言バグを回避している。upstream が修正されたら解除する。
 
-### settings（pnpm 本体のバグ回避）
-
-| 設定                      | 値      | 理由                                                                                                                                                                                                                                                               | 解除条件                           |
-| ------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- |
-| `minimumReleaseAgeStrict` | `false` | pnpm v11.0.4 以降、ユーザーが `minimumReleaseAge` を設定すると暗黙で strict=true になる ( pnpm/pnpm#11436 )。strict 経路では abbreviated metadata の `time` 欠落で `ERR_PNPM_MISSING_TIME` を rethrow し、`minimumReleaseAgeIgnoreMissingTime` の catch に届かない | pnpm/pnpm#11238 が修正されたら削除 |
-
 ### packageExtensions（phantom dependency 補完）
 
 `enableGlobalVirtualStore` により phantom dependency が顕在化するため、upstream が宣言していない依存を補完している。

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,8 +27,6 @@ catalog:
 enableGlobalVirtualStore: true
 
 minimumReleaseAge: 4320
-minimumReleaseAgeStrict: false
-
 
 packageExtensions:
   '@iconify/tailwind4@1.2.3':


### PR DESCRIPTION
## 概要

`pnpm-workspace.yaml` の `minimumReleaseAgeStrict: false` 上書きと、CLAUDE.md の `pnpm ワークアラウンド > settings` サブセクションを削除する。pnpm の暗黙デフォルト（`minimumReleaseAge` 設定時は strict=true）に戻し、サプライチェーン保護を本来の強度に揃える。

## 背景

CLAUDE.md に残っていた解除条件は「pnpm/pnpm issue11238 が修正されたら削除」だった。今回の調査では最初、issue が依然 `open` のまま閉じていないことを根拠に「workaround 継続」と即断したが、これは誤りだった。

実態を ghq クローンの pnpm リポジトリで commit / PR ベースに追ったところ次が分かった:

- CLAUDE.md が説明していた発火経路（「strict 経路では abbreviated metadata の `time` 欠落で `ERR_PNPM_MISSING_TIME` を rethrow し、`minimumReleaseAgeIgnoreMissingTime` の catch に届かない」）は、pnpm/pnpm pr11622 で塞がっている。先頭コミット (`e526f89650`) のメッセージは `fix(npm-resolver): dont rethrow ERR_PNPM_MISSING_TIME from version-spec cache` と invariant に対して一対一で対応している。
- 同 PR は `Add a companion test that exercises the catch fix with the default ignoreMissingTimeField so the invariant holds regardless of that flag.` という回帰テストも追加している。
- `git tag --contains e526f89650` の結果、修正は **v11.1.2** に最初に含まれる。プロジェクトの `pnpm --version` は **v11.1.3** で、修正適用済み。
- 一方 issue11238 が open のままなのは、`ERR_PNPM_MISSING_TIME` という同じメッセージで「別経路」（`trustPolicy: no-downgrade` 経由など）の後続報告がスレッドに積み重なっているため。issue の open/closed 状態は CLAUDE.md が指していた特定 invariant の修正可否とは独立に動く。

実機検証として `minimumReleaseAgeStrict: false` を抜いた状態で `pnpm install` を実行し、`ERR_PNPM_MISSING_TIME` / `WARN ... missing the "time" field` の発火なしで完走することを確認した（`Done in 11.8s using pnpm v11.1.3`、exit 0、`grep -i 'missing_time\|WARN'` ヒット 0）。lockfile / node_modules 等への波及差分もなし。

## 変更内容

### `pnpm-workspace.yaml`

- `minimumReleaseAgeStrict: false` 行と末尾空行を削除し、pnpm デフォルトの暗黙 strict=true に戻す。`minimumReleaseAge: 4320`（3 日）はそのまま維持

### `CLAUDE.md`

- `pnpm ワークアラウンド` 節から `### settings（pnpm 本体のバグ回避）` サブセクションを削除。残るのは `### packageExtensions（phantom dependency 補完）` のみで、節の lead 文（`packageExtensions で upstream の依存宣言バグを回避している`）と整合する

## 今回含めない点

- **今回は対応しない**: `@iconify/tailwind4` の `packageExtensions` 補完は別問題で未解消のため維持。upstream の latest が 1.2.3 のまま動いておらず、`@iconify-json/lucide` は依然 dependency に未宣言

## 確認事項

- [ ] `pnpm install` が `ERR_PNPM_MISSING_TIME` を出さずに完走する
- [ ] `pnpm-workspace.yaml` の差分が `minimumReleaseAgeStrict: false` 行削除のみで、lockfile / 他設定への波及がない
- [ ] CLAUDE.md の `pnpm ワークアラウンド` 節の lead 文と残った `packageExtensions` サブセクションが整合している
