### PR TITLE
fix(dialog): consolidate UA reset in base CSS

### DIFF
--- a/apps/renderer/src/assets/main.css
+++ b/apps/renderer/src/assets/main.css
@@ -5,10 +5,11 @@ button {
   cursor: pointer;
 }
 
-/* Tailwind v4 preflight が `<dialog>` の margin: auto を意図的にリセットする (tailwindlabs/tailwindcss issue 16372) ため、UA 標準の中央配置を復元する */
-/* UA stylesheet の白背景 (background-color: canvas) を打ち消す。dialog の角丸は内側のラッパーで描画するため、要素自体は透明にして角の外側に白がはみ出さないようにする */
+/* `<dialog>` の UA stylesheet（background-color: canvas / border: solid / padding: 1em）を一括打ち消す。dialog の見た目はすべて内側のラッパーで描画する規約のため、UA 装飾は要素単位で剥がす。margin: auto は Tailwind v4 preflight が消す (tailwindlabs/tailwindcss issue 16372) ので合わせて復元する */
 dialog {
   margin: auto;
+  padding: 0;
+  border: none;
   background: transparent;
 }
 

--- a/apps/renderer/src/assets/main.css
+++ b/apps/renderer/src/assets/main.css
@@ -6,8 +6,10 @@ button {
 }
 
 /* Tailwind v4 preflight が `<dialog>` の margin: auto を意図的にリセットする (tailwindlabs/tailwindcss issue 16372) ため、UA 標準の中央配置を復元する */
+/* UA stylesheet の白背景 (background-color: canvas) を打ち消す。dialog の角丸は内側のラッパーで描画するため、要素自体は透明にして角の外側に白がはみ出さないようにする */
 dialog {
   margin: auto;
+  background: transparent;
 }
 
 /* 細いオーバーレイスクロールバー */

--- a/apps/renderer/src/features/palette/features/command-palette/CommandPalette.vue
+++ b/apps/renderer/src/features/palette/features/command-palette/CommandPalette.vue
@@ -168,7 +168,6 @@ onUnmounted(disposeShow);
 ._command-palette-dialog {
   padding: 0;
   border: none;
-  background: transparent;
   margin: 15vh auto 0;
 }
 

--- a/apps/renderer/src/features/palette/features/command-palette/CommandPalette.vue
+++ b/apps/renderer/src/features/palette/features/command-palette/CommandPalette.vue
@@ -166,8 +166,6 @@ onUnmounted(disposeShow);
 <style scoped>
 /* dialog をビューポート上部中央に配置 */
 ._command-palette-dialog {
-  padding: 0;
-  border: none;
   margin: 15vh auto 0;
 }
 

--- a/apps/renderer/src/features/palette/features/issue-picker/IssuePickerDialog.vue
+++ b/apps/renderer/src/features/palette/features/issue-picker/IssuePickerDialog.vue
@@ -194,8 +194,6 @@ useEventListener(dialogRef, "click", (e: MouseEvent) => {
 
 <style scoped>
 ._issue-picker-dialog {
-  padding: 0;
-  border: none;
   margin: 15vh auto 0;
 }
 

--- a/apps/renderer/src/features/palette/features/issue-picker/IssuePickerDialog.vue
+++ b/apps/renderer/src/features/palette/features/issue-picker/IssuePickerDialog.vue
@@ -196,7 +196,6 @@ useEventListener(dialogRef, "click", (e: MouseEvent) => {
 ._issue-picker-dialog {
   padding: 0;
   border: none;
-  background: transparent;
   margin: 15vh auto 0;
 }
 

--- a/apps/renderer/src/features/palette/features/pr-picker/PrPickerDialog.vue
+++ b/apps/renderer/src/features/palette/features/pr-picker/PrPickerDialog.vue
@@ -218,7 +218,6 @@ useEventListener(dialogRef, "click", (e: MouseEvent) => {
 ._pr-picker-dialog {
   padding: 0;
   border: none;
-  background: transparent;
   margin: 15vh auto 0;
 }
 

--- a/apps/renderer/src/features/palette/features/pr-picker/PrPickerDialog.vue
+++ b/apps/renderer/src/features/palette/features/pr-picker/PrPickerDialog.vue
@@ -216,8 +216,6 @@ useEventListener(dialogRef, "click", (e: MouseEvent) => {
 
 <style scoped>
 ._pr-picker-dialog {
-  padding: 0;
-  border: none;
   margin: 15vh auto 0;
 }
 

--- a/apps/renderer/src/features/palette/features/quick-pick/QuickPick.vue
+++ b/apps/renderer/src/features/palette/features/quick-pick/QuickPick.vue
@@ -212,9 +212,6 @@ function handleKeydown(e: KeyboardEvent) {
 
 <style>
 ._quick-pick-dialog {
-  padding: 0;
-  border: none;
-  background: transparent;
   margin: 15vh auto 0;
 }
 

--- a/apps/renderer/src/features/settings/SettingsModal.vue
+++ b/apps/renderer/src/features/settings/SettingsModal.vue
@@ -208,9 +208,6 @@ watch(isOpen, (open) => {
 
 <style>
 ._settings-dialog {
-  padding: 0;
-  border: none;
-  background: transparent;
   margin: 15vh auto 0;
 }
 


### PR DESCRIPTION
## 概要

`<dialog>` 要素の UA stylesheet（`background-color: canvas` / `border: solid` / `padding: 1em`）の打ち消しを base CSS に集約する。これまで dialog を持つ各 SFC が scoped CSS でバラバラに reset していた指定を物理削除し、UA reset を 3 点セットで SSOT 化する。

## 背景

worktree 削除時の確認ダイアログ（`SidebarPane.vue` の `<dialog>`）で、内側ラッパー div の角丸（`rounded-lg bg-zinc-900`）の外側に白い装飾が露出していた。原因は dialog 要素自体に UA stylesheet の `background-color: canvas` / `border: solid` が当たっていたこと。Tailwind v4 preflight は dialog の `margin: auto` をリセットするが、`padding` / `border` / `background` は触らないため、各 SFC で個別に打ち消す必要があった。

実際、既存の dialog（`CommandPalette.vue` / `IssuePickerDialog.vue` / `PrPickerDialog.vue` / `SettingsModal.vue` / `QuickPick.vue`）はそれぞれ scoped CSS で `padding: 0; border: none;` および一部 `background: transparent` を持っていたが、SidebarPane の確認ダイアログだけが対処漏れだった。`<dialog>` 全般に共通する罠であり、新規 dialog を書くたびに踏む構造的問題なので base CSS 側で 1 箇所にまとめる。

## 変更内容

### base CSS

- `apps/renderer/src/assets/main.css` の `dialog` ルールに `padding: 0` / `border: none` / `background: transparent` を追加。既存の `margin: auto`（Tailwind preflight の補完）と並べて UA stylesheet の打ち消しを集約

### scoped CSS の整理

- `CommandPalette.vue` / `IssuePickerDialog.vue` / `PrPickerDialog.vue` / `SettingsModal.vue` / `QuickPick.vue` の scoped CSS から `padding: 0` / `border: none` を削除（5 ファイル）
- `SettingsModal.vue` / `QuickPick.vue` の scoped CSS から `background: transparent` を削除
- 各 SFC には `margin: 15vh auto 0`（上部寄せの位置調整）など、SFC 固有の演出指定のみが残る

## 今回含めない点

- **今回は対応しない**: `::backdrop` 側の `background: rgb(0 0 0 / 30%)` / `background: transparent`（QuickPick のオーバーレイなし）等は各 dialog 固有の演出として SFC 側に残す。base に持ち上げると個別調整の自由度を失う
- **今回は対応しない**: 各 SFC の `margin: 15vh auto 0`（上部寄せ）/ デフォルトの中央配置といった位置調整も dialog ごとの演出として SFC に残す

## 確認事項

- [ ] worktree 削除確認ダイアログ（SidebarPane）を開き、角丸の外側に白がはみ出さないことを確認
- [ ] コマンドパレット / Issue ピッカー / PR ピッカー / Settings / QuickPick を順次開き、ラッパー div の `bg-zinc-800` / `bg-zinc-900` 以外の背景・border・padding が見えないこと
- [ ] DevTools の Computed で `<dialog>` の `padding` が `0px`、`border-style` が `none`、`background-color` が `rgba(0, 0, 0, 0)` になっていること（Tailwind preflight との cascade 順を実機確認）
- [ ] `::backdrop` の暗いオーバーレイは各 dialog で従来通り表示されること（QuickPick のみ透明）
