### PR TITLE
feat(git-graph): add current branch only toggle

### DIFF
--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -178,7 +178,9 @@ public enum GitOps {
   ///
   /// `try?` で 3 種を区別せず潰すと、git-graph が「空」「gozd が git を解決できていない」
   /// 「ユーザーが git をインストールしていない」を見分けられなくなる。
-  public static func logBoth(dir: String, maxCount: UInt32, firstParentOnly: Bool) async throws
+  public static func logBoth(
+    dir: String, maxCount: UInt32, firstParentOnly: Bool, currentBranchOnly: Bool
+  ) async throws
     -> LogResult
   {
     async let headTask = log(
@@ -191,7 +193,9 @@ public enum GitOps {
     }
     let head = try await headTask
     var defaultCommits: [CommitInfo] = []
-    if !defaultBranch.isEmpty {
+    // currentBranchOnly では default branch 系統の log fetch を skip する。`defaultBranch` 文字列は
+    // `symbolic-ref` だけは引き続き解決して返す (renderer の RefBadge `isDefault` 表示に使う)。
+    if !defaultBranch.isEmpty && !currentBranchOnly {
       do {
         defaultCommits = try await log(
           dir: dir, ref: "origin/\(defaultBranch)", maxCount: maxCount,

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -665,7 +665,8 @@ public actor RpcDispatcher {
   private func handleGitLog(_ body: Data) async throws -> Data {
     let req = try Gozd_V1_GitLogRequest(jsonUTF8Data: body)
     let result = try await GitOps.logBoth(
-      dir: req.dir, maxCount: req.maxCount, firstParentOnly: req.firstParentOnly)
+      dir: req.dir, maxCount: req.maxCount, firstParentOnly: req.firstParentOnly,
+      currentBranchOnly: req.currentBranchOnly)
     func toProto(_ c: CommitInfo) -> Gozd_V1_GitCommit {
       var pb = Gozd_V1_GitCommit()
       pb.hash = c.hash

--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -58,6 +58,10 @@ const defaultBranch = ref<string | undefined>();
 const layout = ref<GraphLayout>({ nodes: [], lines: [], maxLanes: 1 });
 const firstParentOnly = ref(false);
 const sortMode = ref<SortMode>("date");
+/** ON のとき default branch 系統 (`origin/HEAD` の log) を merge せず、HEAD 系統のみ描画する。
+ * fetch 自体はそのまま行い、`mergeCommitStreams` への入力で `defaultBranchCommits` を空に倒す。
+ * `defaultBranch` 文字列値は RefBadge の `isDefault` 判定 SSOT なので保持する。 */
+const currentBranchOnly = ref(false);
 
 /** 変更ファイル数 */
 const uncommittedChangeCount = computed(() => Object.keys(gitStatuses.value).length);
@@ -206,7 +210,7 @@ async function runLoadLog(): Promise<boolean> {
 
   const merged = mergeCommitStreams({
     headCommits: result.headCommits,
-    defaultBranchCommits: result.defaultBranchCommits,
+    defaultBranchCommits: currentBranchOnly.value ? [] : result.defaultBranchCommits,
     sortMode: sortMode.value,
   });
 
@@ -258,6 +262,10 @@ watch(firstParentOnly, () => {
   void loadLog();
 });
 watch(sortMode, () => {
+  gitGraphStore.resetSelection();
+  void loadLog();
+});
+watch(currentBranchOnly, () => {
   gitGraphStore.resetSelection();
   void loadLog();
 });
@@ -882,6 +890,16 @@ const isWorkingTreeActive = computed(
         @click="firstParentOnly = !firstParentOnly"
       >
         First Parent
+      </button>
+      <button
+        class="rounded-sm px-1.5 py-0.5 text-[10px]"
+        :class="
+          currentBranchOnly ? 'bg-blue-800 text-blue-200' : 'text-zinc-500 hover:text-zinc-300'
+        "
+        title="Hide default branch and show current branch only"
+        @click="currentBranchOnly = !currentBranchOnly"
+      >
+        Current Branch
       </button>
       <button
         class="rounded-sm px-1.5 py-0.5 text-[10px]"

--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -58,9 +58,6 @@ const defaultBranch = ref<string | undefined>();
 const layout = ref<GraphLayout>({ nodes: [], lines: [], maxLanes: 1 });
 const firstParentOnly = ref(false);
 const sortMode = ref<SortMode>("date");
-/** ON のとき default branch 系統 (`origin/HEAD` の log) を merge せず、HEAD 系統のみ描画する。
- * fetch 自体はそのまま行い、`mergeCommitStreams` への入力で `defaultBranchCommits` を空に倒す。
- * `defaultBranch` 文字列値は RefBadge の `isDefault` 判定 SSOT なので保持する。 */
 const currentBranchOnly = ref(false);
 
 /** 変更ファイル数 */
@@ -82,6 +79,11 @@ const currentBranch = computed(() => {
  * ローカルとリモートが異なるコミットに存在するブランチ名の Set。
  * 同じコミットにローカルとリモートが両方あれば synced（computeDisplayRefs で処理）。
  * 別コミットに分かれていれば out-of-sync としてここで検出する。
+ *
+ * 検出範囲は `commits.value` に出現する ref に限定される。`currentBranchOnly` が ON のとき
+ * `defaultBranchCommits` 由来の commit が消えるため、HEAD 系統から到達しない ref ペアの
+ * out-of-sync は検出できない。これは toggle の意味（「current branch だけ表示」=「他系統を
+ * 隠す」）の直接の帰結であり、副作用ではない。
  */
 const outOfSyncBranches = computed(() => {
   const localCommits = new Map<string, string>();
@@ -205,12 +207,13 @@ async function runLoadLog(): Promise<boolean> {
     dir,
     maxCount: 200,
     firstParentOnly: firstParentOnly.value,
+    currentBranchOnly: currentBranchOnly.value,
   });
   if (gen !== loadLogGen) return false;
 
   const merged = mergeCommitStreams({
     headCommits: result.headCommits,
-    defaultBranchCommits: currentBranchOnly.value ? [] : result.defaultBranchCommits,
+    defaultBranchCommits: result.defaultBranchCommits,
     sortMode: sortMode.value,
   });
 
@@ -887,6 +890,7 @@ const isWorkingTreeActive = computed(
       <button
         class="rounded-sm px-1.5 py-0.5 text-[10px]"
         :class="firstParentOnly ? 'bg-blue-800 text-blue-200' : 'text-zinc-500 hover:text-zinc-300'"
+        :aria-pressed="firstParentOnly"
         @click="firstParentOnly = !firstParentOnly"
       >
         First Parent
@@ -896,6 +900,7 @@ const isWorkingTreeActive = computed(
         :class="
           currentBranchOnly ? 'bg-blue-800 text-blue-200' : 'text-zinc-500 hover:text-zinc-300'
         "
+        :aria-pressed="currentBranchOnly"
         title="Hide default branch and show current branch only"
         @click="currentBranchOnly = !currentBranchOnly"
       >
@@ -906,6 +911,7 @@ const isWorkingTreeActive = computed(
         :class="
           sortMode === 'topo' ? 'bg-blue-800 text-blue-200' : 'text-zinc-500 hover:text-zinc-300'
         "
+        :aria-pressed="sortMode === 'topo'"
         @click="sortMode = sortMode === 'date' ? 'topo' : 'date'"
       >
         {{ sortMode === "date" ? "Date Order" : "Topo Order" }}
@@ -919,6 +925,7 @@ const isWorkingTreeActive = computed(
       <button
         class="ml-auto rounded-sm px-1.5 py-0.5 text-[10px]"
         :class="detailOpen ? 'bg-blue-800 text-blue-200' : 'text-zinc-500 hover:text-zinc-300'"
+        :aria-pressed="detailOpen"
         title="Toggle commit detail"
         aria-label="Toggle commit detail"
         @click="detailOpen = !detailOpen"

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_git_ops.pb.swift
@@ -160,6 +160,11 @@ public struct Gozd_V1_GitLogRequest: Sendable {
 
   public var firstParentOnly: Bool = false
 
+  /// true のとき `origin/<default>` の log 取得を完全に skip し、`default_branch_commits` を
+  /// 空配列で返す。`default_branch` 文字列は `git symbolic-ref` だけは引き続き解決して返す
+  /// (RefBadge の `isDefault` 表示に使う)。
+  public var currentBranchOnly: Bool = false
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -924,7 +929,7 @@ extension Gozd_V1_GitWorktreeListResponse: SwiftProtobuf.Message, SwiftProtobuf.
 
 extension Gozd_V1_GitLogRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".GitLogRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}dir\0\u{3}max_count\0\u{3}first_parent_only\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}dir\0\u{3}max_count\0\u{3}first_parent_only\0\u{3}current_branch_only\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -935,6 +940,7 @@ extension Gozd_V1_GitLogRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
       case 1: try { try decoder.decodeSingularStringField(value: &self.dir) }()
       case 2: try { try decoder.decodeSingularUInt32Field(value: &self.maxCount) }()
       case 3: try { try decoder.decodeSingularBoolField(value: &self.firstParentOnly) }()
+      case 4: try { try decoder.decodeSingularBoolField(value: &self.currentBranchOnly) }()
       default: break
       }
     }
@@ -950,6 +956,9 @@ extension Gozd_V1_GitLogRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     if self.firstParentOnly != false {
       try visitor.visitSingularBoolField(value: self.firstParentOnly, fieldNumber: 3)
     }
+    if self.currentBranchOnly != false {
+      try visitor.visitSingularBoolField(value: self.currentBranchOnly, fieldNumber: 4)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -957,6 +966,7 @@ extension Gozd_V1_GitLogRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
     if lhs.dir != rhs.dir {return false}
     if lhs.maxCount != rhs.maxCount {return false}
     if lhs.firstParentOnly != rhs.firstParentOnly {return false}
+    if lhs.currentBranchOnly != rhs.currentBranchOnly {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/git_ops.ts
@@ -134,6 +134,12 @@ export interface GitLogRequest {
   dir: string;
   maxCount: number;
   firstParentOnly: boolean;
+  /**
+   * true のとき `origin/<default>` の log 取得を完全に skip し、`default_branch_commits` を
+   * 空配列で返す。`default_branch` 文字列は `git symbolic-ref` だけは引き続き解決して返す
+   * (RefBadge の `isDefault` 表示に使う)。
+   */
+  currentBranchOnly: boolean;
 }
 
 export interface GitLogResponse {
@@ -593,7 +599,7 @@ export const GitWorktreeListResponse: MessageFns<GitWorktreeListResponse> = {
 };
 
 function createBaseGitLogRequest(): GitLogRequest {
-  return { dir: "", maxCount: 0, firstParentOnly: false };
+  return { dir: "", maxCount: 0, firstParentOnly: false, currentBranchOnly: false };
 }
 
 export const GitLogRequest: MessageFns<GitLogRequest> = {
@@ -606,6 +612,9 @@ export const GitLogRequest: MessageFns<GitLogRequest> = {
     }
     if (message.firstParentOnly !== false) {
       writer.uint32(24).bool(message.firstParentOnly);
+    }
+    if (message.currentBranchOnly !== false) {
+      writer.uint32(32).bool(message.currentBranchOnly);
     }
     return writer;
   },
@@ -641,6 +650,14 @@ export const GitLogRequest: MessageFns<GitLogRequest> = {
           message.firstParentOnly = reader.bool();
           continue;
         }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.currentBranchOnly = reader.bool();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -663,6 +680,11 @@ export const GitLogRequest: MessageFns<GitLogRequest> = {
         : isSet(object.first_parent_only)
         ? globalThis.Boolean(object.first_parent_only)
         : false,
+      currentBranchOnly: isSet(object.currentBranchOnly)
+        ? globalThis.Boolean(object.currentBranchOnly)
+        : isSet(object.current_branch_only)
+        ? globalThis.Boolean(object.current_branch_only)
+        : false,
     };
   },
 
@@ -677,6 +699,9 @@ export const GitLogRequest: MessageFns<GitLogRequest> = {
     if (message.firstParentOnly !== false) {
       obj.firstParentOnly = message.firstParentOnly;
     }
+    if (message.currentBranchOnly !== false) {
+      obj.currentBranchOnly = message.currentBranchOnly;
+    }
     return obj;
   },
 
@@ -688,6 +713,7 @@ export const GitLogRequest: MessageFns<GitLogRequest> = {
     message.dir = object.dir ?? "";
     message.maxCount = object.maxCount ?? 0;
     message.firstParentOnly = object.firstParentOnly ?? false;
+    message.currentBranchOnly = object.currentBranchOnly ?? false;
     return message;
   },
 };

--- a/packages/proto/gozd/v1/git_ops.proto
+++ b/packages/proto/gozd/v1/git_ops.proto
@@ -19,6 +19,10 @@ message GitLogRequest {
   string dir = 1;
   uint32 max_count = 2;
   bool first_parent_only = 3;
+  // true のとき `origin/<default>` の log 取得を完全に skip し、`default_branch_commits` を
+  // 空配列で返す。`default_branch` 文字列は `git symbolic-ref` だけは引き続き解決して返す
+  // (RefBadge の `isDefault` 表示に使う)。
+  bool current_branch_only = 4;
 }
 message GitLogResponse {
   repeated GitCommit head_commits = 1;


### PR DESCRIPTION
## 概要

git-graph に「現在ブランチのみ表示する」モードを追加した。ツールバーに `Current Branch` toggle を追加し、ON のときは default branch 系統 (`origin/HEAD` の log) を取得せず、HEAD 系統のコミットのみを描画する。

## 背景

git-graph は標準で「current worktree branch」と「default branch (`origin/HEAD`)」の log を union して 1 つの graph に表示する。これは worktree が default branch から派生した経緯を一目で把握できる反面、長期間 default branch との合流が遠い worktree や、default branch 側に commit が多数積まれている状況では、現在ブランチに直接関係しないコミットが画面を占有して見通しを悪化させる。

「現在のブランチで自分が積んでいる commit 列だけ集中して見たい」という運用要件に対し、既存の `First Parent` (`git log --first-parent`) や `Date/Topo Order` ではこの軸の切り替えができなかった。

## 変更内容

### proto / native

- `packages/proto/gozd/v1/git_ops.proto` の `GitLogRequest` に `current_branch_only` フィールドを追加。生成物 (`packages/proto-ts/` / `packages/proto-swift/`) も更新
- `apps/native/Sources/GozdCore/GitOps.swift` の `logBoth(...)` に `currentBranchOnly: Bool` を追加。true のとき `origin/<default>` の `git log` 呼び出しを skip し、`defaultBranchCommits: []` で返す。`defaultBranch` 文字列は `git symbolic-ref` で引き続き解決して返す (renderer の `RefBadge` `isDefault` 表示に使うため)
- `apps/native/Sources/GozdCore/RpcDispatcher.swift` の `handleGitLog` で新規 field を `logBoth` に渡す

### git-graph (renderer)

- `apps/renderer/src/features/git-graph/GitGraphPane.vue` に `currentBranchOnly` の ref とトグルボタンを追加。`First Parent` / `sortMode` と同じ `watch → loadLog` pattern で再フェッチをトリガー
- `rpcGitLog` 呼び出しに `currentBranchOnly` を渡し、native 側で fetch をスキップさせる。renderer 側で「fetch してから捨てる」構造は持たない (`firstParentOnly` と責務を揃え、native = fetch 制御 / renderer = render 制御 の分離を維持)
- `outOfSyncBranches` computed に意図コメントを追加: `commits.value` に出現する ref に限定する検出スコープが、`currentBranchOnly` ON 時に縮退するのは toggle の意味（他系統を隠す）と整合する設計上の挙動である旨を固定
- toolbar の全 toggle ボタン (`First Parent` / `Current Branch` / `Date/Topo Order` / commit detail) に `aria-pressed` を追加し、スクリーンリーダーで ON/OFF 状態が読み上げられるようにする

## 確認事項

- [ ] `Current Branch` toggle を ON にすると default branch (`origin/main` 等) のコミット行が graph から消える
- [ ] toggle を OFF に戻すと default branch のコミット行が再表示される
- [ ] 現在ブランチが default branch (`main` 等) と一致している状態で toggle を ON にしても、`RefBadge` の default 色装飾 (`isDefault`) が維持される
- [ ] toggle 切替後に並走している `gitStatusChange` / `remoteRefsChange` 由来の `scheduleLoadLog` が走っても、graph が最終的に新 toggle 値の結果に収束する (世代管理が機能していること)
- [ ] `First Parent` と `Current Branch` の両方を ON にした状態で、HEAD から first-parent でたどった列のみが描画される (直交した axis として共存)
- [ ] スクリーンリーダーで toolbar の toggle ボタンを focus したとき "pressed" / "not pressed" の状態が読み上げられる
