### PR TITLE
feat(voicevox): キャラクター・スタイル選択 UI を追加

### DIFF
--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -383,6 +383,8 @@ public actor RpcDispatcher {
       return try await handleVoicevoxLaunch(body)
     case "/voicevox/checkEngine":
       return try await handleVoicevoxCheckEngine(body)
+    case "/voicevox/listSpeakers":
+      return try await handleVoicevoxListSpeakers(body)
     case "/voicevox/speak":
       return try await handleVoicevoxSpeak(body)
     case "/window/close":
@@ -1287,6 +1289,25 @@ public actor RpcDispatcher {
     _ = try Gozd_V1_VoicevoxCheckEngineRequest(jsonUTF8Data: body)
     var resp = Gozd_V1_VoicevoxCheckEngineResponse()
     resp.ok = await VoicevoxOps.checkEngine()
+    return try resp.jsonUTF8Data()
+  }
+
+  private func handleVoicevoxListSpeakers(_ body: Data) async throws -> Data {
+    _ = try Gozd_V1_VoicevoxListSpeakersRequest(jsonUTF8Data: body)
+    var resp = Gozd_V1_VoicevoxListSpeakersResponse()
+    if let speakers = await VoicevoxOps.listSpeakers() {
+      resp.speakers = speakers.map { speaker in
+        var s = Gozd_V1_VoicevoxSpeaker()
+        s.name = speaker.name
+        s.styles = speaker.styles.map { style in
+          var st = Gozd_V1_VoicevoxSpeakerStyle()
+          st.name = style.name
+          st.id = style.id
+          return st
+        }
+        return s
+      }
+    }
     return try resp.jsonUTF8Data()
   }
 

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -1307,6 +1307,8 @@ public actor RpcDispatcher {
         }
         return s
       }
+    } else {
+      FileHandle.standardError.write(Data("[handleVoicevoxListSpeakers] listSpeakers returned nil; responding with empty list\n".utf8))
     }
     return try resp.jsonUTF8Data()
   }

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -1308,7 +1308,10 @@ public actor RpcDispatcher {
         return s
       }
     } else {
-      FileHandle.standardError.write(Data("[handleVoicevoxListSpeakers] listSpeakers returned nil; responding with empty list\n".utf8))
+      StderrLog.write(
+        tag: "handleVoicevoxListSpeakers",
+        "listSpeakers returned nil; responding with empty list"
+      )
     }
     return try resp.jsonUTF8Data()
   }

--- a/apps/native/Sources/GozdCore/VoicevoxOps.swift
+++ b/apps/native/Sources/GozdCore/VoicevoxOps.swift
@@ -29,21 +29,35 @@ public enum VoicevoxOps {
     req.timeoutInterval = 5
     do {
       let (data, resp) = try await URLSession.shared.data(for: req)
-      guard let http = resp as? HTTPURLResponse, http.statusCode == 200 else { return nil }
+      guard let http = resp as? HTTPURLResponse, http.statusCode == 200 else {
+        let code = (resp as? HTTPURLResponse)?.statusCode ?? -1
+        FileHandle.standardError.write(Data("[VoicevoxOps.listSpeakers] non-200 status: \(code)\n".utf8))
+        return nil
+      }
       guard let arr = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+        FileHandle.standardError.write(Data("[VoicevoxOps.listSpeakers] root is not array of object\n".utf8))
         return nil
       }
       return arr.compactMap { entry in
         guard let name = entry["name"] as? String,
           let styleArr = entry["styles"] as? [[String: Any]]
-        else { return nil }
+        else {
+          FileHandle.standardError.write(Data("[VoicevoxOps.listSpeakers] skipping malformed speaker entry: \(entry)\n".utf8))
+          return nil
+        }
         let styles: [Speaker.Style] = styleArr.compactMap { s in
-          guard let n = s["name"] as? String, let id = s["id"] as? Int else { return nil }
-          return Speaker.Style(name: n, id: UInt32(id))
+          guard let n = s["name"] as? String, let idRaw = s["id"] as? Int,
+            let id = UInt32(exactly: idRaw)
+          else {
+            FileHandle.standardError.write(Data("[VoicevoxOps.listSpeakers] skipping malformed style entry: \(s)\n".utf8))
+            return nil
+          }
+          return Speaker.Style(name: n, id: id)
         }
         return Speaker(name: name, styles: styles)
       }
     } catch {
+      FileHandle.standardError.write(Data("[VoicevoxOps.listSpeakers] request/decode failed: \(error)\n".utf8))
       return nil
     }
   }

--- a/apps/native/Sources/GozdCore/VoicevoxOps.swift
+++ b/apps/native/Sources/GozdCore/VoicevoxOps.swift
@@ -141,7 +141,12 @@ public enum VoicevoxOps {
     }
     json["speedScale"] = speedScale
     json["volumeScale"] = volumeScale
-    return try? JSONSerialization.data(withJSONObject: json)
+    do {
+      return try JSONSerialization.data(withJSONObject: json)
+    } catch {
+      FileHandle.standardError.write(Data("[VoicevoxOps.mutateAudioQuery] failed to encode mutated query: \(error)\n".utf8))
+      return nil
+    }
   }
 
   private static func synthesize(audioQuery: Data, speakerId: UInt32) async -> Data? {

--- a/apps/native/Sources/GozdCore/VoicevoxOps.swift
+++ b/apps/native/Sources/GozdCore/VoicevoxOps.swift
@@ -70,6 +70,11 @@ public enum VoicevoxOps {
       guard let http = resp as? HTTPURLResponse else { return false }
       return http.statusCode == 200
     } catch {
+      // Engine 未起動時の polling 用途で頻発するため、転送エラー (URLError) はログを出さない。
+      // それ以外の予期しない error のみ stderr に残す
+      if !(error is URLError) {
+        FileHandle.standardError.write(Data("[VoicevoxOps.checkEngine] unexpected error: \(error)\n".utf8))
+      }
       return false
     }
   }
@@ -82,8 +87,12 @@ public enum VoicevoxOps {
     do {
       try process.run()
       process.waitUntilExit()
+      if process.terminationStatus != 0 {
+        FileHandle.standardError.write(Data("[VoicevoxOps.launch] open -a VOICEVOX exited with status \(process.terminationStatus)\n".utf8))
+      }
       return process.terminationStatus == 0
     } catch {
+      FileHandle.standardError.write(Data("[VoicevoxOps.launch] failed to spawn open: \(error)\n".utf8))
       return false
     }
   }
@@ -111,9 +120,14 @@ public enum VoicevoxOps {
     req.timeoutInterval = 10
     do {
       let (data, resp) = try await URLSession.shared.data(for: req)
-      guard let http = resp as? HTTPURLResponse, http.statusCode == 200 else { return nil }
+      guard let http = resp as? HTTPURLResponse, http.statusCode == 200 else {
+        let code = (resp as? HTTPURLResponse)?.statusCode ?? -1
+        FileHandle.standardError.write(Data("[VoicevoxOps.audioQuery] non-200 status: \(code) (speaker=\(speakerId))\n".utf8))
+        return nil
+      }
       return data
     } catch {
+      FileHandle.standardError.write(Data("[VoicevoxOps.audioQuery] request failed: \(error)\n".utf8))
       return nil
     }
   }
@@ -122,6 +136,7 @@ public enum VoicevoxOps {
     -> Data?
   {
     guard var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+      FileHandle.standardError.write(Data("[VoicevoxOps.mutateAudioQuery] failed to parse audio_query response as JSON object\n".utf8))
       return nil
     }
     json["speedScale"] = speedScale
@@ -139,9 +154,14 @@ public enum VoicevoxOps {
     req.timeoutInterval = 60
     do {
       let (data, resp) = try await URLSession.shared.data(for: req)
-      guard let http = resp as? HTTPURLResponse, http.statusCode == 200 else { return nil }
+      guard let http = resp as? HTTPURLResponse, http.statusCode == 200 else {
+        let code = (resp as? HTTPURLResponse)?.statusCode ?? -1
+        FileHandle.standardError.write(Data("[VoicevoxOps.synthesize] non-200 status: \(code) (speaker=\(speakerId))\n".utf8))
+        return nil
+      }
       return data
     } catch {
+      FileHandle.standardError.write(Data("[VoicevoxOps.synthesize] request failed: \(error)\n".utf8))
       return nil
     }
   }

--- a/apps/native/Sources/GozdCore/VoicevoxOps.swift
+++ b/apps/native/Sources/GozdCore/VoicevoxOps.swift
@@ -14,6 +14,40 @@ import Foundation
 public enum VoicevoxOps {
   static let baseUrl = URL(string: "http://127.0.0.1:50021")!
 
+  /// `/speakers` レスポンスの型。1 entry = 1 キャラ ＋ style 配列。
+  public struct Speaker: Sendable {
+    public struct Style: Sendable {
+      public let name: String
+      public let id: UInt32
+    }
+    public let name: String
+    public let styles: [Style]
+  }
+
+  public static func listSpeakers() async -> [Speaker]? {
+    var req = URLRequest(url: baseUrl.appendingPathComponent("speakers"))
+    req.timeoutInterval = 5
+    do {
+      let (data, resp) = try await URLSession.shared.data(for: req)
+      guard let http = resp as? HTTPURLResponse, http.statusCode == 200 else { return nil }
+      guard let arr = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+        return nil
+      }
+      return arr.compactMap { entry in
+        guard let name = entry["name"] as? String,
+          let styleArr = entry["styles"] as? [[String: Any]]
+        else { return nil }
+        let styles: [Speaker.Style] = styleArr.compactMap { s in
+          guard let n = s["name"] as? String, let id = s["id"] as? Int else { return nil }
+          return Speaker.Style(name: n, id: UInt32(id))
+        }
+        return Speaker(name: name, styles: styles)
+      }
+    } catch {
+      return nil
+    }
+  }
+
   public static func checkEngine() async -> Bool {
     var req = URLRequest(url: baseUrl.appendingPathComponent("version"))
     req.timeoutInterval = 1.5

--- a/apps/native/Sources/GozdCore/VoicevoxOps.swift
+++ b/apps/native/Sources/GozdCore/VoicevoxOps.swift
@@ -31,25 +31,31 @@ public enum VoicevoxOps {
       let (data, resp) = try await URLSession.shared.data(for: req)
       guard let http = resp as? HTTPURLResponse, http.statusCode == 200 else {
         let code = (resp as? HTTPURLResponse)?.statusCode ?? -1
-        FileHandle.standardError.write(Data("[VoicevoxOps.listSpeakers] non-200 status: \(code)\n".utf8))
+        StderrLog.write(tag: "VoicevoxOps.listSpeakers", "non-200 status: \(code)")
         return nil
       }
       guard let arr = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
-        FileHandle.standardError.write(Data("[VoicevoxOps.listSpeakers] root is not array of object\n".utf8))
+        StderrLog.write(tag: "VoicevoxOps.listSpeakers", "root is not array of object")
         return nil
       }
       return arr.compactMap { entry in
         guard let name = entry["name"] as? String,
           let styleArr = entry["styles"] as? [[String: Any]]
         else {
-          FileHandle.standardError.write(Data("[VoicevoxOps.listSpeakers] skipping malformed speaker entry: \(entry)\n".utf8))
+          StderrLog.write(
+            tag: "VoicevoxOps.listSpeakers",
+            "skipping malformed speaker entry: \(entry)"
+          )
           return nil
         }
         let styles: [Speaker.Style] = styleArr.compactMap { s in
           guard let n = s["name"] as? String, let idRaw = s["id"] as? Int,
             let id = UInt32(exactly: idRaw)
           else {
-            FileHandle.standardError.write(Data("[VoicevoxOps.listSpeakers] skipping malformed style entry: \(s)\n".utf8))
+            StderrLog.write(
+              tag: "VoicevoxOps.listSpeakers",
+              "skipping malformed style entry: \(s)"
+            )
             return nil
           }
           return Speaker.Style(name: n, id: id)
@@ -57,7 +63,7 @@ public enum VoicevoxOps {
         return Speaker(name: name, styles: styles)
       }
     } catch {
-      FileHandle.standardError.write(Data("[VoicevoxOps.listSpeakers] request/decode failed: \(error)\n".utf8))
+      StderrLog.write(tag: "VoicevoxOps.listSpeakers", "request/decode failed: \(error)")
       return nil
     }
   }
@@ -73,7 +79,7 @@ public enum VoicevoxOps {
       // Engine 未起動時の polling 用途で頻発するため、転送エラー (URLError) はログを出さない。
       // それ以外の予期しない error のみ stderr に残す
       if !(error is URLError) {
-        FileHandle.standardError.write(Data("[VoicevoxOps.checkEngine] unexpected error: \(error)\n".utf8))
+        StderrLog.write(tag: "VoicevoxOps.checkEngine", "unexpected error: \(error)")
       }
       return false
     }
@@ -88,11 +94,14 @@ public enum VoicevoxOps {
       try process.run()
       process.waitUntilExit()
       if process.terminationStatus != 0 {
-        FileHandle.standardError.write(Data("[VoicevoxOps.launch] open -a VOICEVOX exited with status \(process.terminationStatus)\n".utf8))
+        StderrLog.write(
+          tag: "VoicevoxOps.launch",
+          "open -a VOICEVOX exited with status \(process.terminationStatus)"
+        )
       }
       return process.terminationStatus == 0
     } catch {
-      FileHandle.standardError.write(Data("[VoicevoxOps.launch] failed to spawn open: \(error)\n".utf8))
+      StderrLog.write(tag: "VoicevoxOps.launch", "failed to spawn open: \(error)")
       return false
     }
   }
@@ -122,12 +131,15 @@ public enum VoicevoxOps {
       let (data, resp) = try await URLSession.shared.data(for: req)
       guard let http = resp as? HTTPURLResponse, http.statusCode == 200 else {
         let code = (resp as? HTTPURLResponse)?.statusCode ?? -1
-        FileHandle.standardError.write(Data("[VoicevoxOps.audioQuery] non-200 status: \(code) (speaker=\(speakerId))\n".utf8))
+        StderrLog.write(
+          tag: "VoicevoxOps.audioQuery",
+          "non-200 status: \(code) (speaker=\(speakerId))"
+        )
         return nil
       }
       return data
     } catch {
-      FileHandle.standardError.write(Data("[VoicevoxOps.audioQuery] request failed: \(error)\n".utf8))
+      StderrLog.write(tag: "VoicevoxOps.audioQuery", "request failed: \(error)")
       return nil
     }
   }
@@ -136,7 +148,10 @@ public enum VoicevoxOps {
     -> Data?
   {
     guard var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-      FileHandle.standardError.write(Data("[VoicevoxOps.mutateAudioQuery] failed to parse audio_query response as JSON object\n".utf8))
+      StderrLog.write(
+        tag: "VoicevoxOps.mutateAudioQuery",
+        "failed to parse audio_query response as JSON object"
+      )
       return nil
     }
     json["speedScale"] = speedScale
@@ -144,7 +159,10 @@ public enum VoicevoxOps {
     do {
       return try JSONSerialization.data(withJSONObject: json)
     } catch {
-      FileHandle.standardError.write(Data("[VoicevoxOps.mutateAudioQuery] failed to encode mutated query: \(error)\n".utf8))
+      StderrLog.write(
+        tag: "VoicevoxOps.mutateAudioQuery",
+        "failed to encode mutated query: \(error)"
+      )
       return nil
     }
   }
@@ -161,12 +179,15 @@ public enum VoicevoxOps {
       let (data, resp) = try await URLSession.shared.data(for: req)
       guard let http = resp as? HTTPURLResponse, http.statusCode == 200 else {
         let code = (resp as? HTTPURLResponse)?.statusCode ?? -1
-        FileHandle.standardError.write(Data("[VoicevoxOps.synthesize] non-200 status: \(code) (speaker=\(speakerId))\n".utf8))
+        StderrLog.write(
+          tag: "VoicevoxOps.synthesize",
+          "non-200 status: \(code) (speaker=\(speakerId))"
+        )
         return nil
       }
       return data
     } catch {
-      FileHandle.standardError.write(Data("[VoicevoxOps.synthesize] request failed: \(error)\n".utf8))
+      StderrLog.write(tag: "VoicevoxOps.synthesize", "request failed: \(error)")
       return nil
     }
   }

--- a/apps/renderer/src/features/settings/SettingField.vue
+++ b/apps/renderer/src/features/settings/SettingField.vue
@@ -9,6 +9,7 @@ import EnumWidget from "./widgets/EnumWidget.vue";
 import NumberWidget from "./widgets/NumberWidget.vue";
 import StringArrayWidget from "./widgets/StringArrayWidget.vue";
 import StringWidget from "./widgets/StringWidget.vue";
+import VoicevoxSpeakerWidget from "./widgets/VoicevoxSpeakerWidget.vue";
 
 defineProps<{
   setting: SettingDefinition;
@@ -51,6 +52,7 @@ const model = defineModel<unknown>({ required: true });
         v-model="model as string[]"
         :setting="setting"
       />
+      <VoicevoxSpeakerWidget v-else-if="setting.widget === 'voicevoxSpeaker'" :setting="setting" />
     </div>
   </div>
 </template>

--- a/apps/renderer/src/features/settings/SettingField.vue
+++ b/apps/renderer/src/features/settings/SettingField.vue
@@ -15,7 +15,9 @@ defineProps<{
   setting: SettingDefinition;
 }>();
 
-const model = defineModel<unknown>({ required: true });
+// voicevoxSpeaker widget は store と直結するため v-model 経路を通らず、
+// SettingSection から undefined が渡される。required: true だと契約違反になるため緩める
+const model = defineModel<unknown>();
 </script>
 
 <template>

--- a/apps/renderer/src/features/settings/SettingSection.vue
+++ b/apps/renderer/src/features/settings/SettingSection.vue
@@ -26,7 +26,7 @@ const emit = defineEmits<{
         v-for="(setting, key) in section.settings"
         :key="key"
         :setting="setting"
-        :model-value="values[key] ?? setting.defaultValue"
+        :model-value="values[key] ?? ('defaultValue' in setting ? setting.defaultValue : undefined)"
         @update:model-value="emit('change', key as string, $event)"
       />
     </div>

--- a/apps/renderer/src/features/settings/SettingsModal.vue
+++ b/apps/renderer/src/features/settings/SettingsModal.vue
@@ -109,12 +109,6 @@ function handleGlobalChange(key: string, value: unknown) {
     voicevoxStore.volumeScale = value;
     return;
   }
-  // speakerId は VoicevoxSpeakerWidget 内で setSpeakerId を直接呼ぶため、
-  // SettingField からの change event は発火しない。来た場合のみ store 経由で同期する。
-  if (key === "voicevox.speakerId" && typeof value === "number") {
-    voicevoxStore.setSpeakerId(value);
-    return;
-  }
 
   // リアクティブ ref との同期
   REACTIVE_SYNC[key]?.(value);

--- a/apps/renderer/src/features/settings/SettingsModal.vue
+++ b/apps/renderer/src/features/settings/SettingsModal.vue
@@ -109,6 +109,12 @@ function handleGlobalChange(key: string, value: unknown) {
     voicevoxStore.volumeScale = value;
     return;
   }
+  // speakerId は VoicevoxSpeakerWidget 内で setSpeakerId を直接呼ぶため、
+  // SettingField からの change event は発火しない。来た場合のみ store 経由で同期する。
+  if (key === "voicevox.speakerId" && typeof value === "number") {
+    voicevoxStore.setSpeakerId(value);
+    return;
+  }
 
   // リアクティブ ref との同期
   REACTIVE_SYNC[key]?.(value);

--- a/apps/renderer/src/features/settings/globalSettingsSchema.ts
+++ b/apps/renderer/src/features/settings/globalSettingsSchema.ts
@@ -83,7 +83,6 @@ export const globalSettingsSections: readonly SettingSection[] = [
         widget: "voicevoxSpeaker",
         label: "Speaker",
         description: "Character and style. Loaded from running VOICEVOX engine.",
-        defaultValue: 3,
       },
     },
   },

--- a/apps/renderer/src/features/settings/globalSettingsSchema.ts
+++ b/apps/renderer/src/features/settings/globalSettingsSchema.ts
@@ -79,6 +79,12 @@ export const globalSettingsSections: readonly SettingSection[] = [
         max: 2.0,
         step: 0.1,
       },
+      "voicevox.speakerId": {
+        widget: "voicevoxSpeaker",
+        label: "Speaker",
+        description: "Character and style. Loaded from running VOICEVOX engine.",
+        defaultValue: 3,
+      },
     },
   },
 ];

--- a/apps/renderer/src/features/settings/rpc.ts
+++ b/apps/renderer/src/features/settings/rpc.ts
@@ -60,7 +60,12 @@ export function flattenAppConfig(c: AppConfig | undefined): Record<string, unkno
 function applyDotKey(config: AppConfig, key: string, value: unknown): void {
   const terminal = config.terminal ?? { theme: "", fontFamily: "", fontSize: 0 };
   const preview = config.preview ?? { fontFamily: "", fontSize: 0 };
-  const voicevox = config.voicevox ?? { enabled: false, speedScale: 0, volumeScale: 0 };
+  const voicevox = config.voicevox ?? {
+    enabled: false,
+    speedScale: 0,
+    volumeScale: 0,
+    speakerId: 0,
+  };
   config.terminal = terminal;
   config.preview = preview;
   config.voicevox = voicevox;

--- a/apps/renderer/src/features/settings/rpc.ts
+++ b/apps/renderer/src/features/settings/rpc.ts
@@ -53,7 +53,7 @@ export function flattenAppConfig(c: AppConfig | undefined): Record<string, unkno
     "voicevox.enabled": c?.voicevox?.enabled ?? false,
     "voicevox.speedScale": c?.voicevox?.speedScale ?? 1.5,
     "voicevox.volumeScale": c?.voicevox?.volumeScale ?? 1.0,
-    "voicevox.speakerId": c?.voicevox?.speakerId ?? 3,
+    // voicevox.speakerId は VoicevoxSpeakerWidget が store と直結するため flatten 経路を通らない
   };
 }
 
@@ -94,9 +94,6 @@ function applyDotKey(config: AppConfig, key: string, value: unknown): void {
       break;
     case "voicevox.volumeScale":
       if (typeof value === "number") voicevox.volumeScale = value;
-      break;
-    case "voicevox.speakerId":
-      if (typeof value === "number") voicevox.speakerId = value;
       break;
   }
 }

--- a/apps/renderer/src/features/settings/rpc.ts
+++ b/apps/renderer/src/features/settings/rpc.ts
@@ -53,6 +53,7 @@ export function flattenAppConfig(c: AppConfig | undefined): Record<string, unkno
     "voicevox.enabled": c?.voicevox?.enabled ?? false,
     "voicevox.speedScale": c?.voicevox?.speedScale ?? 1.5,
     "voicevox.volumeScale": c?.voicevox?.volumeScale ?? 1.0,
+    "voicevox.speakerId": c?.voicevox?.speakerId ?? 3,
   };
 }
 
@@ -64,7 +65,7 @@ function applyDotKey(config: AppConfig, key: string, value: unknown): void {
     enabled: false,
     speedScale: 0,
     volumeScale: 0,
-    speakerId: 0,
+    speakerId: undefined,
   };
   config.terminal = terminal;
   config.preview = preview;
@@ -93,6 +94,9 @@ function applyDotKey(config: AppConfig, key: string, value: unknown): void {
       break;
     case "voicevox.volumeScale":
       if (typeof value === "number") voicevox.volumeScale = value;
+      break;
+    case "voicevox.speakerId":
+      if (typeof value === "number") voicevox.speakerId = value;
       break;
   }
 }

--- a/apps/renderer/src/features/settings/types.ts
+++ b/apps/renderer/src/features/settings/types.ts
@@ -44,10 +44,12 @@ export interface StringArraySetting extends SettingBase {
   placeholder?: string;
 }
 
-/** VOICEVOX のキャラ + スタイル選択 → 2 段 select（widget 自体が voicevox store に依存） */
+/**
+ * VOICEVOX のキャラ + スタイル選択 → 2 段 select。
+ * widget 内部で voicevox store と直結するため defaultValue / dot-key 経由の値は持たない。
+ */
 export interface VoicevoxSpeakerSetting extends SettingBase {
   widget: "voicevoxSpeaker";
-  defaultValue: number;
 }
 
 export type SettingDefinition =

--- a/apps/renderer/src/features/settings/types.ts
+++ b/apps/renderer/src/features/settings/types.ts
@@ -44,12 +44,19 @@ export interface StringArraySetting extends SettingBase {
   placeholder?: string;
 }
 
+/** VOICEVOX のキャラ + スタイル選択 → 2 段 select（widget 自体が voicevox store に依存） */
+export interface VoicevoxSpeakerSetting extends SettingBase {
+  widget: "voicevoxSpeaker";
+  defaultValue: number;
+}
+
 export type SettingDefinition =
   | BooleanSetting
   | NumberSetting
   | EnumSetting
   | StringSetting
-  | StringArraySetting;
+  | StringArraySetting
+  | VoicevoxSpeakerSetting;
 
 /** 設定セクション（グループ化） */
 export interface SettingSection {

--- a/apps/renderer/src/features/settings/widgets/VoicevoxSpeakerWidget.vue
+++ b/apps/renderer/src/features/settings/widgets/VoicevoxSpeakerWidget.vue
@@ -1,0 +1,23 @@
+<doc lang="md">
+VOICEVOX キャラ・スタイル選択用 widget。
+voicevox feature の VoicevoxSpeakerSelect を薄くラップする。
+
+## 注意
+
+実体は voicevox store に直接結合しているため、model は store 内 speakerId と二重管理にならないよう
+ここでは defineModel を使わず、表示のみ store 経由で完結させる。
+保存経路も store の watch 経由で AppConfig に書き込まれるため、settings の patch 経由は通らない。
+</doc>
+
+<script setup lang="ts">
+import { VoicevoxSpeakerSelect } from "../../voicevox";
+import type { VoicevoxSpeakerSetting } from "../types";
+
+defineProps<{
+  setting: VoicevoxSpeakerSetting;
+}>();
+</script>
+
+<template>
+  <VoicevoxSpeakerSelect />
+</template>

--- a/apps/renderer/src/features/sidebar/VoicevoxPanel.vue
+++ b/apps/renderer/src/features/sidebar/VoicevoxPanel.vue
@@ -6,6 +6,7 @@
 
 <script setup lang="ts">
 import { useVoicevoxStore } from "../voicevox";
+import VoicevoxSpeakerSelect from "./VoicevoxSpeakerSelect.vue";
 
 const voicevoxStore = useVoicevoxStore();
 
@@ -34,6 +35,7 @@ async function handleActivate() {
           <span class="icon-[lucide--volume-2] size-4 shrink-0 animate-pulse" />
           <span>Playing...</span>
         </button>
+        <VoicevoxSpeakerSelect />
         <div class="flex items-center gap-2 text-xs text-zinc-500">
           <span class="icon-[lucide--gauge] size-4 shrink-0" title="Speed" />
           <input

--- a/apps/renderer/src/features/sidebar/VoicevoxPanel.vue
+++ b/apps/renderer/src/features/sidebar/VoicevoxPanel.vue
@@ -5,8 +5,7 @@
 </doc>
 
 <script setup lang="ts">
-import { useVoicevoxStore } from "../voicevox";
-import VoicevoxSpeakerSelect from "./VoicevoxSpeakerSelect.vue";
+import { useVoicevoxStore, VoicevoxSpeakerSelect } from "../voicevox";
 
 const voicevoxStore = useVoicevoxStore();
 

--- a/apps/renderer/src/features/sidebar/VoicevoxSpeakerSelect.vue
+++ b/apps/renderer/src/features/sidebar/VoicevoxSpeakerSelect.vue
@@ -1,0 +1,64 @@
+<doc lang="md">
+VOICEVOX のキャラとスタイルを 2 段 select で選ぶコンポーネント。
+キャラを変更したら、そのキャラの先頭 style の id に切り替える。
+</doc>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useVoicevoxStore } from "../voicevox";
+
+const voicevoxStore = useVoicevoxStore();
+
+const currentSpeaker = computed(() =>
+  voicevoxStore.speakers.find((s) =>
+    s.styles.some((style) => style.id === voicevoxStore.speakerId),
+  ),
+);
+
+const currentStyles = computed(() => currentSpeaker.value?.styles ?? []);
+
+function handleSpeakerChange(event: Event) {
+  const speakerName = (event.target as HTMLSelectElement).value;
+  const speaker = voicevoxStore.speakers.find((s) => s.name === speakerName);
+  const firstStyleId = speaker?.styles[0]?.id;
+  if (firstStyleId !== undefined) {
+    voicevoxStore.speakerId = firstStyleId;
+  }
+}
+
+function handleStyleChange(event: Event) {
+  voicevoxStore.speakerId = Number((event.target as HTMLSelectElement).value);
+}
+</script>
+
+<template>
+  <div v-if="voicevoxStore.speakers.length > 0" class="flex flex-col gap-1">
+    <div class="flex items-center gap-2 text-xs text-zinc-500">
+      <span class="icon-[lucide--user] size-4 shrink-0" title="Character" />
+      <select
+        aria-label="VOICEVOX character"
+        class="min-w-0 flex-1 rounded-sm bg-zinc-800 px-1 py-0.5 text-zinc-300"
+        :value="currentSpeaker?.name ?? ''"
+        @change="handleSpeakerChange"
+      >
+        <option v-for="speaker in voicevoxStore.speakers" :key="speaker.name" :value="speaker.name">
+          {{ speaker.name }}
+        </option>
+      </select>
+    </div>
+    <div class="flex items-center gap-2 text-xs text-zinc-500">
+      <span class="icon-[lucide--palette] size-4 shrink-0" title="Style" />
+      <select
+        aria-label="VOICEVOX style"
+        class="min-w-0 flex-1 rounded-sm bg-zinc-800 px-1 py-0.5 text-zinc-300 disabled:opacity-50"
+        :disabled="currentStyles.length <= 1"
+        :value="voicevoxStore.speakerId"
+        @change="handleStyleChange"
+      >
+        <option v-for="style in currentStyles" :key="style.id" :value="style.id">
+          {{ style.name }}
+        </option>
+      </select>
+    </div>
+  </div>
+</template>

--- a/apps/renderer/src/features/voicevox/VoicevoxSpeakerSelect.vue
+++ b/apps/renderer/src/features/voicevox/VoicevoxSpeakerSelect.vue
@@ -22,12 +22,12 @@ function handleSpeakerChange(event: Event) {
   const speaker = voicevoxStore.speakers.find((s) => s.name === speakerName);
   const firstStyleId = speaker?.styles[0]?.id;
   if (firstStyleId !== undefined) {
-    voicevoxStore.speakerId = firstStyleId;
+    voicevoxStore.setSpeakerId(firstStyleId);
   }
 }
 
 function handleStyleChange(event: Event) {
-  voicevoxStore.speakerId = Number((event.target as HTMLSelectElement).value);
+  voicevoxStore.setSpeakerId(Number((event.target as HTMLSelectElement).value));
 }
 </script>
 

--- a/apps/renderer/src/features/voicevox/VoicevoxSpeakerSelect.vue
+++ b/apps/renderer/src/features/voicevox/VoicevoxSpeakerSelect.vue
@@ -5,12 +5,14 @@ VOICEVOX のキャラとスタイルを 2 段 select で選ぶコンポーネン
 ## stale speakerId
 
 保存された speakerId が現エンジンに存在しない場合、`effectiveSpeakerId` (再生用) はデフォルトに倒れるが、
-ユーザー選択 (`speakerId`) は保持される。この時 inline 警告と Reset to default ボタンを出す。
+ユーザー選択 (`speakerId`) は保持される。この時 inline 警告と Use default ボタンを出す。
+Use default は `setSpeakerId(DEFAULT_SPEAKER_ID)` と等価で、reset 専用 API は持たない (SSOT)。
 </doc>
 
 <script setup lang="ts">
 import { computed } from "vue";
 import { useVoicevoxStore } from "../voicevox";
+import { DEFAULT_SPEAKER_ID } from "./useVoicevoxStore";
 
 const voicevoxStore = useVoicevoxStore();
 
@@ -51,9 +53,9 @@ function handleStyleChange(event: Event) {
           <button
             type="button"
             class="ml-1 underline hover:text-amber-200"
-            @click="voicevoxStore.resetSpeakerId()"
+            @click="voicevoxStore.setSpeakerId(DEFAULT_SPEAKER_ID)"
           >
-            Reset
+            Use default
           </button>
         </div>
       </div>

--- a/apps/renderer/src/features/voicevox/VoicevoxSpeakerSelect.vue
+++ b/apps/renderer/src/features/voicevox/VoicevoxSpeakerSelect.vue
@@ -4,15 +4,16 @@ VOICEVOX のキャラとスタイルを 2 段 select で選ぶコンポーネン
 
 ## stale speakerId
 
-保存された speakerId が現エンジンに存在しない場合、`effectiveSpeakerId` (再生用) はデフォルトに倒れるが、
-ユーザー選択 (`speakerId`) は保持される。この時 inline 警告と Use default ボタンを出す。
-Use default は `setSpeakerId(DEFAULT_SPEAKER_ID)` と等価で、reset 専用 API は持たない (SSOT)。
+保存された speakerId が現エンジンに存在しない場合、`effectiveSpeakerId` (再生用) はメモリ上 fallback
+されるが、ユーザー選択 (`speakerId`) は保持される。この時 inline 警告と Use default ボタンを出す。
+Use default は `setSpeakerId(effectiveSpeakerId)` を呼ぶ。effectiveSpeakerId は
+DEFAULT → speakers[0].styles[0].id の順で live fallback されるため、DEFAULT が engine に
+無い稀ケースでも常に有効な値が渡る。
 </doc>
 
 <script setup lang="ts">
 import { computed } from "vue";
 import { useVoicevoxStore } from "../voicevox";
-import { DEFAULT_SPEAKER_ID } from "./useVoicevoxStore";
 
 const voicevoxStore = useVoicevoxStore();
 
@@ -53,7 +54,7 @@ function handleStyleChange(event: Event) {
           <button
             type="button"
             class="ml-1 underline hover:text-amber-200"
-            @click="voicevoxStore.setSpeakerId(DEFAULT_SPEAKER_ID)"
+            @click="voicevoxStore.setSpeakerId(voicevoxStore.effectiveSpeakerId)"
           >
             Use default
           </button>

--- a/apps/renderer/src/features/voicevox/VoicevoxSpeakerSelect.vue
+++ b/apps/renderer/src/features/voicevox/VoicevoxSpeakerSelect.vue
@@ -1,6 +1,11 @@
 <doc lang="md">
 VOICEVOX のキャラとスタイルを 2 段 select で選ぶコンポーネント。
 キャラを変更したら、そのキャラの先頭 style の id に切り替える。
+
+## stale speakerId
+
+保存された speakerId が現エンジンに存在しない場合、`effectiveSpeakerId` (再生用) はデフォルトに倒れるが、
+ユーザー選択 (`speakerId`) は保持される。この時 inline 警告と Reset to default ボタンを出す。
 </doc>
 
 <script setup lang="ts">
@@ -9,9 +14,10 @@ import { useVoicevoxStore } from "../voicevox";
 
 const voicevoxStore = useVoicevoxStore();
 
+// effectiveSpeakerId ベースで表示する → ユーザーが見ている select と実際の再生音声が一致する
 const currentSpeaker = computed(() =>
   voicevoxStore.speakers.find((s) =>
-    s.styles.some((style) => style.id === voicevoxStore.speakerId),
+    s.styles.some((style) => style.id === voicevoxStore.effectiveSpeakerId),
   ),
 );
 
@@ -34,6 +40,23 @@ function handleStyleChange(event: Event) {
 <template>
   <div class="flex flex-col gap-1">
     <template v-if="voicevoxStore.speakers.length > 0">
+      <div
+        v-if="voicevoxStore.speakerIdIsStale"
+        class="flex items-start gap-2 rounded-sm bg-amber-950/40 px-2 py-1 text-xs text-amber-300"
+      >
+        <span class="icon-[lucide--triangle-alert] size-4 shrink-0" />
+        <div class="flex-1">
+          Saved speaker (id {{ voicevoxStore.speakerId }}) is not in current engine; playing with
+          default.
+          <button
+            type="button"
+            class="ml-1 underline hover:text-amber-200"
+            @click="voicevoxStore.resetSpeakerId()"
+          >
+            Reset
+          </button>
+        </div>
+      </div>
       <div class="flex items-center gap-2 text-xs text-zinc-500">
         <span class="icon-[lucide--user] size-4 shrink-0" title="Character" />
         <select
@@ -57,7 +80,7 @@ function handleStyleChange(event: Event) {
           aria-label="VOICEVOX style"
           class="min-w-0 flex-1 rounded-sm bg-zinc-800 px-1 py-0.5 text-zinc-300 disabled:opacity-50"
           :disabled="currentStyles.length <= 1"
-          :value="voicevoxStore.speakerId"
+          :value="voicevoxStore.effectiveSpeakerId"
           @change="handleStyleChange"
         >
           <option v-for="style in currentStyles" :key="style.id" :value="style.id">

--- a/apps/renderer/src/features/voicevox/VoicevoxSpeakerSelect.vue
+++ b/apps/renderer/src/features/voicevox/VoicevoxSpeakerSelect.vue
@@ -32,33 +32,40 @@ function handleStyleChange(event: Event) {
 </script>
 
 <template>
-  <div v-if="voicevoxStore.speakers.length > 0" class="flex flex-col gap-1">
-    <div class="flex items-center gap-2 text-xs text-zinc-500">
-      <span class="icon-[lucide--user] size-4 shrink-0" title="Character" />
-      <select
-        aria-label="VOICEVOX character"
-        class="min-w-0 flex-1 rounded-sm bg-zinc-800 px-1 py-0.5 text-zinc-300"
-        :value="currentSpeaker?.name ?? ''"
-        @change="handleSpeakerChange"
-      >
-        <option v-for="speaker in voicevoxStore.speakers" :key="speaker.name" :value="speaker.name">
-          {{ speaker.name }}
-        </option>
-      </select>
-    </div>
-    <div class="flex items-center gap-2 text-xs text-zinc-500">
-      <span class="icon-[lucide--palette] size-4 shrink-0" title="Style" />
-      <select
-        aria-label="VOICEVOX style"
-        class="min-w-0 flex-1 rounded-sm bg-zinc-800 px-1 py-0.5 text-zinc-300 disabled:opacity-50"
-        :disabled="currentStyles.length <= 1"
-        :value="voicevoxStore.speakerId"
-        @change="handleStyleChange"
-      >
-        <option v-for="style in currentStyles" :key="style.id" :value="style.id">
-          {{ style.name }}
-        </option>
-      </select>
-    </div>
+  <div class="flex flex-col gap-1">
+    <template v-if="voicevoxStore.speakers.length > 0">
+      <div class="flex items-center gap-2 text-xs text-zinc-500">
+        <span class="icon-[lucide--user] size-4 shrink-0" title="Character" />
+        <select
+          aria-label="VOICEVOX character"
+          class="min-w-0 flex-1 rounded-sm bg-zinc-800 px-1 py-0.5 text-zinc-300"
+          :value="currentSpeaker?.name ?? ''"
+          @change="handleSpeakerChange"
+        >
+          <option
+            v-for="speaker in voicevoxStore.speakers"
+            :key="speaker.name"
+            :value="speaker.name"
+          >
+            {{ speaker.name }}
+          </option>
+        </select>
+      </div>
+      <div class="flex items-center gap-2 text-xs text-zinc-500">
+        <span class="icon-[lucide--palette] size-4 shrink-0" title="Style" />
+        <select
+          aria-label="VOICEVOX style"
+          class="min-w-0 flex-1 rounded-sm bg-zinc-800 px-1 py-0.5 text-zinc-300 disabled:opacity-50"
+          :disabled="currentStyles.length <= 1"
+          :value="voicevoxStore.speakerId"
+          @change="handleStyleChange"
+        >
+          <option v-for="style in currentStyles" :key="style.id" :value="style.id">
+            {{ style.name }}
+          </option>
+        </select>
+      </div>
+    </template>
+    <div v-else class="text-xs text-zinc-500 italic">Enable VOICEVOX to load characters</div>
   </div>
 </template>

--- a/apps/renderer/src/features/voicevox/index.ts
+++ b/apps/renderer/src/features/voicevox/index.ts
@@ -1,2 +1,3 @@
 export { extractAskingText, extractFirstSentence } from "./speechText";
 export { useVoicevoxStore } from "./useVoicevoxStore";
+export { default as VoicevoxSpeakerSelect } from "./VoicevoxSpeakerSelect.vue";

--- a/apps/renderer/src/features/voicevox/index.ts
+++ b/apps/renderer/src/features/voicevox/index.ts
@@ -1,3 +1,3 @@
 export { extractAskingText, extractFirstSentence } from "./speechText";
-export {  useVoicevoxStore } from "./useVoicevoxStore";
+export { useVoicevoxStore } from "./useVoicevoxStore";
 export { default as VoicevoxSpeakerSelect } from "./VoicevoxSpeakerSelect.vue";

--- a/apps/renderer/src/features/voicevox/index.ts
+++ b/apps/renderer/src/features/voicevox/index.ts
@@ -1,3 +1,3 @@
 export { extractAskingText, extractFirstSentence } from "./speechText";
-export { useVoicevoxStore } from "./useVoicevoxStore";
+export {  useVoicevoxStore } from "./useVoicevoxStore";
 export { default as VoicevoxSpeakerSelect } from "./VoicevoxSpeakerSelect.vue";

--- a/apps/renderer/src/features/voicevox/rpc.ts
+++ b/apps/renderer/src/features/voicevox/rpc.ts
@@ -3,6 +3,8 @@ import {
   VoicevoxCheckEngineResponse,
   VoicevoxLaunchRequest,
   VoicevoxLaunchResponse,
+  VoicevoxListSpeakersRequest,
+  VoicevoxListSpeakersResponse,
   VoicevoxSpeakRequest,
   VoicevoxSpeakResponse,
 } from "@gozd/proto";
@@ -15,6 +17,10 @@ export const rpcVoicevoxLaunch = (req: VoicevoxLaunchRequest = VoicevoxLaunchReq
 export const rpcVoicevoxCheckEngine = (
   req: VoicevoxCheckEngineRequest = VoicevoxCheckEngineRequest.create(),
 ) => rpc("/voicevox/checkEngine", req, VoicevoxCheckEngineRequest, VoicevoxCheckEngineResponse);
+
+export const rpcVoicevoxListSpeakers = (
+  req: VoicevoxListSpeakersRequest = VoicevoxListSpeakersRequest.create(),
+) => rpc("/voicevox/listSpeakers", req, VoicevoxListSpeakersRequest, VoicevoxListSpeakersResponse);
 
 export const rpcVoicevoxSpeak = (req: VoicevoxSpeakRequest) =>
   rpc("/voicevox/speak", req, VoicevoxSpeakRequest, VoicevoxSpeakResponse);

--- a/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
+++ b/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
@@ -114,7 +114,6 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
   /**
    * 外部から speakerId を変更する公式入口。speakers ロード後は存在検証する。
    * speakers ロード前 (config 復元中 / Engine 未起動) は無条件で受け入れる。
-   * Reset to default も `setSpeakerId(DEFAULT_SPEAKER_ID)` で表現する (resetSpeakerId は持たない)。
    */
   function setSpeakerId(id: number): void {
     if (speakers.value.length > 0 && !hasSpeakerStyle(id)) {

--- a/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
+++ b/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
@@ -1,10 +1,16 @@
+import type { VoicevoxSpeaker } from "@gozd/proto";
 import { tryCatch } from "@gozd/shared";
 import { acceptHMRUpdate, defineStore } from "pinia";
 import { ref, watch } from "vue";
 import { onMessage } from "../../shared/rpc";
 import { rpcLoadAppConfig, rpcSaveAppConfig } from "../settings";
 import type { HookPayload } from "../terminal";
-import { rpcVoicevoxCheckEngine, rpcVoicevoxLaunch, rpcVoicevoxSpeak } from "./rpc";
+import {
+  rpcVoicevoxCheckEngine,
+  rpcVoicevoxLaunch,
+  rpcVoicevoxListSpeakers,
+  rpcVoicevoxSpeak,
+} from "./rpc";
 import { extractSpeechText } from "./speechText";
 
 /** ずんだもん（ノーマル） */
@@ -64,8 +70,18 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
   const enabled = ref(false);
   const speedScale = ref(DEFAULT_SPEED_SCALE);
   const volumeScale = ref(DEFAULT_VOLUME_SCALE);
+  const speakerId = ref<number>(DEFAULT_SPEAKER_ID);
+  /** Engine `/speakers` から取得したキャラ一覧。enable + Engine 起動済みでロードされる */
+  const speakers = ref<VoicevoxSpeaker[]>([]);
   /** 有効化処理中 */
   const activating = ref(false);
+
+  /** Engine から speakers を取得して保持する */
+  async function loadSpeakers(): Promise<void> {
+    const result = await tryCatch(rpcVoicevoxListSpeakers());
+    if (!result.ok) return;
+    speakers.value = result.value.speakers;
+  }
 
   /** RPC 経由で Engine の起動状態を確認する */
   async function checkEngineRunning(): Promise<boolean> {
@@ -93,7 +109,7 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
           text,
           speedScale: speed,
           volumeScale: volume,
-          speakerId: DEFAULT_SPEAKER_ID,
+          speakerId: speakerId.value,
         }),
       );
       if (!result.ok || result.value.wav.length === 0) return;
@@ -117,10 +133,13 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
     if (cfg !== undefined) {
       if (cfg.speedScale > 0) speedScale.value = cfg.speedScale;
       if (cfg.volumeScale > 0) volumeScale.value = cfg.volumeScale;
+      if (cfg.speakerId > 0) speakerId.value = cfg.speakerId;
       if (cfg.enabled) {
         enabled.value = true;
         // Engine が起動していなければバックグラウンドで起動だけ試みる（ポーリングしない）
-        if (!(await checkEngineRunning())) {
+        if (await checkEngineRunning()) {
+          void loadSpeakers();
+        } else {
           void tryCatch(rpcVoicevoxLaunch());
         }
       }
@@ -139,12 +158,13 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
       enabled: enabled.value,
       speedScale: speedScale.value,
       volumeScale: volumeScale.value,
+      speakerId: speakerId.value,
     };
     void tryCatch(rpcSaveAppConfig(config));
   }
 
   // 設定変更時に保存
-  watch([enabled, speedScale, volumeScale], () => {
+  watch([enabled, speedScale, volumeScale, speakerId], () => {
     void saveSettings();
   });
 
@@ -161,6 +181,7 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
     // Engine が既に起動しているかチェック
     if (await checkEngineRunning()) {
       enabled.value = true;
+      void loadSpeakers();
       activating.value = false;
       return undefined;
     }
@@ -175,6 +196,7 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
     // Engine の起動を待つ
     if (await waitForEngine()) {
       enabled.value = true;
+      void loadSpeakers();
       activating.value = false;
       return undefined;
     }
@@ -220,7 +242,18 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
 
   initHookSubscription();
 
-  return { enabled, playing, speedScale, volumeScale, activating, activate, deactivate, stopAudio };
+  return {
+    enabled,
+    playing,
+    speedScale,
+    volumeScale,
+    speakerId,
+    speakers,
+    activating,
+    activate,
+    deactivate,
+    stopAudio,
+  };
 });
 
 if (import.meta.hot) {

--- a/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
+++ b/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
@@ -15,7 +15,7 @@ import {
 import { extractSpeechText } from "./speechText";
 
 /** ずんだもん（ノーマル）。voicevox 設定の唯一の SSOT */
-export const DEFAULT_SPEAKER_ID = 3;
+const DEFAULT_SPEAKER_ID = 3;
 const DEFAULT_SPEED_SCALE = 1.5;
 const DEFAULT_VOLUME_SCALE = 1.0;
 
@@ -90,13 +90,17 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
 
   /**
    * speak 経路で実際に使う speaker id。
-   * speakers ロード後に speakerId が存在しなければ DEFAULT にメモリ上 fallback する。
-   * 永続化される speakerId は touch しないため、Engine 構成が一時的に変わってもユーザー選択は破壊しない。
+   * speakers ロード後に speakerId が存在しなければ DEFAULT → speakers[0].styles[0].id の順で
+   * メモリ上 fallback する。永続化される speakerId は touch しないため、Engine 構成が
+   * 一時的に変わってもユーザー選択は破壊しない。
    */
   const effectiveSpeakerId = computed(() => {
     const id = speakerId.value;
     if (speakers.value.length === 0) return id; // ロード前は信用して通す
-    return hasSpeakerStyle(id) ? id : DEFAULT_SPEAKER_ID;
+    if (hasSpeakerStyle(id)) return id;
+    if (hasSpeakerStyle(DEFAULT_SPEAKER_ID)) return DEFAULT_SPEAKER_ID;
+    // DEFAULT も無いカスタムビルド等の稀ケース: 最初の利用可能な style に live fallback
+    return speakers.value[0]?.styles[0]?.id ?? id;
   });
 
   /**
@@ -121,8 +125,9 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
   }
 
   /**
-   * Engine から speakers を取得する。永続化値が現存しない場合は notify.info で伝えるのみで、
-   * speakerId.value は touch しない (実効値は effectiveSpeakerId computed が DEFAULT に倒す)。
+   * Engine から speakers を取得する。永続化値が現存しない状態は speakerIdIsStale computed
+   * → VoicevoxSpeakerSelect の inline 警告経由でユーザーに伝える (SSOT)。
+   * speakerId.value は touch しない (実効値は effectiveSpeakerId computed が memory 上 fallback する)。
    */
   async function loadSpeakers(): Promise<void> {
     const result = await tryCatch(rpcVoicevoxListSpeakers());

--- a/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
+++ b/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
@@ -2,6 +2,7 @@ import type { VoicevoxSpeaker } from "@gozd/proto";
 import { tryCatch } from "@gozd/shared";
 import { acceptHMRUpdate, defineStore } from "pinia";
 import { ref, watch } from "vue";
+import { useNotificationStore } from "../../shared/notification";
 import { onMessage } from "../../shared/rpc";
 import { rpcLoadAppConfig, rpcSaveAppConfig } from "../settings";
 import type { HookPayload } from "../terminal";
@@ -67,6 +68,7 @@ let speakGeneration = 0;
 let disposeHookListener: (() => void) | undefined;
 
 export const useVoicevoxStore = defineStore("voicevox", () => {
+  const notify = useNotificationStore();
   const enabled = ref(false);
   const speedScale = ref(DEFAULT_SPEED_SCALE);
   const volumeScale = ref(DEFAULT_VOLUME_SCALE);
@@ -76,11 +78,38 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
   /** 有効化処理中 */
   const activating = ref(false);
 
-  /** Engine から speakers を取得して保持する */
+  /** speakers の中に該当 style.id が存在するか */
+  function hasSpeakerStyle(id: number): boolean {
+    return speakers.value.some((s) => s.styles.some((st) => st.id === id));
+  }
+
+  /**
+   * 外部から speakerId を変更する公式入口。speakers ロード後は存在検証する。
+   * speakers ロード前 (config 復元中 / Engine 未起動) は無条件で受け入れる。
+   */
+  function setSpeakerId(id: number): void {
+    if (speakers.value.length > 0 && !hasSpeakerStyle(id)) {
+      notify.error(`VOICEVOX speaker id ${id} not found in current speakers list`);
+      return;
+    }
+    speakerId.value = id;
+  }
+
+  /** Engine から speakers を取得して保持し、永続化値の存在検証も行う */
   async function loadSpeakers(): Promise<void> {
     const result = await tryCatch(rpcVoicevoxListSpeakers());
-    if (!result.ok) return;
+    if (!result.ok) {
+      notify.error("Failed to load VOICEVOX speakers", result.error);
+      return;
+    }
     speakers.value = result.value.speakers;
+    // ロード完了後、永続化された speakerId が現存しなければ default に fallback
+    if (speakers.value.length > 0 && !hasSpeakerStyle(speakerId.value)) {
+      notify.info(
+        `VOICEVOX speaker id ${speakerId.value} not found; using default (${DEFAULT_SPEAKER_ID})`,
+      );
+      speakerId.value = DEFAULT_SPEAKER_ID;
+    }
   }
 
   /** RPC 経由で Engine の起動状態を確認する */
@@ -133,7 +162,7 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
     if (cfg !== undefined) {
       if (cfg.speedScale > 0) speedScale.value = cfg.speedScale;
       if (cfg.volumeScale > 0) volumeScale.value = cfg.volumeScale;
-      if (cfg.speakerId > 0) speakerId.value = cfg.speakerId;
+      if (cfg.speakerId !== undefined) speakerId.value = cfg.speakerId;
       if (cfg.enabled) {
         enabled.value = true;
         // Engine が起動していなければバックグラウンドで起動だけ試みる（ポーリングしない）
@@ -253,6 +282,7 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
     activate,
     deactivate,
     stopAudio,
+    setSpeakerId,
   };
 });
 

--- a/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
+++ b/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
@@ -15,7 +15,7 @@ import {
 import { extractSpeechText } from "./speechText";
 
 /** ずんだもん（ノーマル）。voicevox 設定の唯一の SSOT */
-const DEFAULT_SPEAKER_ID = 3;
+export const DEFAULT_SPEAKER_ID = 3;
 const DEFAULT_SPEED_SCALE = 1.5;
 const DEFAULT_VOLUME_SCALE = 1.0;
 
@@ -73,10 +73,11 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
   const speedScale = ref(DEFAULT_SPEED_SCALE);
   const volumeScale = ref(DEFAULT_VOLUME_SCALE);
   /**
-   * ユーザーが明示的に選んだ speaker id。undefined はデフォルト追従 (proto3 optional の「未設定」)。
-   * 永続化値が現エンジンに存在しなくても touch しない (effectiveSpeakerId が memory 上 fallback する)。
+   * 現在の speaker id。初期値は DEFAULT。永続化値が現エンジンに存在しなくても touch しない
+   * (effectiveSpeakerId が memory 上 fallback する)。proto3 optional は load 経路で
+   * 「初期インストール (未保存)」と「ID 0 を正規値として保存」の区別にだけ使う。
    */
-  const speakerId = ref<number | undefined>(undefined);
+  const speakerId = ref<number>(DEFAULT_SPEAKER_ID);
   /** Engine `/speakers` から取得したキャラ一覧。enable + Engine 起動済みでロードされる */
   const speakers = ref<VoicevoxSpeaker[]>([]);
   /** 有効化処理中 */
@@ -89,12 +90,11 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
 
   /**
    * speak 経路で実際に使う speaker id。
-   * undefined / speakers にない値 / speakers ロード前で値が無い場合は DEFAULT にメモリ上 fallback する。
+   * speakers ロード後に speakerId が存在しなければ DEFAULT にメモリ上 fallback する。
    * 永続化される speakerId は touch しないため、Engine 構成が一時的に変わってもユーザー選択は破壊しない。
    */
   const effectiveSpeakerId = computed(() => {
     const id = speakerId.value;
-    if (id === undefined) return DEFAULT_SPEAKER_ID;
     if (speakers.value.length === 0) return id; // ロード前は信用して通す
     return hasSpeakerStyle(id) ? id : DEFAULT_SPEAKER_ID;
   });
@@ -103,16 +103,14 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
    * 永続化された speakerId が現エンジンの speakers に存在しないか。
    * UI が「保存値は壊れていないが現在は再生に使えない」状態をユーザーに伝えるための signal。
    */
-  const speakerIdIsStale = computed(() => {
-    const id = speakerId.value;
-    if (id === undefined) return false;
-    if (speakers.value.length === 0) return false;
-    return !hasSpeakerStyle(id);
-  });
+  const speakerIdIsStale = computed(
+    () => speakers.value.length > 0 && !hasSpeakerStyle(speakerId.value),
+  );
 
   /**
    * 外部から speakerId を変更する公式入口。speakers ロード後は存在検証する。
    * speakers ロード前 (config 復元中 / Engine 未起動) は無条件で受け入れる。
+   * Reset to default も `setSpeakerId(DEFAULT_SPEAKER_ID)` で表現する (resetSpeakerId は持たない)。
    */
   function setSpeakerId(id: number): void {
     if (speakers.value.length > 0 && !hasSpeakerStyle(id)) {
@@ -120,11 +118,6 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
       return;
     }
     speakerId.value = id;
-  }
-
-  /** 明示選択を解除しデフォルト追従に戻す。proto3 optional 上は「未設定」で永続化される */
-  function resetSpeakerId(): void {
-    speakerId.value = undefined;
   }
 
   /**
@@ -138,12 +131,8 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
       return;
     }
     speakers.value = result.value.speakers;
-    const id = speakerId.value;
-    if (id !== undefined && speakers.value.length > 0 && !hasSpeakerStyle(id)) {
-      notify.info(
-        `VOICEVOX speaker id ${id} not found in current engine; using default (${DEFAULT_SPEAKER_ID}) for playback`,
-      );
-    }
+    // stale 状態 (永続値 not in speakers) は speakerIdIsStale computed → UI 側の inline 警告で伝える。
+    // トースト通知をここで重複発火させない (SSOT)
   }
 
   /** RPC 経由で Engine の起動状態を確認する */
@@ -312,7 +301,7 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
     playing,
     speedScale,
     volumeScale,
-    // speakerId は readonly。書き換えは setSpeakerId / resetSpeakerId を経由させる (存在検証で SSOT を守るため)
+    // speakerId は readonly。書き換えは setSpeakerId 経由のみ (存在検証で SSOT を守るため)
     speakerId: readonly(speakerId),
     effectiveSpeakerId,
     speakerIdIsStale,
@@ -322,7 +311,6 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
     deactivate,
     stopAudio,
     setSpeakerId,
-    resetSpeakerId,
   };
 });
 

--- a/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
+++ b/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
@@ -1,7 +1,7 @@
 import type { VoicevoxSpeaker } from "@gozd/proto";
 import { tryCatch } from "@gozd/shared";
 import { acceptHMRUpdate, defineStore } from "pinia";
-import { ref, watch } from "vue";
+import { computed, readonly, ref, watch } from "vue";
 import { useNotificationStore } from "../../shared/notification";
 import { onMessage } from "../../shared/rpc";
 import { rpcLoadAppConfig, rpcSaveAppConfig } from "../settings";
@@ -14,7 +14,7 @@ import {
 } from "./rpc";
 import { extractSpeechText } from "./speechText";
 
-/** ずんだもん（ノーマル） */
+/** ずんだもん（ノーマル）。voicevox 設定の唯一の SSOT */
 const DEFAULT_SPEAKER_ID = 3;
 const DEFAULT_SPEED_SCALE = 1.5;
 const DEFAULT_VOLUME_SCALE = 1.0;
@@ -84,6 +84,16 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
   }
 
   /**
+   * speak 経路で実際に使う speaker id。
+   * speakers ロード前 / 該当 style が存在しない場合は DEFAULT_SPEAKER_ID にメモリ上 fallback する。
+   * 永続化される speakerId は touch しないため、Engine 構成が一時的に変わってもユーザー選択は破壊しない。
+   */
+  const effectiveSpeakerId = computed(() => {
+    if (speakers.value.length === 0) return speakerId.value;
+    return hasSpeakerStyle(speakerId.value) ? speakerId.value : DEFAULT_SPEAKER_ID;
+  });
+
+  /**
    * 外部から speakerId を変更する公式入口。speakers ロード後は存在検証する。
    * speakers ロード前 (config 復元中 / Engine 未起動) は無条件で受け入れる。
    */
@@ -95,7 +105,10 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
     speakerId.value = id;
   }
 
-  /** Engine から speakers を取得して保持し、永続化値の存在検証も行う */
+  /**
+   * Engine から speakers を取得する。永続化値が現存しない場合は notify.info で伝えるのみで、
+   * speakerId.value は touch しない (実効値は effectiveSpeakerId computed が DEFAULT に倒す)。
+   */
   async function loadSpeakers(): Promise<void> {
     const result = await tryCatch(rpcVoicevoxListSpeakers());
     if (!result.ok) {
@@ -103,12 +116,10 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
       return;
     }
     speakers.value = result.value.speakers;
-    // ロード完了後、永続化された speakerId が現存しなければ default に fallback
     if (speakers.value.length > 0 && !hasSpeakerStyle(speakerId.value)) {
       notify.info(
-        `VOICEVOX speaker id ${speakerId.value} not found; using default (${DEFAULT_SPEAKER_ID})`,
+        `VOICEVOX speaker id ${speakerId.value} not found in current engine; using default (${DEFAULT_SPEAKER_ID}) for playback`,
       );
-      speakerId.value = DEFAULT_SPEAKER_ID;
     }
   }
 
@@ -138,7 +149,7 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
           text,
           speedScale: speed,
           volumeScale: volume,
-          speakerId: speakerId.value,
+          speakerId: effectiveSpeakerId.value,
         }),
       );
       if (!result.ok || result.value.wav.length === 0) return;
@@ -276,7 +287,8 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
     playing,
     speedScale,
     volumeScale,
-    speakerId,
+    // speakerId は readonly。書き換えは setSpeakerId を経由させる (存在検証で SSOT を守るため)
+    speakerId: readonly(speakerId),
     speakers,
     activating,
     activate,

--- a/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
+++ b/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
@@ -72,7 +72,11 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
   const enabled = ref(false);
   const speedScale = ref(DEFAULT_SPEED_SCALE);
   const volumeScale = ref(DEFAULT_VOLUME_SCALE);
-  const speakerId = ref<number>(DEFAULT_SPEAKER_ID);
+  /**
+   * ユーザーが明示的に選んだ speaker id。undefined はデフォルト追従 (proto3 optional の「未設定」)。
+   * 永続化値が現エンジンに存在しなくても touch しない (effectiveSpeakerId が memory 上 fallback する)。
+   */
+  const speakerId = ref<number | undefined>(undefined);
   /** Engine `/speakers` から取得したキャラ一覧。enable + Engine 起動済みでロードされる */
   const speakers = ref<VoicevoxSpeaker[]>([]);
   /** 有効化処理中 */
@@ -85,12 +89,25 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
 
   /**
    * speak 経路で実際に使う speaker id。
-   * speakers ロード前 / 該当 style が存在しない場合は DEFAULT_SPEAKER_ID にメモリ上 fallback する。
+   * undefined / speakers にない値 / speakers ロード前で値が無い場合は DEFAULT にメモリ上 fallback する。
    * 永続化される speakerId は touch しないため、Engine 構成が一時的に変わってもユーザー選択は破壊しない。
    */
   const effectiveSpeakerId = computed(() => {
-    if (speakers.value.length === 0) return speakerId.value;
-    return hasSpeakerStyle(speakerId.value) ? speakerId.value : DEFAULT_SPEAKER_ID;
+    const id = speakerId.value;
+    if (id === undefined) return DEFAULT_SPEAKER_ID;
+    if (speakers.value.length === 0) return id; // ロード前は信用して通す
+    return hasSpeakerStyle(id) ? id : DEFAULT_SPEAKER_ID;
+  });
+
+  /**
+   * 永続化された speakerId が現エンジンの speakers に存在しないか。
+   * UI が「保存値は壊れていないが現在は再生に使えない」状態をユーザーに伝えるための signal。
+   */
+  const speakerIdIsStale = computed(() => {
+    const id = speakerId.value;
+    if (id === undefined) return false;
+    if (speakers.value.length === 0) return false;
+    return !hasSpeakerStyle(id);
   });
 
   /**
@@ -105,6 +122,11 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
     speakerId.value = id;
   }
 
+  /** 明示選択を解除しデフォルト追従に戻す。proto3 optional 上は「未設定」で永続化される */
+  function resetSpeakerId(): void {
+    speakerId.value = undefined;
+  }
+
   /**
    * Engine から speakers を取得する。永続化値が現存しない場合は notify.info で伝えるのみで、
    * speakerId.value は touch しない (実効値は effectiveSpeakerId computed が DEFAULT に倒す)。
@@ -116,9 +138,10 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
       return;
     }
     speakers.value = result.value.speakers;
-    if (speakers.value.length > 0 && !hasSpeakerStyle(speakerId.value)) {
+    const id = speakerId.value;
+    if (id !== undefined && speakers.value.length > 0 && !hasSpeakerStyle(id)) {
       notify.info(
-        `VOICEVOX speaker id ${speakerId.value} not found in current engine; using default (${DEFAULT_SPEAKER_ID}) for playback`,
+        `VOICEVOX speaker id ${id} not found in current engine; using default (${DEFAULT_SPEAKER_ID}) for playback`,
       );
     }
   }
@@ -256,6 +279,8 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
     speakGeneration++;
     releaseAudio();
     enabled.value = false;
+    // Engine 停止と表示の整合を取るため speakers state も clear する
+    speakers.value = [];
   }
 
   // --- Hook 購読（HMR 再実行時に前回のリスナーを解除するため disposer は関数外に置く） ---
@@ -287,14 +312,17 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
     playing,
     speedScale,
     volumeScale,
-    // speakerId は readonly。書き換えは setSpeakerId を経由させる (存在検証で SSOT を守るため)
+    // speakerId は readonly。書き換えは setSpeakerId / resetSpeakerId を経由させる (存在検証で SSOT を守るため)
     speakerId: readonly(speakerId),
+    effectiveSpeakerId,
+    speakerIdIsStale,
     speakers,
     activating,
     activate,
     deactivate,
     stopAudio,
     setSpeakerId,
+    resetSpeakerId,
   };
 });
 

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -26,7 +26,7 @@ renderer（Vue / WebKit）と native（Swift）間の通信。`.proto` を SSOT 
 | `app_config.proto`     | ユーザー設定（terminal / preview / voicevox）                      |
 | `project_config.proto` | プロジェクト固有設定（worktreeSymlinks 等）                        |
 | `claude_session.proto` | Claude session の listByDir / removeByPty                          |
-| `voicevox.proto`       | VOICEVOX engine の launch / check / speak                          |
+| `voicevox.proto`       | VOICEVOX engine の launch / check / listSpeakers / speak           |
 | `shell_command.proto`  | `gozd` CLI の install / uninstall                                  |
 | `window.proto`         | window close / setTitleContext                                     |
 | `open_external.proto`  | `open` コマンド経由の外部 URL / app open                           |

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_app_config.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_app_config.pb.swift
@@ -115,12 +115,22 @@ public struct Gozd_V1_VoicevoxConfig: Sendable {
 
   public var volumeScale: Double = 0
 
-  /// 0 ならデフォルト (renderer 側 fallback)
-  public var speakerID: UInt32 = 0
+  /// 未設定なら renderer 側 default にフォールバック。
+  /// VOICEVOX の正規 style ID 0 (四国めたん あまあま) と未設定を区別するため optional で wrap する。
+  public var speakerID: UInt32 {
+    get {_speakerID ?? 0}
+    set {_speakerID = newValue}
+  }
+  /// Returns true if `speakerID` has been explicitly set.
+  public var hasSpeakerID: Bool {self._speakerID != nil}
+  /// Clears the value of `speakerID`. Subsequent reads from it will return its default value.
+  public mutating func clearSpeakerID() {self._speakerID = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
+
+  fileprivate var _speakerID: UInt32? = nil
 }
 
 public struct Gozd_V1_LoadAppConfigRequest: Sendable {
@@ -321,13 +331,17 @@ extension Gozd_V1_VoicevoxConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageI
       case 1: try { try decoder.decodeSingularBoolField(value: &self.enabled) }()
       case 2: try { try decoder.decodeSingularDoubleField(value: &self.speedScale) }()
       case 3: try { try decoder.decodeSingularDoubleField(value: &self.volumeScale) }()
-      case 4: try { try decoder.decodeSingularUInt32Field(value: &self.speakerID) }()
+      case 4: try { try decoder.decodeSingularUInt32Field(value: &self._speakerID) }()
       default: break
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if self.enabled != false {
       try visitor.visitSingularBoolField(value: self.enabled, fieldNumber: 1)
     }
@@ -337,9 +351,9 @@ extension Gozd_V1_VoicevoxConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     if self.volumeScale.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.volumeScale, fieldNumber: 3)
     }
-    if self.speakerID != 0 {
-      try visitor.visitSingularUInt32Field(value: self.speakerID, fieldNumber: 4)
-    }
+    try { if let v = self._speakerID {
+      try visitor.visitSingularUInt32Field(value: v, fieldNumber: 4)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -347,7 +361,7 @@ extension Gozd_V1_VoicevoxConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     if lhs.enabled != rhs.enabled {return false}
     if lhs.speedScale != rhs.speedScale {return false}
     if lhs.volumeScale != rhs.volumeScale {return false}
-    if lhs.speakerID != rhs.speakerID {return false}
+    if lhs._speakerID != rhs._speakerID {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_app_config.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_app_config.pb.swift
@@ -115,6 +115,9 @@ public struct Gozd_V1_VoicevoxConfig: Sendable {
 
   public var volumeScale: Double = 0
 
+  /// 0 ならデフォルト (renderer 側 fallback)
+  public var speakerID: UInt32 = 0
+
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
@@ -307,7 +310,7 @@ extension Gozd_V1_PreviewConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageIm
 
 extension Gozd_V1_VoicevoxConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".VoicevoxConfig"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}enabled\0\u{3}speed_scale\0\u{3}volume_scale\0")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}enabled\0\u{3}speed_scale\0\u{3}volume_scale\0\u{3}speaker_id\0")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -318,6 +321,7 @@ extension Gozd_V1_VoicevoxConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageI
       case 1: try { try decoder.decodeSingularBoolField(value: &self.enabled) }()
       case 2: try { try decoder.decodeSingularDoubleField(value: &self.speedScale) }()
       case 3: try { try decoder.decodeSingularDoubleField(value: &self.volumeScale) }()
+      case 4: try { try decoder.decodeSingularUInt32Field(value: &self.speakerID) }()
       default: break
       }
     }
@@ -333,6 +337,9 @@ extension Gozd_V1_VoicevoxConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     if self.volumeScale.bitPattern != 0 {
       try visitor.visitSingularDoubleField(value: self.volumeScale, fieldNumber: 3)
     }
+    if self.speakerID != 0 {
+      try visitor.visitSingularUInt32Field(value: self.speakerID, fieldNumber: 4)
+    }
     try unknownFields.traverse(visitor: &visitor)
   }
 
@@ -340,6 +347,7 @@ extension Gozd_V1_VoicevoxConfig: SwiftProtobuf.Message, SwiftProtobuf._MessageI
     if lhs.enabled != rhs.enabled {return false}
     if lhs.speedScale != rhs.speedScale {return false}
     if lhs.volumeScale != rhs.volumeScale {return false}
+    if lhs.speakerID != rhs.speakerID {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/packages/proto-swift/Sources/GozdProto/gozd_v1_voicevox.pb.swift
+++ b/packages/proto-swift/Sources/GozdProto/gozd_v1_voicevox.pb.swift
@@ -100,6 +100,57 @@ public struct Gozd_V1_VoicevoxSpeakResponse: Sendable {
   public init() {}
 }
 
+/// Engine `/speakers` の薄いラッパー。キャラと style 一覧を返す。
+public struct Gozd_V1_VoicevoxListSpeakersRequest: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public struct Gozd_V1_VoicevoxListSpeakersResponse: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var speakers: [Gozd_V1_VoicevoxSpeaker] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public struct Gozd_V1_VoicevoxSpeaker: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var name: String = String()
+
+  public var styles: [Gozd_V1_VoicevoxSpeakerStyle] = []
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
+public struct Gozd_V1_VoicevoxSpeakerStyle: Sendable {
+  // SwiftProtobuf.Message conformance is added in an extension below. See the
+  // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
+  // methods supported on all messages.
+
+  public var name: String = String()
+
+  public var id: UInt32 = 0
+
+  public var unknownFields = SwiftProtobuf.UnknownStorage()
+
+  public init() {}
+}
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 fileprivate let _protobuf_package = "gozd.v1"
@@ -272,6 +323,125 @@ extension Gozd_V1_VoicevoxSpeakResponse: SwiftProtobuf.Message, SwiftProtobuf._M
 
   public static func ==(lhs: Gozd_V1_VoicevoxSpeakResponse, rhs: Gozd_V1_VoicevoxSpeakResponse) -> Bool {
     if lhs.wav != rhs.wav {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Gozd_V1_VoicevoxListSpeakersRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".VoicevoxListSpeakersRequest"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap()
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    // Load everything into unknown fields
+    while try decoder.nextFieldNumber() != nil {}
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Gozd_V1_VoicevoxListSpeakersRequest, rhs: Gozd_V1_VoicevoxListSpeakersRequest) -> Bool {
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Gozd_V1_VoicevoxListSpeakersResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".VoicevoxListSpeakersResponse"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}speakers\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.speakers) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.speakers.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.speakers, fieldNumber: 1)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Gozd_V1_VoicevoxListSpeakersResponse, rhs: Gozd_V1_VoicevoxListSpeakersResponse) -> Bool {
+    if lhs.speakers != rhs.speakers {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Gozd_V1_VoicevoxSpeaker: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".VoicevoxSpeaker"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}styles\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.name) }()
+      case 2: try { try decoder.decodeRepeatedMessageField(value: &self.styles) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.name.isEmpty {
+      try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
+    }
+    if !self.styles.isEmpty {
+      try visitor.visitRepeatedMessageField(value: self.styles, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Gozd_V1_VoicevoxSpeaker, rhs: Gozd_V1_VoicevoxSpeaker) -> Bool {
+    if lhs.name != rhs.name {return false}
+    if lhs.styles != rhs.styles {return false}
+    if lhs.unknownFields != rhs.unknownFields {return false}
+    return true
+  }
+}
+
+extension Gozd_V1_VoicevoxSpeakerStyle: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
+  public static let protoMessageName: String = _protobuf_package + ".VoicevoxSpeakerStyle"
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}id\0")
+
+  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+    while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
+      switch fieldNumber {
+      case 1: try { try decoder.decodeSingularStringField(value: &self.name) }()
+      case 2: try { try decoder.decodeSingularUInt32Field(value: &self.id) }()
+      default: break
+      }
+    }
+  }
+
+  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    if !self.name.isEmpty {
+      try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
+    }
+    if self.id != 0 {
+      try visitor.visitSingularUInt32Field(value: self.id, fieldNumber: 2)
+    }
+    try unknownFields.traverse(visitor: &visitor)
+  }
+
+  public static func ==(lhs: Gozd_V1_VoicevoxSpeakerStyle, rhs: Gozd_V1_VoicevoxSpeakerStyle) -> Bool {
+    if lhs.name != rhs.name {return false}
+    if lhs.id != rhs.id {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/packages/proto-ts/src/generated/gozd/v1/app_config.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/app_config.ts
@@ -45,6 +45,8 @@ export interface VoicevoxConfig {
   enabled: boolean;
   speedScale: number;
   volumeScale: number;
+  /** 0 ならデフォルト (renderer 側 fallback) */
+  speakerId: number;
 }
 
 export interface LoadAppConfigRequest {
@@ -344,7 +346,7 @@ export const PreviewConfig: MessageFns<PreviewConfig> = {
 };
 
 function createBaseVoicevoxConfig(): VoicevoxConfig {
-  return { enabled: false, speedScale: 0, volumeScale: 0 };
+  return { enabled: false, speedScale: 0, volumeScale: 0, speakerId: 0 };
 }
 
 export const VoicevoxConfig: MessageFns<VoicevoxConfig> = {
@@ -357,6 +359,9 @@ export const VoicevoxConfig: MessageFns<VoicevoxConfig> = {
     }
     if (message.volumeScale !== 0) {
       writer.uint32(25).double(message.volumeScale);
+    }
+    if (message.speakerId !== 0) {
+      writer.uint32(32).uint32(message.speakerId);
     }
     return writer;
   },
@@ -392,6 +397,14 @@ export const VoicevoxConfig: MessageFns<VoicevoxConfig> = {
           message.volumeScale = reader.double();
           continue;
         }
+        case 4: {
+          if (tag !== 32) {
+            break;
+          }
+
+          message.speakerId = reader.uint32();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -414,6 +427,11 @@ export const VoicevoxConfig: MessageFns<VoicevoxConfig> = {
         : isSet(object.volume_scale)
         ? globalThis.Number(object.volume_scale)
         : 0,
+      speakerId: isSet(object.speakerId)
+        ? globalThis.Number(object.speakerId)
+        : isSet(object.speaker_id)
+        ? globalThis.Number(object.speaker_id)
+        : 0,
     };
   },
 
@@ -428,6 +446,9 @@ export const VoicevoxConfig: MessageFns<VoicevoxConfig> = {
     if (message.volumeScale !== 0) {
       obj.volumeScale = message.volumeScale;
     }
+    if (message.speakerId !== 0) {
+      obj.speakerId = Math.round(message.speakerId);
+    }
     return obj;
   },
 
@@ -439,6 +460,7 @@ export const VoicevoxConfig: MessageFns<VoicevoxConfig> = {
     message.enabled = object.enabled ?? false;
     message.speedScale = object.speedScale ?? 0;
     message.volumeScale = object.volumeScale ?? 0;
+    message.speakerId = object.speakerId ?? 0;
     return message;
   },
 };

--- a/packages/proto-ts/src/generated/gozd/v1/app_config.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/app_config.ts
@@ -45,8 +45,11 @@ export interface VoicevoxConfig {
   enabled: boolean;
   speedScale: number;
   volumeScale: number;
-  /** 0 ならデフォルト (renderer 側 fallback) */
-  speakerId: number;
+  /**
+   * 未設定なら renderer 側 default にフォールバック。
+   * VOICEVOX の正規 style ID 0 (四国めたん あまあま) と未設定を区別するため optional で wrap する。
+   */
+  speakerId?: number | undefined;
 }
 
 export interface LoadAppConfigRequest {
@@ -346,7 +349,7 @@ export const PreviewConfig: MessageFns<PreviewConfig> = {
 };
 
 function createBaseVoicevoxConfig(): VoicevoxConfig {
-  return { enabled: false, speedScale: 0, volumeScale: 0, speakerId: 0 };
+  return { enabled: false, speedScale: 0, volumeScale: 0, speakerId: undefined };
 }
 
 export const VoicevoxConfig: MessageFns<VoicevoxConfig> = {
@@ -360,7 +363,7 @@ export const VoicevoxConfig: MessageFns<VoicevoxConfig> = {
     if (message.volumeScale !== 0) {
       writer.uint32(25).double(message.volumeScale);
     }
-    if (message.speakerId !== 0) {
+    if (message.speakerId !== undefined) {
       writer.uint32(32).uint32(message.speakerId);
     }
     return writer;
@@ -431,7 +434,7 @@ export const VoicevoxConfig: MessageFns<VoicevoxConfig> = {
         ? globalThis.Number(object.speakerId)
         : isSet(object.speaker_id)
         ? globalThis.Number(object.speaker_id)
-        : 0,
+        : undefined,
     };
   },
 
@@ -446,7 +449,7 @@ export const VoicevoxConfig: MessageFns<VoicevoxConfig> = {
     if (message.volumeScale !== 0) {
       obj.volumeScale = message.volumeScale;
     }
-    if (message.speakerId !== 0) {
+    if (message.speakerId !== undefined) {
       obj.speakerId = Math.round(message.speakerId);
     }
     return obj;
@@ -460,7 +463,7 @@ export const VoicevoxConfig: MessageFns<VoicevoxConfig> = {
     message.enabled = object.enabled ?? false;
     message.speedScale = object.speedScale ?? 0;
     message.volumeScale = object.volumeScale ?? 0;
-    message.speakerId = object.speakerId ?? 0;
+    message.speakerId = object.speakerId ?? undefined;
     return message;
   },
 };

--- a/packages/proto-ts/src/generated/gozd/v1/voicevox.ts
+++ b/packages/proto-ts/src/generated/gozd/v1/voicevox.ts
@@ -35,6 +35,24 @@ export interface VoicevoxSpeakResponse {
   wav: Uint8Array;
 }
 
+/** Engine `/speakers` の薄いラッパー。キャラと style 一覧を返す。 */
+export interface VoicevoxListSpeakersRequest {
+}
+
+export interface VoicevoxListSpeakersResponse {
+  speakers: VoicevoxSpeaker[];
+}
+
+export interface VoicevoxSpeaker {
+  name: string;
+  styles: VoicevoxSpeakerStyle[];
+}
+
+export interface VoicevoxSpeakerStyle {
+  name: string;
+  id: number;
+}
+
 function createBaseVoicevoxLaunchRequest(): VoicevoxLaunchRequest {
   return {};
 }
@@ -411,6 +429,265 @@ export const VoicevoxSpeakResponse: MessageFns<VoicevoxSpeakResponse> = {
   fromPartial(object: DeepPartial<VoicevoxSpeakResponse>): VoicevoxSpeakResponse {
     const message = createBaseVoicevoxSpeakResponse();
     message.wav = object.wav ?? new Uint8Array(0);
+    return message;
+  },
+};
+
+function createBaseVoicevoxListSpeakersRequest(): VoicevoxListSpeakersRequest {
+  return {};
+}
+
+export const VoicevoxListSpeakersRequest: MessageFns<VoicevoxListSpeakersRequest> = {
+  encode(_: VoicevoxListSpeakersRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): VoicevoxListSpeakersRequest {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseVoicevoxListSpeakersRequest();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(_: any): VoicevoxListSpeakersRequest {
+    return {};
+  },
+
+  toJSON(_: VoicevoxListSpeakersRequest): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  create(base?: DeepPartial<VoicevoxListSpeakersRequest>): VoicevoxListSpeakersRequest {
+    return VoicevoxListSpeakersRequest.fromPartial(base ?? {});
+  },
+  fromPartial(_: DeepPartial<VoicevoxListSpeakersRequest>): VoicevoxListSpeakersRequest {
+    const message = createBaseVoicevoxListSpeakersRequest();
+    return message;
+  },
+};
+
+function createBaseVoicevoxListSpeakersResponse(): VoicevoxListSpeakersResponse {
+  return { speakers: [] };
+}
+
+export const VoicevoxListSpeakersResponse: MessageFns<VoicevoxListSpeakersResponse> = {
+  encode(message: VoicevoxListSpeakersResponse, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    for (const v of message.speakers) {
+      VoicevoxSpeaker.encode(v!, writer.uint32(10).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): VoicevoxListSpeakersResponse {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseVoicevoxListSpeakersResponse();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.speakers.push(VoicevoxSpeaker.decode(reader, reader.uint32()));
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): VoicevoxListSpeakersResponse {
+    return {
+      speakers: globalThis.Array.isArray(object?.speakers)
+        ? object.speakers.map((e: any) => VoicevoxSpeaker.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: VoicevoxListSpeakersResponse): unknown {
+    const obj: any = {};
+    if (message.speakers?.length) {
+      obj.speakers = message.speakers.map((e) => VoicevoxSpeaker.toJSON(e));
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<VoicevoxListSpeakersResponse>): VoicevoxListSpeakersResponse {
+    return VoicevoxListSpeakersResponse.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<VoicevoxListSpeakersResponse>): VoicevoxListSpeakersResponse {
+    const message = createBaseVoicevoxListSpeakersResponse();
+    message.speakers = object.speakers?.map((e) => VoicevoxSpeaker.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseVoicevoxSpeaker(): VoicevoxSpeaker {
+  return { name: "", styles: [] };
+}
+
+export const VoicevoxSpeaker: MessageFns<VoicevoxSpeaker> = {
+  encode(message: VoicevoxSpeaker, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.name !== "") {
+      writer.uint32(10).string(message.name);
+    }
+    for (const v of message.styles) {
+      VoicevoxSpeakerStyle.encode(v!, writer.uint32(18).fork()).join();
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): VoicevoxSpeaker {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseVoicevoxSpeaker();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.name = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 18) {
+            break;
+          }
+
+          message.styles.push(VoicevoxSpeakerStyle.decode(reader, reader.uint32()));
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): VoicevoxSpeaker {
+    return {
+      name: isSet(object.name) ? globalThis.String(object.name) : "",
+      styles: globalThis.Array.isArray(object?.styles)
+        ? object.styles.map((e: any) => VoicevoxSpeakerStyle.fromJSON(e))
+        : [],
+    };
+  },
+
+  toJSON(message: VoicevoxSpeaker): unknown {
+    const obj: any = {};
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.styles?.length) {
+      obj.styles = message.styles.map((e) => VoicevoxSpeakerStyle.toJSON(e));
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<VoicevoxSpeaker>): VoicevoxSpeaker {
+    return VoicevoxSpeaker.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<VoicevoxSpeaker>): VoicevoxSpeaker {
+    const message = createBaseVoicevoxSpeaker();
+    message.name = object.name ?? "";
+    message.styles = object.styles?.map((e) => VoicevoxSpeakerStyle.fromPartial(e)) || [];
+    return message;
+  },
+};
+
+function createBaseVoicevoxSpeakerStyle(): VoicevoxSpeakerStyle {
+  return { name: "", id: 0 };
+}
+
+export const VoicevoxSpeakerStyle: MessageFns<VoicevoxSpeakerStyle> = {
+  encode(message: VoicevoxSpeakerStyle, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
+    if (message.name !== "") {
+      writer.uint32(10).string(message.name);
+    }
+    if (message.id !== 0) {
+      writer.uint32(16).uint32(message.id);
+    }
+    return writer;
+  },
+
+  decode(input: BinaryReader | Uint8Array, length?: number): VoicevoxSpeakerStyle {
+    const reader = input instanceof BinaryReader ? input : new BinaryReader(input);
+    const end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseVoicevoxSpeakerStyle();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1: {
+          if (tag !== 10) {
+            break;
+          }
+
+          message.name = reader.string();
+          continue;
+        }
+        case 2: {
+          if (tag !== 16) {
+            break;
+          }
+
+          message.id = reader.uint32();
+          continue;
+        }
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skip(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): VoicevoxSpeakerStyle {
+    return {
+      name: isSet(object.name) ? globalThis.String(object.name) : "",
+      id: isSet(object.id) ? globalThis.Number(object.id) : 0,
+    };
+  },
+
+  toJSON(message: VoicevoxSpeakerStyle): unknown {
+    const obj: any = {};
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.id !== 0) {
+      obj.id = Math.round(message.id);
+    }
+    return obj;
+  },
+
+  create(base?: DeepPartial<VoicevoxSpeakerStyle>): VoicevoxSpeakerStyle {
+    return VoicevoxSpeakerStyle.fromPartial(base ?? {});
+  },
+  fromPartial(object: DeepPartial<VoicevoxSpeakerStyle>): VoicevoxSpeakerStyle {
+    const message = createBaseVoicevoxSpeakerStyle();
+    message.name = object.name ?? "";
+    message.id = object.id ?? 0;
     return message;
   },
 };

--- a/packages/proto-ts/src/index.ts
+++ b/packages/proto-ts/src/index.ts
@@ -161,6 +161,10 @@ export {
   VoicevoxCheckEngineResponse,
   VoicevoxLaunchRequest,
   VoicevoxLaunchResponse,
+  VoicevoxListSpeakersRequest,
+  VoicevoxListSpeakersResponse,
+  VoicevoxSpeaker,
+  VoicevoxSpeakerStyle,
   VoicevoxSpeakRequest,
   VoicevoxSpeakResponse,
 } from "./generated/gozd/v1/voicevox";

--- a/packages/proto/gozd/v1/app_config.proto
+++ b/packages/proto/gozd/v1/app_config.proto
@@ -36,8 +36,9 @@ message VoicevoxConfig {
   bool enabled = 1;
   double speed_scale = 2;
   double volume_scale = 3;
-  // 0 ならデフォルト (renderer 側 fallback)
-  uint32 speaker_id = 4;
+  // 未設定なら renderer 側 default にフォールバック。
+  // VOICEVOX の正規 style ID 0 (四国めたん あまあま) と未設定を区別するため optional で wrap する。
+  optional uint32 speaker_id = 4;
 }
 
 message LoadAppConfigRequest {}

--- a/packages/proto/gozd/v1/app_config.proto
+++ b/packages/proto/gozd/v1/app_config.proto
@@ -36,6 +36,8 @@ message VoicevoxConfig {
   bool enabled = 1;
   double speed_scale = 2;
   double volume_scale = 3;
+  // 0 ならデフォルト (renderer 側 fallback)
+  uint32 speaker_id = 4;
 }
 
 message LoadAppConfigRequest {}

--- a/packages/proto/gozd/v1/voicevox.proto
+++ b/packages/proto/gozd/v1/voicevox.proto
@@ -24,3 +24,19 @@ message VoicevoxSpeakResponse {
   // 合成成功時の wav バイト列。失敗時は空。再生は呼び出し側（renderer）の責務。
   bytes wav = 1;
 }
+
+// Engine `/speakers` の薄いラッパー。キャラと style 一覧を返す。
+message VoicevoxListSpeakersRequest {}
+message VoicevoxListSpeakersResponse {
+  repeated VoicevoxSpeaker speakers = 1;
+}
+
+message VoicevoxSpeaker {
+  string name = 1;
+  repeated VoicevoxSpeakerStyle styles = 2;
+}
+
+message VoicevoxSpeakerStyle {
+  string name = 1;
+  uint32 id = 2;
+}


### PR DESCRIPTION
## 概要

VOICEVOX のキャラクター・スタイルをサイドバーパネルから選択できるようにする。Engine の `/speakers` を叩いて動的に一覧を取得し、選択した `speaker_id` は `AppConfig` に永続化される。

## 背景

これまで `useVoicevoxStore` 内で `DEFAULT_SPEAKER_ID = 3`（ずんだもん ノーマル）をハードコードしており、ユーザーが他のキャラを使いたい場合にコードを書き換える必要があった。VOICEVOX Engine は `/speakers` で「キャラ名 + style 配列（id 含む）」を返すため、これを RPC 経由で叩けば追加インストールされたキャラにも自動追従できる。

UI 粒度は「キャラ select + スタイル select の 2 段」を採用。1 つの flat select に全 style を並べると、キャラ名と style 名の階層が潰れて可読性が下がるため。

スタイルが 1 つしかないキャラ（例: スタイル 1 種類のみのキャラ）では、スタイル select を非表示にすると次に複数 style のキャラを選んだ瞬間に行が増えて UI がガタつく。そのため `:disabled` で表示は維持しつつ操作不能にする方式に揃えている。

## 変更内容

### proto

- `VoicevoxConfig.speaker_id` を追加（`uint32`、0 は renderer 側 fallback）
- `VoicevoxListSpeakersRequest` / `VoicevoxListSpeakersResponse` / `VoicevoxSpeaker` / `VoicevoxSpeakerStyle` を追加
- `buf generate` で TS / Swift 生成物を更新し、`@gozd/proto` の barrel に新規型を追加

### native (Swift)

- `VoicevoxOps.listSpeakers()` を追加。Engine `/speakers` を 5 秒タイムアウトで叩き、`Speaker` / `Speaker.Style` の配列に変換する
- `RpcDispatcher` に `/voicevox/listSpeakers` ハンドラを追加

### renderer

- `rpcVoicevoxListSpeakers` を追加（`features/voicevox/rpc.ts`）
- `useVoicevoxStore` に `speakerId` / `speakers` state、`loadSpeakers` action を追加。speak リクエストで固定 ID の代わりに store の `speakerId` を使う
- 設定読み込み時、enabled かつ Engine 既起動なら `loadSpeakers` を呼ぶ。`activate` 成功経路でも同様
- `VoicevoxSpeakerSelect.vue` を新規追加。キャラ select でキャラを切り替えると、そのキャラの先頭 style id に自動で切り替える
- スタイルが 1 個のキャラでは style select を `:disabled` + `opacity-50` で表示維持
- `VoicevoxPanel.vue` に `VoicevoxSpeakerSelect` を組み込み（playing ボタンの下、speed/volume スライダーの上）
- `settings/rpc.ts` の defaults object に `speakerId: 0` を追加（proto-generated TS interface が exact-shape を要求するため）

### docs

- `docs/rpc.md` の voicevox.proto 行に `listSpeakers` を追記

## 確認事項

- [ ] VOICEVOX を未起動の状態から「Enable VOICEVOX」を押し、Engine が立ち上がった後にキャラ一覧が表示される
- [ ] キャラ select を切り替えると、そのキャラの先頭 style に自動で切り替わる
- [ ] スタイルが複数あるキャラでは style select が操作可能、スタイルが 1 個のキャラでは disable 表示で行高が維持される
- [ ] 選択した speaker でハッシュ通知（done / needs-input）の読み上げが行われる
- [ ] アプリ再起動後に最後に選択した speaker が保持されている（`~/.config/gozd/config.json` の `voicevox.speakerId`）
