### PR TITLE
feat(preview): widen default width, disable popover light dismiss, and unify close icon

### DIFF
--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -178,7 +178,8 @@ function onPreviewToggle(e: ToggleEvent) {
 // HTML popover が popover="auto" で持っていた ESC dismiss の性質を自前で代替する。
 // 他の popover (BlamePopover 等) や dialog (SettingsModal 等) が前面にあるときはそちらに ESC を譲り、
 // すべて閉じた次の ESC で preview を閉じる。preventDefault は macOS の NSBeep 抑止に必須。
-useEventListener(window, "keydown", (e: KeyboardEvent) => {
+useEventListener(document, "keydown", (e: KeyboardEvent) => {
+  if (e.defaultPrevented) return;
   if (isIMEActive(e) || e.key !== "Escape") return;
   if (!previewOpen.value) return;
   const otherPopoverOpen = Array.from(document.querySelectorAll<HTMLElement>(":popover-open")).some(

--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -15,7 +15,7 @@
 </doc>
 
 <script setup lang="ts">
-import { useWindowSize } from "@vueuse/core";
+import { useEventListener, useWindowSize } from "@vueuse/core";
 import { computed, onUnmounted, ref, useTemplateRef, watch } from "vue";
 import { useCommandRegistry, useContextKeys } from "../../shared/command";
 import { useRepoStore } from "../../shared/repo";
@@ -173,6 +173,16 @@ function closePreview() {
 function onPreviewToggle(e: ToggleEvent) {
   previewOpen.value = e.newState === "open";
 }
+
+// ESC で preview を閉じる。popover="manual" で OS の自動 dismiss が無いため自前で処理する。
+// 他の popover (BlamePopover 等) や dialog (SettingsModal 等) が開いている間はそちらに ESC を譲り、
+// 全てが閉じた次の ESC で preview を閉じる。
+useEventListener(window, "keydown", (e: KeyboardEvent) => {
+  if (e.isComposing || e.key !== "Escape") return;
+  if (!previewOpen.value) return;
+  if (document.querySelector(":popover-open:not(._preview-popover), dialog[open]")) return;
+  closePreview();
+});
 
 // ファイル選択時に Preview を自動オープン (path 軸で識別; selection object identity の発火は避ける)
 watch(

--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -176,11 +176,13 @@ function onPreviewToggle(e: ToggleEvent) {
 
 // ESC で preview を閉じる。popover="manual" で OS の自動 dismiss が無いため自前で処理する。
 // 他の popover (BlamePopover 等) や dialog (SettingsModal 等) が開いている間はそちらに ESC を譲り、
-// 全てが閉じた次の ESC で preview を閉じる。
+// 全てが閉じた次の ESC で preview を閉じる。preventDefault は macOS の NSBeep (未処理 ESC のシステム
+// ビープ) 抑止のために必須。
 useEventListener(window, "keydown", (e: KeyboardEvent) => {
   if (e.isComposing || e.key !== "Escape") return;
   if (!previewOpen.value) return;
   if (document.querySelector(":popover-open:not(._preview-popover), dialog[open]")) return;
+  e.preventDefault();
   closePreview();
 });
 

--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -338,8 +338,4 @@ watch(
   height: 100dvh;
   max-height: none;
 }
-
-._preview-popover::backdrop {
-  background-color: rgb(0 0 0 / 0.3);
-}
 </style>

--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -17,7 +17,7 @@
 <script setup lang="ts">
 import { useEventListener, useWindowSize } from "@vueuse/core";
 import { computed, onUnmounted, ref, useTemplateRef, watch } from "vue";
-import { useCommandRegistry, useContextKeys } from "../../shared/command";
+import { isIMEActive, useCommandRegistry, useContextKeys } from "../../shared/command";
 import { useRepoStore } from "../../shared/repo";
 import { useChangesSummaryStore } from "../changes";
 import { GitGraphPane } from "../git-graph";
@@ -174,14 +174,18 @@ function onPreviewToggle(e: ToggleEvent) {
   previewOpen.value = e.newState === "open";
 }
 
-// ESC で preview を閉じる。popover="manual" で OS の自動 dismiss が無いため自前で処理する。
-// 他の popover (BlamePopover 等) や dialog (SettingsModal 等) が開いている間はそちらに ESC を譲り、
-// 全てが閉じた次の ESC で preview を閉じる。preventDefault は macOS の NSBeep (未処理 ESC のシステム
-// ビープ) 抑止のために必須。
+// ESC で preview を閉じる。popover="manual" によって OS の auto dismiss が無いため、
+// HTML popover が popover="auto" で持っていた ESC dismiss の性質を自前で代替する。
+// 他の popover (BlamePopover 等) や dialog (SettingsModal 等) が前面にあるときはそちらに ESC を譲り、
+// すべて閉じた次の ESC で preview を閉じる。preventDefault は macOS の NSBeep 抑止に必須。
 useEventListener(window, "keydown", (e: KeyboardEvent) => {
-  if (e.isComposing || e.key !== "Escape") return;
+  if (isIMEActive(e) || e.key !== "Escape") return;
   if (!previewOpen.value) return;
-  if (document.querySelector(":popover-open:not(._preview-popover), dialog[open]")) return;
+  const otherPopoverOpen = Array.from(document.querySelectorAll<HTMLElement>(":popover-open")).some(
+    (el) => el !== previewPopoverRef.value,
+  );
+  if (otherPopoverOpen) return;
+  if (document.querySelector("dialog[open]") !== null) return;
   e.preventDefault();
   closePreview();
 });

--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -286,7 +286,7 @@ watch(
     <!-- Preview popover: 開閉ボタンをアンカーにして左側に展開 -->
     <div
       ref="previewPopover"
-      popover="auto"
+      popover="manual"
       class="_preview-popover overflow-hidden border-0 border-l border-zinc-700 bg-zinc-900 p-0 [&:popover-open]:flex"
       :style="{ width: `${previewWidth}px` }"
       @toggle="onPreviewToggle"

--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -96,7 +96,7 @@ const centerTerminalRef = useTemplateRef<HTMLElement>("centerTerminal");
 
 const sidebarWidth = ref(260);
 const navigatorWidth = ref(256);
-const previewWidth = ref(480);
+const previewWidth = ref(1200);
 const previewOpen = ref(false);
 const gitGraphHeight = ref(128);
 

--- a/apps/renderer/src/features/preview/ChangesSummaryView.vue
+++ b/apps/renderer/src/features/preview/ChangesSummaryView.vue
@@ -81,7 +81,7 @@ onUnmounted(() => {
         aria-label="Close preview"
         @click="emit('close')"
       >
-        <span class="icon-[lucide--panel-right-close] size-4" />
+        <span class="icon-[lucide--x] size-4" />
       </button>
     </div>
 

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -730,7 +730,7 @@ watch(
         aria-label="Close preview"
         @click="emit('close')"
       >
-        <span class="icon-[lucide--panel-right-close] size-4" />
+        <span class="icon-[lucide--x] size-4" />
       </button>
     </div>
 

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -79,8 +79,10 @@ git 変更ファイルには Original / Diff / Current の3タブを表示する
 - ファイル選択時に自動オープン
 - ヘッダーの close ボタンで閉じる
 - `preview.toggle` コマンドで切り替え
-- HTML Popover API の `popover="manual"` を使用するため、外側クリック (light dismiss) では閉じない
-- ESC キーは MainLayout の `useEventListener("keydown")` で自前ハンドリングして閉じる。他の popover (BlamePopover 等) や dialog (SettingsModal 等) が開いている間はそちらに ESC を譲り、全てが閉じた次の ESC で preview を閉じる
+- 外側クリックでは閉じない
+- ESC キーで閉じる。ただし他の popover (BlamePopover 等) や dialog (SettingsModal 等) が前面にあるときはそれらが優先され、すべて閉じた次の ESC で preview が閉じる
+- IME 変換中の ESC（変換キャンセル）では閉じない
+- input / textarea にフォーカスがある間は ESC で閉じない
 
 ## データ取得
 

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -82,7 +82,6 @@ git 変更ファイルには Original / Diff / Current の3タブを表示する
 - 外側クリックでは閉じない
 - ESC キーで閉じる。ただし他の popover (BlamePopover 等) や dialog (SettingsModal 等) が前面にあるときはそれらが優先され、すべて閉じた次の ESC で preview が閉じる
 - IME 変換中の ESC（変換キャンセル）では閉じない
-- input / textarea にフォーカスがある間は ESC で閉じない
 
 ## データ取得
 

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -79,7 +79,8 @@ git 変更ファイルには Original / Diff / Current の3タブを表示する
 - ファイル選択時に自動オープン
 - ヘッダーの close ボタンで閉じる
 - `preview.toggle` コマンドで切り替え
-- HTML Popover API の `popover="manual"` を使用するため、外側クリックや ESC では閉じない。操作経路は close ボタン / toggle コマンド / 中央カラム右端の開閉ボタンの 3 つに限定する
+- HTML Popover API の `popover="manual"` を使用するため、外側クリック (light dismiss) では閉じない
+- ESC キーは MainLayout の `useEventListener("keydown")` で自前ハンドリングして閉じる。他の popover (BlamePopover 等) や dialog (SettingsModal 等) が開いている間はそちらに ESC を譲り、全てが閉じた次の ESC で preview を閉じる
 
 ## データ取得
 

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -78,7 +78,7 @@ git 変更ファイルには Original / Diff / Current の3タブを表示する
 
 - ファイル選択時に自動オープン
 - ヘッダーの close ボタンで閉じる
-- `terminal.togglePreview` コマンドで切り替え
+- `preview.toggle` コマンドで切り替え
 - HTML Popover API の `popover="manual"` を使用するため、外側クリックや ESC では閉じない。操作経路は close ボタン / toggle コマンド / 中央カラム右端の開閉ボタンの 3 つに限定する
 
 ## データ取得

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -79,6 +79,7 @@ git 変更ファイルには Original / Diff / Current の3タブを表示する
 - ファイル選択時に自動オープン
 - ヘッダーの close ボタンで閉じる
 - `terminal.togglePreview` コマンドで切り替え
+- HTML Popover API の `popover="manual"` を使用するため、外側クリックや ESC では閉じない。操作経路は close ボタン / toggle コマンド / 中央カラム右端の開閉ボタンの 3 つに限定する
 
 ## データ取得
 

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -96,7 +96,6 @@ leafNode
 | `terminal.focusRight`      | 右の leaf にフォーカス移動              |
 | `terminal.focusUp`         | 上の leaf にフォーカス移動              |
 | `terminal.focusDown`       | 下の leaf にフォーカス移動              |
-| `terminal.togglePreview`   | プレビューペインの表示切替              |
 
 ## Worktree ごとのレイアウト保持
 


### PR DESCRIPTION
## 概要

preview ペインの UX を調整する。

- デフォルト幅を `480px` → `1200px` に拡大
- HTML Popover API を `popover="auto"` → `"manual"` に変更し、外側クリック (light dismiss) による自動クローズを停止
- ESC キーで preview を閉じる挙動は維持（`popover="manual"` で OS の自動 dismiss が失われるため、`useEventListener("keydown")` で自前ハンドリング）
- macOS の NSBeep (未処理 ESC のシステムビープ) を `preventDefault()` で抑止
- `popover="auto"` 前提だった `::backdrop` 半透明黒スタイルを削除
- ヘッダー close ボタンのアイコンを `lucide--panel-right-close` → `lucide--x` に置換（PreviewPane / ChangesSummaryView の両方で統一）
- `preview.toggle` コマンドの正規記述を `docs/preview.md` に集約し、`docs/terminal.md` の表記揺れ（旧名 `terminal.togglePreview`）を解消

## 背景

実利用で preview ペインを開きながら他箇所を操作する場面が多く、以下 2 つの摩擦があった。

- 480px ではコードプレビュー / diff / Markdown いずれも表示領域が窮屈で、毎回手動でリサイズしていた
- `popover="auto"` の light dismiss 仕様により、preview の外側（terminal や sidebar 等）をクリックしただけで preview が閉じてしまい、preview を参照しながら他のペインで作業するフローを阻害していた

加えて、close ボタンのアイコンが `lucide--panel-right-close`（右パネルを閉じる）という機能的メタファーだったが、一般的な「閉じる」記号としては `lucide--x` の方が視認性が高い。

## 変更内容

### preview ペインのデフォルト幅

- `apps/renderer/src/features/layout/MainLayout.vue` の `previewWidth` 初期値を 480 → 1200 に変更
- 既存の `maxPreviewWidth` クランプは変更なし。ウィンドウ幅が約 1957px 未満の場合は起動時に最大幅まで縮められる

### popover 自動クローズの停止と ESC の自前ハンドリング

- `apps/renderer/src/features/layout/MainLayout.vue` の preview popover 要素を `popover="auto"` → `"manual"` に変更
- `popover="manual"` への切替で OS による外側クリック light dismiss と ESC 自動 dismiss が両方とも止まるため、ESC で閉じる UX は `useEventListener(window, "keydown")` で自前実装
- ハンドラは以下の条件で `closePreview()` を呼ぶ
  - `e.isComposing` が false かつ `e.key === "Escape"` であること
  - `previewOpen.value` が true であること
  - 他の `:popover-open` 要素（BlamePopover 等）または `dialog[open]` 要素が存在しないこと（存在する場合は ESC をそちらに譲り、それらが閉じた次の ESC で preview を閉じる）
- `e.preventDefault()` を呼んで macOS の NSBeep (未処理 ESC のシステムビープ) を抑止
- close 操作の経路は以下の 4 つ
  - ESC キー（自前ハンドラ）
  - `preview.toggle` コマンド（コマンドパレット / キーバインド）
  - 中央カラム右端の開閉ボタン
  - PreviewPane / ChangesSummaryView の close ボタン
- HTML Popover API は `auto` / `manual` の二択しかなく、「ESC は受ける / 外側クリックは受けない」のような細粒度設定は仕様上不可。今回は `manual` + 自前 ESC ハンドラがその要求を満たす唯一の整合解

### popover backdrop の削除

- `apps/renderer/src/features/layout/MainLayout.vue` の `._preview-popover::backdrop { background-color: rgb(0 0 0 / 0.3) }` を削除
- `popover="auto"` 時代の「モーダル的に他を遮蔽する」装飾の名残。`manual` への切替で「preview を開いたまま他ペインで作業を続ける」目的と矛盾する（他ペインが永続的に半透明黒で覆われる）ため削除

### close ボタンのアイコン変更

- `apps/renderer/src/features/preview/PreviewPane.vue` と `apps/renderer/src/features/preview/ChangesSummaryView.vue` の close ボタンアイコンを `lucide--panel-right-close` → `lucide--x` に変更
- aria-label / title（"Close preview"）は据え置き。アクセシビリティ上の SSOT はテキスト側にあるため、視覚アイコンのみの差し替え

### ドキュメント

- `docs/preview.md` の「開閉機能」セクションに、外側クリックでは閉じないこと / ESC は自前ハンドラで閉じることを追記
- `docs/preview.md` 内の旧コマンド名 `terminal.togglePreview` を実装に合わせて `preview.toggle` に修正
- `docs/terminal.md` のコマンド表から `terminal.togglePreview` 行を削除。preview.toggle は preview feature 所有のコマンドであり、`docs/preview.md` 側を正規記述として SSOT 化

## 確認事項

- [ ] preview を開いた状態で terminal / sidebar / filer 等をクリックしても preview が閉じないこと
- [ ] preview を開いた状態で ESC キーを押すと preview が閉じ、macOS のシステムビープ (NSBeep) が鳴らないこと
- [ ] BlamePopover（`popover="auto"`）を preview 内で開いた状態で ESC を押したとき、BlamePopover のみが閉じて preview popover は閉じないこと（次の ESC で preview が閉じる）
- [ ] SettingsModal などの dialog を preview を開いた状態で開いている間は ESC で dialog が閉じるが preview は閉じないこと
- [ ] close ボタン（✕）/ 中央カラム右端の開閉ボタン / `preview.toggle` コマンドそれぞれで preview が閉じること
- [ ] ChangesSummaryView の close ボタンも ✕ アイコンで表示され、クリックで preview が閉じること
- [ ] preview popover を開いている間、terminal / sidebar / filer 等の他ペインが半透明黒で覆われないこと
- [ ] 起動時の preview 幅が 1200px であること（ウィンドウ幅が十分広い場合）
- [ ] ウィンドウ幅 1957px 未満で起動した場合に preview 幅が `maxPreviewWidth` までクランプされ、`PREVIEW_MIN_WIDTH` (200px) を下回らないこと
