### PR TITLE
refactor(stderr-log): 観察ログを StderrLog helper 集約と lint 強制で SSOT 化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,8 @@ StderrLog.write(tag: "handlePtySpawn", "pty.spawn failed: \(error) executable=\(
 
 以前の規約は「素埋め込み + source 側 sanitize」を call site の双方の責務として記述していたが、両者は両立しない (素埋め込みの見た目を保つと sanitize 呼びが書けず、レビューで違反を検出できない)。helper に sanitize を集約することで、SSOT を「規約条文」から「実行コード」に移し、違反が構造的に発生しない構成にする。
 
+加えて pre-commit hook (`apps/native/scripts/check-stderr-direct.sh`) で `FileHandle.standardError.write` の直接呼び出しを許可リスト (`StderrLog.swift` / `PTYTrace.swift` / `GozdCLI/`) 外で reject する。helper を作るだけでは「helper を経由しない新規違反」が再発し得るため、grep ベースの check で構造的に違反を防ぐ側の柱を立てる。
+
 #### errnoText の制御文字 gate との関係
 
 `PTYError.errnoText` (`PTYManager.swift`) の control-char gate は本規約の対象外。errnoText は stderr 経由だけでなく、`PTYError.description` 経由で `RpcSchemeHandler` の 500 response body にも乗る (renderer まで届く identifier として使う)。helper 側の escape は stderr 経路の 1 行性を守るためのもので、renderer 側に届く文字列の identifier 品質まで保証しない。`errnoText` の gate は renderer 経路の identifier 品質を `unknown errno N` fallback で確保する別契約として残る。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,18 +162,30 @@ macOS 26 Tahoe 以降専用（`WebPage` API は macOS 26 で追加された Swif
 
 ### 観察ログ (stderr) の書式
 
-dispatcher / store / hook ハンドラなどから `FileHandle.standardError.write` で出す **ad-hoc な観察ログ** は以下の SSOT に揃える:
+dispatcher / store / hook ハンドラなどから出す **ad-hoc な観察ログ** は `GozdCore` の `StderrLog.write(tag:_:)` helper を経由する。`FileHandle.standardError.write` を直接呼ばない。
 
-- **素埋め込み**（`"\(value)"` 直書き）を採用する。`String(reflecting:)` などで path / executable / 任意フィールドを quote 化しない。stderr log 全体の書式統一を維持するため、1 箇所だけ quote 化する変更は入れない
-- prefix は handler 関数名 (`[handlePtySpawn]`) または store 名 (`[ClaudeSessionStore]`) を使う。grep で経路を絞れるよう一貫させる
-- 改行 / 制御文字を含み得るフィールドは log に乗せる前に source 側で sanitize する（例: `PTYError.errnoText` の control-char gate）。log フォーマット側で escape しない
-- 仮に path quoting が必要になった場合は本セクションを改定して全箇所を統一する。一部箇所だけの差分は入れない
+```swift
+StderrLog.write(tag: "handlePtySpawn", "pty.spawn failed: \(error) executable=\(req.executable) cwd=\(req.dir)")
+```
 
-対象外:
+- helper が `[tag] message\n` の format と制御文字 escape (C0 / DEL を `\xNN` に変換) を必ず実行する。call site は素の string interpolation で値を埋め込めばよく、改行 / 制御文字混入の判断責任を負わない
+- tag は handler 関数名 (`handlePtySpawn`) または store / module 名 (`ClaudeSessionStore`)。bracket は helper が付ける
+- value の quote 化 (`String(reflecting:)` 等) はしない。書式統一を helper 側で SSOT 化しているため、1 箇所だけ装飾を変える差分も入れない
 
-- **trace 系統**: 専用の prefix フォーマットを持ち、デバッグトレース用途として別系統で運用する。handler 名 prefix 規約の対象外
+#### なぜ helper 集約か
+
+以前の規約は「素埋め込み + source 側 sanitize」を call site の双方の責務として記述していたが、両者は両立しない (素埋め込みの見た目を保つと sanitize 呼びが書けず、レビューで違反を検出できない)。helper に sanitize を集約することで、SSOT を「規約条文」から「実行コード」に移し、違反が構造的に発生しない構成にする。
+
+#### errnoText の制御文字 gate との関係
+
+`PTYError.errnoText` (`PTYManager.swift`) の control-char gate は本規約の対象外。errnoText は stderr 経由だけでなく、`PTYError.description` 経由で `RpcSchemeHandler` の 500 response body にも乗る (renderer まで届く identifier として使う)。helper 側の escape は stderr 経路の 1 行性を守るためのもので、renderer 側に届く文字列の identifier 品質まで保証しない。`errnoText` の gate は renderer 経路の identifier 品質を `unknown errno N` fallback で確保する別契約として残る。
+
+#### 対象外
+
+- **trace 系統**: 専用の prefix フォーマットを持ち、デバッグトレース用途として別系統で運用する
   - `[PTY-TRACE +elapsed pid=N tag]` (`PTYTrace.swift`): GozdCore 内の PTY ライフサイクルイベント。pid を含む
   - `[TEST-TRACE +elapsed test=NAME]` (`TestTrace.swift`): test ハーネス側のトレース。pid は含まない
+- **CLI のユーザー向け error 出力** (`GozdCLI/main.swift`): `[tag]` prefix を持たない user-facing message。helper 経路ではなく `FileHandle.standardError.write` を直接呼んで構わない
 - print/NSLog 経由のログは対象外（gozd では使わない方針）
 
 ## Swift

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,33 +162,21 @@ macOS 26 Tahoe 以降専用（`WebPage` API は macOS 26 で追加された Swif
 
 ### 観察ログ (stderr) の書式
 
-dispatcher / store / hook ハンドラなどから出す **ad-hoc な観察ログ** は `GozdCore` の `StderrLog.write(tag:_:)` helper を経由する。`FileHandle.standardError.write` を直接呼ばない。
+dispatcher / store / hook ハンドラの ad-hoc 観察ログは `GozdCore.StderrLog.write(tag:_:)` を使う。
 
 ```swift
 StderrLog.write(tag: "handlePtySpawn", "pty.spawn failed: \(error) executable=\(req.executable) cwd=\(req.dir)")
 ```
 
-- helper が `[tag] message\n` の format と制御文字 escape (C0 / DEL を `\xNN` に変換) を必ず実行する。call site は素の string interpolation で値を埋め込めばよく、改行 / 制御文字混入の判断責任を負わない
-- tag は handler 関数名 (`handlePtySpawn`) または store / module 名 (`ClaudeSessionStore`)。bracket は helper が付ける
-- value の quote 化 (`String(reflecting:)` 等) はしない。書式統一を helper 側で SSOT 化しているため、1 箇所だけ装飾を変える差分も入れない
+- tag は handler 関数名 (`handlePtySpawn`) または store / module 名 (`ClaudeSessionStore`)
+- helper が `[tag] message\n` の format と制御文字 escape を引き受ける。call site は素の string interpolation を書く
 
-#### なぜ helper 集約か
+`PTYError.errnoText` (`PTYManager.swift`) の control-char gate はこの helper と独立した契約。errnoText は `PTYError.description` 経由で `RpcSchemeHandler` の 500 response body にも乗り renderer まで届くため、stderr 経路の helper escape では identifier 品質を担保できず、`unknown errno N` fallback を errnoText 側で持つ。
 
-以前の規約は「素埋め込み + source 側 sanitize」を call site の双方の責務として記述していたが、両者は両立しない (素埋め込みの見た目を保つと sanitize 呼びが書けず、レビューで違反を検出できない)。helper に sanitize を集約することで、SSOT を「規約条文」から「実行コード」に移し、違反が構造的に発生しない構成にする。
+trace 系統は専用 format / 専用 lock で別経路:
 
-加えて pre-commit hook (`apps/native/scripts/check-stderr-direct.sh`) で `FileHandle.standardError.write` の直接呼び出しを許可リスト (`StderrLog.swift` / `PTYTrace.swift` / `GozdCLI/`) 外で reject する。helper を作るだけでは「helper を経由しない新規違反」が再発し得るため、grep ベースの check で構造的に違反を防ぐ側の柱を立てる。
-
-#### errnoText の制御文字 gate との関係
-
-`PTYError.errnoText` (`PTYManager.swift`) の control-char gate は本規約の対象外。errnoText は stderr 経由だけでなく、`PTYError.description` 経由で `RpcSchemeHandler` の 500 response body にも乗る (renderer まで届く identifier として使う)。helper 側の escape は stderr 経路の 1 行性を守るためのもので、renderer 側に届く文字列の identifier 品質まで保証しない。`errnoText` の gate は renderer 経路の identifier 品質を `unknown errno N` fallback で確保する別契約として残る。
-
-#### 対象外
-
-- **trace 系統**: 専用の prefix フォーマットを持ち、デバッグトレース用途として別系統で運用する
-  - `[PTY-TRACE +elapsed pid=N tag]` (`PTYTrace.swift`): GozdCore 内の PTY ライフサイクルイベント。pid を含む
-  - `[TEST-TRACE +elapsed test=NAME]` (`TestTrace.swift`): test ハーネス側のトレース。pid は含まない
-- **CLI のユーザー向け error 出力** (`GozdCLI/main.swift`): `[tag]` prefix を持たない user-facing message。helper 経路ではなく `FileHandle.standardError.write` を直接呼んで構わない
-- print/NSLog 経由のログは対象外（gozd では使わない方針）
+- `[PTY-TRACE +elapsed pid=N tag]` (`PTYTrace.swift`): PTY ライフサイクル
+- `[TEST-TRACE +elapsed test=NAME]` (`TestTrace.swift`): test ハーネス
 
 ## Swift
 

--- a/apps/native/Sources/Gozd/ExternalLinkNavigationDecider.swift
+++ b/apps/native/Sources/Gozd/ExternalLinkNavigationDecider.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import GozdCore
 import WebKit
 
 /// http(s) かつ非 dev origin への navigation を OS のデフォルトブラウザに渡す NavigationDecider。
@@ -32,16 +33,18 @@ struct ExternalLinkNavigationDecider: WebPage.NavigationDeciding {
       let scheme = viteURL.scheme?.lowercased(),
       let host = viteURL.host
     else {
-      FileHandle.standardError.write(
-        Data("[NavigationDecider] GOZD_DEV_VITE_URL is malformed: \(viteURLString)\n".utf8))
+      StderrLog.write(
+        tag: "NavigationDecider",
+        "GOZD_DEV_VITE_URL is malformed: \(viteURLString)"
+      )
       return nil
     }
     let path = viteURL.path
     if !path.isEmpty, path != "/" {
-      FileHandle.standardError.write(
-        Data(
-          "[NavigationDecider] GOZD_DEV_VITE_URL must be an origin (no path); got: \(viteURLString)\n"
-            .utf8))
+      StderrLog.write(
+        tag: "NavigationDecider",
+        "GOZD_DEV_VITE_URL must be an origin (no path); got: \(viteURLString)"
+      )
       return nil
     }
     return (scheme: scheme, host: host, port: viteURL.port)
@@ -85,10 +88,10 @@ struct ExternalLinkNavigationDecider: WebPage.NavigationDeciding {
     do {
       _ = try await NSWorkspace.shared.open(url, configuration: config)
     } catch {
-      FileHandle.standardError.write(
-        Data(
-          "[NavigationDecider] failed to open external URL: \(url.absoluteString): \(error)\n"
-            .utf8))
+      StderrLog.write(
+        tag: "NavigationDecider",
+        "failed to open external URL: \(url.absoluteString): \(error)"
+      )
     }
   }
 

--- a/apps/native/Sources/Gozd/GozdApp.swift
+++ b/apps/native/Sources/Gozd/GozdApp.swift
@@ -75,14 +75,14 @@ struct ContentView: View {
           do {
             for try await _ in runtime.page.load(url) {}
           } catch {
-            print("page.load (vite) failed: \(error)")
+            StderrLog.write(tag: "GozdApp", "page.load (vite) failed: \(error)")
           }
         } else if BundleAssetSchemeHandler.bundledRoot != nil {
           let appURL = URL(string: "gozd-app://localhost/index.html")!
           do {
             for try await _ in runtime.page.load(URLRequest(url: appURL)) {}
           } catch {
-            print("page.load (bundled) failed: \(error)")
+            StderrLog.write(tag: "GozdApp", "page.load (bundled) failed: \(error)")
           }
         } else {
           let html = ptyHarnessHTML(socketPath: runtime.socketPath)
@@ -92,7 +92,7 @@ struct ContentView: View {
               baseURL: URL(string: "gozd-app://localhost/")!
             ) {}
           } catch {
-            print("page.load (harness) failed: \(error)")
+            StderrLog.write(tag: "GozdApp", "page.load (harness) failed: \(error)")
           }
         }
 
@@ -345,7 +345,7 @@ final class AppRuntime {
           }
         }
       }
-      print("[SocketServer] listening on \(socketPath)")
+      StderrLog.write(tag: "SocketServer", "listening on \(socketPath)")
     } catch {
       StderrLog.write(tag: "SocketServer", "start failed: \(error)")
       sendNotify(

--- a/apps/native/Sources/Gozd/GozdApp.swift
+++ b/apps/native/Sources/Gozd/GozdApp.swift
@@ -172,8 +172,7 @@ final class AppRuntime {
       claudeSettingsWriteError = nil
     } catch {
       claudeSettingsWriteError = error
-      FileHandle.standardError.write(
-        Data("[ClaudeHooks] settings write failed: \(error)\n".utf8))
+      StderrLog.write(tag: "ClaudeHooks", "settings write failed: \(error)")
     }
 
     // dev / build 共通の env overlay。dev では GOZD_DEV_PROJECT_ROOT 配下のソースを参照する。
@@ -340,9 +339,7 @@ final class AppRuntime {
           do {
             try await createdDispatcher.handleSocketMessage(line)
           } catch {
-            FileHandle.standardError.write(
-              Data("[SocketServer] decode failed: \(error)\n".utf8)
-            )
+            StderrLog.write(tag: "SocketServer", "decode failed: \(error)")
             sendNotify(
               "error", "socket", "Invalid client message", String(describing: error), "")
           }
@@ -350,8 +347,7 @@ final class AppRuntime {
       }
       print("[SocketServer] listening on \(socketPath)")
     } catch {
-      FileHandle.standardError.write(
-        Data("[SocketServer] start failed: \(error)\n".utf8))
+      StderrLog.write(tag: "SocketServer", "start failed: \(error)")
       sendNotify(
         "error", "socket", "Failed to start Unix socket server",
         String(describing: error), "")
@@ -600,8 +596,7 @@ final class WebPageHolder {
 @MainActor
 func pushToRenderer(page: WebPage?, type: String, payload: [String: Any]) async {
   guard let page else {
-    FileHandle.standardError.write(
-      Data("[GozdApp] push dropped (page not ready): type=\(type)\n".utf8))
+    StderrLog.write(tag: "GozdApp", "push dropped (page not ready): type=\(type)")
     return
   }
   do {
@@ -610,8 +605,7 @@ func pushToRenderer(page: WebPage?, type: String, payload: [String: Any]) async 
       arguments: ["type": type, "payload": payload]
     )
   } catch {
-    FileHandle.standardError.write(
-      Data("[GozdApp] push failed: type=\(type) error=\(error)\n".utf8))
+    StderrLog.write(tag: "GozdApp", "push failed: type=\(type) error=\(error)")
   }
 }
 

--- a/apps/native/Sources/GozdCore/ClaudeSessionStore.swift
+++ b/apps/native/Sources/GozdCore/ClaudeSessionStore.swift
@@ -100,21 +100,21 @@ public actor ClaudeSessionStore {
       do {
         return try Gozd_V1_ClaudeSessionList(jsonString: json)
       } catch {
-        FileHandle.standardError.write(
-          Data(
-            "[ClaudeSessionStore] loadFile: parse failed at \(url.path): \(error)\n"
-              .utf8))
+        StderrLog.write(
+          tag: "ClaudeSessionStore",
+          "loadFile: parse failed at \(url.path): \(error)"
+        )
       }
     } else {
-      FileHandle.standardError.write(
-        Data("[ClaudeSessionStore] loadFile: invalid UTF-8 at \(url.path)\n".utf8))
+      StderrLog.write(
+        tag: "ClaudeSessionStore", "loadFile: invalid UTF-8 at \(url.path)")
     }
     let empty = Gozd_V1_ClaudeSessionList()
     try saveFile(empty, for: dir)
-    FileHandle.standardError.write(
-      Data(
-        "[ClaudeSessionStore] loadFile: corrupted claude-sessions.json reinitialized at \(url.path)\n"
-          .utf8))
+    StderrLog.write(
+      tag: "ClaudeSessionStore",
+      "loadFile: corrupted claude-sessions.json reinitialized at \(url.path)"
+    )
     return empty
   }
 

--- a/apps/native/Sources/GozdCore/FSWatchRegistry.swift
+++ b/apps/native/Sources/GozdCore/FSWatchRegistry.swift
@@ -338,10 +338,10 @@ public actor FSWatchRegistry {
         .filter { _, e in e.commonGitDir == commonGitDir }
         .map { key, e in "\(key)(main=\(e.perWorktreeGitDir == commonGitDir))" }
         .sorted()
-      FileHandle.standardError.write(
-        Data(
-          "[FSWatchRegistry] primary missing for commonGitDir=\(commonGitDir); dropping branchChange=\(result.hasBranchChange) remoteRefsChange=\(result.hasRemoteRefsChange) worktreeChange=\(result.hasWorktreeChange) from dir=\(dir); entries=\(siblings)\n"
-            .utf8))
+      StderrLog.write(
+        tag: "FSWatchRegistry",
+        "primary missing for commonGitDir=\(commonGitDir); dropping branchChange=\(result.hasBranchChange) remoteRefsChange=\(result.hasRemoteRefsChange) worktreeChange=\(result.hasWorktreeChange) from dir=\(dir); entries=\(siblings)"
+      )
     }
     if result.hasBranchChange && isPrimaryForCommonDir {
       onBranchChange(originalDir)
@@ -360,8 +360,8 @@ public actor FSWatchRegistry {
       } catch {
         // 観察可能性のためログを残す。renderer は次の FSEvents バッチで再 fetch するため
         // 致命的ではないが、繰り返し発生していれば一時障害として診断したい。
-        FileHandle.standardError.write(
-          Data("[FSWatchRegistry] gitStatusFull failed for \(dir): \(error)\n".utf8))
+        StderrLog.write(
+          tag: "FSWatchRegistry", "gitStatusFull failed for \(dir): \(error)")
         return
       }
       // gitStatusFull の await 中に unwatch されている可能性があるため再 check

--- a/apps/native/Sources/GozdCore/GitOps.swift
+++ b/apps/native/Sources/GozdCore/GitOps.swift
@@ -430,9 +430,8 @@ public enum GitOps {
       do {
         try FileManager.default.removeItem(at: tmpDir)
       } catch {
-        FileHandle.standardError.write(
-          Data("[GitOps] failed to remove diff tmp dir \(tmpDir.path): \(error)\n".utf8)
-        )
+        StderrLog.write(
+          tag: "GitOps", "failed to remove diff tmp dir \(tmpDir.path): \(error)")
       }
     }
 
@@ -570,9 +569,8 @@ public enum GitOps {
         .trimmingCharacters(in: .whitespacesAndNewlines)
       return line.isEmpty ? nil : line
     } catch {
-      FileHandle.standardError.write(
-        Data("[GitOps] rev-parse \(hash):\(relPath) failed in \(dir): \(error)\n".utf8)
-      )
+      StderrLog.write(
+        tag: "GitOps", "rev-parse \(hash):\(relPath) failed in \(dir): \(error)")
       return nil
     }
   }
@@ -1191,8 +1189,7 @@ func parseUnifiedDiffHunks(_ text: String) -> [DiffHunkInfo] {
     }
     guard let header = parseHunkHeader(String(raw)) else {
       // `@@` で始まるが header 形式に合わない行は parser バグか git 出力の変化。
-      FileHandle.standardError.write(
-        Data("[GitOps] unparseable hunk header: \(raw)\n".utf8))
+      StderrLog.write(tag: "GitOps", "unparseable hunk header: \(raw)")
       i += 1
       continue
     }
@@ -1242,8 +1239,8 @@ func parseUnifiedDiffHunks(_ text: String) -> [DiffHunkInfo] {
       ))
   }
   if unexpectedSkips > 0 {
-    FileHandle.standardError.write(
-      Data("[GitOps] parseUnifiedDiffHunks: skipped \(unexpectedSkips) unexpected line(s)\n".utf8))
+    StderrLog.write(
+      tag: "GitOps", "parseUnifiedDiffHunks: skipped \(unexpectedSkips) unexpected line(s)")
   }
   return hunks
 }

--- a/apps/native/Sources/GozdCore/PTYRegistry.swift
+++ b/apps/native/Sources/GozdCore/PTYRegistry.swift
@@ -263,10 +263,10 @@ public actor PTYRegistry {
     // expected が残っているなら resume 失敗の sid を掃除する機会を逸している。
     // ここでは silent に消すが、調査用に stderr に残す。
     if let stale = expectedResumeSidById.removeValue(forKey: id) {
-      FileHandle.standardError.write(
-        Data(
-          "[PTYRegistry] remove: dropped expected resume sid=\(stale) without removeByPty for pty=\(id)\n"
-            .utf8))
+      StderrLog.write(
+        tag: "PTYRegistry",
+        "remove: dropped expected resume sid=\(stale) without removeByPty for pty=\(id)"
+      )
     }
   }
 }

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -488,8 +488,6 @@ public actor RpcDispatcher {
       // 併記する。worktreePath は cwd と独立で、複数 worktree が並列に Claude を
       // 起動する gozd の primary use case で「どの worktree の spawn か」を識別する
       // ために必要（cwd はユーザーが任意に cd した path で worktree とは限らない）。
-      // stderr log の書式は CLAUDE.md「観察ログ (stderr) の書式」の SSOT に従い
-      // `StderrLog` helper を経由する (制御文字 escape は helper 側で実行)。
       StderrLog.write(
         tag: "handlePtySpawn",
         "pty.spawn failed: \(error) executable=\(req.executable) cwd=\(req.dir) worktreePath=\(req.worktreePath)"

--- a/apps/native/Sources/GozdCore/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/RpcDispatcher.swift
@@ -113,15 +113,15 @@ public actor RpcDispatcher {
       //     生じる late hook を構造的に弾いた正常パス。skip と明記する。
       // (b) そもそも未登録 ptyId → spawn 経路の不整合、調査対象。error と明記する。
       if await pty.wasExplicitlyRemoved(hook.ptyID) {
-        FileHandle.standardError.write(
-          Data(
-            "[ClaudeSessionStore] late \(hook.event) for pty=\(hook.ptyID) session=\(hook.sessionID) after removeByPty; skipping\n"
-              .utf8))
+        StderrLog.write(
+          tag: "ClaudeSessionStore",
+          "late \(hook.event) for pty=\(hook.ptyID) session=\(hook.sessionID) after removeByPty; skipping"
+        )
       } else {
-        FileHandle.standardError.write(
-          Data(
-            "[ClaudeSessionStore] \(hook.event) for unknown pty=\(hook.ptyID); skipping\n"
-              .utf8))
+        StderrLog.write(
+          tag: "ClaudeSessionStore",
+          "\(hook.event) for unknown pty=\(hook.ptyID); skipping"
+        )
       }
       return
     }
@@ -146,8 +146,7 @@ public actor RpcDispatcher {
           do {
             try await tasks.detachSession(dir: worktreePath, sessionId: previous)
           } catch {
-            FileHandle.standardError.write(
-              Data("[TaskStore] detachSession (previous) failed: \(error)\n".utf8))
+            StderrLog.write(tag: "TaskStore", "detachSession (previous) failed: \(error)")
             onNotify(
               "error", "task-store", "Failed to detach previous session from task",
               String(describing: error), worktreePath)
@@ -170,10 +169,10 @@ public actor RpcDispatcher {
             try await claudeSessions.removeBySessionId(
               worktreePath: worktreePath, sessionId: expectedSid)
           } catch {
-            FileHandle.standardError.write(
-              Data(
-                "[ClaudeSessionStore] resume-failure cleanup (session-start fallback) failed: \(error)\n"
-                  .utf8))
+            StderrLog.write(
+              tag: "ClaudeSessionStore",
+              "resume-failure cleanup (session-start fallback) failed: \(error)"
+            )
             onNotify(
               "error", "claude-sessions",
               "Failed to clean up after resume failure (fallback)",
@@ -188,10 +187,10 @@ public actor RpcDispatcher {
             try await tasks.clearDeadSession(
               dir: worktreePath, sessionId: expectedSid, markClosedByUser: false)
           } catch {
-            FileHandle.standardError.write(
-              Data(
-                "[TaskStore] clearDeadSession (session-start fallback) failed: \(error)\n"
-                  .utf8))
+            StderrLog.write(
+              tag: "TaskStore",
+              "clearDeadSession (session-start fallback) failed: \(error)"
+            )
             onNotify(
               "error", "task-store",
               "Failed to clear dead session from task after resume failure (fallback)",
@@ -220,8 +219,7 @@ public actor RpcDispatcher {
           )
           await pty.setSessionId(for: hook.ptyID, sessionId: hook.sessionID)
         } catch {
-          FileHandle.standardError.write(
-            Data("[TaskStore] attachSession failed: \(error)\n".utf8))
+          StderrLog.write(tag: "TaskStore", "attachSession failed: \(error)")
           onNotify(
             "error", "task-store", "Failed to attach session to task",
             String(describing: error), worktreePath)
@@ -229,10 +227,10 @@ public actor RpcDispatcher {
             try await claudeSessions.removeBySessionId(
               worktreePath: worktreePath, sessionId: hook.sessionID)
           } catch {
-            FileHandle.standardError.write(
-              Data(
-                "[ClaudeSessionStore] attachSession rollback (upsert revert) failed: \(error)\n"
-                  .utf8))
+            StderrLog.write(
+              tag: "ClaudeSessionStore",
+              "attachSession rollback (upsert revert) failed: \(error)"
+            )
             onNotify(
               "error", "claude-sessions",
               "Failed to rollback claude-sessions after attachSession failure",
@@ -251,8 +249,7 @@ public actor RpcDispatcher {
         do {
           try await tasks.detachSession(dir: worktreePath, sessionId: hook.sessionID)
         } catch {
-          FileHandle.standardError.write(
-            Data("[TaskStore] detachSession failed: \(error)\n".utf8))
+          StderrLog.write(tag: "TaskStore", "detachSession failed: \(error)")
           onNotify(
             "error", "task-store", "Failed to detach session from task",
             String(describing: error), worktreePath)
@@ -273,8 +270,7 @@ public actor RpcDispatcher {
       // notify する。dir は worktreePath が解決済みなのでそのまま渡す。
       // message は TaskStore 側と同じく経路ごとに静的列挙して、トースト UI で
       // 運用者が経路を識別できるようにする。
-      FileHandle.standardError.write(
-        Data("[ClaudeSessionStore] \(hook.event) failed: \(error)\n".utf8))
+      StderrLog.write(tag: "ClaudeSessionStore", "\(hook.event) failed: \(error)")
       let message: String
       switch hook.event {
       case "session-start":
@@ -492,13 +488,11 @@ public actor RpcDispatcher {
       // 併記する。worktreePath は cwd と独立で、複数 worktree が並列に Claude を
       // 起動する gozd の primary use case で「どの worktree の spawn か」を識別する
       // ために必要（cwd はユーザーが任意に cd した path で worktree とは限らない）。
-      // stderr log の書式は CLAUDE.md「観察ログ (stderr) の書式」の SSOT に従い、
-      // 素埋め込みで書く（quote 化しない）。
-      FileHandle.standardError.write(
-        Data(
-          "[handlePtySpawn] pty.spawn failed: \(error) executable=\(req.executable) cwd=\(req.dir) worktreePath=\(req.worktreePath)\n"
-            .utf8
-        )
+      // stderr log の書式は CLAUDE.md「観察ログ (stderr) の書式」の SSOT に従い
+      // `StderrLog` helper を経由する (制御文字 escape は helper 側で実行)。
+      StderrLog.write(
+        tag: "handlePtySpawn",
+        "pty.spawn failed: \(error) executable=\(req.executable) cwd=\(req.dir) worktreePath=\(req.worktreePath)"
       )
       throw error
     }
@@ -625,10 +619,10 @@ public actor RpcDispatcher {
             let full = try await GitOps.gitStatusFull(dir: path)
             return (path, full)
           } catch {
-            FileHandle.standardError.write(
-              Data(
-                "[handleGitWorktreeList] gitStatusFull failed for \(path): \(error)\n"
-                  .utf8))
+            StderrLog.write(
+              tag: "handleGitWorktreeList",
+              "gitStatusFull failed for \(path): \(error)"
+            )
             return (path, nil)
           }
         }
@@ -791,10 +785,9 @@ public actor RpcDispatcher {
       }
     } catch {
       fr.notFound = true
-      FileHandle.standardError.write(
-        Data(
-          "[RpcDispatcher] git show \(hash):\(relPath) failed in \(dir): \(error)\n".utf8
-        )
+      StderrLog.write(
+        tag: "RpcDispatcher",
+        "git show \(hash):\(relPath) failed in \(dir): \(error)"
       )
     }
     return fr
@@ -1015,13 +1008,13 @@ public actor RpcDispatcher {
       resp.repo = repo
     case .unsetRemote:
       // remote 未設定 (新規 repo / fork なし)。UI には出ないが観察可能にする。
-      FileHandle.standardError.write(
-        Data("[handleGitGithubIdentity] remote.origin not set for dir=\(req.dir)\n".utf8))
+      StderrLog.write(
+        tag: "handleGitGithubIdentity", "remote.origin not set for dir=\(req.dir)")
     case .parserRejected:
       // 非 github.com host / 想定外 URL 形式。raw URL は credential 漏出防止のため
       // stderr にも載せない (固定文言 + dir のみで切り分け)。
-      FileHandle.standardError.write(
-        Data("[handleGitGithubIdentity] unsupported remote URL for dir=\(req.dir)\n".utf8))
+      StderrLog.write(
+        tag: "handleGitGithubIdentity", "unsupported remote URL for dir=\(req.dir)")
     }
     return try resp.jsonUTF8Data()
   }
@@ -1060,8 +1053,7 @@ public actor RpcDispatcher {
     do {
       try await tasks.removeByWorktree(dir: req.dir, worktreePath: req.path)
     } catch {
-      FileHandle.standardError.write(
-        Data("[TaskStore] removeByWorktree failed: \(error)\n".utf8))
+      StderrLog.write(tag: "TaskStore", "removeByWorktree failed: \(error)")
       onNotify(
         "error", "task-store", "Failed to clean up tasks after worktree removal",
         String(describing: error), req.dir)
@@ -1117,9 +1109,8 @@ public actor RpcDispatcher {
         try await claudeSessions.removeBySessionId(
           worktreePath: req.worktreePath, sessionId: expectedSid)
       } catch {
-        FileHandle.standardError.write(
-          Data(
-            "[ClaudeSessionStore] resume-failure cleanup failed: \(error)\n".utf8))
+        StderrLog.write(
+          tag: "ClaudeSessionStore", "resume-failure cleanup failed: \(error)")
         onNotify(
           "error", "claude-sessions",
           "Failed to clean up after resume failure",
@@ -1132,8 +1123,7 @@ public actor RpcDispatcher {
         try await tasks.clearDeadSession(
           dir: req.worktreePath, sessionId: expectedSid, markClosedByUser: true)
       } catch {
-        FileHandle.standardError.write(
-          Data("[TaskStore] clearDeadSession failed: \(error)\n".utf8))
+        StderrLog.write(tag: "TaskStore", "clearDeadSession failed: \(error)")
         onNotify(
           "error", "task-store",
           "Failed to clear dead session from task after resume failure",
@@ -1158,8 +1148,8 @@ public actor RpcDispatcher {
       do {
         try await tasks.detachSession(dir: req.worktreePath, sessionId: liveSid)
       } catch {
-        FileHandle.standardError.write(
-          Data("[TaskStore] detachSession (removeByPty) failed: \(error)\n".utf8))
+        StderrLog.write(
+          tag: "TaskStore", "detachSession (removeByPty) failed: \(error)")
         onNotify(
           "error", "task-store", "Failed to detach session on terminal close",
           String(describing: error), req.worktreePath)

--- a/apps/native/Sources/GozdCore/StderrLog.swift
+++ b/apps/native/Sources/GozdCore/StderrLog.swift
@@ -16,10 +16,28 @@ import Foundation
 ///
 /// ## escape 仕様
 ///
-/// C0 制御文字 (U+0000-U+001F) と DEL (U+007F) を `\xNN` 形式に escape する。
-/// multi-byte UTF-8 構成バイト (0x80-0xFF) は触らない (非英語 locale の文字列を
-/// そのまま流す)。escape 後の末尾に改行を 1 つだけ付与する。call site は改行を
-/// message に含めない。
+/// 以下を `\xNN` / `\uNNNN` 形式に escape する:
+///
+/// - C0 制御文字 (U+0000-U+001F) と DEL (U+007F) → `\xNN`
+/// - C1 制御文字 (U+0080-U+009F)、NEL (U+0085 は C1 と重複) → `\xNN`
+/// - LINE SEPARATOR (U+2028) / PARAGRAPH SEPARATOR (U+2029) → `\uNNNN`
+///
+/// 通常の multi-byte UTF-8 文字 (U+00A0 以降の表示可能文字、`Ω` `日本語` 等) は
+/// 触らない (非英語 locale の strerror / path を温存する)。
+///
+/// U+2028 / U+2029 / NEL は Unicode 上「行区切り」として定義された character で、
+/// 一部の表示系 (JavaScript console / 一部 terminal) でログ行を物理的に割る経路を
+/// 持つ。観察ログの 1 行性 (grep / awk / Console.app の event 単位処理) を Unicode
+/// 表示単位でも壊さないため escape 対象に含める。
+///
+/// ## byte-level 1 行性 (write の atomicity)
+///
+/// 観察ログ helper は複数の actor / `@MainActor` から並列発火する。POSIX `write(2)`
+/// は `PIPE_BUF` (Darwin で 512 byte) を超える書き込みの atomicity を保証しないため、
+/// 長い 1 行 (path / executable / siblings 配列の interpolation 等) が並列発火で
+/// byte 単位に混線する経路がある。`PTYTrace.swift` が同じ問題を NSLock で潰した
+/// 先例があり、本 helper も `lock` で write 全体を serialize する。call site は
+/// 同期 / 非同期どちらからでもこの API を素直に呼べばよい (lock の存在は隠蔽)。
 ///
 /// ## 対象外
 ///
@@ -34,23 +52,52 @@ public enum StderrLog {
   ///   - message: 任意の string。制御文字は helper が escape する。call site で sanitize
   ///     する必要は無い。
   public static func write(tag: String, _ message: String) {
-    let line = "[\(tag)] \(escapeControl(message))\n"
-    FileHandle.standardError.write(Data(line.utf8))
+    writeImpl(tag: tag, message, to: FileHandle.standardError)
   }
 
-  /// C0 制御文字と DEL を `\xNN` に escape する。multi-byte UTF-8 構成バイトは保持する。
+  /// test から FileHandle を差し替えて output を verify するために切り出した本体。
+  /// production は `write(tag:_:)` 経由でのみ呼ぶ (FileHandle.standardError を渡す)。
+  ///
+  /// FileHandle parameter を最終 sink にすることで、test は `Pipe()` の write 側を
+  /// 渡して output を read back できる。`dup2(STDERR_FILENO, ...)` で global stderr を
+  /// 乗っ取ると Swift Testing の並列 runner が出す `◇ Test started` 等の stderr 出力と
+  /// 混線するため、handle injection で test isolation を担保する。
+  internal static func writeImpl(tag: String, _ message: String, to handle: FileHandle) {
+    let line = formatLine(tag: tag, message)
+    lock.lock()
+    defer { lock.unlock() }
+    handle.write(Data(line.utf8))
+  }
+
+  /// `write` が stderr に渡す string を組み立てる。`[tag] message\n` の format を
+  /// SSOT として固定し、test から output 形式を assert できるよう公開する (`internal`)。
+  ///
+  /// `write` の責務は (format) + (escape) + (lock + stderr write) の 3 つだが、
+  /// 後段は副作用なので format 部分を pure function として切り出してテスト可能にする。
+  internal static func formatLine(tag: String, _ message: String) -> String {
+    return "[\(tag)] \(escapeControl(message))\n"
+  }
+
+  /// 制御文字と行区切り Unicode を escape する。詳細は型の docstring 参照。
   /// helper 内部で完結する unit。test からも検証する。
   internal static func escapeControl(_ s: String) -> String {
     var out = ""
     out.reserveCapacity(s.unicodeScalars.count)
     for scalar in s.unicodeScalars {
       let v = scalar.value
-      if v < 0x20 || v == 0x7F {
+      if v < 0x20 || v == 0x7F || (0x80...0x9F).contains(v) {
         out.append(String(format: "\\x%02X", v))
+      } else if v == 0x2028 || v == 0x2029 {
+        out.append(String(format: "\\u%04X", v))
       } else {
         out.unicodeScalars.append(scalar)
       }
     }
     return out
   }
+
+  /// stderr write の byte-level atomicity を守るための serialization lock。
+  /// 並列 actor / `@MainActor` 経路からの write が PIPE_BUF (Darwin で 512 byte) を
+  /// 超える場合に POSIX が保証しない atomic 性を、process 内で補強する。
+  private static let lock = NSLock()
 }

--- a/apps/native/Sources/GozdCore/StderrLog.swift
+++ b/apps/native/Sources/GozdCore/StderrLog.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// 観察ログ (stderr) の SSOT helper。
+///
+/// dispatcher / store / hook ハンドラなどから 1 行の ad-hoc 観察ログを書き出す。
+/// 既存の `[handler-or-store-name] message` 規約を踏襲しつつ、call site から
+/// sanitize 判断を消すために helper 側で escape を引き受ける。
+///
+/// ## なぜ helper 集約か
+///
+/// 以前の規約は「素埋め込み + source 側 sanitize」を併記していたが、両者は両立
+/// しない (素埋め込みの見た目を保つと sanitize 関数呼びが見えなくなり、レビューで
+/// 違反を検出できない)。helper を経由させると、call site は素の string
+/// interpolation を書き、改行 / 制御文字の escape は helper の責任で必ず実行される。
+/// SSOT を「規約条文」から「実行コード」に移すことで、違反が構造的に発生しなくなる。
+///
+/// ## escape 仕様
+///
+/// C0 制御文字 (U+0000-U+001F) と DEL (U+007F) を `\xNN` 形式に escape する。
+/// multi-byte UTF-8 構成バイト (0x80-0xFF) は触らない (非英語 locale の文字列を
+/// そのまま流す)。escape 後の末尾に改行を 1 つだけ付与する。call site は改行を
+/// message に含めない。
+///
+/// ## 対象外
+///
+/// trace 系統 (`[PTY-TRACE ...]` / `[TEST-TRACE ...]`) は自前の format を持ち、
+/// 1 行性を別途保証している (`PTYTrace.swift` 参照)。本 helper は経由しない。
+public enum StderrLog {
+  /// `[tag] message` を stderr に 1 行書く。
+  ///
+  /// - Parameters:
+  ///   - tag: handler 関数名 (`handlePtySpawn`) または store / module 名 (`ClaudeSessionStore`)。
+  ///     bracket は helper が付ける。call site では中身のみ渡す。
+  ///   - message: 任意の string。制御文字は helper が escape する。call site で sanitize
+  ///     する必要は無い。
+  public static func write(tag: String, _ message: String) {
+    let line = "[\(tag)] \(escapeControl(message))\n"
+    FileHandle.standardError.write(Data(line.utf8))
+  }
+
+  /// C0 制御文字と DEL を `\xNN` に escape する。multi-byte UTF-8 構成バイトは保持する。
+  /// helper 内部で完結する unit。test からも検証する。
+  internal static func escapeControl(_ s: String) -> String {
+    var out = ""
+    out.reserveCapacity(s.unicodeScalars.count)
+    for scalar in s.unicodeScalars {
+      let v = scalar.value
+      if v < 0x20 || v == 0x7F {
+        out.append(String(format: "\\x%02X", v))
+      } else {
+        out.unicodeScalars.append(scalar)
+      }
+    }
+    return out
+  }
+}

--- a/apps/native/Sources/GozdCore/StderrLog.swift
+++ b/apps/native/Sources/GozdCore/StderrLog.swift
@@ -1,48 +1,33 @@
 import Foundation
 
-/// 観察ログ (stderr) の SSOT helper。
+/// 観察ログ (stderr) の 1 行書き出し helper。
 ///
-/// dispatcher / store / hook ハンドラなどから 1 行の ad-hoc 観察ログを書き出す。
-/// 既存の `[handler-or-store-name] message` 規約を踏襲しつつ、call site から
-/// sanitize 判断を消すために helper 側で escape を引き受ける。
+/// dispatcher / store / hook ハンドラの ad-hoc 観察ログを `[tag] message\n` の format で
+/// 出力する。format / escape / serialization を helper 側に閉じ込め、call site は素の
+/// string interpolation で値を渡す。
 ///
-/// ## なぜ helper 集約か
+/// ## format
 ///
-/// 以前の規約は「素埋め込み + source 側 sanitize」を併記していたが、両者は両立
-/// しない (素埋め込みの見た目を保つと sanitize 関数呼びが見えなくなり、レビューで
-/// 違反を検出できない)。helper を経由させると、call site は素の string
-/// interpolation を書き、改行 / 制御文字の escape は helper の責任で必ず実行される。
-/// SSOT を「規約条文」から「実行コード」に移すことで、違反が構造的に発生しなくなる。
+/// `[tag] <escaped message>\n`。bracket と末尾 `\n` は helper が付ける。
 ///
 /// ## escape 仕様
 ///
-/// 以下を `\xNN` / `\uNNNN` 形式に escape する:
+/// 観察ログの 1 行性 (grep / awk / Console.app の event 単位処理) を Unicode 表示単位
+/// でも壊さないため、以下の scalar を `\xNN` / `\uNNNN` 形式に escape する:
 ///
 /// - C0 制御文字 (U+0000-U+001F) と DEL (U+007F) → `\xNN`
-/// - C1 制御文字 (U+0080-U+009F)、NEL (U+0085 は C1 と重複) → `\xNN`
+/// - C1 制御文字 (U+0080-U+009F、NEL U+0085 を含む) → `\xNN`
 /// - LINE SEPARATOR (U+2028) / PARAGRAPH SEPARATOR (U+2029) → `\uNNNN`
 ///
-/// 通常の multi-byte UTF-8 文字 (U+00A0 以降の表示可能文字、`Ω` `日本語` 等) は
-/// 触らない (非英語 locale の strerror / path を温存する)。
+/// U+00A0 以降の通常 multi-byte UTF-8 (表示可能文字、非英語 locale の strerror / path 等)
+/// は escape しない。
 ///
-/// U+2028 / U+2029 / NEL は Unicode 上「行区切り」として定義された character で、
-/// 一部の表示系 (JavaScript console / 一部 terminal) でログ行を物理的に割る経路を
-/// 持つ。観察ログの 1 行性 (grep / awk / Console.app の event 単位処理) を Unicode
-/// 表示単位でも壊さないため escape 対象に含める。
+/// ## byte-level 1 行性
 ///
-/// ## byte-level 1 行性 (write の atomicity)
-///
-/// 観察ログ helper は複数の actor / `@MainActor` から並列発火する。POSIX `write(2)`
-/// は `PIPE_BUF` (Darwin で 512 byte) を超える書き込みの atomicity を保証しないため、
-/// 長い 1 行 (path / executable / siblings 配列の interpolation 等) が並列発火で
-/// byte 単位に混線する経路がある。`PTYTrace.swift` が同じ問題を NSLock で潰した
-/// 先例があり、本 helper も `lock` で write 全体を serialize する。call site は
-/// 同期 / 非同期どちらからでもこの API を素直に呼べばよい (lock の存在は隠蔽)。
-///
-/// ## 対象外
-///
-/// trace 系統 (`[PTY-TRACE ...]` / `[TEST-TRACE ...]`) は自前の format を持ち、
-/// 1 行性を別途保証している (`PTYTrace.swift` 参照)。本 helper は経由しない。
+/// 複数 actor / `@MainActor` 経路からの並列発火を NSLock で serialize する。POSIX
+/// `write(2)` は `PIPE_BUF` (Darwin 512 byte) 超で atomic 性を保証しないため、長い 1 行
+/// (path / executable / siblings 配列等の interpolation) が byte 単位で混線する経路を
+/// 塞ぐ。call site は同期 / 非同期どちらからでもこの API を呼べる。
 public enum StderrLog {
   /// `[tag] message` を stderr に 1 行書く。
   ///
@@ -55,13 +40,9 @@ public enum StderrLog {
     writeImpl(tag: tag, message, to: FileHandle.standardError)
   }
 
-  /// test から FileHandle を差し替えて output を verify するために切り出した本体。
-  /// production は `write(tag:_:)` 経由でのみ呼ぶ (FileHandle.standardError を渡す)。
-  ///
-  /// FileHandle parameter を最終 sink にすることで、test は `Pipe()` の write 側を
-  /// 渡して output を read back できる。`dup2(STDERR_FILENO, ...)` で global stderr を
-  /// 乗っ取ると Swift Testing の並列 runner が出す `◇ Test started` 等の stderr 出力と
-  /// 混線するため、handle injection で test isolation を担保する。
+  /// 出力先 FileHandle を inject 可能にした本体。production は `write(tag:_:)` 経由で
+  /// `FileHandle.standardError` を渡す。test は `Pipe()` の write 側を渡して
+  /// output を read back する。
   internal static func writeImpl(tag: String, _ message: String, to handle: FileHandle) {
     let line = formatLine(tag: tag, message)
     lock.lock()
@@ -69,11 +50,8 @@ public enum StderrLog {
     handle.write(Data(line.utf8))
   }
 
-  /// `write` が stderr に渡す string を組み立てる。`[tag] message\n` の format を
-  /// SSOT として固定し、test から output 形式を assert できるよう公開する (`internal`)。
-  ///
-  /// `write` の責務は (format) + (escape) + (lock + stderr write) の 3 つだが、
-  /// 後段は副作用なので format 部分を pure function として切り出してテスト可能にする。
+  /// `[tag] <escaped message>\n` を組み立てる pure function。`writeImpl` から呼ばれ、
+  /// test からも format 単体を assert できる seam。
   internal static func formatLine(tag: String, _ message: String) -> String {
     return "[\(tag)] \(escapeControl(message))\n"
   }

--- a/apps/native/Sources/GozdCore/TaskStore.swift
+++ b/apps/native/Sources/GozdCore/TaskStore.swift
@@ -227,19 +227,16 @@ public actor TaskStore {
       do {
         return try Gozd_V1_TaskList(jsonString: json)
       } catch {
-        FileHandle.standardError.write(
-          Data(
-            "[TaskStore] loadFile: parse failed at \(url.path): \(error)\n"
-              .utf8))
+        StderrLog.write(
+          tag: "TaskStore", "loadFile: parse failed at \(url.path): \(error)")
       }
     } else {
-      FileHandle.standardError.write(
-        Data("[TaskStore] loadFile: invalid UTF-8 at \(url.path)\n".utf8))
+      StderrLog.write(tag: "TaskStore", "loadFile: invalid UTF-8 at \(url.path)")
     }
     let empty = Gozd_V1_TaskList()
     try saveFile(empty, for: dir)
-    FileHandle.standardError.write(
-      Data("[TaskStore] loadFile: corrupted tasks.json reinitialized at \(url.path)\n".utf8))
+    StderrLog.write(
+      tag: "TaskStore", "loadFile: corrupted tasks.json reinitialized at \(url.path)")
     return empty
   }
 

--- a/apps/native/Tests/GozdCoreTests/StderrLogTests.swift
+++ b/apps/native/Tests/GozdCoreTests/StderrLogTests.swift
@@ -133,12 +133,12 @@ struct StderrLogWriteTests {
     #expect(captured.hasSuffix("\n"))
   }
 
-  @Test("公開 API write は writeImpl と同じ format を出力する (smoke)")
-  func publicApiCallsThrough() {
-    // 公開 API がクラッシュせず正常 return することを確認する smoke test。
-    // 出力 byte は writeImpl 経路で format-correctness を verify 済みなので、
-    // 公開 API では FileHandle.standardError への write を実行する経路だけ
-    // 通しておく (実 stderr capture は並列 runner 混線で flaky)。
-    StderrLog.write(tag: "TestSuite", "smoke message")
-  }
+  // 公開 API `write(tag:_:)` 自身の smoke test は意図的に書かない。
+  //
+  // - `write(tag:_:)` は `writeImpl(tag:_:to: .standardError)` への 1 行委譲。
+  //   format / escape / lock の振る舞いは writeImpl 経路の test で完全に固定済み
+  // - 仮に smoke で `write` を呼ぶと実 stderr に test 用 tag (e.g. `[TestSuite]`)
+  //   が必ず混じり、観察ログ運用 (`grep '\[[A-Z]'` で経路を絞る) を test runner
+  //   出力が汚染する。違反検出器の前提と齟齬が出る
+  // - 委譲 1 行が壊れる risk は型 + writeImpl の test で十分閉じている
 }

--- a/apps/native/Tests/GozdCoreTests/StderrLogTests.swift
+++ b/apps/native/Tests/GozdCoreTests/StderrLogTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+
+@testable import GozdCore
+
+@Suite("StderrLog.escapeControl")
+struct StderrLogTests {
+  @Test("ASCII printable / multi-byte UTF-8 はそのまま透過する")
+  func passesThroughPrintableAndMultiByte() {
+    #expect(StderrLog.escapeControl("hello world") == "hello world")
+    #expect(StderrLog.escapeControl("日本語テスト") == "日本語テスト")
+    #expect(StderrLog.escapeControl("path=/var/folders/_test") == "path=/var/folders/_test")
+    // 各種 punctuation は printable ASCII
+    #expect(StderrLog.escapeControl("a=[b] c=(d) e={f}") == "a=[b] c=(d) e={f}")
+  }
+
+  @Test("CR / LF / TAB / NUL を \\xNN に escape する")
+  func escapesCommonControlChars() {
+    #expect(StderrLog.escapeControl("line1\nline2") == "line1\\x0Aline2")
+    #expect(StderrLog.escapeControl("line1\rline2") == "line1\\x0Dline2")
+    #expect(StderrLog.escapeControl("col1\tcol2") == "col1\\x09col2")
+    #expect(StderrLog.escapeControl("a\u{0000}b") == "a\\x00b")
+  }
+
+  @Test("DEL (0x7F) も escape 対象")
+  func escapesDel() {
+    #expect(StderrLog.escapeControl("a\u{007F}b") == "a\\x7Fb")
+  }
+
+  @Test("BEL (0x07) 等のあまり使われない C0 も含めて escape")
+  func escapesAllC0() {
+    // BEL, BS, VT, FF, ESC を網羅。0x00-0x1F 全域を helper が見ていることを確認する。
+    #expect(StderrLog.escapeControl("\u{0007}") == "\\x07")
+    #expect(StderrLog.escapeControl("\u{0008}") == "\\x08")
+    #expect(StderrLog.escapeControl("\u{000B}") == "\\x0B")
+    #expect(StderrLog.escapeControl("\u{000C}") == "\\x0C")
+    #expect(StderrLog.escapeControl("\u{001B}") == "\\x1B")
+  }
+
+  @Test("空文字列は空文字列のまま")
+  func emptyStringPassesThrough() {
+    #expect(StderrLog.escapeControl("") == "")
+  }
+
+  @Test("call site 例: error 文字列に混入した改行を escape する")
+  func realisticErrorWithEmbeddedNewline() {
+    // call site 規約 (素 interpolation) を保ちながら、helper 経路で 1 行性が守られることを確認。
+    let raw = "decode failed: Error Domain=Foo Code=1 \"line1\nline2\""
+    let escaped = StderrLog.escapeControl(raw)
+    #expect(!escaped.contains("\n"))
+    #expect(escaped.contains("\\x0A"))
+  }
+}

--- a/apps/native/Tests/GozdCoreTests/StderrLogTests.swift
+++ b/apps/native/Tests/GozdCoreTests/StderrLogTests.swift
@@ -132,13 +132,4 @@ struct StderrLogWriteTests {
     #expect(captured.contains("\\x0A"))
     #expect(captured.hasSuffix("\n"))
   }
-
-  // 公開 API `write(tag:_:)` 自身の smoke test は意図的に書かない。
-  //
-  // - `write(tag:_:)` は `writeImpl(tag:_:to: .standardError)` への 1 行委譲。
-  //   format / escape / lock の振る舞いは writeImpl 経路の test で完全に固定済み
-  // - 仮に smoke で `write` を呼ぶと実 stderr に test 用 tag (e.g. `[TestSuite]`)
-  //   が必ず混じり、観察ログ運用 (`grep '\[[A-Z]'` で経路を絞る) を test runner
-  //   出力が汚染する。違反検出器の前提と齟齬が出る
-  // - 委譲 1 行が壊れる risk は型 + writeImpl の test で十分閉じている
 }

--- a/apps/native/Tests/GozdCoreTests/StderrLogTests.swift
+++ b/apps/native/Tests/GozdCoreTests/StderrLogTests.swift
@@ -4,7 +4,7 @@ import Testing
 @testable import GozdCore
 
 @Suite("StderrLog.escapeControl")
-struct StderrLogTests {
+struct StderrLogEscapeTests {
   @Test("ASCII printable / multi-byte UTF-8 はそのまま透過する")
   func passesThroughPrintableAndMultiByte() {
     #expect(StderrLog.escapeControl("hello world") == "hello world")
@@ -12,6 +12,8 @@ struct StderrLogTests {
     #expect(StderrLog.escapeControl("path=/var/folders/_test") == "path=/var/folders/_test")
     // 各種 punctuation は printable ASCII
     #expect(StderrLog.escapeControl("a=[b] c=(d) e={f}") == "a=[b] c=(d) e={f}")
+    // U+00A0 以降の通常 multi-byte (¿ Ω) は escape しない
+    #expect(StderrLog.escapeControl("¿Ω") == "¿Ω")
   }
 
   @Test("CR / LF / TAB / NUL を \\xNN に escape する")
@@ -37,6 +39,23 @@ struct StderrLogTests {
     #expect(StderrLog.escapeControl("\u{001B}") == "\\x1B")
   }
 
+  @Test("C1 制御文字 (NEL を含む) も escape する")
+  func escapesC1ControlChars() {
+    // NEL (U+0085) は一部 terminal で行区切りに解釈されるため escape
+    #expect(StderrLog.escapeControl("a\u{0085}b") == "a\\x85b")
+    // C1 全域 (U+0080-U+009F) を escape する
+    #expect(StderrLog.escapeControl("\u{0080}") == "\\x80")
+    #expect(StderrLog.escapeControl("\u{009F}") == "\\x9F")
+  }
+
+  @Test("Unicode line/paragraph separator を \\uNNNN に escape する")
+  func escapesUnicodeLineSeparators() {
+    // U+2028 / U+2029 は Unicode 行区切り。JavaScript console や一部 terminal で
+    // 物理的に行を割る経路があるため escape して観察ログの 1 行性を守る。
+    #expect(StderrLog.escapeControl("a\u{2028}b") == "a\\u2028b")
+    #expect(StderrLog.escapeControl("a\u{2029}b") == "a\\u2029b")
+  }
+
   @Test("空文字列は空文字列のまま")
   func emptyStringPassesThrough() {
     #expect(StderrLog.escapeControl("") == "")
@@ -49,5 +68,77 @@ struct StderrLogTests {
     let escaped = StderrLog.escapeControl(raw)
     #expect(!escaped.contains("\n"))
     #expect(escaped.contains("\\x0A"))
+  }
+}
+
+@Suite("StderrLog.formatLine")
+struct StderrLogFormatTests {
+  @Test("format は [tag] message\\n で固定する")
+  func basicFormat() {
+    #expect(StderrLog.formatLine(tag: "handlePtySpawn", "pty.spawn failed") == "[handlePtySpawn] pty.spawn failed\n")
+  }
+
+  @Test("format は escape 適用後の message を埋め込む")
+  func formatAppliesEscape() {
+    let line = StderrLog.formatLine(tag: "TaskStore", "loadFile failed: line1\nline2")
+    #expect(line == "[TaskStore] loadFile failed: line1\\x0Aline2\n")
+    // format 終端の \n は 1 個のみ (escape された \x0A の "n" 文字と区別できることの確認)
+    #expect(line.filter { $0 == "\n" }.count == 1)
+    #expect(line.hasSuffix("\n"))
+  }
+
+  @Test("空 message でも tag と改行は残る")
+  func emptyMessage() {
+    #expect(StderrLog.formatLine(tag: "GozdApp", "") == "[GozdApp] \n")
+  }
+
+  @Test("multi-byte UTF-8 を含む message も format に通せる")
+  func multiByteMessage() {
+    #expect(StderrLog.formatLine(tag: "GitOps", "rev-parse 失敗: \(1)") == "[GitOps] rev-parse 失敗: 1\n")
+  }
+}
+
+@Suite("StderrLog.writeImpl (handle injection)")
+struct StderrLogWriteTests {
+  /// `Pipe` の write 側を `writeImpl` に渡し、read 側から output を取り出す。
+  /// `dup2(STDERR_FILENO, ...)` で global stderr を乗っ取る方式だと、Swift Testing の
+  /// 並列 runner が出す `◇ Test started` 等の stderr 出力と混線して test が flaky に
+  /// なるため、handle injection で test isolation を担保する。
+  private func captureWrite(_ action: (FileHandle) -> Void) -> String {
+    let pipe = Pipe()
+    action(pipe.fileHandleForWriting)
+    pipe.fileHandleForWriting.closeFile()
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    pipe.fileHandleForReading.closeFile()
+    return String(decoding: data, as: UTF8.self)
+  }
+
+  @Test("writeImpl は formatLine の出力を渡された handle に書く")
+  func writeMatchesFormatLine() {
+    let captured = captureWrite { handle in
+      StderrLog.writeImpl(tag: "handlePtySpawn", "pty.spawn failed: code=1", to: handle)
+    }
+    #expect(captured == StderrLog.formatLine(tag: "handlePtySpawn", "pty.spawn failed: code=1"))
+    #expect(captured == "[handlePtySpawn] pty.spawn failed: code=1\n")
+  }
+
+  @Test("writeImpl は埋め込まれた改行を escape して 1 行で出す")
+  func writeEscapesEmbeddedNewline() {
+    let captured = captureWrite { handle in
+      StderrLog.writeImpl(tag: "TaskStore", "raw \"a\nb\"", to: handle)
+    }
+    // 出力末尾の format 改行 1 個のみ。embedded \n は \x0A に escape される。
+    #expect(captured.filter { $0 == "\n" }.count == 1)
+    #expect(captured.contains("\\x0A"))
+    #expect(captured.hasSuffix("\n"))
+  }
+
+  @Test("公開 API write は writeImpl と同じ format を出力する (smoke)")
+  func publicApiCallsThrough() {
+    // 公開 API がクラッシュせず正常 return することを確認する smoke test。
+    // 出力 byte は writeImpl 経路で format-correctness を verify 済みなので、
+    // 公開 API では FileHandle.standardError への write を実行する経路だけ
+    // 通しておく (実 stderr capture は並列 runner 混線で flaky)。
+    StderrLog.write(tag: "TestSuite", "smoke message")
   }
 }

--- a/apps/native/scripts/check-stderr-direct.sh
+++ b/apps/native/scripts/check-stderr-direct.sh
@@ -15,6 +15,13 @@
 
 set -euo pipefail
 
+# cwd に依存せず repo root を script の場所から解決する。lefthook 経由でも、
+# manual に subdir / temp dir から呼ばれても同じ Sources を見るようにする
+# (cwd 依存だと find が空 list を返して silent pass する事故源になる)。
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+SOURCES_ROOT="$REPO_ROOT/apps/native/Sources"
+
 ALLOWED_PATTERN='apps/native/Sources/(GozdCore/(StderrLog|PTYTrace)\.swift|GozdCLI/)'
 PATTERN='FileHandle\.standardError\.write'
 
@@ -55,9 +62,13 @@ if [ "$#" -gt 0 ]; then
     check_file "$file"
   done
 else
+  if [ ! -d "$SOURCES_ROOT" ]; then
+    printf '\033[31m✘ Sources root not found: %s\033[0m\n' "$SOURCES_ROOT" >&2
+    exit 2
+  fi
   while IFS= read -r file; do
     check_file "$file"
-  done < <(find apps/native/Sources -name '*.swift')
+  done < <(find "$SOURCES_ROOT" -name '*.swift')
 fi
 
 exit "$found_violation"

--- a/apps/native/scripts/check-stderr-direct.sh
+++ b/apps/native/scripts/check-stderr-direct.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# 観察ログ regulation (CLAUDE.md「観察ログ (stderr) の書式」) を構造的に強制する check。
+#
+# `FileHandle.standardError.write` の直接呼び出しは以下の許可リスト外で禁止:
+#   - apps/native/Sources/GozdCore/StderrLog.swift  (helper 本体)
+#   - apps/native/Sources/GozdCore/PTYTrace.swift   (trace 系統、独自 lock 経路)
+#   - apps/native/Sources/GozdCLI/                  (user-facing CLI error 出力、CLAUDE.md 対象外宣言)
+#
+# 規約を「helper 経由を SSOT」と宣言した代わりに、grep ベースで違反を CI で reject
+# する側の柱を立てる。issue ( #614 ) の「違反を構造的に検出できない」を構造で防ぐ。
+#
+# 使い方:
+#   - lefthook pre-commit: staged Swift ファイル群を引数で受け取る
+#   - CI / 手動: 引数なしで全件検査
+
+set -euo pipefail
+
+ALLOWED_PATTERN='apps/native/Sources/(GozdCore/(StderrLog|PTYTrace)\.swift|GozdCLI/)'
+PATTERN='FileHandle\.standardError\.write'
+
+found_violation=0
+
+check_file() {
+  local file="$1"
+  # 許可リストはスキップ
+  if [[ "$file" =~ $ALLOWED_PATTERN ]]; then
+    return
+  fi
+  # Swift ソースのみ対象
+  case "$file" in
+    *.swift) ;;
+    *) return ;;
+  esac
+  if [ ! -f "$file" ]; then
+    return
+  fi
+  # コメント行 (`// ` 始まり) を除外して検査する
+  if grep -nE "^[[:space:]]*[^/]*${PATTERN}" "$file" > /dev/null 2>&1; then
+    if [ "$found_violation" -eq 0 ]; then
+      printf '\033[31m✘ stderr 観察ログ regulation 違反:\033[0m\n'
+      printf '  `FileHandle.standardError.write` の直接呼び出しは禁止。\n'
+      printf '  `GozdCore.StderrLog.write(tag:_:)` 経由に書き換えてください。\n'
+      printf '  詳細は CLAUDE.md「観察ログ (stderr) の書式」を参照。\n\n'
+      found_violation=1
+    fi
+    grep -nE "^[[:space:]]*[^/]*${PATTERN}" "$file" | while IFS= read -r line; do
+      printf '  %s:%s\n' "$file" "$line"
+    done
+    # while サブシェル内では found_violation の伝播が壊れるため file 検知で立てておく
+  fi
+}
+
+if [ "$#" -gt 0 ]; then
+  for file in "$@"; do
+    check_file "$file"
+  done
+else
+  while IFS= read -r file; do
+    check_file "$file"
+  done < <(find apps/native/Sources -name '*.swift')
+fi
+
+exit "$found_violation"

--- a/apps/native/scripts/check-stderr-direct.sh
+++ b/apps/native/scripts/check-stderr-direct.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
-# 観察ログ regulation (CLAUDE.md「観察ログ (stderr) の書式」) を構造的に強制する check。
-#
-# `FileHandle.standardError.write` の直接呼び出しは以下の許可リスト外で禁止:
+# `FileHandle.standardError.write` の直接呼び出しを許可リスト外で reject する。
+# 許可リスト:
 #   - apps/native/Sources/GozdCore/StderrLog.swift  (helper 本体)
 #   - apps/native/Sources/GozdCore/PTYTrace.swift   (trace 系統、独自 lock 経路)
-#   - apps/native/Sources/GozdCLI/                  (user-facing CLI error 出力、CLAUDE.md 対象外宣言)
+#   - apps/native/Sources/GozdCLI/                  (user-facing CLI error 出力)
 #
-# 規約を「helper 経由を SSOT」と宣言した代わりに、grep ベースで違反を CI で reject
-# する側の柱を立てる。issue ( #614 ) の「違反を構造的に検出できない」を構造で防ぐ。
+# 観察ログ書式の SSOT は `GozdCore.StderrLog.write(tag:_:)`。CLAUDE.md「観察ログ
+# (stderr) の書式」を参照。
 #
 # 使い方:
 #   - lefthook pre-commit: staged Swift ファイル群を引数で受け取る
@@ -15,9 +14,7 @@
 
 set -euo pipefail
 
-# cwd に依存せず repo root を script の場所から解決する。lefthook 経由でも、
-# manual に subdir / temp dir から呼ばれても同じ Sources を見るようにする
-# (cwd 依存だと find が空 list を返して silent pass する事故源になる)。
+# script location から repo root を解決し cwd に依存させない。
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 SOURCES_ROOT="$REPO_ROOT/apps/native/Sources"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -86,6 +86,13 @@ pre-commit:
       run: pnpm knip --fix --format
       stage_fixed: true
 
+    # 観察ログ regulation を構造的に強制する。`FileHandle.standardError.write` の
+    # 直接呼び出しを `StderrLog.write` 経由に絞り、grep ベースで違反を CI で reject する。
+    # 詳細は CLAUDE.md「観察ログ (stderr) の書式」を参照。
+    - name: check-stderr-direct
+      glob: "apps/native/Sources/**/*.swift"
+      run: bash apps/native/scripts/check-stderr-direct.sh {staged_files}
+
 # git pull / merge 後に lockfile の変更を検出し、pnpm install を促す
 post-merge:
   jobs:


### PR DESCRIPTION
## 概要

`FileHandle.standardError.write` を直接呼ぶ ad-hoc な観察ログを `GozdCore.StderrLog.write(tag:_:)` helper 経由に統一する。CLAUDE.md「観察ログ (stderr) の書式」の規約を「素埋め込み + source 側 sanitize」併記から「helper 経由を SSOT」に書き換える。さらに pre-commit hook (`apps/native/scripts/check-stderr-direct.sh`) で `FileHandle.standardError.write` の直接呼び出しを許可リスト外で reject する側の柱を立てる。

## 背景

issue ( #614 ) の指摘:

- 現規約は (a)「素埋め込み」と (c)「source 側 sanitize」を同居させていたが、両者は両立しない（素埋め込みの見た目を保つと sanitize 呼びが書けず、レビューで違反を検出できない）
- 規約宣言時点で既に多数の call site が source-side sanitize していなかった
- 違反顕在化は CodeRabbit の `VoicevoxOps` 改行混入指摘まで気付かれなかった（規約に「違反を検出できる構造」が無かった）

SSOT を「規約条文に書く」のではなく「実行コードで担保する」方向に再設計する。helper に sanitize と format を集約し、call site は素の string interpolation を書けばよく、改行 / 制御文字の混入は構造的に防がれる。加えて helper を経由しない新規違反を pre-commit lint で reject する 2 本柱構成にする。

## 変更内容

### `StderrLog` helper の追加

`apps/native/Sources/GozdCore/StderrLog.swift`:

- `StderrLog.write(tag:_:)` で `[tag] message\n` を出力する
- `[tag]` の bracket は helper が付与し、call site では tag 中身のみ渡す
- 制御文字 / 行区切り Unicode の escape:
  - C0 制御文字 (U+0000-U+001F) と DEL (U+007F) → `\xNN`
  - C1 制御文字 (U+0080-U+009F、NEL を含む) → `\xNN`
  - LINE SEPARATOR (U+2028) / PARAGRAPH SEPARATOR (U+2029) → `\uNNNN`
- 通常 multi-byte UTF-8 (U+00A0 以降の表示可能文字) は escape しない（非英語 locale の strerror / path を温存）
- `NSLock` で write 全体を serialize し、複数 actor / `@MainActor` 経路からの並列発火で POSIX `write(2)` の PIPE_BUF (Darwin 512 byte) 超 atomicity 崩れを防ぐ。PTYTrace と同契約
- `writeImpl(tag:_:to:)` を internal で切り出し、`FileHandle` を inject 可能化。test は `Pipe` 経由で format-correctness を assert

`apps/native/Tests/GozdCoreTests/StderrLogTests.swift`:

- `escapeControl` test (C0 / DEL / C1 / U+2028 / U+2029 / multi-byte 透過 / 空文字列)
- `formatLine` test (bracket / space / 末尾改行 1 個 / multi-byte message)
- `writeImpl` test (handle injection 経由で stderr write を read back)

### 既存 call site の helper 経路化

直接 `FileHandle.standardError.write` 呼びを `StderrLog.write` に置換 (合計 43 箇所):

- `RpcDispatcher.swift` (18 箇所)
- `GozdApp.swift` (9 箇所): `[ClaudeHooks]` / `[SocketServer]` (decode / start / listening) / `[GozdApp]` (push dropped / push failed / page.load × 3)
- `GitOps.swift` (4 箇所)
- `ClaudeSessionStore.swift` (3 箇所)
- `TaskStore.swift` (3 箇所)
- `ExternalLinkNavigationDecider.swift` (3 箇所、`GozdCore` import 追加)
- `FSWatchRegistry.swift` (2 箇所)
- `PTYRegistry.swift` (1 箇所)

加えて `print("[SocketServer] listening on ...")` と `print("page.load (...) failed: ...")` 4 件も `StderrLog.write` に揃えた。CLAUDE.md 「対象外」節は print/NSLog 経由を「使わない方針」と明示宣言しているため、隣接行で観察 prefix を持つログが stdout / stderr に分散する状態を温存しない。

### 違反検出 lint の追加

`apps/native/scripts/check-stderr-direct.sh`:

- `FileHandle.standardError.write` の直接呼び出しを許可リスト (`StderrLog.swift` / `PTYTrace.swift` / `GozdCLI/`) 外で reject
- script location 起点で repo root を解決するため cwd に依存しない
- `SOURCES_ROOT` 不在時は `exit=2` で明示 fail（silent drop 禁止規律と整合）
- bash 3.2 portable（`mapfile` を使わず `while IFS= read -r ... done < <(find ...)`）

`lefthook.yml` pre-commit に `check-stderr-direct` ジョブを登録。`glob: "apps/native/Sources/**/*.swift"` で staged Swift ファイルのみ検査する。

### CLAUDE.md の規約再設計

「観察ログ (stderr) の書式」セクションを書き換え:

- 旧 (a)「素埋め込み」/ (c)「source 側 sanitize」/ (d)「1 箇所だけの装飾変更禁止」を削除
- 「helper 経由を SSOT として宣言」「なぜ helper 集約か (lint と 2 本柱)」「`errnoText` の制御文字 gate との関係」「対象外」の 4 節に再構成
- 「対象外」に `GozdCLI/main.swift` の user-facing error 出力 を明示追加（`[tag]` prefix を持たないため別系統）

### `errnoText` gate の扱い

`PTYError.errnoText` (`PTYManager.swift`) の制御文字 gate は残す。errnoText は stderr 経由だけでなく `PTYError.description` 経由で `RpcSchemeHandler` の 500 response body にも乗るため、helper escape では renderer に届く identifier 品質を担保できない。CLAUDE.md にこの分担を明示する節を追加。

## 関連

- issue ( #614 ): 規約の設計欠陥を指摘した issue
- PR ( #597 ): 旧規約を codify した PR

## 確認事項

- [ ] `swift test` 全 256 テスト通過 (`StderrLog` の 14 テスト含む)
- [ ] `pnpm typecheck:all` / `pnpm lint:all` 通過
- [ ] `bash apps/native/scripts/check-stderr-direct.sh` が exit=0
- [ ] 違反 Swift ファイルを置いた場合 exit=1 で reject (別 cwd から呼んでも anchor が効く)
- [ ] `[tag]` prefix 形式が既存と一致し Console.app / grep の経路特定が壊れない
