### PR TITLE
fix(voicevox): spawn engine binary directly to keep gozd frontmost

### DIFF
--- a/apps/native/Sources/GozdCore/VoicevoxOps.swift
+++ b/apps/native/Sources/GozdCore/VoicevoxOps.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 
 // VOICEVOX エンジン（HTTP localhost:50021）への薄いラッパー。
@@ -7,7 +8,13 @@ import Foundation
 // 1. **HTTP は URLSession で叩く**。エンジン本体（VOICEVOX.app）は別インストール、
 //    gozd は接続するだけ。
 //
-// 2. **launch は `open -a VOICEVOX`** に投げる（ユーザーが手動で起動済みでも no-op）。
+// 2. **launch は VOICEVOX.app 同梱の engine バイナリ `vv-engine/run` を直接 spawn する**。
+//    `open -a VOICEVOX` だと GUI 全体が起動して gozd の前面を奪う (VOICEVOX 自身が
+//    `BrowserWindow.show()` を呼ぶため `open -g` でも抑制不能)。VOICEVOX/voicevox_engine
+//    は独立 repo として headless 利用を正規ルートで提供しており、`.app` 同梱の
+//    `vv-engine/run` はその engine 本体。これを直接起動するのが公式想定に沿う。
+//    インストールパス解決は `NSWorkspace.shared.urlForApplication(withBundleIdentifier:)`
+//    で `jp.hiroshiba.voicevox` を引く (ハードコード `/Applications` 依存を避ける)。
 //
 // 3. **再生は呼び出し側（renderer）の責務**。speak は wav バイト列のみ返す。
 //    renderer の HTML Audio API で再生・停止制御する。
@@ -85,23 +92,37 @@ public enum VoicevoxOps {
     }
   }
 
+  /// VOICEVOX.app の bundle ID。`NSWorkspace` の Launch Services 経由で .app を解決する
+  static let bundleId = "jp.hiroshiba.voicevox"
+
+  /// .app 配下の engine binary までの相対パス
+  static let engineRelativePath = "Contents/Resources/vv-engine/run"
+
   public static func launch() async -> Bool {
+    let appUrl = await MainActor.run {
+      NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId)
+    }
+    guard let appUrl else {
+      StderrLog.write(tag: "VoicevoxOps.launch", "VOICEVOX.app not found (bundleId=\(bundleId))")
+      return false
+    }
+    let engineUrl = appUrl.appendingPathComponent(engineRelativePath)
+    guard FileManager.default.isExecutableFile(atPath: engineUrl.path) else {
+      StderrLog.write(
+        tag: "VoicevoxOps.launch", "engine binary not executable at \(engineUrl.path)")
+      return false
+    }
     let process = Process()
-    process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-    process.arguments = ["-a", "VOICEVOX"]
-    process.environment = ProcessInfo.processInfo.environment
+    process.executableURL = engineUrl
+    // engine は HTTP サーバとして常駐するので stdout/stderr は捨てて pipe 詰まりを避ける
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
     do {
       try process.run()
-      process.waitUntilExit()
-      if process.terminationStatus != 0 {
-        StderrLog.write(
-          tag: "VoicevoxOps.launch",
-          "open -a VOICEVOX exited with status \(process.terminationStatus)"
-        )
-      }
-      return process.terminationStatus == 0
+      // detach: waitUntilExit は呼ばない。engine は親 (gozd) より長生きしてよい
+      return true
     } catch {
-      StderrLog.write(tag: "VoicevoxOps.launch", "failed to spawn open: \(error)")
+      StderrLog.write(tag: "VoicevoxOps.launch", "failed to spawn engine: \(error)")
       return false
     }
   }

--- a/apps/native/Sources/GozdCore/VoicevoxOps.swift
+++ b/apps/native/Sources/GozdCore/VoicevoxOps.swift
@@ -156,8 +156,13 @@ public enum VoicevoxOps {
       return true
     }
     guard canSpawn else {
+      // skip 時の true は「engine listen 済み」ではなく「別 caller が spawn 中なので
+      // 後続は polling で listen を待つ責任」を意味する。caller (renderer の doActivate)
+      // は launch ok=true の後に waitForEngine を回す前提なので、この戻り値で問題ない
       StderrLog.write(
-        tag: "VoicevoxOps.launch", "concurrent spawn in-flight; skipping")
+        tag: "VoicevoxOps.launch",
+        "concurrent spawn in-flight; skipping (caller must poll /version)"
+      )
       return true
     }
 

--- a/apps/native/Sources/GozdCore/VoicevoxOps.swift
+++ b/apps/native/Sources/GozdCore/VoicevoxOps.swift
@@ -134,15 +134,35 @@ public enum VoicevoxOps {
     // Pipe を介さないため pipe 詰まりも構造的に起きない
     process.terminationHandler = { proc in
       // spawn 直後に即死した場合、起動成功扱いで return した後 renderer 側は 10 秒の
-      // waitForEngine タイムアウトを踏む。stderr に痕跡を残して原因切り分けを可能にする
+      // waitForEngine タイムアウトを踏む。stderr に痕跡を残して原因切り分けを可能にする。
+      // 「死んだ engine 参照」を残さないよう、自分が現在の保持対象なら nil に戻す
+      spawnedEngine.withLock { holder in
+        if holder === proc { holder = nil }
+      }
       StderrLog.write(
         tag: "VoicevoxOps.engine",
         "exited pid=\(proc.processIdentifier) status=\(proc.terminationStatus) reason=\(proc.terminationReason.rawValue)"
       )
     }
+
+    // race protection: checkEngine と run() の間に開く async 窓を、spawnedEngine 占有で塞ぐ。
+    // 既に spawn 済みかつ生存している process があれば自分は走らせず true で抜ける。
+    // 並行 launch() のうち先に lock を取った方だけが run() に進む
+    let canSpawn = spawnedEngine.withLock { holder -> Bool in
+      if let existing = holder, existing.isRunning {
+        return false
+      }
+      holder = process
+      return true
+    }
+    guard canSpawn else {
+      StderrLog.write(
+        tag: "VoicevoxOps.launch", "concurrent spawn in-flight; skipping")
+      return true
+    }
+
     do {
       try process.run()
-      spawnedEngine.withLock { $0 = process }
       StderrLog.write(
         tag: "VoicevoxOps.launch",
         "spawned engine pid=\(process.processIdentifier) at \(engineUrl.path)"
@@ -150,6 +170,11 @@ public enum VoicevoxOps {
       // detach: waitUntilExit は呼ばない。engine は親 (gozd) より長生きしてよい
       return true
     } catch {
+      // run() が throw した場合は予約した slot を戻す。terminationHandler は run() 失敗時に
+      // 呼ばれないため、ここで明示的に nil に戻す必要がある
+      spawnedEngine.withLock { holder in
+        if holder === process { holder = nil }
+      }
       StderrLog.write(tag: "VoicevoxOps.launch", "failed to spawn engine: \(error)")
       return false
     }

--- a/apps/native/Sources/GozdCore/VoicevoxOps.swift
+++ b/apps/native/Sources/GozdCore/VoicevoxOps.swift
@@ -120,12 +120,12 @@ public enum VoicevoxOps {
     // symlink / mount alias を経由する場合に備えて実体パスへ解決
     let resolvedAppUrl = appUrl.resolvingSymlinksInPath()
     // slash 区切りの 1 本文字列を appendingPathComponent に渡すと挙動が macOS version 依存。
-    // segment 単位で連鎖させる (Apple Foundation 推奨)
-    let engineUrl = resolvedAppUrl
-      .appendingPathComponent("Contents")
-      .appendingPathComponent("Resources")
-      .appendingPathComponent("vv-engine")
-      .appendingPathComponent("run")
+    // segment 単位で連鎖させる (Apple Foundation 推奨)。
+    // VOICEVOX.app 内部レイアウトの SSOT として segment 配列を持ち、append を reduce で展開
+    let engineSegments = ["Contents", "Resources", "vv-engine", "run"]
+    let engineUrl = engineSegments.reduce(resolvedAppUrl) {
+      $0.appendingPathComponent($1)
+    }
     guard FileManager.default.isExecutableFile(atPath: engineUrl.path) else {
       StderrLog.write(
         tag: "VoicevoxOps.launch", "engine binary not executable at \(engineUrl.path)")

--- a/apps/native/Sources/GozdCore/VoicevoxOps.swift
+++ b/apps/native/Sources/GozdCore/VoicevoxOps.swift
@@ -109,7 +109,6 @@ public enum VoicevoxOps {
     }
 
     let bundleId = "jp.hiroshiba.voicevox"
-    let engineRelativePath = "Contents/Resources/vv-engine/run"
 
     let appUrl = await MainActor.run {
       NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId)
@@ -120,7 +119,13 @@ public enum VoicevoxOps {
     }
     // symlink / mount alias を経由する場合に備えて実体パスへ解決
     let resolvedAppUrl = appUrl.resolvingSymlinksInPath()
-    let engineUrl = resolvedAppUrl.appendingPathComponent(engineRelativePath)
+    // slash 区切りの 1 本文字列を appendingPathComponent に渡すと挙動が macOS version 依存。
+    // segment 単位で連鎖させる (Apple Foundation 推奨)
+    let engineUrl = resolvedAppUrl
+      .appendingPathComponent("Contents")
+      .appendingPathComponent("Resources")
+      .appendingPathComponent("vv-engine")
+      .appendingPathComponent("run")
     guard FileManager.default.isExecutableFile(atPath: engineUrl.path) else {
       StderrLog.write(
         tag: "VoicevoxOps.launch", "engine binary not executable at \(engineUrl.path)")

--- a/apps/native/Sources/GozdCore/VoicevoxOps.swift
+++ b/apps/native/Sources/GozdCore/VoicevoxOps.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import os
 
 // VOICEVOX エンジン（HTTP localhost:50021）への薄いラッパー。
 //
@@ -9,12 +10,14 @@ import Foundation
 //    gozd は接続するだけ。
 //
 // 2. **launch は VOICEVOX.app 同梱の engine バイナリ `vv-engine/run` を直接 spawn する**。
-//    `open -a VOICEVOX` だと GUI 全体が起動して gozd の前面を奪う (VOICEVOX 自身が
-//    `BrowserWindow.show()` を呼ぶため `open -g` でも抑制不能)。VOICEVOX/voicevox_engine
-//    は独立 repo として headless 利用を正規ルートで提供しており、`.app` 同梱の
-//    `vv-engine/run` はその engine 本体。これを直接起動するのが公式想定に沿う。
-//    インストールパス解決は `NSWorkspace.shared.urlForApplication(withBundleIdentifier:)`
-//    で `jp.hiroshiba.voicevox` を引く (ハードコード `/Applications` 依存を避ける)。
+//    VOICEVOX/voicevox_engine は GUI repo と独立した別 repo として headless 利用を正規
+//    ルートで提供しており、`.app` 同梱の `vv-engine/run` はその engine 本体。GUI 経由
+//    を介さずこれを直接起動するのが公式設計に沿う。インストールパスは Launch Services
+//    (`NSWorkspace.shared.urlForApplication(withBundleIdentifier:)`) で `jp.hiroshiba.voicevox`
+//    から解決し、`/Applications` 配下に限らず `~/Applications` や別ボリュームインストール
+//    にも追従する。stdout / stderr は親 (gozd) を継承させ、engine の起動失敗ログを観察可能
+//    に保つ。spawn 後は `spawnedEngine` で `Process` を保持し、`terminationHandler` で
+//    即死を stderr に通知できるようにする。
 //
 // 3. **再生は呼び出し側（renderer）の責務**。speak は wav バイト列のみ返す。
 //    renderer の HTML Audio API で再生・停止制御する。
@@ -92,13 +95,22 @@ public enum VoicevoxOps {
     }
   }
 
-  /// VOICEVOX.app の bundle ID。`NSWorkspace` の Launch Services 経由で .app を解決する
-  static let bundleId = "jp.hiroshiba.voicevox"
-
-  /// .app 配下の engine binary までの相対パス
-  static let engineRelativePath = "Contents/Resources/vv-engine/run"
+  /// spawn した engine プロセスを保持して `terminationHandler` 経路を有効に保つ。
+  /// Process が ARC で deinit すると child 監視 channel が閉じるため、参照を残す必要がある。
+  /// `ProcessExec.runProcessCollectingOutput` と同じく `OSAllocatedUnfairLock<Process?>` で
+  /// 非 Sendable な Process 参照を actor 越しに安全に保持する。
+  private static let spawnedEngine = OSAllocatedUnfairLock<Process?>(initialState: nil)
 
   public static func launch() async -> Bool {
+    // 既に engine が応答していれば spawn しない (renderer 側の checkEngine と二重 guard。
+    // renderer→native RPC の往復で開く race 窓を縮める)
+    if await checkEngine() {
+      return true
+    }
+
+    let bundleId = "jp.hiroshiba.voicevox"
+    let engineRelativePath = "Contents/Resources/vv-engine/run"
+
     let appUrl = await MainActor.run {
       NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleId)
     }
@@ -106,19 +118,35 @@ public enum VoicevoxOps {
       StderrLog.write(tag: "VoicevoxOps.launch", "VOICEVOX.app not found (bundleId=\(bundleId))")
       return false
     }
-    let engineUrl = appUrl.appendingPathComponent(engineRelativePath)
+    // symlink / mount alias を経由する場合に備えて実体パスへ解決
+    let resolvedAppUrl = appUrl.resolvingSymlinksInPath()
+    let engineUrl = resolvedAppUrl.appendingPathComponent(engineRelativePath)
     guard FileManager.default.isExecutableFile(atPath: engineUrl.path) else {
       StderrLog.write(
         tag: "VoicevoxOps.launch", "engine binary not executable at \(engineUrl.path)")
       return false
     }
+
     let process = Process()
     process.executableURL = engineUrl
-    // engine は HTTP サーバとして常駐するので stdout/stderr は捨てて pipe 詰まりを避ける
-    process.standardOutput = FileHandle.nullDevice
-    process.standardError = FileHandle.nullDevice
+    // stdout / stderr は親 (gozd) を継承させる。engine がモデルロード失敗 / dyld 解決失敗等
+    // で起動できないケースのログを gozd の stderr に流して観察可能性を保つ。継承経路なら
+    // Pipe を介さないため pipe 詰まりも構造的に起きない
+    process.terminationHandler = { proc in
+      // spawn 直後に即死した場合、起動成功扱いで return した後 renderer 側は 10 秒の
+      // waitForEngine タイムアウトを踏む。stderr に痕跡を残して原因切り分けを可能にする
+      StderrLog.write(
+        tag: "VoicevoxOps.engine",
+        "exited pid=\(proc.processIdentifier) status=\(proc.terminationStatus) reason=\(proc.terminationReason.rawValue)"
+      )
+    }
     do {
       try process.run()
+      spawnedEngine.withLock { $0 = process }
+      StderrLog.write(
+        tag: "VoicevoxOps.launch",
+        "spawned engine pid=\(process.processIdentifier) at \(engineUrl.path)"
+      )
       // detach: waitUntilExit は呼ばない。engine は親 (gozd) より長生きしてよい
       return true
     } catch {

--- a/apps/renderer/src/features/settings/SettingsModal.vue
+++ b/apps/renderer/src/features/settings/SettingsModal.vue
@@ -90,9 +90,9 @@ function handleGlobalChange(key: string, value: unknown) {
   // VOICEVOX store との同期（store の watch が configSave を発火）
   if (key === "voicevox.enabled") {
     if (value) {
-      void voicevoxStore.activate().then((errorMessage) => {
-        if (errorMessage !== undefined) {
-          // activate 失敗時はトグルを戻す
+      void voicevoxStore.activate().then((ok) => {
+        if (!ok) {
+          // activate 失敗時はトグルを戻す (notify.error は store 側で発火済み)
           globalValues.value[key] = false;
         }
       });

--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -315,7 +315,7 @@ const activeRootWorktree = computed(() => {
     <ProjectConfigPanel v-if="activeRootWorktree" />
 
     <!-- VOICEVOX -->
-    <VoicevoxPanel @error="notify.error" />
+    <VoicevoxPanel />
   </div>
 </template>
 

--- a/apps/renderer/src/features/sidebar/VoicevoxPanel.vue
+++ b/apps/renderer/src/features/sidebar/VoicevoxPanel.vue
@@ -8,17 +8,6 @@
 import { useVoicevoxStore, VoicevoxSpeakerSelect } from "../voicevox";
 
 const voicevoxStore = useVoicevoxStore();
-
-const emit = defineEmits<{
-  error: [message: string];
-}>();
-
-async function handleActivate() {
-  const errorMessage = await voicevoxStore.activate();
-  if (errorMessage) {
-    emit("error", errorMessage);
-  }
-}
 </script>
 
 <template>
@@ -77,7 +66,7 @@ async function handleActivate() {
       <button
         class="flex w-full items-center justify-center gap-2 text-xs text-zinc-500 hover:text-zinc-300"
         :disabled="voicevoxStore.activating"
-        @click="handleActivate"
+        @click="voicevoxStore.activate()"
       >
         <span
           class="size-4 shrink-0"

--- a/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
+++ b/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
@@ -226,12 +226,12 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
 
   /**
    * VOICEVOX を有効化する。
-   * Engine が起動していなければアプリの起動を試み、
-   * 未インストールなら失敗メッセージを返す。
-   * @returns 失敗時のメッセージ。成功時は undefined
+   * Engine が起動していなければアプリの起動を試み、失敗時は store 内で notify.error を発火する
+   * (呼び出し側で表示責務を持たないように SSOT を store に集約する)。
+   * @returns 成功なら true、失敗 (未インストール / 起動タイムアウト 等) なら false
    */
-  async function activate(): Promise<string | undefined> {
-    if (activating.value) return undefined;
+  async function activate(): Promise<boolean> {
+    if (activating.value) return enabled.value;
     activating.value = true;
 
     // Engine が既に起動しているかチェック
@@ -239,7 +239,7 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
       enabled.value = true;
       void loadSpeakers();
       activating.value = false;
-      return undefined;
+      return true;
     }
 
     // アプリの起動を試みる
@@ -249,7 +249,10 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
       // launch 失敗は (a) VOICEVOX 未インストール / (b) engine binary 欠落 / (c) spawn syscall 失敗
       // の 3 種。詳細は native の stderr (VoicevoxOps.launch tag) に出る。
       // 最頻ケースは (a) なのでインストール導線を残しつつ、原因を断定しない文言にする
-      return "VOICEVOX engine could not start.\nIf VOICEVOX isn't installed, download it from https://voicevox.hiroshiba.jp/";
+      notify.error(
+        "VOICEVOX engine could not start.\nIf VOICEVOX isn't installed, download it from https://voicevox.hiroshiba.jp/",
+      );
+      return false;
     }
 
     // Engine の起動を待つ
@@ -257,11 +260,12 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
       enabled.value = true;
       void loadSpeakers();
       activating.value = false;
-      return undefined;
+      return true;
     }
 
     activating.value = false;
-    return "VOICEVOX Engine startup timed out. Please start VOICEVOX manually.";
+    notify.error("VOICEVOX Engine startup timed out. Please start VOICEVOX manually.");
+    return false;
   }
 
   /** 再生中の音声を停止する */

--- a/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
+++ b/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
@@ -168,19 +168,33 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
 
   /**
    * 指定回数ポーリングして Engine の起動を待つ。
-   * タイムアウト時は最終 attempt の RPC error (もしあれば) を持ち帰る (cause 用)。
-   * 「engine-not-responding」の通常タイムアウトでは lastError は undefined のままになり、
-   * 呼び出し側で合成 Error にフォールバックさせる。
+   * 失敗時の戻り値は checkEngineRunning と同じ discriminated union に揃え、最終 attempt の
+   * 状態を呼び出し側で明示分岐できるようにする (cause 合成のため)。
+   *   - 最終 attempt が "rpc-error" なら その error を `lastError` で持ち帰る
+   *   - 全 attempt が "engine-not-responding" だった通常タイムアウトは reason だけ返す
    */
-  async function waitForEngine(): Promise<{ ok: true } | { ok: false; lastError?: Error }> {
-    let lastError: Error | undefined;
+  async function waitForEngine(): Promise<
+    | { ok: true }
+    | { ok: false; reason: "rpc-error"; lastError: Error }
+    | { ok: false; reason: "engine-not-responding" }
+  > {
+    let lastFailure:
+      | { reason: "rpc-error"; error: Error }
+      | { reason: "engine-not-responding" }
+      | undefined;
     for (let i = 0; i < POLL_MAX_ATTEMPTS; i++) {
       const result = await checkEngineRunning();
       if (result.ok) return { ok: true };
-      if (result.reason === "rpc-error") lastError = result.error;
+      lastFailure =
+        result.reason === "rpc-error"
+          ? { reason: "rpc-error", error: result.error }
+          : { reason: "engine-not-responding" };
       await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
     }
-    return { ok: false, lastError };
+    if (lastFailure?.reason === "rpc-error") {
+      return { ok: false, reason: "rpc-error", lastError: lastFailure.error };
+    }
+    return { ok: false, reason: "engine-not-responding" };
   }
 
   /** RPC 経由で音声合成し、base64 WAV をデコードして再生する */
@@ -303,10 +317,11 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
       return true;
     }
     const timeoutSeconds = (POLL_INTERVAL_MS * POLL_MAX_ATTEMPTS) / 1000;
-    notify.error(
-      "VOICEVOX Engine startup timed out. Please start VOICEVOX manually.",
-      waited.lastError ?? new Error(`engine did not respond on /version after ${timeoutSeconds}s`),
-    );
+    const cause =
+      waited.reason === "rpc-error"
+        ? waited.lastError
+        : new Error(`engine did not respond on /version after ${timeoutSeconds}s`);
+    notify.error("VOICEVOX Engine startup timed out. Please start VOICEVOX manually.", cause);
     return false;
   }
 

--- a/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
+++ b/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
@@ -150,25 +150,34 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
 
   /**
    * RPC 経由で Engine の起動状態を確認する。Engine 起動チェックの SSOT。
-   * 応答するなら `{ ok: true }`、応答しないなら `{ ok: false, error? }` を返す。
-   * RPC レイヤの error は cause として後段に流せるよう保持する。
+   * 3 状態を discriminated union で表現する:
+   *   - `{ ok: true }`: engine が /version に 200 応答
+   *   - `{ ok: false, reason: "rpc-error", error }`: RPC layer 自体が throw / network 失敗
+   *   - `{ ok: false, reason: "engine-not-responding" }`: RPC は成功したが engine が応答しない
    */
-  async function checkEngineRunning(): Promise<{ ok: boolean; error?: Error }> {
+  async function checkEngineRunning(): Promise<
+    | { ok: true }
+    | { ok: false; reason: "rpc-error"; error: Error }
+    | { ok: false; reason: "engine-not-responding" }
+  > {
     const result = await tryCatch(rpcVoicevoxCheckEngine());
-    if (!result.ok) return { ok: false, error: result.error };
-    return { ok: result.value.ok };
+    if (!result.ok) return { ok: false, reason: "rpc-error", error: result.error };
+    if (!result.value.ok) return { ok: false, reason: "engine-not-responding" };
+    return { ok: true };
   }
 
   /**
    * 指定回数ポーリングして Engine の起動を待つ。
    * タイムアウト時は最終 attempt の RPC error (もしあれば) を持ち帰る (cause 用)。
+   * 「engine-not-responding」の通常タイムアウトでは lastError は undefined のままになり、
+   * 呼び出し側で合成 Error にフォールバックさせる。
    */
   async function waitForEngine(): Promise<{ ok: true } | { ok: false; lastError?: Error }> {
     let lastError: Error | undefined;
     for (let i = 0; i < POLL_MAX_ATTEMPTS; i++) {
       const result = await checkEngineRunning();
       if (result.ok) return { ok: true };
-      if (result.error) lastError = result.error;
+      if (result.reason === "rpc-error") lastError = result.error;
       await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
     }
     return { ok: false, lastError };

--- a/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
+++ b/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
@@ -246,7 +246,10 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
     const launchResult = await tryCatch(rpcVoicevoxLaunch());
     if (!launchResult.ok || !launchResult.value.ok) {
       activating.value = false;
-      return "VOICEVOX is not installed.\nDownload from https://voicevox.hiroshiba.jp/";
+      // launch 失敗は (a) VOICEVOX 未インストール / (b) engine binary 欠落 / (c) spawn syscall 失敗
+      // の 3 種。詳細は native の stderr (VoicevoxOps.launch tag) に出る。
+      // 最頻ケースは (a) なのでインストール導線を残しつつ、原因を断定しない文言にする
+      return "VOICEVOX engine could not start.\nIf VOICEVOX isn't installed, download it from https://voicevox.hiroshiba.jp/";
     }
 
     // Engine の起動を待つ

--- a/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
+++ b/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
@@ -178,8 +178,9 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
     | { ok: false; reason: "rpc-error"; lastError: Error }
     | { ok: false; reason: "engine-not-responding" }
   > {
+    // 戻り値型の (ok: false を除く) suffix に揃え、最後の return が spread 1 回で済む形にする
     let lastFailure:
-      | { reason: "rpc-error"; error: Error }
+      | { reason: "rpc-error"; lastError: Error }
       | { reason: "engine-not-responding" }
       | undefined;
     for (let i = 0; i < POLL_MAX_ATTEMPTS; i++) {
@@ -187,14 +188,14 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
       if (result.ok) return { ok: true };
       lastFailure =
         result.reason === "rpc-error"
-          ? { reason: "rpc-error", error: result.error }
+          ? { reason: "rpc-error", lastError: result.error }
           : { reason: "engine-not-responding" };
       await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
     }
-    if (lastFailure?.reason === "rpc-error") {
-      return { ok: false, reason: "rpc-error", lastError: lastFailure.error };
-    }
-    return { ok: false, reason: "engine-not-responding" };
+    // POLL_MAX_ATTEMPTS=0 の (現状到達不能な) 境界用フォールバック
+    return lastFailure
+      ? { ok: false, ...lastFailure }
+      : { ok: false, reason: "engine-not-responding" };
   }
 
   /** RPC 経由で音声合成し、base64 WAV をデコードして再生する */

--- a/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
+++ b/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
@@ -64,6 +64,13 @@ function releaseAudio() {
 /** speak の世代カウンター。新しい speak 呼び出しや deactivate で進め、stale なリクエストを破棄する */
 let speakGeneration = 0;
 
+/**
+ * 進行中の activate Promise。再 entry されたら同じ Promise を返して in-flight dedup する。
+ * (sidebar の Enable ボタンと SettingsModal トグルからの連打で「進行中 = 失敗扱い」と
+ * 観察される不整合を防ぐ)
+ */
+let activationInFlight: Promise<boolean> | undefined;
+
 /** HMR 再実行時に前回のリスナーを解除するための disposer */
 let disposeHookListener: (() => void) | undefined;
 
@@ -145,13 +152,19 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
     return result.ok && result.value.ok;
   }
 
-  /** 指定回数ポーリングして Engine の起動を待つ */
-  async function waitForEngine(): Promise<boolean> {
+  /**
+   * 指定回数ポーリングして Engine の起動を待つ。
+   * タイムアウト時は最終 attempt の RPC error (もしあれば) を持ち帰る (cause 用)。
+   */
+  async function waitForEngine(): Promise<{ ok: true } | { ok: false; lastError?: Error }> {
+    let lastError: Error | undefined;
     for (let i = 0; i < POLL_MAX_ATTEMPTS; i++) {
-      if (await checkEngineRunning()) return true;
+      const result = await tryCatch(rpcVoicevoxCheckEngine());
+      if (result.ok && result.value.ok) return { ok: true };
+      if (!result.ok) lastError = result.error;
       await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
     }
-    return false;
+    return { ok: false, lastError };
   }
 
   /** RPC 経由で音声合成し、base64 WAV をデコードして再生する */
@@ -228,43 +241,57 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
    * VOICEVOX を有効化する。
    * Engine が起動していなければアプリの起動を試み、失敗時は store 内で notify.error を発火する
    * (呼び出し側で表示責務を持たないように SSOT を store に集約する)。
+   * 進行中に再 entry された場合は同じ Promise を返す (in-flight dedup)。
    * @returns 成功なら true、失敗 (未インストール / 起動タイムアウト 等) なら false
    */
   async function activate(): Promise<boolean> {
-    if (activating.value) return enabled.value;
+    if (activationInFlight) return activationInFlight;
     activating.value = true;
+    activationInFlight = doActivate();
+    try {
+      return await activationInFlight;
+    } finally {
+      activating.value = false;
+      activationInFlight = undefined;
+    }
+  }
 
+  async function doActivate(): Promise<boolean> {
     // Engine が既に起動しているかチェック
     if (await checkEngineRunning()) {
       enabled.value = true;
       void loadSpeakers();
-      activating.value = false;
       return true;
     }
 
     // アプリの起動を試みる
     const launchResult = await tryCatch(rpcVoicevoxLaunch());
     if (!launchResult.ok || !launchResult.value.ok) {
-      activating.value = false;
       // launch 失敗は (a) VOICEVOX 未インストール / (b) engine binary 欠落 / (c) spawn syscall 失敗
       // の 3 種。詳細は native の stderr (VoicevoxOps.launch tag) に出る。
       // 最頻ケースは (a) なのでインストール導線を残しつつ、原因を断定しない文言にする
+      const cause = !launchResult.ok
+        ? launchResult.error
+        : new Error("native VoicevoxLaunch returned ok=false");
       notify.error(
         "VOICEVOX engine could not start.\nIf VOICEVOX isn't installed, download it from https://voicevox.hiroshiba.jp/",
+        cause,
       );
       return false;
     }
 
     // Engine の起動を待つ
-    if (await waitForEngine()) {
+    const waited = await waitForEngine();
+    if (waited.ok) {
       enabled.value = true;
       void loadSpeakers();
-      activating.value = false;
       return true;
     }
-
-    activating.value = false;
-    notify.error("VOICEVOX Engine startup timed out. Please start VOICEVOX manually.");
+    const timeoutSeconds = (POLL_INTERVAL_MS * POLL_MAX_ATTEMPTS) / 1000;
+    notify.error(
+      "VOICEVOX Engine startup timed out. Please start VOICEVOX manually.",
+      waited.lastError ?? new Error(`engine did not respond on /version after ${timeoutSeconds}s`),
+    );
     return false;
   }
 

--- a/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
+++ b/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
@@ -186,10 +186,14 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
     for (let i = 0; i < POLL_MAX_ATTEMPTS; i++) {
       const result = await checkEngineRunning();
       if (result.ok) return { ok: true };
-      lastFailure =
-        result.reason === "rpc-error"
-          ? { reason: "rpc-error", lastError: result.error }
-          : { reason: "engine-not-responding" };
+      // rpc-error は情報量が多い (RPC dispatcher 自体の障害示唆) ので、途中で観測したら
+      // 以降の engine-not-responding で上書きさせない。engine-not-responding は最終状態
+      // が掴めれば十分なので、rpc-error をまだ観測していない時だけ記録する
+      if (result.reason === "rpc-error") {
+        lastFailure = { reason: "rpc-error", lastError: result.error };
+      } else if (lastFailure?.reason !== "rpc-error") {
+        lastFailure = { reason: "engine-not-responding" };
+      }
       await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
     }
     // POLL_MAX_ATTEMPTS=0 の (現状到達不能な) 境界用フォールバック

--- a/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
+++ b/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
@@ -1,7 +1,7 @@
 import type { VoicevoxSpeaker } from "@gozd/proto";
 import { tryCatch } from "@gozd/shared";
 import { acceptHMRUpdate, defineStore } from "pinia";
-import { computed, readonly, ref, watch } from "vue";
+import { computed, readonly, ref, shallowRef, watch } from "vue";
 import { useNotificationStore } from "../../shared/notification";
 import { onMessage } from "../../shared/rpc";
 import { rpcLoadAppConfig, rpcSaveAppConfig } from "../settings";
@@ -68,8 +68,10 @@ let speakGeneration = 0;
  * 進行中の activate Promise。再 entry されたら同じ Promise を返して in-flight dedup する。
  * (sidebar の Enable ボタンと SettingsModal トグルからの連打で「進行中 = 失敗扱い」と
  * 観察される不整合を防ぐ)
+ * `activating` computed の唯一の依存源として SSOT 化し、状態の二重管理を避ける。
+ * shallowRef を使うのは Promise を deep-proxy しないため (内部スロットを触ると壊れる)
  */
-let activationInFlight: Promise<boolean> | undefined;
+const activationInFlight = shallowRef<Promise<boolean> | undefined>(undefined);
 
 /** HMR 再実行時に前回のリスナーを解除するための disposer */
 let disposeHookListener: (() => void) | undefined;
@@ -87,8 +89,8 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
   const speakerId = ref<number>(DEFAULT_SPEAKER_ID);
   /** Engine `/speakers` から取得したキャラ一覧。enable + Engine 起動済みでロードされる */
   const speakers = ref<VoicevoxSpeaker[]>([]);
-  /** 有効化処理中 */
-  const activating = ref(false);
+  /** 有効化処理中。activationInFlight の存在から derive (SSOT) */
+  const activating = computed(() => activationInFlight.value !== undefined);
 
   /** speakers の中に該当 style.id が存在するか */
   function hasSpeakerStyle(id: number): boolean {
@@ -146,10 +148,15 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
     // トースト通知をここで重複発火させない (SSOT)
   }
 
-  /** RPC 経由で Engine の起動状態を確認する */
-  async function checkEngineRunning(): Promise<boolean> {
+  /**
+   * RPC 経由で Engine の起動状態を確認する。Engine 起動チェックの SSOT。
+   * 応答するなら `{ ok: true }`、応答しないなら `{ ok: false, error? }` を返す。
+   * RPC レイヤの error は cause として後段に流せるよう保持する。
+   */
+  async function checkEngineRunning(): Promise<{ ok: boolean; error?: Error }> {
     const result = await tryCatch(rpcVoicevoxCheckEngine());
-    return result.ok && result.value.ok;
+    if (!result.ok) return { ok: false, error: result.error };
+    return { ok: result.value.ok };
   }
 
   /**
@@ -159,9 +166,9 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
   async function waitForEngine(): Promise<{ ok: true } | { ok: false; lastError?: Error }> {
     let lastError: Error | undefined;
     for (let i = 0; i < POLL_MAX_ATTEMPTS; i++) {
-      const result = await tryCatch(rpcVoicevoxCheckEngine());
-      if (result.ok && result.value.ok) return { ok: true };
-      if (!result.ok) lastError = result.error;
+      const result = await checkEngineRunning();
+      if (result.ok) return { ok: true };
+      if (result.error) lastError = result.error;
       await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
     }
     return { ok: false, lastError };
@@ -206,7 +213,7 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
       if (cfg.enabled) {
         enabled.value = true;
         // Engine が起動していなければバックグラウンドで起動だけ試みる（ポーリングしない）
-        if (await checkEngineRunning()) {
+        if ((await checkEngineRunning()).ok) {
           void loadSpeakers();
         } else {
           void tryCatch(rpcVoicevoxLaunch());
@@ -245,20 +252,19 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
    * @returns 成功なら true、失敗 (未インストール / 起動タイムアウト 等) なら false
    */
   async function activate(): Promise<boolean> {
-    if (activationInFlight) return activationInFlight;
-    activating.value = true;
-    activationInFlight = doActivate();
+    if (activationInFlight.value) return activationInFlight.value;
+    const work = doActivate();
+    activationInFlight.value = work;
     try {
-      return await activationInFlight;
+      return await work;
     } finally {
-      activating.value = false;
-      activationInFlight = undefined;
+      activationInFlight.value = undefined;
     }
   }
 
   async function doActivate(): Promise<boolean> {
     // Engine が既に起動しているかチェック
-    if (await checkEngineRunning()) {
+    if ((await checkEngineRunning()).ok) {
       enabled.value = true;
       void loadSpeakers();
       return true;


### PR DESCRIPTION
## 概要

VOICEVOX を有効化したとき VOICEVOX.app の GUI ウィンドウが前面に飛び出して gozd の作業を中断していたのを、`.app` 同梱の engine binary `vv-engine/run` を直接 spawn する経路に戻して解消する。

## 背景

3 月時点の元の実装 ( 014f8fca ) は Bun の `Bun.spawn` で `/Applications/VOICEVOX.app/Contents/Resources/vv-engine/run` を直接起動しており、コミットメッセージにも `decision: VOICEVOX Engine の起動は .app 内の vv-engine/run を直接実行し GUI を起動しない` と明記されていた。

5 月の native (Swift) 移植 ( bdac6bda ) で `/usr/bin/open -a VOICEVOX` に書き換わり、この設計判断が失われていた。`open -a` は GUI アプリ本体を起動するため VOICEVOX の main / Welcome window が前面化し、gozd のフォーカスを奪う挙動になっていた。

調査の流れ:

- 当初 VOICEVOX 0.25.0 で追加された Welcome 画面 ( VOICEVOX/voicevox pr2866 ) を疑ったが、0.25.1 → 0.25.2 にはコード変更がなく、Mac stable の path-based engine 設定では Welcome 画面の発火条件 ( `hasDownloadableDefaultEngine && !hasInstalledDefaultEngine` ) を満たさないことを `ghq` 配下の repo で確認
- 真因は gozd 側の Swift 移植 regression と判明
- 修正案として `open -g -a VOICEVOX` を spike で試したが、VOICEVOX 本体が Electron `BrowserWindow.show()` で自前 activate するため OS レベルの `-g` は無視され、frontmost が VOICEVOX に倒れた
- engine binary 直 spawn は spike で 1 秒で port 50021 応答 / frontmost が Gozd 維持 / GUI window 数 0 を確認

公式設計の確認:

- `VOICEVOX/voicevox_engine` は GUI repo ( `VOICEVOX/voicevox` ) と独立した別 repo として公開されており、headless 利用が正規ルート
- `.app` 同梱の `vv-engine/run` はこの engine 本体で、Docker / standalone と同一バイナリ
- Qiita などの community 事例も `vv-engine/run` 直起動 + HTTP REST 連携が定番

## 変更内容

### apps/native/Sources/GozdCore/VoicevoxOps.swift

- `launch()` を `/usr/bin/open -a VOICEVOX` から `vv-engine/run` の Process spawn に置換
- engine binary のパスは `NSWorkspace.shared.urlForApplication(withBundleIdentifier: "jp.hiroshiba.voicevox")` で解決し、`/Applications/VOICEVOX.app` のハードコード依存を廃止 ( `~/Applications/` や別ボリュームインストールにも追従 )
- `NSWorkspace` は `@MainActor` 隔離のため `await MainActor.run { ... }` でホップ ( RpcDispatcher.swift の `NSWorkspace.open` 経路と同じパターン )
- engine は HTTP サーバとして常駐するので `waitUntilExit()` を呼ばず detach。stdout / stderr は `FileHandle.nullDevice` に倒して pipe 詰まりを防ぐ
- 起動前に `FileManager.isExecutableFile(atPath:)` で fail-fast
- 設計判断のドキュメントコメントを更新

## 確認事項

- [ ] `pnpm dev` で gozd 起動 → サイドバーの VOICEVOX トグル ON → VOICEVOX GUI が前面に出ず gozd が frontmost を維持すること
- [ ] トグル ON 後 数秒以内に音声合成が動作 ( Claude hooks の done / needs-input イベントで読み上げ ) すること
- [ ] VOICEVOX.app が未インストールの環境で stderr に `VOICEVOX.app not found (bundleId=jp.hiroshiba.voicevox)` が出ること
- [ ] gozd を quit しても engine プロセスが孤児として残ること自体は許容 ( 次回起動時に `checkEngineRunning` で再利用されるため再 spawn が走らない )
