### PR TITLE
fix(preview): worktree 切替時に preview popover を自動 close する

### DIFF
--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -191,20 +191,14 @@ useEventListener(document, "keydown", (e: KeyboardEvent) => {
   closePreview();
 });
 
-// worktree 切替 (dir 変化) で新 dir 上に選択ファイルが無ければ Preview を auto-close。
-// setOpen は selectDir → selectRelPath を同期で続けて呼ぶ経路があるため (gozdOpen 経由で
-// 別 worktree のファイルを selection 付きで指定するケース)、close 判定を flush: 'post' まで
-// 遅らせて selection 確定後の selectedDisplayPath を観測する。selection ありで切り替わった
-// 場合は close せず、後続の selectedDisplayPath watch の auto-open に委ねることで
-// 「close → 即 open」のちらつきを避ける。
+// worktree 切替 (dir 変化) で Preview を auto-close。
+// 新 worktree でファイル選択を伴う経路 (gozdOpen 経由等) では、後続の
+// selectedDisplayPath watch が auto-open で開き直すため、最終状態は新ファイルで表示継続になる。
 watch(
   () => worktreeStore.dir,
   () => {
-    if (worktreeStore.selectedDisplayPath === undefined) {
-      closePreview();
-    }
+    closePreview();
   },
-  { flush: "post" },
 );
 
 // ファイル選択時に Preview を自動オープン (path 軸で識別; selection object identity の発火は避ける)

--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -191,15 +191,20 @@ useEventListener(document, "keydown", (e: KeyboardEvent) => {
   closePreview();
 });
 
-// worktree 切替 (dir 変化) で Preview を自動 close。Filer 選択 / Changes summary の clear と対称に、
-// worktree 跨ぎで preview 表示を維持する要件はない。flush: 'sync' で「dir change → 旧 preview を即 close →
-// 新 dir の selectedDisplayPath 変化に基づく auto-open 判定」の順序を担保する。
+// worktree 切替 (dir 変化) で新 dir 上に選択ファイルが無ければ Preview を auto-close。
+// setOpen は selectDir → selectRelPath を同期で続けて呼ぶ経路があるため (gozdOpen 経由で
+// 別 worktree のファイルを selection 付きで指定するケース)、close 判定を flush: 'post' まで
+// 遅らせて selection 確定後の selectedDisplayPath を観測する。selection ありで切り替わった
+// 場合は close せず、後続の selectedDisplayPath watch の auto-open に委ねることで
+// 「close → 即 open」のちらつきを避ける。
 watch(
   () => worktreeStore.dir,
   () => {
-    closePreview();
+    if (worktreeStore.selectedDisplayPath === undefined) {
+      closePreview();
+    }
   },
-  { flush: "sync" },
+  { flush: "post" },
 );
 
 // ファイル選択時に Preview を自動オープン (path 軸で識別; selection object identity の発火は避ける)

--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -191,6 +191,17 @@ useEventListener(document, "keydown", (e: KeyboardEvent) => {
   closePreview();
 });
 
+// worktree 切替 (dir 変化) で Preview を自動 close。Filer 選択 / Changes summary の clear と対称に、
+// worktree 跨ぎで preview 表示を維持する要件はない。flush: 'sync' で「dir change → 旧 preview を即 close →
+// 新 dir の selectedDisplayPath 変化に基づく auto-open 判定」の順序を担保する。
+watch(
+  () => worktreeStore.dir,
+  () => {
+    closePreview();
+  },
+  { flush: "sync" },
+);
+
 // ファイル選択時に Preview を自動オープン (path 軸で識別; selection object identity の発火は避ける)
 watch(
   () => worktreeStore.selectedDisplayPath,

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -77,7 +77,7 @@ git 変更ファイルには Original / Diff / Current の3タブを表示する
 プレビューペインは右端に配置され、開閉可能。デフォルトは closed。
 
 - ファイル選択時に自動オープン
-- worktree 切替 (dir 変化) で自動クローズ。Filer 選択 / Changes summary の clear と対称で、worktree 跨ぎで preview 表示を維持する要件はない
+- worktree 切替 (dir 変化) 後に新 worktree でファイル選択が無い場合は自動クローズ。`gozdOpen` 等で別 worktree のファイル選択を伴って切り替えた場合は close せず、選択ファイルの内容に切り替えて表示を続ける
 - ヘッダーの close ボタンで閉じる
 - `preview.toggle` コマンドで切り替え
 - 外側クリックでは閉じない

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -77,7 +77,7 @@ git 変更ファイルには Original / Diff / Current の3タブを表示する
 プレビューペインは右端に配置され、開閉可能。デフォルトは closed。
 
 - ファイル選択時に自動オープン
-- worktree 切替 (dir 変化) 後に新 worktree でファイル選択が無い場合は自動クローズ。ファイル選択を伴う dir 切替 (`gozdOpen` で別 worktree のファイルを指定した経路等) では close せず、選択ファイルの内容に切り替えて表示を続ける
+- worktree 切替 (dir 変化) で自動クローズ。新 worktree でファイル選択を伴う dir 切替 (`gozdOpen` で別 worktree のファイルを指定した経路等) では、続けて選択ファイルで auto-open されるため最終状態は新ファイルで表示継続になる
 - ヘッダーの close ボタンで閉じる
 - `preview.toggle` コマンドで切り替え
 - 外側クリックでは閉じない

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -77,6 +77,7 @@ git 変更ファイルには Original / Diff / Current の3タブを表示する
 プレビューペインは右端に配置され、開閉可能。デフォルトは closed。
 
 - ファイル選択時に自動オープン
+- worktree 切替 (dir 変化) で自動クローズ。Filer 選択 / Changes summary の clear と対称で、worktree 跨ぎで preview 表示を維持する要件はない
 - ヘッダーの close ボタンで閉じる
 - `preview.toggle` コマンドで切り替え
 - 外側クリックでは閉じない

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -77,7 +77,7 @@ git 変更ファイルには Original / Diff / Current の3タブを表示する
 プレビューペインは右端に配置され、開閉可能。デフォルトは closed。
 
 - ファイル選択時に自動オープン
-- worktree 切替 (dir 変化) 後に新 worktree でファイル選択が無い場合は自動クローズ。`gozdOpen` 等で別 worktree のファイル選択を伴って切り替えた場合は close せず、選択ファイルの内容に切り替えて表示を続ける
+- worktree 切替 (dir 変化) 後に新 worktree でファイル選択が無い場合は自動クローズ。ファイル選択を伴う dir 切替 (`gozdOpen` で別 worktree のファイルを指定した経路等) では close せず、選択ファイルの内容に切り替えて表示を続ける
 - ヘッダーの close ボタンで閉じる
 - `preview.toggle` コマンドで切り替え
 - 外側クリックでは閉じない


### PR DESCRIPTION
## 概要

worktree を切り替えたときに preview popover を自動 close する。

## 背景

preview を開いた状態で別の worktree を選択すると、旧 worktree のファイルを表示したまま popover が前面に残るという報告があった。

調査の結果、worktree 切替時に既に reset される状態が複数あるのに対し、preview popover だけ取り残されていることが分かった:

- `useWorktreeStore` の dir watch で `selection` が clear される
- `useChangesSummaryStore` の dir watch で summary view が `enabled = false` に戻る
- preview popover は dir 変化に紐づいた close 経路がなく、旧 worktree の文脈で表示が残る

ChangesPane の Filer 選択 / Changes summary が worktree 跨ぎで残らないのと対称的に、preview も worktree 跨ぎで保持する要件はないため、自動 close するのが期待挙動。

## 設計選定の経緯

レビュー過程で 2 案を検討した:

- 案 A: dir watch を `flush: 'post'` + `selectedDisplayPath === undefined` ガード付きにし、selection 付き dir 切替 (`gozdOpen` 経由) では close をスキップして popover を開いたまま中身を差し替える
- 案 B: dir watch は無条件 `closePreview()`。selection 付き dir 切替でも一度 close を挟むが、続く `selectedDisplayPath` watch が新 path で auto-open するため最終状態は表示継続

最終的に **案 B** を採用。理由:

- Vue 3 reactivity のバッチング上、PreviewPane の `flush: 'pre'` watch は selection が undefined → 新値 と同期で書き換わっても **最終値だけを 1 回観測** するため、案 A が想定していた「fetch の余計な往復」は発生しない (前 commit `199313fa` の `learned` セクションでこの誤評価を撤回)
- 案 B で残る差分は popover の `toggle` event が closed → open と 1 往復することによる `previewVisible` context key の ms オーダー vibrate のみで、実害は極小
- 案 A は dir watch 内で別 store の派生 state (`selectedDisplayPath`) を時間的に読む依存を持ち込むコスト (5 行のコメントを要する) に見合う実利益が無い
- 「dir 変化で旧 worktree のものを閉じる」「新 selection で開く」という直交した責務に分離する案 B の方が設計として素直

## 変更内容

### `apps/renderer/src/features/layout/MainLayout.vue`

- `worktreeStore.dir` の watch を追加し、変化時に無条件で `closePreview()` を呼ぶ
- selection 付きで切り替わる経路 (`gozdOpen` 等) では、続く `selectedDisplayPath` watch (既存) が auto-open で開き直すため最終状態は新ファイルで表示継続になる

### `docs/preview.md`

- 「開閉機能」セクションに「worktree 切替 (dir 変化) で自動クローズ」を追記。ファイル選択を伴う dir 切替では最終状態が表示継続になる旨も明示

## 確認事項

- [ ] preview を開いた状態でサイドバーから別 worktree を選択すると popover が閉じる
- [ ] 切替後に新 worktree でファイルを選択すると、再度 preview が auto-open される
- [ ] 同一 worktree 内のファイル切替では preview は閉じない
- [ ] Changes summary を有効化した状態で worktree を切り替えると、summary と preview の両方が閉じる
- [ ] ターミナルで `gozd <別 worktree 配下のファイルパス>` を実行したとき、preview が一瞬閉じて開き直すちらつきが視覚的に認識されないこと (案 B 採用の正当性確認。認識される flicker が出る場合は案 A への戻しを検討)
- [ ] worktree A で BlamePopover を開いた状態で別 worktree に切り替えたとき、BlamePopover が前面に残らずに閉じること (PreviewPane の close watch が path 変化で `blamePopover.close()` を発火する経路の実機確認)
