### PR TITLE
feat(preview): close preview when reselecting the displayed file

### DIFF
--- a/apps/renderer/src/features/filer/FilerPane.vue
+++ b/apps/renderer/src/features/filer/FilerPane.vue
@@ -6,7 +6,7 @@
 - worktree の dir が設定されると、worktree 自体を表す不可視ルート FileTreeItem を 1 個描画する
 - ツリー全体（ルート直下を含む）の管理は FileTreeItem 側に再帰委譲する
 - dir 切替時は `:key="dir"` でルート FileTreeItem を再マウントする（旧 dir の in-flight loadChildren を構造的に破棄）
-- file クリックは `select` emit で親 (NavigatorPane) に委譲する。preview toggle 等の副作用は親側で扱う（ChangesPane と対称）
+- file クリックは `select` emit で親に委譲する（副作用は親側で扱う / ChangesPane と対称）
 
 ## gitStatus / fsChange の購読
 

--- a/apps/renderer/src/features/filer/FilerPane.vue
+++ b/apps/renderer/src/features/filer/FilerPane.vue
@@ -6,6 +6,7 @@
 - worktree の dir が設定されると、worktree 自体を表す不可視ルート FileTreeItem を 1 個描画する
 - ツリー全体（ルート直下を含む）の管理は FileTreeItem 側に再帰委譲する
 - dir 切替時は `:key="dir"` でルート FileTreeItem を再マウントする（旧 dir の in-flight loadChildren を構造的に破棄）
+- file クリックは `select` emit で親 (NavigatorPane) に委譲する。preview toggle 等の副作用は親側で扱う（ChangesPane と対称）
 
 ## gitStatus / fsChange の購読
 
@@ -22,15 +23,15 @@ import FileTreeItem from "./FileTreeItem.vue";
 import type { FsChangePayload } from "./rpc";
 import { useFilerEventStore } from "./useFilerEventStore";
 
+const emit = defineEmits<{
+  select: [relPath: string];
+}>();
+
 const worktreeStore = useWorktreeStore();
 const { dir, selectedRelPath } = storeToRefs(worktreeStore);
 const gitStatusStore = useGitStatusStore();
 const { gitStatuses } = storeToRefs(gitStatusStore);
 const filerEventStore = useFilerEventStore();
-
-function onSelect(path: string) {
-  worktreeStore.selectRelPath(path);
-}
 
 function handleFsChange(eventDir: string, relDir: string) {
   // useFsWatchSync は全 worktree を watch するため、別 repo / 別 worktree の
@@ -82,7 +83,7 @@ onUnmounted(() => {
         :git-statuses="gitStatuses"
         :depth="-1"
         :selected-rel-path="selectedRelPath"
-        @select="onSelect"
+        @select="(path: string) => emit('select', path)"
       />
     </div>
   </div>

--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -30,7 +30,12 @@ import {
   registerIssueCommand,
   registerPrCommand,
 } from "../palette";
-import { BlamePopover, PreviewPane, registerMarkdownHistoryCommands } from "../preview";
+import {
+  BlamePopover,
+  PreviewPane,
+  registerMarkdownHistoryCommands,
+  usePreviewStore,
+} from "../preview";
 import { registerSettingsCommand, SettingsModal } from "../settings";
 import { registerShellCommandActions } from "../shell-command";
 import { SidebarPane } from "../sidebar";
@@ -43,6 +48,7 @@ import { rpcWindowClose } from "./rpc";
 const worktreeStore = useWorktreeStore();
 const repoStore = useRepoStore();
 const summaryStore = useChangesSummaryStore();
+const previewStore = usePreviewStore();
 const contextKeys = useContextKeys();
 const previewPopoverRef = useTemplateRef<HTMLElement>("previewPopover");
 
@@ -51,11 +57,7 @@ const { register } = useCommandRegistry();
 const disposePreviewToggle = register("preview.toggle", {
   label: "Preview: Toggle",
   handler: () => {
-    if (previewOpen.value) {
-      closePreview();
-    } else {
-      openPreview();
-    }
+    previewStore.toggle();
     return true;
   },
 });
@@ -97,7 +99,6 @@ const centerTerminalRef = useTemplateRef<HTMLElement>("centerTerminal");
 const sidebarWidth = ref(260);
 const navigatorWidth = ref(256);
 const previewWidth = ref(1200);
-const previewOpen = ref(false);
 const gitGraphHeight = ref(128);
 
 /** Preview 開閉ボタンの固定幅（px-1 × 2 + size-4 + border-l） */
@@ -147,32 +148,23 @@ const getPreviewBeforeSize = () =>
 const getPreviewAfterSize = () =>
   previewPopoverRef.value?.getBoundingClientRect().width ?? previewWidth.value;
 
-// previewVisible context key を実際の表示状態と同期
+// popover の DOM 参照を store に bind。bindPopover(undefined) は onUnmounted で呼ぶ。
 watch(
-  previewOpen,
+  previewPopoverRef,
+  (el) => {
+    previewStore.bindPopover(el ?? undefined);
+  },
+  { immediate: true },
+);
+
+// previewVisible context key を store の isOpen と同期
+watch(
+  () => previewStore.isOpen,
   (open) => {
     contextKeys.set("previewVisible", open);
   },
   { immediate: true },
 );
-
-/** :popover-open でガードして二重呼び出し例外を防止 */
-function openPreview() {
-  const el = previewPopoverRef.value;
-  if (!el || el.matches(":popover-open")) return;
-  el.showPopover();
-}
-
-function closePreview() {
-  const el = previewPopoverRef.value;
-  if (!el || !el.matches(":popover-open")) return;
-  el.hidePopover();
-}
-
-/** popover の toggle イベントで previewOpen ref と同期 */
-function onPreviewToggle(e: ToggleEvent) {
-  previewOpen.value = e.newState === "open";
-}
 
 // ESC で preview を閉じる。popover="manual" によって OS の auto dismiss が無いため、
 // HTML popover が popover="auto" で持っていた ESC dismiss の性質を自前で代替する。
@@ -181,14 +173,14 @@ function onPreviewToggle(e: ToggleEvent) {
 useEventListener(document, "keydown", (e: KeyboardEvent) => {
   if (e.defaultPrevented) return;
   if (isIMEActive(e) || e.key !== "Escape") return;
-  if (!previewOpen.value) return;
+  if (!previewStore.isOpen) return;
   const otherPopoverOpen = Array.from(document.querySelectorAll<HTMLElement>(":popover-open")).some(
     (el) => el !== previewPopoverRef.value,
   );
   if (otherPopoverOpen) return;
   if (document.querySelector("dialog[open]") !== null) return;
   e.preventDefault();
-  closePreview();
+  previewStore.close();
 });
 
 // worktree 切替 (dir 変化) で Preview を auto-close。
@@ -197,7 +189,7 @@ useEventListener(document, "keydown", (e: KeyboardEvent) => {
 watch(
   () => worktreeStore.dir,
   () => {
-    closePreview();
+    previewStore.close();
   },
 );
 
@@ -206,7 +198,7 @@ watch(
   () => worktreeStore.selectedDisplayPath,
   (path) => {
     if (path === undefined) return;
-    openPreview();
+    previewStore.open();
   },
 );
 
@@ -215,7 +207,7 @@ watch(
   () => worktreeStore.revealVersion,
   () => {
     if (worktreeStore.selectedDisplayPath === undefined) return;
-    openPreview();
+    previewStore.open();
   },
 );
 
@@ -223,7 +215,7 @@ watch(
 watch(
   () => summaryStore.enabled,
   (enabled) => {
-    if (enabled) openPreview();
+    if (enabled) previewStore.open();
   },
 );
 
@@ -300,7 +292,7 @@ watch(
         class="_preview-anchor flex shrink-0 items-center justify-center border-l border-zinc-700 px-1 text-zinc-500 hover:text-zinc-300"
         title="Toggle preview"
         aria-label="Toggle preview"
-        @click="previewOpen ? closePreview() : openPreview()"
+        @click="previewStore.toggle()"
       >
         <span class="icon-[lucide--panel-right-open] size-4" />
       </button>
@@ -316,7 +308,7 @@ watch(
       popover="manual"
       class="_preview-popover overflow-hidden border-0 border-l border-zinc-700 bg-zinc-900 p-0 [&:popover-open]:flex"
       :style="{ width: `${previewWidth}px` }"
-      @toggle="onPreviewToggle"
+      @toggle="previewStore.syncFromToggleEvent"
     >
       <!-- 左端リサイズハンドル -->
       <ResizeHandle
@@ -329,7 +321,7 @@ watch(
       />
 
       <div class="min-w-0 flex-1 overflow-hidden">
-        <PreviewPane @close="closePreview" />
+        <PreviewPane @close="previewStore.close()" />
       </div>
     </div>
 

--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -148,7 +148,9 @@ const getPreviewBeforeSize = () =>
 const getPreviewAfterSize = () =>
   previewPopoverRef.value?.getBoundingClientRect().width ?? previewWidth.value;
 
-// popover の DOM 参照を store に bind。bindPopover(undefined) は onUnmounted で呼ぶ。
+// popover の DOM 参照を store に bind。template ref が null に戻った時点
+// (= previewPopover element の unmount) に bindPopover(undefined) が呼ばれ
+// dangling 参照を切る。
 watch(
   previewPopoverRef,
   (el) => {

--- a/apps/renderer/src/features/navigator/NavigatorPane.vue
+++ b/apps/renderer/src/features/navigator/NavigatorPane.vue
@@ -7,18 +7,19 @@ Filer（上）と Changes（下）を垂直分割で表示するコンテナ。
 - ResizeHandle で上下の比率をリサイズ可能
 - git リポジトリでない場合は Filer のみ表示
 - FilerPane の reveal は worktreeStore.revealVersion を内部で購読しているため props 経由不要
-- FilerPane / ChangesPane の `select` emit はどちらも `onFileSelect` に集約し、preview 表示中に同一 file を再選択された場合は `preview.toggle` で閉じる（`selectRelPath` 非呼び出しなので revealVersion は bump されず、gozdOpen 等「常に開く」経路には影響しない）
+- FilerPane / ChangesPane の `select` emit はどちらも `onFileSelect` に集約。action 決定は `decideSelectAction` (pure) に委譲し、`select` / `toggle-close` / `exit-summary` の 3 分岐で navigator 経由の選択挙動を表現する。CLI の `gozd <file>` 等 navigator 外の open 経路はこの判定を通らない
 </doc>
 
 <script setup lang="ts">
 import { useElementSize } from "@vueuse/core";
 import { ref, useTemplateRef, watch } from "vue";
-import { useCommandRegistry, useContextKeys } from "../../shared/command";
 import { useRepoStore } from "../../shared/repo";
-import { ChangesPane } from "../changes";
+import { ChangesPane, useChangesSummaryStore } from "../changes";
 import { FilerPane } from "../filer";
 import { ResizeHandle } from "../layout";
+import { usePreviewStore } from "../preview";
 import { useWorktreeStore } from "../worktree";
+import { decideSelectAction } from "./decideSelectAction";
 
 const HANDLE_HEIGHT = 8;
 const FILER_MIN_HEIGHT = 100;
@@ -26,8 +27,8 @@ const CHANGES_MIN_HEIGHT = 60;
 
 const repoStore = useRepoStore();
 const worktreeStore = useWorktreeStore();
-const contextKeys = useContextKeys();
-const commandRegistry = useCommandRegistry();
+const previewStore = usePreviewStore();
+const summaryStore = useChangesSummaryStore();
 const filerWrapperRef = useTemplateRef<HTMLElement>("filerWrapper");
 const containerRef = useTemplateRef<HTMLElement>("container");
 const { height: containerHeight } = useElementSize(containerRef);
@@ -56,14 +57,23 @@ function getFilerHeight(): number {
 }
 
 function onFileSelect(relPath: string) {
-  // preview 表示中に同一 file を再選択したら preview を閉じる (toggle 挙動)。
-  // selectRelPath を呼ばないので revealVersion も bump されず、
-  // gozdOpen 等「常に開く」経路の挙動には影響しない。
-  if (relPath === worktreeStore.selectedRelPath && contextKeys.get("previewVisible")) {
-    commandRegistry.execute("preview.toggle");
-    return;
+  const action = decideSelectAction({
+    relPath,
+    selectedRelPath: worktreeStore.selectedRelPath,
+    previewVisible: previewStore.isOpen,
+    summaryEnabled: summaryStore.enabled,
+  });
+  switch (action.kind) {
+    case "toggle-close":
+      previewStore.close();
+      return;
+    case "exit-summary":
+      summaryStore.disable();
+      return;
+    case "select":
+      worktreeStore.selectRelPath(relPath);
+      return;
   }
-  worktreeStore.selectRelPath(relPath);
 }
 </script>
 

--- a/apps/renderer/src/features/navigator/NavigatorPane.vue
+++ b/apps/renderer/src/features/navigator/NavigatorPane.vue
@@ -7,12 +7,13 @@ Filer（上）と Changes（下）を垂直分割で表示するコンテナ。
 - ResizeHandle で上下の比率をリサイズ可能
 - git リポジトリでない場合は Filer のみ表示
 - FilerPane の reveal は worktreeStore.revealVersion を内部で購読しているため props 経由不要
-- ChangesPane の `select` emit を `worktreeStore.selectRelPath()` に接続
+- FilerPane / ChangesPane の `select` emit はどちらも `onFileSelect` に集約し、preview 表示中に同一 file を再選択された場合は `preview.toggle` で閉じる（`selectRelPath` 非呼び出しなので revealVersion は bump されず、gozdOpen 等「常に開く」経路には影響しない）
 </doc>
 
 <script setup lang="ts">
 import { useElementSize } from "@vueuse/core";
 import { ref, useTemplateRef, watch } from "vue";
+import { useCommandRegistry, useContextKeys } from "../../shared/command";
 import { useRepoStore } from "../../shared/repo";
 import { ChangesPane } from "../changes";
 import { FilerPane } from "../filer";
@@ -25,6 +26,8 @@ const CHANGES_MIN_HEIGHT = 60;
 
 const repoStore = useRepoStore();
 const worktreeStore = useWorktreeStore();
+const contextKeys = useContextKeys();
+const commandRegistry = useCommandRegistry();
 const filerWrapperRef = useTemplateRef<HTMLElement>("filerWrapper");
 const containerRef = useTemplateRef<HTMLElement>("container");
 const { height: containerHeight } = useElementSize(containerRef);
@@ -52,7 +55,14 @@ function getFilerHeight(): number {
   return filerWrapperRef.value?.offsetHeight ?? FILER_MIN_HEIGHT;
 }
 
-function onChangesSelect(relPath: string) {
+function onFileSelect(relPath: string) {
+  // preview 表示中に同一 file を再選択したら preview を閉じる (toggle 挙動)。
+  // selectRelPath を呼ばないので revealVersion も bump されず、
+  // gozdOpen 等「常に開く」経路の挙動には影響しない。
+  if (relPath === worktreeStore.selectedRelPath && contextKeys.get("previewVisible")) {
+    commandRegistry.execute("preview.toggle");
+    return;
+  }
   worktreeStore.selectRelPath(relPath);
 }
 </script>
@@ -71,7 +81,7 @@ function onChangesSelect(relPath: string) {
         </span>
       </div>
       <div class="min-h-0 flex-1 overflow-hidden">
-        <FilerPane />
+        <FilerPane @select="onFileSelect" />
       </div>
     </div>
 
@@ -85,7 +95,7 @@ function onChangesSelect(relPath: string) {
         :get-before-size="getFilerHeight"
       />
       <div class="shrink-0 overflow-hidden" :style="{ height: `${changesHeight}px` }">
-        <ChangesPane @select="onChangesSelect" />
+        <ChangesPane @select="onFileSelect" />
       </div>
     </template>
   </div>

--- a/apps/renderer/src/features/navigator/decideSelectAction.test.ts
+++ b/apps/renderer/src/features/navigator/decideSelectAction.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+import {
+  decideSelectAction,
+  type SelectAction,
+  type SelectActionInput,
+} from "./decideSelectAction";
+
+/** 4 入力 → 1 action の table driven test。8 状態 + selectedRelPath undefined の境界を網羅 */
+const cases: Array<{ name: string; input: SelectActionInput; expected: SelectAction["kind"] }> = [
+  // 同 path + preview 開 → summary on/off で分岐
+  {
+    name: "same path + preview open + summary on → exit-summary",
+    input: {
+      relPath: "a.ts",
+      selectedRelPath: "a.ts",
+      previewVisible: true,
+      summaryEnabled: true,
+    },
+    expected: "exit-summary",
+  },
+  {
+    name: "same path + preview open + summary off → toggle-close",
+    input: {
+      relPath: "a.ts",
+      selectedRelPath: "a.ts",
+      previewVisible: true,
+      summaryEnabled: false,
+    },
+    expected: "toggle-close",
+  },
+  // 同 path + preview 閉 → summary 値に関わらず select
+  {
+    name: "same path + preview closed + summary on → select",
+    input: {
+      relPath: "a.ts",
+      selectedRelPath: "a.ts",
+      previewVisible: false,
+      summaryEnabled: true,
+    },
+    expected: "select",
+  },
+  {
+    name: "same path + preview closed + summary off → select",
+    input: {
+      relPath: "a.ts",
+      selectedRelPath: "a.ts",
+      previewVisible: false,
+      summaryEnabled: false,
+    },
+    expected: "select",
+  },
+  // 別 path → 残り変数に関わらず select
+  {
+    name: "different path + preview open + summary on → select",
+    input: {
+      relPath: "b.ts",
+      selectedRelPath: "a.ts",
+      previewVisible: true,
+      summaryEnabled: true,
+    },
+    expected: "select",
+  },
+  {
+    name: "different path + preview open + summary off → select",
+    input: {
+      relPath: "b.ts",
+      selectedRelPath: "a.ts",
+      previewVisible: true,
+      summaryEnabled: false,
+    },
+    expected: "select",
+  },
+  {
+    name: "different path + preview closed + summary on → select",
+    input: {
+      relPath: "b.ts",
+      selectedRelPath: "a.ts",
+      previewVisible: false,
+      summaryEnabled: true,
+    },
+    expected: "select",
+  },
+  {
+    name: "different path + preview closed + summary off → select",
+    input: {
+      relPath: "b.ts",
+      selectedRelPath: "a.ts",
+      previewVisible: false,
+      summaryEnabled: false,
+    },
+    expected: "select",
+  },
+  // 境界: selectedRelPath undefined (selection 未選択 / absolute 選択中)
+  {
+    name: "selectedRelPath undefined + preview open → select",
+    input: {
+      relPath: "a.ts",
+      selectedRelPath: undefined,
+      previewVisible: true,
+      summaryEnabled: false,
+    },
+    expected: "select",
+  },
+  {
+    name: "selectedRelPath undefined + preview closed → select",
+    input: {
+      relPath: "a.ts",
+      selectedRelPath: undefined,
+      previewVisible: false,
+      summaryEnabled: false,
+    },
+    expected: "select",
+  },
+];
+
+describe("decideSelectAction", () => {
+  for (const c of cases) {
+    test(c.name, () => {
+      expect(decideSelectAction(c.input).kind).toBe(c.expected);
+    });
+  }
+});

--- a/apps/renderer/src/features/navigator/decideSelectAction.ts
+++ b/apps/renderer/src/features/navigator/decideSelectAction.ts
@@ -1,0 +1,33 @@
+/**
+ * Navigator (Filer / Changes) で file を select する経路の action 決定。
+ *
+ * 3 状態:
+ * - 別 file / preview 閉 / selection 未選択 のいずれか → `select` (通常の selectRelPath)
+ * - 同 file かつ preview 開 かつ summary 表示中 → `exit-summary` (summary を抜けて単一 file view へ)
+ * - 同 file かつ preview 開 かつ summary 非表示 → `toggle-close` (preview を閉じる)
+ *
+ * summary 表示中の同 file 再選択を `toggle-close` に倒さないのは、ユーザーの意図が
+ * 「summary を抜けてこの file を見たい」である方が自然なため。`onCloseSummary`
+ * (明示 close button) と同じく `summaryStore.disable()` を経由する。
+ */
+export type SelectAction = { kind: "toggle-close" } | { kind: "exit-summary" } | { kind: "select" };
+
+export interface SelectActionInput {
+  relPath: string;
+  selectedRelPath: string | undefined;
+  previewVisible: boolean;
+  summaryEnabled: boolean;
+}
+
+export function decideSelectAction({
+  relPath,
+  selectedRelPath,
+  previewVisible,
+  summaryEnabled,
+}: SelectActionInput): SelectAction {
+  if (relPath !== selectedRelPath || !previewVisible) {
+    return { kind: "select" };
+  }
+  if (summaryEnabled) return { kind: "exit-summary" };
+  return { kind: "toggle-close" };
+}

--- a/apps/renderer/src/features/preview/index.ts
+++ b/apps/renderer/src/features/preview/index.ts
@@ -2,3 +2,4 @@ export { default as BlamePopover } from "./BlamePopover.vue";
 export { default as PreviewPane } from "./PreviewPane.vue";
 export { previewFontFamily, previewFontSize } from "./previewConfig";
 export { registerMarkdownHistoryCommands } from "./registerMarkdownHistoryCommands";
+export { usePreviewStore } from "./usePreviewStore";

--- a/apps/renderer/src/features/preview/usePreviewStore.ts
+++ b/apps/renderer/src/features/preview/usePreviewStore.ts
@@ -7,12 +7,16 @@ import { ref } from "vue";
  * `isOpen` は popover DOM の状態ではなく自前 ref で持つ。HTML Popover API の
  * `toggle` event は spec 上 task に queue される非同期発火のため、`hidePopover()`
  * / `showPopover()` 直後の同 tick で `popoverEl.matches(":popover-open")` を
- * 読んでも前の状態が見える窓がある。`open()` / `close()` 内で同 tick に `isOpen`
- * を直接書き換えることで、navigator pane 等の同期消費側に race を露呈させない。
+ * 読んでも前の状態が見える窓がある。`open()` / `close()` の冪等 gate も自前 ref
+ * のみで判定し、DOM state は判定材料にしない（DOM gate と ref gate が両方ある
+ * と外因 race で「DOM=open / ref=closed」のような乖離状態に陥り、後続の close
+ * 呼び出しが no-op に倒れて ref が永久にズレる）。
  *
- * `syncFromToggleEvent` は popover の `@toggle` event ハンドラから呼ぶ backup。
- * 自前 `open` / `close` を経由しない外因 (ESC dismiss など) で state が動いたとき
- * の整合を取る。自前経路は既に同期で書き換えているため event 経由は no-op になる。
+ * `syncFromToggleEvent` は popover の `@toggle` event ハンドラから呼ぶ後追い同期。
+ * `popover="manual"` では外因で open になる経路は存在せず close 方向の dismiss
+ * （ESC handler が経路を持つが、自前 `close()` を通すよう揃えている）も自前経路を
+ * 通す契約なので、event 経由は基本 no-op。ただし将来 popover 種別変更や外部経路
+ * 追加で外因 close が起きた場合の保険として closed 方向のみ反映する。
  */
 export const usePreviewStore = defineStore("preview", () => {
   const popoverEl = ref<HTMLElement>();
@@ -23,15 +27,17 @@ export const usePreviewStore = defineStore("preview", () => {
   }
 
   function open() {
+    if (isOpen.value) return;
     const el = popoverEl.value;
-    if (!el || el.matches(":popover-open")) return;
+    if (!el) return;
     el.showPopover();
     isOpen.value = true;
   }
 
   function close() {
+    if (!isOpen.value) return;
     const el = popoverEl.value;
-    if (!el || !el.matches(":popover-open")) return;
+    if (!el) return;
     el.hidePopover();
     isOpen.value = false;
   }
@@ -45,7 +51,9 @@ export const usePreviewStore = defineStore("preview", () => {
   }
 
   function syncFromToggleEvent(e: ToggleEvent) {
-    isOpen.value = e.newState === "open";
+    if (e.newState === "closed") {
+      isOpen.value = false;
+    }
   }
 
   return { isOpen, bindPopover, open, close, toggle, syncFromToggleEvent };

--- a/apps/renderer/src/features/preview/usePreviewStore.ts
+++ b/apps/renderer/src/features/preview/usePreviewStore.ts
@@ -1,0 +1,56 @@
+import { acceptHMRUpdate, defineStore } from "pinia";
+import { ref } from "vue";
+
+/**
+ * Preview popover の開閉状態を保持する SSOT。
+ *
+ * `isOpen` は popover DOM の状態ではなく自前 ref で持つ。HTML Popover API の
+ * `toggle` event は spec 上 task に queue される非同期発火のため、`hidePopover()`
+ * / `showPopover()` 直後の同 tick で `popoverEl.matches(":popover-open")` を
+ * 読んでも前の状態が見える窓がある。`open()` / `close()` 内で同 tick に `isOpen`
+ * を直接書き換えることで、navigator pane 等の同期消費側に race を露呈させない。
+ *
+ * `syncFromToggleEvent` は popover の `@toggle` event ハンドラから呼ぶ backup。
+ * 自前 `open` / `close` を経由しない外因 (ESC dismiss など) で state が動いたとき
+ * の整合を取る。自前経路は既に同期で書き換えているため event 経由は no-op になる。
+ */
+export const usePreviewStore = defineStore("preview", () => {
+  const popoverEl = ref<HTMLElement>();
+  const isOpen = ref(false);
+
+  function bindPopover(el: HTMLElement | undefined) {
+    popoverEl.value = el;
+  }
+
+  function open() {
+    const el = popoverEl.value;
+    if (!el || el.matches(":popover-open")) return;
+    el.showPopover();
+    isOpen.value = true;
+  }
+
+  function close() {
+    const el = popoverEl.value;
+    if (!el || !el.matches(":popover-open")) return;
+    el.hidePopover();
+    isOpen.value = false;
+  }
+
+  function toggle() {
+    if (isOpen.value) {
+      close();
+    } else {
+      open();
+    }
+  }
+
+  function syncFromToggleEvent(e: ToggleEvent) {
+    isOpen.value = e.newState === "open";
+  }
+
+  return { isOpen, bindPopover, open, close, toggle, syncFromToggleEvent };
+});
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(usePreviewStore, import.meta.hot));
+}

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -77,6 +77,7 @@ git 変更ファイルには Original / Diff / Current の3タブを表示する
 プレビューペインは右端に配置され、開閉可能。デフォルトは closed。
 
 - ファイル選択時に自動オープン
+- preview 表示中に同一ファイルを navigator 経由 (Filer / Changes) で再選択するとクローズ（toggle 挙動）。`selectRelPath` を呼ばないため `revealVersion` は bump されず、`gozdOpen` 等「常に開く」経路には影響しない。toggle 判定は navigator 内 `onFileSelect` (`NavigatorPane.vue`) に集約
 - worktree 切替 (dir 変化) で自動クローズ。新 worktree でファイル選択を伴う dir 切替 (`gozdOpen` で別 worktree のファイルを指定した経路等) では、続けて選択ファイルで auto-open されるため最終状態は新ファイルで表示継続になる
 - ヘッダーの close ボタンで閉じる
 - `preview.toggle` コマンドで切り替え

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -77,7 +77,7 @@ git 変更ファイルには Original / Diff / Current の3タブを表示する
 プレビューペインは右端に配置され、開閉可能。デフォルトは closed。
 
 - ファイル選択時に自動オープン
-- preview 表示中に同一ファイルを navigator 経由 (Filer / Changes) で再選択するとクローズ（toggle 挙動）。`selectRelPath` を呼ばないため `revealVersion` は bump されず、`gozdOpen` 等「常に開く」経路には影響しない。toggle 判定は navigator 内 `onFileSelect` (`NavigatorPane.vue`) に集約
+- preview 表示中に同一ファイルを navigator (Filer / Changes) で再選択するとクローズする。summary 表示中の同一ファイル再選択は preview を閉じず summary を抜けて単一 file 表示に戻る。CLI の `gozd <file>` 等 navigator 外の open 経路はこの toggle 判定を通らず常に開く
 - worktree 切替 (dir 変化) で自動クローズ。新 worktree でファイル選択を伴う dir 切替 (`gozdOpen` で別 worktree のファイルを指定した経路等) では、続けて選択ファイルで auto-open されるため最終状態は新ファイルで表示継続になる
 - ヘッダーの close ボタンで閉じる
 - `preview.toggle` コマンドで切り替え


### PR DESCRIPTION
## 概要

Navigator (Filer / Changes) で preview 表示中のファイルを再選択した場合の挙動を 3 分岐に整理し、preview 開閉状態を `usePreviewStore` (pinia) に SSOT 化する。

- 同一ファイル再選択 + summary 非表示 → preview を閉じる (toggle close)
- 同一ファイル再選択 + summary 表示中 → summary を抜けて単一 file 表示に戻る (`summaryStore.disable()`)
- それ以外 → 従来通り `selectRelPath`

## 背景

これまで navigator pane (Filer / Changes) から file を選択する経路は常に `worktreeStore.selectRelPath` を呼び、`MainLayout` の `revealVersion` watch が preview を auto-open する一方向の動作だった。preview を閉じたい場合はヘッダの close ボタン / ESC / `preview.toggle` コマンドのいずれかを使う必要があった。「表示中ファイルをもう一度クリックしたら閉じる」 toggle 挙動は VS Code 等の file explorer でも一般的で、preview の開閉操作を navigator 内に閉じ込められる。

実装方針の検討で次の選択肢を却下した。

- `MainLayout` の `revealVersion` watch に toggle 判定を入れる: `gozdOpen` (CLI からの `gozd <file>`) で同 path が再オープンされたケースも toggle close に倒れてしまい、CLI 側の「常に開く」契約が壊れる
- FilerPane と NavigatorPane でそれぞれ toggle ロジックを書く: `selectedRelPath` と preview 開閉状態の参照点が分散して SSOT が崩れる
- preview 開閉状態を context key 経由でのみ参照する: HTML Popover の `toggle` event は spec 上 task に queue される非同期発火のため、`hidePopover()` 直後の同 tick で context key が古い値を返す race の窓が残る
- toggle を `useCommandRegistry().execute("preview.toggle")` で呼ぶ: navigator が close 意図を持って呼ぶのに toggle command 経由は意味的に冗長で、間接化と race を温存する

結果、preview 開閉状態を `usePreviewStore` に集約し navigator がそれを同期的に読む構造に変更した上で、summary 表示中の同一ファイル再選択は popover を閉じるのではなく `summaryStore.disable()` で summary を抜ける挙動とした。`onCloseSummary` (明示 close button) と意味が揃う。

## 変更内容

### preview

- `usePreviewStore` (pinia) を新設し popover 開閉状態を SSOT 化。`open()` / `close()` 内で `isOpen` ref を同 tick に直接書き換えるため、navigator pane 等の同期消費側に popover toggle event の非同期発火 race が露呈しない
- `open()` / `close()` の冪等 gate を `isOpen` ref 単一判定にし、DOM gate との混在で起きる「DOM=open / ref=closed」乖離経路を構造的に排除
- `syncFromToggleEvent` は closed 方向のみ反映する保険として残置 (popover="manual" では外因 open 経路は無く、close 経路も自前 `close()` を通す契約)

### layout

- `MainLayout` の `previewOpen` ref / `openPreview` / `closePreview` / `onPreviewToggle` を撤去し、`previewStore` の関数を直接呼ぶ
- `previewVisible` context key は `previewStore.isOpen` の watch で同期 (keybinding の when 評価専用)
- template の close ボタン / ESC handler / popover @toggle ハンドラも store 経由に置き換え

### navigator

- FilerPane の file クリックを `worktreeStore.selectRelPath` 直接呼び出しから `select` emit に変更し、ChangesPane と対称な構造に揃えた
- 親 NavigatorPane に `onFileSelect` を集約し、FilerPane / ChangesPane 両方の `@select` を接続
- action 決定を pure function `decideSelectAction` に切り出し、`toggle-close` / `exit-summary` / `select` の 3 分岐を discriminated union で表現
- `decideSelectAction.test.ts` を追加 (8 状態 + `selectedRelPath === undefined` 境界を table driven で網羅)

### docs

- `docs/preview.md` の「開閉機能」に navigator 経由の同一ファイル再選択 toggle 挙動と summary 表示中の例外を追記
- `NavigatorPane.vue` / `FilerPane.vue` の `<doc>` ブロックを更新

## 確認事項

- [ ] Filer でファイル A をクリック → preview が開く → 同じ A を再クリックすると preview が閉じる
- [ ] Changes でファイル A をクリック → preview が開く → 同じ A を再クリックすると preview が閉じる
- [ ] preview が閉じた状態で同じ A を再クリック → preview が開き直す
- [ ] preview 表示中に別ファイル B を選択 → preview が B の内容に切り替わる（閉じない）
- [ ] View all で summary 表示中に summary 内の file A 行をクリック → summary が閉じて A の単一 file preview に戻る（popover は閉じない）
- [ ] summary 表示中に summary 外 (Filer) の file B 行をクリック → summary が閉じて B の単一 file preview に切り替わる
- [ ] worktree 切替で preview が閉じる挙動は維持されている
- [ ] CLI から `gozd <file>` を 2 回実行しても preview が閉じない（「常に開く」契約）
- [ ] Filer で同一 file 行を高速 2 連クリック → 閉じる方向に確定し、開き直しの揺れが出ない（popover toggle event の race が露呈しないこと）
