### PR TITLE
fix(wait-until): Task.sleep polling を dedicated NSThread に置き換えて統合

### DIFF
--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -30,11 +30,7 @@ struct PTYManagerTests {
       onExit: { exit.set($0) }
     )
 
-    // issue ( #566 ) 観測: 本 test は CI attempt 1 で tick=1 ( +0.124s ) → tick=2 ( +2.405s )
-    // と `Task.sleep(50ms)` が 2.28s stall した。polling loop 全体を GCD thread 上で完結
-    // させる `waitUntilThreaded` に切り替えて、cooperative executor 外で tick が動くかを
-    // 観測する。
-    await waitUntilThreaded(timeout: .seconds(3)) { exit.snapshot() != nil }
+    await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
 
     // pty (tty mode) は ONLCR で \n を \r\n に変換する。
     let text = String(decoding: data.snapshot(), as: UTF8.self)
@@ -66,12 +62,12 @@ struct PTYManagerTests {
 
     pty.write(Data("ping\n".utf8))
 
-    try await waitUntil(timeout: .seconds(2)) {
+    await waitUntil(timeout: .seconds(2)) {
       String(decoding: data.snapshot(), as: UTF8.self).contains("ping")
     }
 
     pty.kill()
-    try await waitUntil(timeout: .seconds(2)) { exit.snapshot() != nil }
+    await waitUntil(timeout: .seconds(2)) { exit.snapshot() != nil }
 
     if case .signaled(let sig, _) = exit.snapshot() {
       #expect(sig == SIGHUP)
@@ -100,7 +96,7 @@ struct PTYManagerTests {
     )
     pty.resize(rows: 40, cols: 120)
     pty.kill()
-    try await waitUntil(timeout: .seconds(2)) { exit.snapshot() != nil }
+    await waitUntil(timeout: .seconds(2)) { exit.snapshot() != nil }
     #expect(exit.snapshot() != nil)
   }
 
@@ -123,7 +119,7 @@ struct PTYManagerTests {
       onExit: { exit.set($0) }
     )
 
-    try await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
+    await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
 
     // /usr/bin/true は何も出力せず exit 0 で終わる。
     // tty mode で promptless なので、データは 0 byte または echo 由来の数 byte のみ。
@@ -149,7 +145,7 @@ struct PTYManagerTests {
       onExit: { exit.set($0) }
     )
 
-    try await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
+    await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
 
     // login_tty で slave fd は stdin/stdout/stderr すべてに dup2 されているため
     // stderr 出力も master 経由で観測できる。
@@ -185,7 +181,7 @@ struct PTYManagerTests {
       onExit: { exit.set($0) }
     )
 
-    try await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
+    await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
     #expect(exit.snapshot() == .exited(code: 124))
   }
 
@@ -210,7 +206,7 @@ struct PTYManagerTests {
       onExit: { exit.set($0) }
     )
 
-    try await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
+    await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
     #expect(exit.snapshot() == .exited(code: 126))
   }
 
@@ -233,7 +229,7 @@ struct PTYManagerTests {
       onExit: { exit.set($0) }
     )
 
-    try await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
+    await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
 
     // POSIX shell 慣例 / CPty.c の child で execve ENOENT → _exit(127)。
     #expect(exit.snapshot() == .exited(code: 127))
@@ -410,11 +406,8 @@ private func expectedErrnoText(_ code: Int32) -> String {
 
 // MARK: - Helpers
 
-// `waitUntil` / `waitUntilThreaded` は `WaitUntil.swift` の共有実装を使う
-// （issue #556 観測項目 3 / issue #566 観測項目）。
-// tick polling 履歴を持ち、timeout 時に Issue.record の message に inline する。
-// `receivesOutputAndExit` のみ `waitUntilThreaded` ( GCD thread で polling loop 完結 ) を使い、
-// 他 test は `waitUntil` ( Task.sleep 経路 ) のまま並走させて同 stall window で経路を比較する。
+// `waitUntil` は `WaitUntil.swift` の共有実装 ( dedicated NSThread 上で polling loop を完結 )。
+// tick polling 履歴を保持し、timeout 時に Issue.record の message に inline する。
 
 private final class DataCollector: @unchecked Sendable {
   private let lock = NSLock()

--- a/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
@@ -41,11 +41,7 @@ struct PTYRegistryTests {
     // test である本 test の副次 assertion に統合した（PR #597 review feedback）。
     #expect(id2 == id1 + 1)
 
-    // issue ( #566 ) 観測: 本 test は CI attempt 1 で tick=1 ( +1.161s ) → tick=2 ( +2.534s )
-    // と `Task.sleep(50ms)` が 1.37s stall した ( SocketServer / receivesOutputAndExit と
-    // 同じ stall window )。polling loop 全体を GCD thread 上で完結させる
-    // `waitUntilThreaded` に切り替えて経路を完全分離する。
-    await waitUntilThreaded(timeout: .seconds(3)) {
+    await waitUntil(timeout: .seconds(3)) {
       events.exitedIds().contains(id1) && events.exitedIds().contains(id2)
     }
 
@@ -76,7 +72,7 @@ struct PTYRegistryTests {
     try await Task.sleep(for: .milliseconds(100))
     await registry.kill(id: id)
 
-    try await waitUntil(timeout: .seconds(2)) {
+    await waitUntil(timeout: .seconds(2)) {
       events.exitedIds().contains(id)
     }
     // remove は exit handler 経由で `Task { await self.remove }` で発火するため、
@@ -188,10 +184,8 @@ struct PTYRegistryTests {
 
 // MARK: - Helpers
 
-// `waitUntil` / `waitUntilThreaded` は `WaitUntil.swift` の共有実装を使う
-// （issue #556 観測項目 3 / issue #566 観測項目）。
-// `spawnAndExitDispatch` のみ `waitUntilThreaded` ( GCD thread で polling loop 完結 ) を使い、
-// 他 test は `waitUntil` ( Task.sleep 経路 ) のまま並走させて同 stall window で経路を比較する。
+// `waitUntil` は `WaitUntil.swift` の共有実装 ( dedicated NSThread 上で polling loop を完結 )。
+// tick polling 履歴を保持し、timeout 時に Issue.record の message に inline する。
 
 private final class EventCollector: @unchecked Sendable {
   private let lock = NSLock()

--- a/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
@@ -86,7 +86,7 @@ struct PTYRegistryTests {
   }
 
   @Test("未知の ptyId への write / resize / kill は no-op")
-  func unknownIdIsNoop() async throws {
+  func unknownIdIsNoop() async {
     testTrace("started")
     defer { testTrace("ended") }
     let events = EventCollector()

--- a/apps/native/Tests/GozdCoreTests/SocketServerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/SocketServerTests.swift
@@ -18,20 +18,11 @@ struct SocketServerTests {
     try server.start { data in messages.append(data) }
     defer { server.stop() }
 
-    // issue ( #566 ) 観測: SocketServer suite の `fileExists` polling は CI attempt 1 で
-    // `Task.sleep` 経路の stall を踏んだ。polling loop 全体を GCD thread 上で完結させる
-    // `waitUntilThreaded` に置き換えて、cooperative executor 外で tick が発火し続けるか
-    // を観測する。先行版 `waitUntilDispatch` ( CI run 26029332080 attempt 1 で実証 ) は
-    // resume 経路が cooperative executor に hop して観測精度が不十分だった。
-    await waitUntilThreaded(timeout: .seconds(2)) { fileExists(path) }
+    await waitUntil(timeout: .seconds(2)) { fileExists(path) }
 
     try sendOverUnixSocket(path: path, data: Data(#"{"type":"ping"}\#n"#.utf8))
 
-    // 後段 polling は attempt 1 で stall を踏んでいない ( fileExists 段で test が fail し
-    // ここまで到達しない )。同 test 内に Task.sleep 経路の比較対象を残すため waitUntil の
-    // ままにする。fileExists ( GCD ) と message-count ( Task ) が並走して、同 stall window
-    // でどちらが先に詰まるかを観測できる。
-    try await waitUntil(timeout: .seconds(2)) { messages.snapshot().count == 1 }
+    await waitUntil(timeout: .seconds(2)) { messages.snapshot().count == 1 }
     let received = messages.snapshot()
     #expect(received.count == 1)
     #expect(String(decoding: received[0], as: UTF8.self) == #"{"type":"ping"}"#)
@@ -49,7 +40,7 @@ struct SocketServerTests {
     try server.start { data in messages.append(data) }
     defer { server.stop() }
 
-    await waitUntilThreaded(timeout: .seconds(2)) { fileExists(path) }
+    await waitUntil(timeout: .seconds(2)) { fileExists(path) }
 
     let payload = Data(
       """
@@ -60,8 +51,7 @@ struct SocketServerTests {
       """.utf8)
     try sendOverUnixSocket(path: path, data: payload)
 
-    // 後段 polling は比較対象として waitUntil を残す ( receivesSingleLine と同設計 )。
-    try await waitUntil(timeout: .seconds(2)) { messages.snapshot().count == 3 }
+    await waitUntil(timeout: .seconds(2)) { messages.snapshot().count == 3 }
     let received = messages.snapshot().map { String(decoding: $0, as: UTF8.self) }
     #expect(received == [#"{"i":1}"#, #"{"i":2}"#, #"{"i":3}"#])
   }
@@ -78,7 +68,7 @@ struct SocketServerTests {
     try server.start { data in messages.append(data) }
     defer { server.stop() }
 
-    await waitUntilThreaded(timeout: .seconds(2)) { fileExists(path) }
+    await waitUntil(timeout: .seconds(2)) { fileExists(path) }
 
     try await withThrowingTaskGroup(of: Void.self) { group in
       for i in 0..<5 {
@@ -89,8 +79,7 @@ struct SocketServerTests {
       try await group.waitForAll()
     }
 
-    // 後段 polling は比較対象として waitUntil を残す ( receivesSingleLine と同設計 )。
-    try await waitUntil(timeout: .seconds(3)) { messages.snapshot().count == 5 }
+    await waitUntil(timeout: .seconds(3)) { messages.snapshot().count == 5 }
     let received = Set(messages.snapshot().map { String(decoding: $0, as: UTF8.self) })
     let expected: Set<String> = (0..<5).map { #"{"i":\#($0)}"# }.reduce(into: Set()) {
       $0.insert($1)
@@ -112,13 +101,8 @@ private func fileExists(_ path: String) -> Bool {
   return stat(path, &st) == 0
 }
 
-// `waitUntil` / `waitUntilThreaded` は `WaitUntil.swift` の共有実装を使う
-// （issue #556 観測項目 3 / issue #566 観測項目）。
-// 旧 silent return 版は timeout 時に Issue.record を呼ばず後段の `#expect` が別症状で
-// 間接 fail していた。共有版は tick 履歴を Issue.record の message に inline する。
-// 本 test は `fileExists` polling を `waitUntilThreaded` ( GCD thread 上で polling loop
-// 完結 )、後段 message-count polling を `waitUntil` ( Task.sleep 経路 ) に分けて、
-// 同 stall window で両経路の挙動を比較する。
+// `waitUntil` は `WaitUntil.swift` の共有実装 ( dedicated NSThread 上で polling loop を完結 )。
+// timeout 時に `Issue.record` で tick 履歴を message に inline する。
 
 enum SocketClientError: Error, CustomStringConvertible {
   case createSocket(errno: Int32)

--- a/apps/native/Tests/GozdCoreTests/WaitUntil.swift
+++ b/apps/native/Tests/GozdCoreTests/WaitUntil.swift
@@ -27,10 +27,15 @@ import Testing
 //
 // trace 出力 ( `[TEST-TRACE]` プレフィックス、`gozdTraceStart` を共有 ):
 //
-//   - entry: `waitUntil entered timeout=... desc=...`
-//   - tick:  `waitUntil tick=<n> elapsed=<dur> wall=<sec> result=<bool>`
-//   - 成功:  `waitUntil resolved tick=<n> elapsed=<dur>`
-//   - timeout: `waitUntil timeout tickCount=<n> elapsed=<dur> lastTicks=[...]`
+//   - entry: `waitUntil mode=threaded entered timeout=... desc=...`
+//   - tick:  `waitUntil mode=threaded tick=<n> elapsed=<dur> wall=<sec> result=<bool>`
+//   - 成功:  `waitUntil mode=threaded resolved tick=<n> elapsed=<dur>`
+//   - timeout: `waitUntil mode=threaded timeout tickCount=<n> elapsed=<dur> lastTicks=[...]`
+//
+// `mode=threaded` は本 helper が NSThread polling であることを示す識別子。
+// 過去 CI log には旧 `waitUntil` ( Task.sleep 経路 ) / `waitUntilThreaded` ( 別シンボル ) の
+// trace が含まれるため、`analyze-stall.sh` で世代を merge して解析するときに kind を
+// 区別するためのもの。世代別 trace 形式 (kind 列の挙動) は `analyze-stall.sh` 側に集約。
 //
 // 直近 10 tick の polling 履歴を保持し、timeout 時に `Issue.record` の message に inline
 // する。50ms poll × 10 = 直近 0.5s 分の挙動が CI ログを遡らずに失敗メッセージから読める。
@@ -45,7 +50,7 @@ func waitUntil(
   _ condition: @escaping @Sendable () -> Bool,
   sourceLocation: SourceLocation = #_sourceLocation
 ) async {
-  testTrace("waitUntil entered timeout=\(timeout) desc=\(description)")
+  testTrace("waitUntil mode=threaded entered timeout=\(timeout) desc=\(description)")
   let result: WaitResult = await withCheckedContinuation { continuation in
     let thread = Thread {
       let started = ContinuousClock.now
@@ -106,7 +111,7 @@ private func threadTrace(_ message: String) {
   guard gozdTraceEnabled else { return }
   let elapsed = ContinuousClock.now - gozdTraceStart
   let testName = Test.current?.name ?? "<threaded>"
-  gozdTraceLine("[TEST-TRACE +\(elapsed) test=\(testName)] waitUntil \(message)\n")
+  gozdTraceLine("[TEST-TRACE +\(elapsed) test=\(testName)] waitUntil mode=threaded \(message)\n")
 }
 
 private enum WaitResult {

--- a/apps/native/Tests/GozdCoreTests/WaitUntil.swift
+++ b/apps/native/Tests/GozdCoreTests/WaitUntil.swift
@@ -3,154 +3,50 @@ import Testing
 
 @testable import GozdCore
 
-// PTYManagerTests / PTYRegistryTests / SocketServerTests で共有する条件待機ヘルパー。
+// `condition()` が true になるまで小さくポーリングで待つ test 共有 helper。
 //
-// 旧実装は各テストファイルに `private func waitUntil` を重複定義しており、
-// timeout 時に「いつから condition が false だったか」が分からなかった（issue #556 観測項目 3）。
-// 本実装は tick ごとの condition 結果を直近 10 件保持し、timeout 時に Issue.record の
-// failure メッセージに inline する。CI ログを遡らずに失敗メッセージから 2 秒分の polling
-// 推移が読めるようにするのが目的。
+// 実装契約:
 //
-// 加えて `[TEST-TRACE]` で entry / tick / resolve / timeout を stderr に流すため、
-// 同じ ContinuousClock 基準を持つ `[PTY-TRACE]` と時系列を突き合わせ可能になる。
+// - polling loop ( condition 評価 / trace 出力 / `Thread.sleep(forTimeInterval:)` ) は
+//   `Thread { ... }.start()` で立てた **dedicated NSThread** 上で完結する。Swift Concurrency
+//   の cooperative executor 経路を一切踏まないため、`Task.sleep` 経由で発火する
+//   executor 固有 stall の影響を受けない。`withCheckedContinuation` の resume は polling
+//   終了 ( resolved / timeout ) 時の 1 回のみ
+// - GCD pool も使わないため `Thread.sleep` の blocking が他 GCD 処理 ( SocketServer 専用
+//   queue 含め `DispatchQueue.global()` worker pool に依存する全経路 ) を阻害しない
+// - `condition` は **同期的に評価できる predicate に限定** する ( `await` を含む condition は
+//   渡してはいけない )。NSThread 上で評価されるため `await` を呼ぶと再び cooperative
+//   executor に hop する。本 helper 利用 test の condition ( `fileExists` /
+//   `MessageCollector.snapshot()` / `ExitCollector.snapshot()` / `events.exitedIds()` 等 ) は
+//   すべて NSLock ベースで同期完結する
+// - 本 helper は **cancel に応答しない** ( `throws` を返さず `Task.checkCancellation` も
+//   呼ばない )。外側 Task が cancel されても polling は timeout まで継続する。NSThread を
+//   `cancel()` で止める分岐は trace 解析の余計なノイズになるため採用しない
+// - timeout 時は `Issue.record` で test を fail させる。silent return すると後段の
+//   `#expect` が別の症状で間接 fail し、timeout だった事象が trace から追跡できなくなる
 //
-// issue ( #566 ) 観測項目:
+// trace 出力 ( `[TEST-TRACE]` プレフィックス、`gozdTraceStart` を共有 ):
 //
-// - tick trace 行に `wall=<Date 秒>` を併記する。`ContinuousClock`
-//   ( `mach_continuous_time` 基盤、suspend 中も進む ) と `Date` ( system clock、NTP 調整 )
-//   を並列に記録し、稀な system clock 異常 ( NTP 巻き戻し / sleep wake 後の補正 ) と
-//   通常の単調進行を区別する保険として残す。(i)/(ii) 切り分けの主軸ではない。
+//   - entry: `waitUntil entered timeout=... desc=...`
+//   - tick:  `waitUntil tick=<n> elapsed=<dur> wall=<sec> result=<bool>`
+//   - 成功:  `waitUntil resolved tick=<n> elapsed=<dur>`
+//   - timeout: `waitUntil timeout tickCount=<n> elapsed=<dur> lastTicks=[...]`
 //
-// - `waitUntilThreaded` を追加する。`Thread { ... }.start()` で立てた dedicated NSThread で
-//   polling loop **全体** ( condition 評価 / trace 出力 / sleep ) を完結させ、
-//   `withCheckedContinuation` の resume は polling 終了 ( resolved / timeout ) 時のみ呼ぶ。
-//   これにより polling loop の実行 thread が Swift Concurrency の cooperative executor から
-//   完全に外れる。GCD pool も使わないため `Thread.sleep(forTimeInterval:)` の blocking が
-//   他 GCD 処理を阻害しない ( SocketServer 専用 queue 含め `DispatchQueue.global()` の
-//   worker pool に依存する他 GCD 処理は worker 枯渇の間接影響を受けない )。
+// 直近 10 tick の polling 履歴を保持し、timeout 時に `Issue.record` の message に inline
+// する。50ms poll × 10 = 直近 0.5s 分の挙動が CI ログを遡らずに失敗メッセージから読める。
 //
-//   先行版の `waitUntilDispatch` ( CI run 26029332080 attempt 1 で実証 ) は `withCheckedContinuation`
-//   経由で sleep の wait phase だけを GCD に逃がし、resume 後の polling iteration が
-//   cooperative executor に hop して戻る構造だった。結果 `Task.sleep` 経路と同じ stall
-//   window で詰まり、(i) cooperative executor 固有 stall / (ii) OS scheduler 全体停止 の
-//   切り分けに不十分だった。`waitUntilThreaded` はこの設計欠陥を構造的に解消する版。
-//
-//   期待される観測:
-//   - (i) cooperative executor 固有が真: `waitUntilThreaded` の tick は stall window 中も
-//     50ms 間隔で発火、同 window で `waitUntil` ( Task.sleep 経路 ) だけが詰まる
-//   - (ii) OS scheduler 全体停止が真: `waitUntilThreaded` も同 window で詰まる
-//
-// 重複の意図: `waitUntil` と `waitUntilThreaded` は polling loop の構造がほぼ同一だが、
-// 観測 PR の独立性 ( 片方を変更しても他方が影響を受けない保証 ) を保つため敢えて重複させる。
-// 観測終了後の fix PR で一本化するかは別判断。
+// `wall=<Date.timeIntervalSinceReferenceDate>` を併記し、`ContinuousClock`
+// ( `mach_continuous_time` 基盤、suspend 中も進む ) と `Date` ( system clock、NTP 調整 ) を
+// 並列に記録する。稀な system clock 異常 ( NTP 巻き戻し / sleep wake 後の補正 ) の検知用。
 
-/// `condition()` が true を返すまで小さくポーリングで待つ ( `Task.sleep` 経路 )。
-/// timeout 到達時に `Issue.record` で test を fail させる。silent return すると後段の
-/// `#expect` が別の症状（exit が nil など）で間接 fail し、timeout だった事象を追跡
-/// できなくなる。
-///
-/// **cancel 経路**: `try await Task.sleep(for:)` を使うため、外側 Task が cancel されると
-/// `CancellationError` を throw する。これは `waitUntilThreaded` ( cancel 非対応 ) との
-/// 意図的な非対称設計。observation PR では Task.sleep 経路と完全独立 thread 経路を
-/// 並走させて挙動を比較するのが目的で、cancel 経路まで揃える必要はない。
-///
-/// - Parameters:
-///   - timeout: 待機の上限。超過時に Issue.record。
-///   - description: timeout 失敗メッセージに含める「何を待っていたか」の説明。
-///   - condition: 各 tick で評価する条件。`@Sendable` な capture のみ可。
-///
-/// trace 出力:
-///   - entry: `waitUntil entered timeout=... desc=...`
-///   - tick: `waitUntil tick=<n> elapsed=<dur> wall=<sec> result=<bool>`
-///   - 成功: `waitUntil resolved tick=<n> elapsed=<dur>`
-///   - timeout: `waitUntil timeout tickCount=<n> elapsed=<dur> lastTicks=[...]`
 func waitUntil(
   timeout: Duration,
   description: String = "condition",
   _ condition: @escaping @Sendable () -> Bool,
   sourceLocation: SourceLocation = #_sourceLocation
-) async throws {
-  let started = ContinuousClock.now
-  let deadline = started.advanced(by: timeout)
-  testTrace("waitUntil entered timeout=\(timeout) desc=\(description)")
-  // 直近 N tick の polling 推移を保持。`N=10` は 50ms poll × 10 = 0.5s 分。
-  // 2 秒 timeout の場合「終端直前 0.5 秒の挙動」が再構築できれば
-  // 「開始直後から nil で固定」/「最後の数 tick だけ nil」の区別が付く。
-  let historyCap = 10
-  var tickHistory: [(elapsed: Duration, result: Bool)] = []
-  var tickCount = 0
-  while ContinuousClock.now < deadline {
-    let elapsed = ContinuousClock.now - started
-    let wall = Date().timeIntervalSinceReferenceDate
-    let result = condition()
-    tickCount += 1
-    tickHistory.append((elapsed, result))
-    if tickHistory.count > historyCap {
-      tickHistory.removeFirst(tickHistory.count - historyCap)
-    }
-    testTrace("waitUntil tick=\(tickCount) elapsed=\(elapsed) wall=\(wall) result=\(result)")
-    if result {
-      testTrace("waitUntil resolved tick=\(tickCount) elapsed=\(elapsed)")
-      return
-    }
-    testTrace("waitUntil before-sleep tick=\(tickCount)")
-    try await Task.sleep(for: .milliseconds(50))
-    testTrace("waitUntil after-sleep tick=\(tickCount)")
-  }
-  let elapsed = ContinuousClock.now - started
-  let historyText = tickHistory
-    .map { "\($0.elapsed):\($0.result)" }
-    .joined(separator: ", ")
-  testTrace(
-    "waitUntil timeout tickCount=\(tickCount) elapsed=\(elapsed) lastTicks=[\(historyText)]")
-  Issue.record(
-    """
-    waitUntil timed out after \(timeout) waiting for: \(description). \
-    elapsed=\(elapsed) tickCount=\(tickCount). \
-    last \(tickHistory.count) ticks: [\(historyText)]
-    """,
-    sourceLocation: sourceLocation)
-}
-
-/// `waitUntil` の **polling loop 全体を dedicated NSThread 上で完結** させる版。Swift
-/// Concurrency の cooperative executor 経路を完全に外し、`Task.sleep` 経路で詰まる
-/// 2 秒 stall ( PR #565 attempt 1 で初観測 ) との切り分けに使う。
-///
-/// 中間版 `waitUntilDispatch` ( GCD `asyncAfter` + `withCheckedContinuation` 経由、
-/// CI run 26029332080 attempt 1 で観測 ) も cooperative executor stall に巻き込まれ
-/// 観測無効と実証されたため、polling loop **全体** を Swift Concurrency runtime から
-/// 外す構造に到達した。
-///
-/// 実装上の契約:
-///
-/// - polling loop ( condition 評価 / trace 出力 / `Thread.sleep(forTimeInterval:)` ) は
-///   `Thread { ... }.start()` で立てた **dedicated NSThread** 上で完結する。GCD worker
-///   thread pool を使わないため、`Thread.sleep` の blocking で GCD pool を専有する経路は
-///   発生しない ( SocketServer 専用 queue 含め、`DispatchQueue.global()` の worker pool に
-///   依存する他 GCD 処理は worker 枯渇の間接影響を受けない )。
-///   `withCheckedContinuation` の resume は polling 終了時 ( resolved / timeout ) の **1 回のみ**
-/// - `condition` は **同期的に評価できる predicate に限定** する ( `await` を含む condition は
-///   渡してはいけない )。内部で async を呼ぶと再び cooperative executor に hop して観測精度が
-///   失われる。本 PR 対象 5 test の condition ( `fileExists` / `MessageCollector.snapshot()` /
-///   `ExitCollector.snapshot()` / `events.exitedIds()` ) はすべて同期完結する NSLock ベースで
-///   契約を満たす
-/// - `Issue.record` は cooperative executor / GCD / NSThread どこから呼んでも safe
-///
-/// **cancel 経路**: 本関数は cancel に応答しない設計 ( `throws` を返さない、`Task.checkCancellation`
-/// を呼ばない )。NSThread を `cancel()` で止める経路は条件分岐コストが trace に乗るので
-/// 観測 PR では採用しない。外側 Task が cancel されても polling は timeout まで継続する。
-/// `waitUntil` ( cancel あり ) との意図的な非対称設計で、両経路の挙動を独立に観測する目的。
-///
-/// trace 出力は `[TEST-TRACE]` 共有 + 行内 `waitUntilThreaded` で grep 分離可能。
-/// `waitUntil` と同じ tick / before-sleep / after-sleep の粒度で出す。
-func waitUntilThreaded(
-  timeout: Duration,
-  description: String = "condition",
-  _ condition: @escaping @Sendable () -> Bool,
-  sourceLocation: SourceLocation = #_sourceLocation
 ) async {
-  testTrace("waitUntilThreaded entered timeout=\(timeout) desc=\(description)")
-  let result: ThreadedWaitResult = await withCheckedContinuation { continuation in
+  testTrace("waitUntil entered timeout=\(timeout) desc=\(description)")
+  let result: WaitResult = await withCheckedContinuation { continuation in
     let thread = Thread {
       let started = ContinuousClock.now
       let deadline = started.advanced(by: timeout)
@@ -166,27 +62,27 @@ func waitUntilThreaded(
         if tickHistory.count > historyCap {
           tickHistory.removeFirst(tickHistory.count - historyCap)
         }
-        threadedTrace(
+        threadTrace(
           "tick=\(tickCount) elapsed=\(elapsed) wall=\(wall) result=\(condResult)")
         if condResult {
-          threadedTrace("resolved tick=\(tickCount) elapsed=\(elapsed)")
+          threadTrace("resolved tick=\(tickCount) elapsed=\(elapsed)")
           continuation.resume(returning: .resolved)
           return
         }
-        threadedTrace("before-sleep tick=\(tickCount)")
+        threadTrace("before-sleep tick=\(tickCount)")
         Thread.sleep(forTimeInterval: 0.050)
-        threadedTrace("after-sleep tick=\(tickCount)")
+        threadTrace("after-sleep tick=\(tickCount)")
       }
       let finalElapsed = ContinuousClock.now - started
       let historyText = tickHistory
         .map { "\($0.elapsed):\($0.result)" }
         .joined(separator: ", ")
-      threadedTrace(
+      threadTrace(
         "timeout tickCount=\(tickCount) elapsed=\(finalElapsed) lastTicks=[\(historyText)]")
       continuation.resume(
         returning: .timeout(elapsed: finalElapsed, tickCount: tickCount, history: historyText))
     }
-    thread.name = "WaitUntilThreaded"
+    thread.name = "WaitUntil"
     thread.start()
   }
   switch result {
@@ -195,7 +91,7 @@ func waitUntilThreaded(
   case .timeout(let elapsed, let tickCount, let history):
     Issue.record(
       """
-      waitUntilThreaded timed out after \(timeout) waiting for: \(description). \
+      waitUntil timed out after \(timeout) waiting for: \(description). \
       elapsed=\(elapsed) tickCount=\(tickCount). \
       last ticks: [\(history)]
       """,
@@ -203,20 +99,17 @@ func waitUntilThreaded(
   }
 }
 
-/// `waitUntilThreaded` 内 dedicated NSThread からの trace は `Test.current` が解決できる
-/// 保証が無いため、`testTrace` ではなく `gozdTraceLine` を直接呼んで `<no-test>` 経由ではなく
-/// `<threaded>` タグで吐く。NSThread と `Test.current` の TaskLocal の関係は未保証
-/// ( TaskLocal は Swift Concurrency の Task に紐づく storage で、NSThread closure は
-/// Task の outside で実行されるため、TaskLocal は伝播せず `Test.current` は nil になる
-/// のが期待動作。実観測は CI run の trace で `<threaded>` が出ることで確認する )。
-private func threadedTrace(_ message: String) {
+/// NSThread closure からの trace。`Test.current` は Swift Concurrency の TaskLocal で
+/// NSThread 上では nil になるため、`testTrace` ではなく `gozdTraceLine` を直接呼んで
+/// `<no-test>` ではなく `<threaded>` タグで出す。
+private func threadTrace(_ message: String) {
   guard gozdTraceEnabled else { return }
   let elapsed = ContinuousClock.now - gozdTraceStart
   let testName = Test.current?.name ?? "<threaded>"
-  gozdTraceLine("[TEST-TRACE +\(elapsed) test=\(testName)] waitUntilThreaded \(message)\n")
+  gozdTraceLine("[TEST-TRACE +\(elapsed) test=\(testName)] waitUntil \(message)\n")
 }
 
-private enum ThreadedWaitResult {
+private enum WaitResult {
   case resolved
   case timeout(elapsed: Duration, tickCount: Int, history: String)
 }

--- a/apps/native/Tests/GozdCoreTests/WaitUntil.swift
+++ b/apps/native/Tests/GozdCoreTests/WaitUntil.swift
@@ -32,10 +32,8 @@ import Testing
 //   - 成功:  `waitUntil mode=threaded resolved tick=<n> elapsed=<dur>`
 //   - timeout: `waitUntil mode=threaded timeout tickCount=<n> elapsed=<dur> lastTicks=[...]`
 //
-// `mode=threaded` は本 helper が NSThread polling であることを示す識別子。
-// 過去 CI log には旧 `waitUntil` ( Task.sleep 経路 ) / `waitUntilThreaded` ( 別シンボル ) の
-// trace が含まれるため、`analyze-stall.sh` で世代を merge して解析するときに kind を
-// 区別するためのもの。世代別 trace 形式 (kind 列の挙動) は `analyze-stall.sh` 側に集約。
+// `mode=threaded` は polling 経路の識別子。`analyze-stall.sh` の kind 列で
+// `waitUntil-threaded` として折り畳まれる。kind 値の SSOT 一覧は `analyze-stall.sh` 側に置く。
 //
 // 直近 10 tick の polling 履歴を保持し、timeout 時に `Issue.record` の message に inline
 // する。50ms poll × 10 = 直近 0.5s 分の挙動が CI ログを遡らずに失敗メッセージから読める。

--- a/apps/native/scripts/analyze-stall.sh
+++ b/apps/native/scripts/analyze-stall.sh
@@ -4,8 +4,11 @@
 # 「同時刻 stall window」を集計する。「どの test の tick がどの時刻に発火したか」
 # 「stall window の幅 ( tick 間 gap が閾値を超える区間 ) はどれか」を 1 view で出す。
 #
-# 対応 helper: `waitUntil` ( dedicated NSThread 上で polling loop を完結 )。perl regex は
-# `waitUntilDispatch` / `waitUntilThreaded` も OR で拾うため、旧版の CI log にも適用可能。
+# 対応 helper: `waitUntil` ( dedicated NSThread 上で polling loop を完結、`mode=threaded` token
+# 付き )。perl regex は旧版 `waitUntil` ( Task.sleep 経路、mode token なし ) / `waitUntilThreaded`
+# ( PR #567 で導入した別シンボル ) / `waitUntilDispatch` ( PR #567 で廃棄した中間版 ) も OR で
+# 拾うため過去の CI log にも適用可能。kind 列は `waitUntil-threaded` ( 現行 ) /
+# `waitUntilThreaded` / `waitUntilDispatch` / `waitUntil` ( 旧 Task.sleep 版 ) の 4 値で区別する。
 #
 # 入力: CI log を stdin に流すか、第 1 引数に log file path を渡す。
 # 出力:
@@ -30,17 +33,19 @@ STALL_THRESHOLD="${STALL_THRESHOLD:-0.5}"
 input="${1:-/dev/stdin}"
 
 # tick 行を `elapsed<TAB>wall<TAB>test<TAB>kind<TAB>tick<TAB>result` に正規化する。
-# trace 行例 ( wall= は新版で付く。旧 trace との互換のためオプショナル ):
+# trace 行例 ( `mode=...` token は現行版 `waitUntil` で付く。旧 trace との互換のためオプショナル ):
+#   2026-05-24T09:00:00.0000000Z [TEST-TRACE +0.004 seconds test=writeRoundTrip()] waitUntil mode=threaded tick=1 elapsed=2.3875e-05 seconds wall=800792337.6 result=false
 #   2026-05-18T09:40:24.2295220Z [TEST-TRACE +0.004299333 seconds test=receivesMultipleLines()] waitUntil tick=1 elapsed=2.3875e-05 seconds wall=800792337.6 result=false
+# mode token がある行は kind 列に `<prefix>-<mode>` ( 例 `waitUntil-threaded` ) として畳み込む。
 extract() {
   perl -ne '
-    next unless /\[TEST-TRACE \+([0-9.eE+\-]+) seconds test=(\S+?)\] (waitUntilThreaded|waitUntilDispatch|waitUntil) tick=(\d+) elapsed=\S+ seconds (?:wall=(\S+) )?result=(true|false)/;
+    next unless /\[TEST-TRACE \+([0-9.eE+\-]+) seconds test=(\S+?)\] (waitUntilThreaded|waitUntilDispatch|waitUntil)(?: mode=(\S+))? tick=(\d+) elapsed=\S+ seconds (?:wall=(\S+) )?result=(true|false)/;
     my $elapsed = $1;
     my $name    = $2;
-    my $kind    = $3;
-    my $tick    = $4;
-    my $wall    = defined($5) ? $5 : "";
-    my $result  = $6;
+    my $kind    = defined($4) ? "$3-$4" : $3;
+    my $tick    = $5;
+    my $wall    = defined($6) ? $6 : "";
+    my $result  = $7;
     print join("\t", $elapsed, $wall, $name, $kind, $tick, $result), "\n";
   ' "$1" | sort -n -k1,1
 }

--- a/apps/native/scripts/analyze-stall.sh
+++ b/apps/native/scripts/analyze-stall.sh
@@ -1,15 +1,11 @@
 #!/usr/bin/env bash
 #
 # CI log の `[TEST-TRACE]` waitUntil tick 行を test 横断で時系列ソートし、
-# 「同時刻 stall window」を集計する。
+# 「同時刻 stall window」を集計する。「どの test の tick がどの時刻に発火したか」
+# 「stall window の幅 ( tick 間 gap が閾値を超える区間 ) はどれか」を 1 view で出す。
 #
-# issue ( #566 ) で観測した stall は SocketServer / PTYManager / PTYRegistry の
-# 並列 test が同一 window ( +0s〜+2.04s ) で `Task.sleep(50ms)` が全停止する pattern
-# だった。本スクリプトは「どの test の tick がどの時刻に発火したか」「stall window
-# の幅 ( tick 間 gap が閾値を超える区間 ) はどれか」を 1 view で出す。
-#
-# 対応 helper: `waitUntil` ( Task.sleep 経路 ) / `waitUntilDispatch` ( 旧版、観測無効と
-# 判明 ) / `waitUntilThreaded` ( polling loop 全体を GCD thread 上で完結 )。kind 列で区別。
+# 対応 helper: `waitUntil` ( dedicated NSThread 上で polling loop を完結 )。perl regex は
+# `waitUntilDispatch` / `waitUntilThreaded` も OR で拾うため、旧版の CI log にも適用可能。
 #
 # 入力: CI log を stdin に流すか、第 1 引数に log file path を渡す。
 # 出力:

--- a/apps/native/scripts/analyze-stall.sh
+++ b/apps/native/scripts/analyze-stall.sh
@@ -4,11 +4,10 @@
 # 「同時刻 stall window」を集計する。「どの test の tick がどの時刻に発火したか」
 # 「stall window の幅 ( tick 間 gap が閾値を超える区間 ) はどれか」を 1 view で出す。
 #
-# 対応 helper: `waitUntil` ( dedicated NSThread 上で polling loop を完結、`mode=threaded` token
-# 付き )。perl regex は旧版 `waitUntil` ( Task.sleep 経路、mode token なし ) / `waitUntilThreaded`
-# ( PR #567 で導入した別シンボル ) / `waitUntilDispatch` ( PR #567 で廃棄した中間版 ) も OR で
-# 拾うため過去の CI log にも適用可能。kind 列は `waitUntil-threaded` ( 現行 ) /
-# `waitUntilThreaded` / `waitUntilDispatch` / `waitUntil` ( 旧 Task.sleep 版 ) の 4 値で区別する。
+# 対応 helper: `waitUntil` ( dedicated NSThread polling、`mode=threaded` token 付き )。
+# perl regex は `waitUntilThreaded` / `waitUntilDispatch` / `waitUntil` ( mode token なし ) も
+# OR で拾い、kind 列を `waitUntil-threaded` / `waitUntilThreaded` / `waitUntilDispatch` /
+# `waitUntil` の 4 値に正規化する。
 #
 # 入力: CI log を stdin に流すか、第 1 引数に log file path を渡す。
 # 出力:


### PR DESCRIPTION
## 概要

`apps/native/Tests/GozdCoreTests/WaitUntil.swift` の `waitUntil` を **dedicated NSThread 上の polling loop** に置き換え、観測 PR ( #567 ) で並走させていた `waitUntilThreaded` と統合する。test infrastructure 全体の polling 経路を Swift Concurrency cooperative executor から構造的に外し、issue ( #566 ) / issue ( #624 ) で 2 度観測された `Task.sleep` stall 由来の flake を根本から解消する。

## 背景

`PTYManagerTests` / `PTYRegistryTests` / `SocketServerTests` の polling timeout は過去に「推定根治」を謳う PR が 2 回失敗してきた:

- PR ( #545 ) — `forkpty` 経路の race を直したが他経路で再発
- PR ( #550 ) — exit handler の即時 markReadClosed で 2 秒遅延を消したが別経路で再発

issue ( #556 ) で trace 粒度を引き上げ、PR ( #565 ) / PR ( #567 ) で `[TEST-TRACE]` `[PTY-TRACE]` と `waitUntilThreaded` ( dedicated NSThread polling ) を導入。CI run 26025564280 / 26029332080 / 26357231742 で次の事実が確定した:

```text
[TEST-TRACE +4.183257875 test=writeRoundTrip()] waitUntil before-sleep tick=1
[TEST-TRACE +6.193379458 test=writeRoundTrip()] waitUntil after-sleep  tick=1   ← 2.01s stall
```

- `Task.sleep(50ms)` だけが 2 秒以上 wake せず、同 window で `Thread.sleep` 経路 ( `waitUntilThreaded` ) は 50ms 間隔で tick が動く
- timeout 直後の再 polling は即時 `result=true` を返す ( = 観測対象は既に成立済、polling 経路だけが詰まっていた )

PR ( #567 ) はこれを `cooperative executor 固有 stall` と分類し、対症的に 5 callsite を `waitUntilThreaded` に逃がした。issue ( #624 ) で 2 callsite が同じ stall に巻き込まれて落ちたため、観測フェーズの結論 ( = `Task.sleep` 経路を残す限り別 test で同じ flake が無限に再生産される ) を踏まえ、本 PR で `Task.sleep` 経路自体を WaitUntil 本体から撤去する。

## 変更内容

### WaitUntil.swift の polling 経路を NSThread 化

- `waitUntil` 内の `try await Task.sleep(for: .milliseconds(50))` を `Thread.sleep(forTimeInterval: 0.050)` に置換し、polling loop 全体を `Thread { ... }.start()` で立てた dedicated NSThread 上で完結させる
- `withCheckedContinuation` の resume は polling 終了 ( resolved / timeout ) 時の 1 回のみ。GCD pool も使わないため `SocketServer` 専用 queue 等の他 GCD 処理を阻害しない
- `condition` は **同期評価可能な predicate に限定** する契約 ( NSThread 上で評価されるため `await` は cooperative executor 再 hop を生む )。本 helper 利用 test の condition ( `fileExists` / `MessageCollector.snapshot()` / `ExitCollector.snapshot()` / `events.exitedIds()` 等 ) はすべて NSLock ベースで同期完結
- `throws` を外し cancel 非応答に統一 ( `Task.checkCancellation` も呼ばない )。外側 Task の cancel で polling を畳む経路は trace 解析の余計なノイズになるため採用しない
- timeout 時は `Issue.record` で test を fail させる契約は維持。silent return すると後段 `#expect` が別症状で間接 fail し timeout 事象が trace から追跡できなくなる
- `waitUntilThreaded` シンボルを削除し callsite を `waitUntil` に統一

### trace 出力に `mode=threaded` 識別子を追加

新版 `waitUntil` ( NSThread polling ) の trace 文字列が旧版 `waitUntil` ( Task.sleep polling ) と完全同形のままだと `analyze-stall.sh` で世代別解析時に kind 列で区別不能になる。これを防ぐため:

- trace 出力を `waitUntil mode=threaded <event> ...` 形式に変更 ( `entered` / `tick` / `resolved` / `timeout` / `before-sleep` / `after-sleep` すべて )
- `analyze-stall.sh` の perl regex に `(?: mode=(\S+))?` optional capture を追加し、`mode` が付いた行は kind 列に `<prefix>-<mode>` ( 例 `waitUntil-threaded` ) として畳み込む
- 旧 CI log ( mode token 無し ) は従来通り `waitUntil` / `waitUntilThreaded` / `waitUntilDispatch` の 3 値 + 現行 `waitUntil-threaded` の 4 値で kind が区別される

### docstring から歴史記述を撤去

`waitUntil` / `waitUntilThreaded` の経緯 ( 観測 PR / 中間版 `waitUntilDispatch` / (i)/(ii) 切り分け仮説 / 並走比較 / cancel 非対称設計 ) を WaitUntil.swift / 各 test ファイルから撤去し、現在仕様 ( dedicated NSThread + sync predicate + cancel 非応答 + Issue.record ) のみを宣言文として残す。経緯は本 PR / issue ( #624 ) と関連 PR 本文に残し source code には残さない。

### `analyze-stall.sh` のコメント修正

「Task.sleep 経路」「GCD thread」記述を現在仕様 ( dedicated NSThread ) に書き換え。kind 列が 4 値で世代を区別する仕様を明示。

### callsite の `try` 削除

`waitUntil` を非 throws 化したため 12 callsite の `try await waitUntil(...)` を `await waitUntil(...)` に書き換え。各 test function の `throws` 宣言は他の `try` ( `pty.spawn` / `registry.spawn` / `sendOverUnixSocket` 等 ) で正当化されるため維持。`unknownIdIsNoop` は `try` を一切持たないため `async throws` → `async` に修正 ( half-baked throws 宣言の解消 )。

## 今回含めない点

- **別 PR で対応**: `PTYManagerTests.swift:61` の `Task.sleep(150ms)` ( tty ready 待ち ) を event-driven 化。`PTYManager` 側に ready event 導入を伴う production 改変。追跡 issue ( #626 )
- **別 PR で対応**: `PTYRegistryTests.swift:72` の `Task.sleep(100ms)` 削除と L79-88 手書き polling の改修。`PTYRegistry` actor に test-side mirror / onRemove callback / nonisolated count snapshot のいずれかを導入する設計判断が必要。追跡 issue ( #627 )
- **別 PR で対応**: `FSWatcherTests` / `FSWatchRegistryTests` / `RpcDispatcherTests` の生 `Task.sleep` ( debounce / 待機 用途で意味論が WaitUntil と異なる、callsite ごとに event-driven 化 or time-based wait helper の使い分けが必要 )。追跡 issue ( #628 )

## 確認事項

- [ ] CI swift-test job を 3 attempt 以上 rerun し、issue ( #624 ) で観測された `writeRoundTrip` / `cleanupOnKill` の stall window 中も両 test が green になることを確認する
- [ ] 同 CI window 内で `[TEST-TRACE +... test=...] waitUntil mode=threaded tick=...` の `before-sleep` → `after-sleep` gap が 50ms 近辺で安定し、秒級 stall が観測されないこと
- [ ] `[TEST-TRACE]` 行に `<threaded>` tag が出ること ( NSThread 上の polling で `Test.current` が nil に倒れる経路の fallback 動作確認 )
- [ ] `apps/native/scripts/analyze-stall.sh` が新版 trace ( `mode=threaded` token 付き ) を kind 列 `waitUntil-threaded` として集計できること、旧 log との混在解析でも kind が区別されること
