### PR TITLE
test infra の Task.sleep を全 callsite 撤去し PTY ready barrier と awaitEmpty を追加

### DIFF
--- a/apps/native/Sources/CPty/CPty.c
+++ b/apps/native/Sources/CPty/CPty.c
@@ -5,15 +5,28 @@ int gozd_pty_spawn(
     int *out_master,
     int *out_slave,
     pid_t *out_pid,
+    int *out_ready_read_fd,
     struct winsize *winsize_p,
     const char *executable,
     char *const argv[],
     char *const envp[],
     const char *cwd
 ) {
+    // ready pipe を openpty / fork より先に作る。失敗時の cleanup を最も小さく抑える。
+    // ready_pipe[0]: 親側 read fd ( awaitReady で blocking read )。
+    // ready_pipe[1]: 子側 write fd ( execve 直前に 1 byte 書く / _exit で kernel が close )。
+    int ready_pipe[2] = { -1, -1 };
+    if (pipe(ready_pipe) == -1) {
+        return -3;
+    }
+
     int master = -1;
     int slave = -1;
     if (openpty(&master, &slave, NULL, NULL, winsize_p) == -1) {
+        int err = errno;
+        close(ready_pipe[0]);
+        close(ready_pipe[1]);
+        errno = err;
         return -1;
     }
 
@@ -22,6 +35,8 @@ int gozd_pty_spawn(
         int err = errno;
         close(master);
         close(slave);
+        close(ready_pipe[0]);
+        close(ready_pipe[1]);
         errno = err;
         return -2;
     }
@@ -47,11 +62,17 @@ int gozd_pty_spawn(
         signal(SIGPIPE, SIG_DFL);
         signal(SIGCHLD, SIG_DFL);
 
+        // 親側 read fd は子で不要。close しないと親がもし read fd を close してもこの
+        // 子が write fd を持っている限り EOF が来ない race を残す。
+        close(ready_pipe[0]);
+
         // 子側で master を閉じる。child は slave 側だけ持つ。
         close(master);
         // setsid + TIOCSCTTY + dup2(slave, 0/1/2) + close(slave > 2) を 1 呼び出しで行う。
         // forkpty が内部で呼んでいるのと同じ標準ヘルパー。失敗時は親が
         // PTYExitReason.exited(code: 125) として観測できるよう専用 exit code で抜ける。
+        // _exit 時 kernel が ready_pipe[1] を閉じるため親 read は EOF を観測する
+        // ( execve 段階に到達しなかったことが ready pipe + waitpid 経由で判別可能 )。
         if (login_tty(slave) == -1) {
             _exit(125);
         }
@@ -65,9 +86,24 @@ int gozd_pty_spawn(
                 _exit(124);
             }
         }
+
+        // execve 直前に ready barrier を立てる。1 byte 書いて close すると親 read が
+        // 1 byte を観測し「子は tty setup 完了 + execve 段階に到達」を確定できる。
+        // partial write / EINTR 対策で retry loop を組む ( fork 後の child では
+        // async-signal-safe な write のみ呼ぶ )。
+        const char ready_byte = 'R';
+        ssize_t w;
+        do {
+            w = write(ready_pipe[1], &ready_byte, 1);
+        } while (w == -1 && errno == EINTR);
+        close(ready_pipe[1]);
+
         execve(executable, argv, envp);
         // execve 失敗時は errno に応じて POSIX shell 慣例の exit code に倒す。
         // 親は exit code から失敗 syscall + 大まかな errno を判別できる。
+        // ( ready byte は既に書かれているので親 read は 1 byte 受信 → 直後 waitpid で
+        //   exit code が回収される。awaitReady だけでは execve 失敗を区別できないが、
+        //   onExit 配送経路で reason が届くので test 側はそちらを観測する。)
         switch (errno) {
             case EACCES:
                 _exit(126);
@@ -79,8 +115,13 @@ int gozd_pty_spawn(
     }
 
     // parent
+    // 親側 write fd は不要。close しないと子が execve / _exit しても親 process が
+    // write fd を 1 reference 持つため EOF が永久に来ず awaitReady が hang する。
+    close(ready_pipe[1]);
+
     *out_master = master;
     *out_slave = slave;
     *out_pid = pid;
+    *out_ready_read_fd = ready_pipe[0];
     return 0;
 }

--- a/apps/native/Sources/CPty/include/CPty.h
+++ b/apps/native/Sources/CPty/include/CPty.h
@@ -28,15 +28,13 @@
 //    ようにし、ttyclose → ttyflush で pending output が drop されるのを防ぐ）。
 //    drain 完了後に親が明示的に slave を close する責務を持つ。
 //
-// ready pipe ( 親←子 ) で execve barrier を立てる。子は login_tty / chdir 完了後、
-// execve 直前に 1 byte 書き、close する。親側は `out_ready_read_fd` を blocking read
-// すれば「子が execve 段階に到達した」ことを構造的に確認できる:
-//   - read が 1 byte ('R') を返した: 子は execve 直前まで進み、tty は ready
-//   - read が 0 byte (EOF) を返した: 子は execve 前に _exit ( login_tty / chdir 失敗 )
-//     したか、execve 自体が失敗した。kernel が _exit で write fd を閉じる経路
-// 親側 `awaitReady()` で 1 度だけ read + close する責務を持つ ( PTYManager.swift )。
-// 親→子 / probe byte echo ( /bin/cat 専用 ) / DispatchSourceRead first event ( kqueue
-// 経由で stall リスク残存 ) より構造的に堅い barrier。
+// 5. **ready pipe ( 親←子 ) で execve barrier を立てる**。子は login_tty / chdir
+//    完了後、execve 直前に 1 byte 書き、close する。親側は `out_ready_read_fd` を
+//    blocking read することで「子が execve 段階に到達した」ことを確認できる:
+//      - read が 1 byte ('R') を返した: 子は execve 直前まで進み、tty は ready
+//      - read が 0 byte (EOF) を返した: 子は execve 前に _exit ( login_tty / chdir
+//        失敗 ) したか、execve 自体が失敗した。kernel が _exit で write fd を閉じる経路
+//    親側 `awaitReady()` で 1 度だけ read + close する責務を持つ ( PTYManager.swift )。
 //
 // 戻り値:
 //   - 0: 成功。out_master / out_slave / out_pid / out_ready_read_fd に値が入る。

--- a/apps/native/Sources/CPty/include/CPty.h
+++ b/apps/native/Sources/CPty/include/CPty.h
@@ -30,10 +30,14 @@
 //
 // 5. **ready pipe ( 親←子 ) で execve barrier を立てる**。子は login_tty / chdir
 //    完了後、execve 直前に 1 byte 書き、close する。親側は `out_ready_read_fd` を
-//    blocking read することで「子が execve 段階に到達した」ことを確認できる:
-//      - read が 1 byte ('R') を返した: 子は execve 直前まで進み、tty は ready
-//      - read が 0 byte (EOF) を返した: 子は execve 前に _exit ( login_tty / chdir
-//        失敗 ) したか、execve 自体が失敗した。kernel が _exit で write fd を閉じる経路
+//    blocking read することで「子が ready byte を書く段階まで到達した」ことを確認できる:
+//      - read が 1 byte ('R') を返した: 子は login_tty / chdir 完了 → execve に進んだ
+//        ( execve 自体の成功 / 失敗は本 barrier では識別しない。失敗した場合も ready byte
+//        は既に書かれており、親 read は 1 byte を受け取る。execve 失敗 ( exit code
+//        123 / 126 / 127 ) は後段の `onExit` 経路で配送される )
+//      - read が 0 byte (EOF) を返した: 子は ready byte を書く前に _exit した
+//        ( login_tty 失敗 → exit 125、chdir 失敗 → exit 124 のいずれか )。kernel が
+//        _exit で write fd を閉じる経路
 //    親側 `awaitReady()` で 1 度だけ read + close する責務を持つ ( PTYManager.swift )。
 //
 // 戻り値:

--- a/apps/native/Sources/CPty/include/CPty.h
+++ b/apps/native/Sources/CPty/include/CPty.h
@@ -28,13 +28,24 @@
 //    ようにし、ttyclose → ttyflush で pending output が drop されるのを防ぐ）。
 //    drain 完了後に親が明示的に slave を close する責務を持つ。
 //
+// ready pipe ( 親←子 ) で execve barrier を立てる。子は login_tty / chdir 完了後、
+// execve 直前に 1 byte 書き、close する。親側は `out_ready_read_fd` を blocking read
+// すれば「子が execve 段階に到達した」ことを構造的に確認できる:
+//   - read が 1 byte ('R') を返した: 子は execve 直前まで進み、tty は ready
+//   - read が 0 byte (EOF) を返した: 子は execve 前に _exit ( login_tty / chdir 失敗 )
+//     したか、execve 自体が失敗した。kernel が _exit で write fd を閉じる経路
+// 親側 `awaitReady()` で 1 度だけ read + close する責務を持つ ( PTYManager.swift )。
+// 親→子 / probe byte echo ( /bin/cat 専用 ) / DispatchSourceRead first event ( kqueue
+// 経由で stall リスク残存 ) より構造的に堅い barrier。
+//
 // 戻り値:
-//   - 0: 成功。out_master / out_slave / out_pid に値が入る。
+//   - 0: 成功。out_master / out_slave / out_pid / out_ready_read_fd に値が入る。
 //   - -1: openpty 失敗（errno が set される）。
 //   - -2: fork 失敗（errno が set される）。
+//   - -3: ready pipe 作成失敗（errno が set される）。
 //
-// 親プロセスは戻り値で openpty / fork のどちらが失敗したかを区別できる。errno のみ
-// では EAGAIN を openpty / fork 双方が返し得るため、syscall を取り違える。
+// 親プロセスは戻り値で openpty / fork / pipe のどれが失敗したかを区別できる。errno
+// のみでは EAGAIN を openpty / fork / pipe いずれも返し得るため、syscall を取り違える。
 //
 // child 側で setup に失敗した場合は execve まで到達せず以下の exit code で抜ける。
 // 親は `PTYExitReason.exited(code: N)` から失敗段階を判別できる:
@@ -48,6 +59,7 @@ int gozd_pty_spawn(
     int *out_master,
     int *out_slave,
     pid_t *out_pid,
+    int *out_ready_read_fd,
     struct winsize *winsize_p,
     const char *executable,
     char *const argv[],

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -85,9 +85,11 @@ public final class PTYManager {
   /// ready pipe fd の所有権を caller に移譲する。1 度だけ呼べる accessor。
   /// `awaitReady` / `awaitReadyPipe` を経由する代わりに caller 自身で fd を消費する
   /// 経路 (`PTYRegistry.spawn` から actor 排他区間内で抽出 → 自由関数で blocking
-  /// read) を作るために公開する。所有権が移った後の close 責務は caller 側にある
-  /// (`awaitReadyPipe` 内 close か、caller の独自経路)。
-  public func takeReadyPipeFd() -> Int32 {
+  /// read) を作るために GozdCore module 内に閉じて公開する。所有権が移った後の close
+  /// 責務は caller 側にある (`awaitReadyPipe` 内 close か、caller の独自経路)。
+  /// `internal` は module 外 ( Gozd target など ) から ready fd 所有権を奪われて
+  /// `awaitReady()` / `deinit` の不変条件を壊される経路を塞ぐため。
+  func takeReadyPipeFd() -> Int32 {
     let fd = readyPipeFd
     readyPipeFd = -1
     return fd

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -48,12 +48,53 @@ public final class PTYManager {
   private var state: PTYFinishState?
   private var readSource: DispatchSourceRead?
   private var exitSource: DispatchSourceProcess?
+  // ready pipe 親側 read fd ( CPty.c の execve barrier )。`awaitReady` が 1 度だけ
+  // blocking read + close する。spawn 失敗時 / awaitReady 後は -1 に倒す。`deinit`
+  // で未消費なら fd リークを防ぐため close する。
+  private var readyPipeFd: Int32 = -1
 
   public init() {}
 
   deinit {
     readSource?.cancel()
     exitSource?.cancel()
+    if readyPipeFd >= 0 {
+      close(readyPipeFd)
+    }
+  }
+
+  /// 子プロセスが execve 段階に到達するまで blocking read で待つ。CPty.c の ready pipe
+  /// ( 子が execve 直前に 1 byte 書き、_exit で kernel が close ) を 1 度だけ消費する。
+  ///
+  /// - read が 1 byte を返す: 子は login_tty + chdir 完了し execve 段階に到達。tty は
+  ///   ready で、`write` / `resize` / 子からの input 経路が機能する状態
+  /// - read が 0 byte ( EOF ) を返す: 子は execve 前に _exit ( login_tty / chdir 失敗 )。
+  ///   `onExit` 経路で exit code (124 / 125) が配送されるので test 側はそちらを観測
+  ///
+  /// Swift Concurrency の cooperative executor 上で blocking read を呼ぶと thread が
+  /// 拘束されるため、dedicated NSThread に hop して read + close + resume の 3 段で完結
+  /// させる。`DispatchSourceRead` も kqueue 経由で executor stall に巻き込まれ得る
+  /// ため不採用 ( issue #630 の analysis 参照 )。
+  ///
+  /// 二重呼び出しは safe ( 2 回目以降は `fd < 0` で即 return )。
+  public func awaitReady() async {
+    let fd = readyPipeFd
+    if fd < 0 { return }
+    readyPipeFd = -1
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+      let thread = Thread {
+        var buf: UInt8 = 0
+        while true {
+          let n = Darwin.read(fd, &buf, 1)
+          if n == -1 && errno == EINTR { continue }
+          break
+        }
+        Darwin.close(fd)
+        continuation.resume()
+      }
+      thread.name = "PTYAwaitReady"
+      thread.start()
+    }
   }
 
   /// 子プロセスを PTY に fork して spawn する。
@@ -112,20 +153,22 @@ public final class PTYManager {
     var masterFd: Int32 = -1
     var slaveFd: Int32 = -1
     var childPid: pid_t = -1
+    var readyReadFd: Int32 = -1
     let spawnRet = gozd_pty_spawn(
       &masterFd,
       &slaveFd,
       &childPid,
+      &readyReadFd,
       &ws,
       cExecutable,
       argv,
       envp,
       cCwd
     )
-    // gozd_pty_spawn 戻り値: 0=成功 / -1=openpty 失敗 / -2=fork 失敗。
-    // errno のみで判別すると EAGAIN を openpty / fork 双方が返し得るため取り違える。
-    // 戻り値で syscall を確実に区別する。
-    // 0/-1/-2 以外は C bridge 側のバグなので `fatalError` で即座に落とす。
+    // gozd_pty_spawn 戻り値: 0=成功 / -1=openpty 失敗 / -2=fork 失敗 / -3=pipe 失敗。
+    // errno のみで判別すると EAGAIN を openpty / fork / pipe 全てが返し得るため
+    // 取り違える。戻り値で syscall を確実に区別する。
+    // 0/-1/-2/-3 以外は C bridge 側のバグなので `fatalError` で即座に落とす。
     // 「想定外なら fallback enum で握り潰す」設計だと観察可能性を失う。
     if spawnRet != 0 {
       let err = errno
@@ -133,12 +176,14 @@ public final class PTYManager {
       switch spawnRet {
       case -1: throw PTYError.openptyFailed(errno: err)
       case -2: throw PTYError.forkFailed(errno: err)
+      case -3: throw PTYError.readyPipeFailed(errno: err)
       default:
         fatalError("gozd_pty_spawn returned unexpected code: \(spawnRet) (errno: \(err))")
       }
     }
 
     pid = childPid
+    readyPipeFd = readyReadFd
     ptyTrace(
       "spawn", pid: childPid,
       "gozd_pty_spawn master=\(masterFd) slave=\(slaveFd) executable=\(executable)")
@@ -337,6 +382,9 @@ public enum PTYError: Error, Equatable {
   case openptyFailed(errno: Int32)
   /// `fork(2)` の失敗（C bridge 戻り値 -2）。
   case forkFailed(errno: Int32)
+  /// ready pipe 作成 (`pipe(2)`) の失敗（C bridge 戻り値 -3）。execve barrier 用 pipe
+  /// が用意できないと awaitReady が hang するため、ここで spawn を諦める。
+  case readyPipeFailed(errno: Int32)
   /// spawn 前段の strdup などで OOM 検出した場合。spawn syscall 自体は呼ばれていないので
   /// `openptyFailed` / `forkFailed` を流用すると上位 log で失敗 syscall を取り違える。
   case preforkAllocFailed(errno: Int32)
@@ -352,6 +400,8 @@ extension PTYError: CustomStringConvertible {
       return "PTYError.openptyFailed(errno=\(errno) \(Self.errnoText(errno)))"
     case .forkFailed(let errno):
       return "PTYError.forkFailed(errno=\(errno) \(Self.errnoText(errno)))"
+    case .readyPipeFailed(let errno):
+      return "PTYError.readyPipeFailed(errno=\(errno) \(Self.errnoText(errno)))"
     case .preforkAllocFailed(let errno):
       return "PTYError.preforkAllocFailed(errno=\(errno) \(Self.errnoText(errno)))"
     }

--- a/apps/native/Sources/GozdCore/PTYManager.swift
+++ b/apps/native/Sources/GozdCore/PTYManager.swift
@@ -71,30 +71,26 @@ public final class PTYManager {
   /// - read が 0 byte ( EOF ) を返す: 子は execve 前に _exit ( login_tty / chdir 失敗 )。
   ///   `onExit` 経路で exit code (124 / 125) が配送されるので test 側はそちらを観測
   ///
-  /// Swift Concurrency の cooperative executor 上で blocking read を呼ぶと thread が
-  /// 拘束されるため、dedicated NSThread に hop して read + close + resume の 3 段で完結
-  /// させる。`DispatchSourceRead` も kqueue 経由で executor stall に巻き込まれ得る
-  /// ため不採用 ( issue #630 の analysis 参照 )。
-  ///
   /// 二重呼び出しは safe ( 2 回目以降は `fd < 0` で即 return )。
+  ///
+  /// actor (`PTYRegistry`) から呼ぶときは class instance を await 越えに sending する
+  /// ことになるため、`takeReadyPipeFd()` で fd を抽出してから自由関数 `awaitReadyPipe`
+  /// に渡す経路を使う ( CLAUDE.md「`@unchecked Sendable` を付けない」規律 + Swift 6.2
+  /// sending diagnostic 回避 )。本 method は PTYManager を直接保持する非 actor caller
+  /// ( `PTYManagerTests` 等 ) 専用。
   public func awaitReady() async {
+    await awaitReadyPipe(fd: takeReadyPipeFd())
+  }
+
+  /// ready pipe fd の所有権を caller に移譲する。1 度だけ呼べる accessor。
+  /// `awaitReady` / `awaitReadyPipe` を経由する代わりに caller 自身で fd を消費する
+  /// 経路 (`PTYRegistry.spawn` から actor 排他区間内で抽出 → 自由関数で blocking
+  /// read) を作るために公開する。所有権が移った後の close 責務は caller 側にある
+  /// (`awaitReadyPipe` 内 close か、caller の独自経路)。
+  public func takeReadyPipeFd() -> Int32 {
     let fd = readyPipeFd
-    if fd < 0 { return }
     readyPipeFd = -1
-    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-      let thread = Thread {
-        var buf: UInt8 = 0
-        while true {
-          let n = Darwin.read(fd, &buf, 1)
-          if n == -1 && errno == EINTR { continue }
-          break
-        }
-        Darwin.close(fd)
-        continuation.resume()
-      }
-      thread.name = "PTYAwaitReady"
-      thread.start()
-    }
+    return fd
   }
 
   /// 子プロセスを PTY に fork して spawn する。
@@ -782,6 +778,33 @@ private func drainPTY(fd: Int32, pid: Int32 = 0, caller: String = "?", onData: (
   return result
 }
 
+
+/// ready pipe fd を消費して 1 byte ( or EOF ) を待つ自由関数。`PTYManager.awaitReady`
+/// と `PTYRegistry.spawn` の両方から呼ばれる SSOT。
+///
+/// blocking read は dedicated NSThread 上で実行し、Swift Concurrency cooperative
+/// executor / GCD pool / kqueue いずれの dispatch 経路にも乗せない。`Continuation` の
+/// resume は read + close 完了時の 1 回のみ。
+///
+/// `fd < 0` ( 未保持 / 既消費 ) なら即 return。fd は所有権が caller から渡された前提で、
+/// 本関数が close 責務を負う。
+func awaitReadyPipe(fd: Int32) async {
+  if fd < 0 { return }
+  await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+    let thread = Thread {
+      var buf: UInt8 = 0
+      while true {
+        let n = Darwin.read(fd, &buf, 1)
+        if n == -1 && errno == EINTR { continue }
+        break
+      }
+      Darwin.close(fd)
+      continuation.resume()
+    }
+    thread.name = "PTYAwaitReady"
+    thread.start()
+  }
+}
 
 private func freeCStrings(
   _ argEntries: [UnsafeMutablePointer<CChar>?],

--- a/apps/native/Sources/GozdCore/PTYRegistry.swift
+++ b/apps/native/Sources/GozdCore/PTYRegistry.swift
@@ -95,6 +95,11 @@ public actor PTYRegistry {
   // PTY exit 後も残しておいて問題ない。
   private var explicitlyRemovedPtyIds: Set<UInt32> = []
   private var nextId: UInt32 = 1
+  // ptys が空になるのを待つ Continuation 群。`awaitEmpty()` で append し、`remove(id:)`
+  // で count==0 到達時に全 resume する。actor isolation により append / drain は serialize
+  // される。test 側の手書き polling ( `registry.count() == 0` を Task.sleep で待つ ) を
+  // 構造的に消すための accessor。
+  private var awaitEmptyContinuations: [CheckedContinuation<Void, Never>] = []
 
   public init(
     onText: @escaping TextHandler,
@@ -116,7 +121,7 @@ public actor PTYRegistry {
     rows: UInt16,
     cols: UInt16,
     worktreePath: String = ""
-  ) throws -> UInt32 {
+  ) async throws -> UInt32 {
     // `nextId` は spawn 成功後に進める。spawn が throw した場合に id を消費せず
     // 次の試行で同じ id を再利用できる（PTY は生成されていないため id 衝突は無い）。
     // 先に進めると失敗時に id が穴開きで上昇し、ptys / worktreePathById マップに
@@ -146,6 +151,11 @@ public actor PTYRegistry {
         continuation.finish()
       }
     )
+    // 子が execve 段階に到達するまで待つ ( CPty.c の ready pipe barrier )。spawn が戻った
+    // 時点では fork 直後で tty が write 可能とは限らないため、ここで barrier を消費して
+    // 「caller は ready 確定 PTY を受け取る」契約に揃える。test 側の 100ms / 150ms 経験的
+    // sleep が **構造的に不要** になる ( = 削除ではなく race の構造的消滅 / issue #630 )。
+    await pty.awaitReady()
     nextId += 1
     ptys[id] = pty
     if !worktreePath.isEmpty {
@@ -196,6 +206,20 @@ public actor PTYRegistry {
 
   public func count() -> Int {
     ptys.count
+  }
+
+  /// ptys が空になるまで待つ。test 側の手書き polling ( `registry.count() == 0` を sleep
+  /// で待つ ) を構造的に消すための accessor。actor isolation で append / drain は serialize
+  /// されるため race フリー。
+  ///
+  /// - 既に `ptys.isEmpty == true` なら即 return ( spawn が一度も成功しなかった registry を
+  ///   含む )
+  /// - そうでなければ Continuation を保持し、`remove(id:)` 経由で count==0 到達時に resume
+  public func awaitEmpty() async {
+    if ptys.isEmpty { return }
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+      awaitEmptyContinuations.append(continuation)
+    }
   }
 
   /// hook 受信側が ptyId から worktreePath を逆引きするための accessor。
@@ -267,6 +291,15 @@ public actor PTYRegistry {
         tag: "PTYRegistry",
         "remove: dropped expected resume sid=\(stale) without removeByPty for pty=\(id)"
       )
+    }
+    // ptys が空になった時点で awaitEmpty 待ちの Continuation を全 resume する。
+    // awaitEmpty は accessor 一つで複数 caller が並列に待ち得るため、配列を flush する。
+    if ptys.isEmpty && !awaitEmptyContinuations.isEmpty {
+      let pending = awaitEmptyContinuations
+      awaitEmptyContinuations.removeAll()
+      for continuation in pending {
+        continuation.resume()
+      }
     }
   }
 }

--- a/apps/native/Sources/GozdCore/PTYRegistry.swift
+++ b/apps/native/Sources/GozdCore/PTYRegistry.swift
@@ -220,7 +220,7 @@ public actor PTYRegistry {
   /// - 呼び出し時点で `ptys.isEmpty == true` なら即 return
   /// - そうでなければ Continuation を append し、`remove(id:)` で count==0 到達時に resume
   ///
-  /// `spawn` の id 採番 / `ptys[id]` 登録は `await pty.awaitReady()` より **前** に
+  /// `spawn` の id 採番 / `ptys[id]` 登録は `await awaitReadyPipe(fd:)` より **前** に
   /// actor 排他区間で完了するため、in-flight spawn 中の registry も `!ptys.isEmpty` で
   /// 観測される ( = 即 return しない )。
   public func awaitEmpty() async {

--- a/apps/native/Sources/GozdCore/PTYRegistry.swift
+++ b/apps/native/Sources/GozdCore/PTYRegistry.swift
@@ -95,10 +95,8 @@ public actor PTYRegistry {
   // PTY exit 後も残しておいて問題ない。
   private var explicitlyRemovedPtyIds: Set<UInt32> = []
   private var nextId: UInt32 = 1
-  // ptys が空になるのを待つ Continuation 群。`awaitEmpty()` で append し、`remove(id:)`
-  // で count==0 到達時に全 resume する。actor isolation により append / drain は serialize
-  // される。test 側の手書き polling ( `registry.count() == 0` を Task.sleep で待つ ) を
-  // 構造的に消すための accessor。
+  // `awaitEmpty()` の suspended continuation 群。`remove(id:)` で count==0 到達時に
+  // 全 resume する。actor isolation により append / drain は serialize される。
   private var awaitEmptyContinuations: [CheckedContinuation<Void, Never>] = []
 
   public init(
@@ -151,11 +149,10 @@ public actor PTYRegistry {
         continuation.finish()
       }
     )
-    // 子が execve 段階に到達するまで待つ ( CPty.c の ready pipe barrier )。spawn が戻った
-    // 時点では fork 直後で tty が write 可能とは限らないため、ここで barrier を消費して
-    // 「caller は ready 確定 PTY を受け取る」契約に揃える。test 側の 100ms / 150ms 経験的
-    // sleep が **構造的に不要** になる ( = 削除ではなく race の構造的消滅 / issue #630 )。
-    await pty.awaitReady()
+    // state mutation はすべて await の **前** で済ませる。`PTYRegistry` は actor だが、
+    // `await` ごとに re-entrancy が許される (SE-0306) ため、id 採番 → await suspend →
+    // 別 caller が同じ id を観測 → ptys[id] 上書き、という race を防ぐには nextId 進行と
+    // ptys / pidTracker / per-id state の登録を 1 つの actor 排他区間に閉じる必要がある。
     nextId += 1
     ptys[id] = pty
     if !worktreePath.isEmpty {
@@ -168,6 +165,12 @@ public actor PTYRegistry {
 
     let pidTracker = self.pidTracker
     let pidForCleanup = pty.pid
+
+    // ready pipe fd を actor 排他区間内で抽出する。`await awaitReadyPipe(fd:)` は fd
+    // (Int32, Sendable) のみを suspend 越しに保持するため、non-Sendable な `pty` を
+    // sending せずに ready barrier を消費できる ( CLAUDE.md「`@unchecked Sendable` を
+    // 付けない」規律 + Swift 6.2 sending diagnostic 回避 )。
+    let readyPipeFd = pty.takeReadyPipeFd()
 
     // consumer Task: AsyncStream の FIFO 順序保証で「全データ → flush → exit」が確定。
     // detached なので actor の isolation を待たずに即座に for-await を回せる。
@@ -189,6 +192,10 @@ public actor PTYRegistry {
       await self?.remove(id: id)
     }
     consumers[id] = task
+
+    // 子が execve 段階に到達するまで待つ。state mutation は全て完了済なので、ここで
+    // await して actor isolation を解放しても他 caller の spawn と id 採番が衝突しない。
+    await awaitReadyPipe(fd: readyPipeFd)
     return id
   }
 
@@ -208,13 +215,14 @@ public actor PTYRegistry {
     ptys.count
   }
 
-  /// ptys が空になるまで待つ。test 側の手書き polling ( `registry.count() == 0` を sleep
-  /// で待つ ) を構造的に消すための accessor。actor isolation で append / drain は serialize
-  /// されるため race フリー。
+  /// `ptys` が空になるまで待つ。
   ///
-  /// - 既に `ptys.isEmpty == true` なら即 return ( spawn が一度も成功しなかった registry を
-  ///   含む )
-  /// - そうでなければ Continuation を保持し、`remove(id:)` 経由で count==0 到達時に resume
+  /// - 呼び出し時点で `ptys.isEmpty == true` なら即 return
+  /// - そうでなければ Continuation を append し、`remove(id:)` で count==0 到達時に resume
+  ///
+  /// `spawn` の id 採番 / `ptys[id]` 登録は `await pty.awaitReady()` より **前** に
+  /// actor 排他区間で完了するため、in-flight spawn 中の registry も `!ptys.isEmpty` で
+  /// 観測される ( = 即 return しない )。
   public func awaitEmpty() async {
     if ptys.isEmpty { return }
     await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in

--- a/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
@@ -20,12 +20,12 @@ struct FSWatchRegistryTests {
     )
 
     try await registry.watch(dir: tmpDir.path)
-    try await Task.sleep(for: .milliseconds(300))
+    await sleepThreaded(.milliseconds(300))
 
     let file = tmpDir.appendingPathComponent("hello.txt")
     try "hello".write(to: file, atomically: true, encoding: .utf8)
 
-    try await waitForEvent(
+    await waitForEvent(
       collector, matching: { $0.hasPrefix("fsChange:") })
     let events = collector.snapshot()
     #expect(events.contains { $0.hasPrefix("fsChange:") })
@@ -47,13 +47,13 @@ struct FSWatchRegistryTests {
     )
 
     try await registry.watch(dir: tmpDir.path)
-    try await Task.sleep(for: .milliseconds(300))
+    await sleepThreaded(.milliseconds(300))
 
     let branchFile = tmpDir.appendingPathComponent(".git/refs/heads/feature-x")
     try "0123456789abcdef0123456789abcdef01234567\n"
       .write(to: branchFile, atomically: true, encoding: .utf8)
 
-    try await waitForEvent(collector, matching: { $0 == "branchChange" })
+    await waitForEvent(collector, matching: { $0 == "branchChange" })
     let events = collector.snapshot()
     #expect(events.contains("branchChange"))
   }
@@ -97,12 +97,12 @@ struct FSWatchRegistryTests {
     )
 
     try await registry.watch(dir: worktreeRootResolved.path)
-    try await Task.sleep(for: .milliseconds(300))
+    await sleepThreaded(.milliseconds(300))
     collector.clear()
 
     try await runGitCmd(["commit", "-m", "add a"], cwd: worktreeRootResolved)
 
-    try await waitForEvent(collector, matching: { $0 == "gitStatusChange" })
+    await waitForEvent(collector, matching: { $0 == "gitStatusChange" })
     let events = collector.snapshot()
     #expect(events.contains("gitStatusChange"))
   }
@@ -131,13 +131,13 @@ struct FSWatchRegistryTests {
     )
 
     try await registry.watch(dir: tmpDir.path)
-    try await Task.sleep(for: .milliseconds(300))
+    await sleepThreaded(.milliseconds(300))
     collector.clear()
 
     try await runGitCmd(["branch", "-m", "renamed-feature"], cwd: tmpDir)
 
-    try await waitForEvent(collector, matching: { $0 == "branchChange" })
-    try await waitForEvent(collector, matching: { $0 == "gitStatusChange" })
+    await waitForEvent(collector, matching: { $0 == "branchChange" })
+    await waitForEvent(collector, matching: { $0 == "gitStatusChange" })
     let events = collector.snapshot()
     #expect(events.contains("branchChange"))
     #expect(events.contains("gitStatusChange"))
@@ -166,14 +166,14 @@ struct FSWatchRegistryTests {
     )
 
     try await registry.watch(dir: tmpDir.path)
-    try await Task.sleep(for: .milliseconds(300))
+    await sleepThreaded(.milliseconds(300))
     collector.clear()
 
     try await runGitCmd(["pack-refs", "--all"], cwd: tmpDir)
 
-    try await waitForEvent(collector, matching: { $0 == "branchChange" })
-    try await waitForEvent(collector, matching: { $0 == "gitStatusChange" })
-    try await waitForEvent(collector, matching: { $0 == "remoteRefsChange" })
+    await waitForEvent(collector, matching: { $0 == "branchChange" })
+    await waitForEvent(collector, matching: { $0 == "gitStatusChange" })
+    await waitForEvent(collector, matching: { $0 == "remoteRefsChange" })
     let events = collector.snapshot()
     #expect(events.contains("branchChange"))
     #expect(events.contains("gitStatusChange"))
@@ -227,7 +227,7 @@ struct FSWatchRegistryTests {
     // main + wt の両方を watch。primary は main worktree に固定されることを期待する。
     try await registry.watch(dir: mainRepo.path)
     try await registry.watch(dir: worktreeRootResolved.path)
-    try await Task.sleep(for: .milliseconds(300))
+    await sleepThreaded(.milliseconds(300))
 
     // ブランチには触らず `.git/worktrees/<name>/` だけを単独削除して
     // `worktreeChange` 単独経路を踏ませる（`bdc` 経由の `branchChange` 伴走 fetch で
@@ -236,7 +236,7 @@ struct FSWatchRegistryTests {
       .appendingPathComponent(worktreeRoot.lastPathComponent)
     try FileManager.default.removeItem(at: perWtGitDir)
 
-    try await waitForCount(worktreeChangeCount, atLeast: 1)
+    await waitForCount(worktreeChangeCount, atLeast: 1)
     #expect(worktreeChangeCount.value >= 1)
     // branchChange は伴走しない (本シナリオは worktreeChange 単独経路) こと。
     // 仮に伴走したら、本 test は「branchChange の伴走 fetch で隠蔽されていた死角」を
@@ -278,11 +278,11 @@ struct FSWatchRegistryTests {
 
     try await registry.watch(dir: mainRepo.path)
     try await registry.watch(dir: worktreeRoot.path)
-    try await Task.sleep(for: .milliseconds(300))
+    await sleepThreaded(.milliseconds(300))
 
     try await runGitCmd(["pack-refs", "--all"], cwd: mainRepo)
 
-    try await waitForCount(remoteRefsChangeCount, atLeast: 1)
+    await waitForCount(remoteRefsChangeCount, atLeast: 1)
     #expect(remoteRefsChangeCount.value >= 1)
   }
 
@@ -305,11 +305,11 @@ struct FSWatchRegistryTests {
     )
 
     try await registry.watch(dir: tmpDir.path)
-    try await Task.sleep(for: .milliseconds(300))
+    await sleepThreaded(.milliseconds(300))
 
     // 2 回目の watch（同 dir）— 旧設計の no-op ではなく再構築されることを担保する。
     try await registry.watch(dir: tmpDir.path)
-    try await Task.sleep(for: .milliseconds(300))
+    await sleepThreaded(.milliseconds(300))
     collector.clear()
 
     // 再構築後も branch ref の変更が dispatch される（= 新 entry が live で動いている）
@@ -317,7 +317,7 @@ struct FSWatchRegistryTests {
     try "0123456789abcdef0123456789abcdef01234567\n"
       .write(to: branchFile, atomically: true, encoding: .utf8)
 
-    try await waitForEvent(collector, matching: { $0 == "branchChange" })
+    await waitForEvent(collector, matching: { $0 == "branchChange" })
     #expect(collector.snapshot().contains("branchChange"))
   }
 
@@ -345,7 +345,7 @@ struct FSWatchRegistryTests {
 
     try await registry.watch(dir: dirA.path)
     try await registry.watch(dir: dirB.path)
-    try await Task.sleep(for: .milliseconds(300))
+    await sleepThreaded(.milliseconds(300))
 
     // 2 entry watched → unwatchAll で 2 を返す
     let count = await registry.unwatchAll()
@@ -360,7 +360,7 @@ struct FSWatchRegistryTests {
     try "x".write(to: fileA, atomically: true, encoding: .utf8)
     try "x".write(to: fileB, atomically: true, encoding: .utf8)
 
-    try await Task.sleep(for: .milliseconds(500))
+    await sleepThreaded(.milliseconds(500))
     #expect(collector.snapshot().isEmpty)
   }
 
@@ -392,7 +392,7 @@ struct FSWatchRegistryTests {
     )
 
     try await registry.watch(dir: tmpDir.path)
-    try await Task.sleep(for: .milliseconds(300))
+    await sleepThreaded(.milliseconds(300))
 
     // unwatch を actor 上で処理させた後に collector を clear する。
     // unwatch 前に clear すると、watch 開始直後の latent event が clear と unwatch の
@@ -404,7 +404,7 @@ struct FSWatchRegistryTests {
     let file = tmpDir.appendingPathComponent("after-unwatch.txt")
     try "x".write(to: file, atomically: true, encoding: .utf8)
 
-    try await Task.sleep(for: .milliseconds(500))
+    await sleepThreaded(.milliseconds(500))
     #expect(collector.snapshot().isEmpty)
   }
 }
@@ -689,40 +689,29 @@ private func initGitRepo(at dir: URL) async throws {
   try await runGitCmd(["init", "-q", "-b", "main"], cwd: dir)
 }
 
-private struct EventTimeout: Error, CustomStringConvertible {
-  let timeout: Duration
-  let observed: [String]
-  var description: String {
-    "waitForEvent timed out after \(timeout). Observed events: \(observed)"
-  }
-}
-
+// `waitUntil` ( WaitUntil.swift / dedicated NSThread 上の polling ) に乗せた wrapper。
+// Task.sleep ベースの手書き polling を撤去し、cooperative executor stall 経路から退避する
+// ( issue #630 )。timeout 時は `waitUntil` 経由で `Issue.record` に inline 出力されるため、
+// 旧 `EventTimeout` throw による「観測値を error message に乗せる」契約は `waitUntil` 側の
+// lastTicks 履歴 ( 直近 0.5s 分 ) に置き換わる。
 private func waitForEvent(
   _ collector: EventNameCollector,
   timeout: Duration = .seconds(2),
-  matching predicate: @escaping (String) -> Bool
-) async throws {
-  let deadline = ContinuousClock.now.advanced(by: timeout)
-  while ContinuousClock.now < deadline {
-    if collector.snapshot().contains(where: predicate) { return }
-    try await Task.sleep(for: .milliseconds(50))
+  matching predicate: @escaping @Sendable (String) -> Bool
+) async {
+  await waitUntil(timeout: timeout, description: "event matching predicate") {
+    collector.snapshot().contains(where: predicate)
   }
-  // タイムアウトを silent return せず throw する。「期待イベントが届かなかった」のか
-  // 「タイムアウトで打ち切った」のかを呼び出し側が区別できるようにする。
-  throw EventTimeout(timeout: timeout, observed: collector.snapshot())
 }
 
 private func waitForCount(
   _ counter: EventCounter,
   atLeast target: Int,
   timeout: Duration = .seconds(2)
-) async throws {
-  let deadline = ContinuousClock.now.advanced(by: timeout)
-  while ContinuousClock.now < deadline {
-    if counter.value >= target { return }
-    try await Task.sleep(for: .milliseconds(50))
+) async {
+  await waitUntil(timeout: timeout, description: "count >= \(target)") {
+    counter.value >= target
   }
-  throw EventTimeout(timeout: timeout, observed: ["count<\(counter.value)>"])
 }
 
 private final class EventCounter: @unchecked Sendable {

--- a/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
@@ -695,29 +695,33 @@ private func initGitRepo(at dir: URL) async throws {
 private func waitForEvent(
   _ collector: EventNameCollector,
   timeout: Duration = .seconds(2),
-  matching predicate: @escaping @Sendable (String) -> Bool
+  matching predicate: @escaping @Sendable (String) -> Bool,
+  sourceLocation: SourceLocation = #_sourceLocation
 ) async {
   await waitUntil(
     timeout: timeout,
     description: "event matching predicate",
-    lastObserved: { collector.snapshot().description }
-  ) {
-    collector.snapshot().contains(where: predicate)
-  }
+    lastObserved: { collector.snapshot().description },
+    {
+      collector.snapshot().contains(where: predicate)
+    },
+    sourceLocation: sourceLocation)
 }
 
 private func waitForCount(
   _ counter: EventCounter,
   atLeast target: Int,
-  timeout: Duration = .seconds(2)
+  timeout: Duration = .seconds(2),
+  sourceLocation: SourceLocation = #_sourceLocation
 ) async {
   await waitUntil(
     timeout: timeout,
     description: "count >= \(target)",
-    lastObserved: { "count=\(counter.value)" }
-  ) {
-    counter.value >= target
-  }
+    lastObserved: { "count=\(counter.value)" },
+    {
+      counter.value >= target
+    },
+    sourceLocation: sourceLocation)
 }
 
 private final class EventCounter: @unchecked Sendable {

--- a/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
@@ -689,17 +689,19 @@ private func initGitRepo(at dir: URL) async throws {
   try await runGitCmd(["init", "-q", "-b", "main"], cwd: dir)
 }
 
-// `waitUntil` ( WaitUntil.swift / dedicated NSThread 上の polling ) に乗せた wrapper。
-// Task.sleep ベースの手書き polling を撤去し、cooperative executor stall 経路から退避する
-// ( issue #630 )。timeout 時は `waitUntil` 経由で `Issue.record` に inline 出力されるため、
-// 旧 `EventTimeout` throw による「観測値を error message に乗せる」契約は `waitUntil` 側の
-// lastTicks 履歴 ( 直近 0.5s 分 ) に置き換わる。
+// `waitUntil` ( dedicated NSThread polling ) の wrapper。timeout 時には `lastObserved`
+// 経路で collector snapshot / counter 値を inline 出力し、tick 履歴 ( true/false 列 ) では
+// 表せない「何が来たか / 実値が幾つか」を Issue.record の message に残す。
 private func waitForEvent(
   _ collector: EventNameCollector,
   timeout: Duration = .seconds(2),
   matching predicate: @escaping @Sendable (String) -> Bool
 ) async {
-  await waitUntil(timeout: timeout, description: "event matching predicate") {
+  await waitUntil(
+    timeout: timeout,
+    description: "event matching predicate",
+    lastObserved: { collector.snapshot().description }
+  ) {
     collector.snapshot().contains(where: predicate)
   }
 }
@@ -709,7 +711,11 @@ private func waitForCount(
   atLeast target: Int,
   timeout: Duration = .seconds(2)
 ) async {
-  await waitUntil(timeout: timeout, description: "count >= \(target)") {
+  await waitUntil(
+    timeout: timeout,
+    description: "count >= \(target)",
+    lastObserved: { "count=\(counter.value)" }
+  ) {
     counter.value >= target
   }
 }

--- a/apps/native/Tests/GozdCoreTests/FSWatcherTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSWatcherTests.swift
@@ -19,8 +19,7 @@ struct FSWatcherTests {
     try watcher.start()
     defer { watcher.stop() }
 
-    // FSEvents が ready になるまで僅かに待つ ( cooperative executor を踏まない
-    // dedicated NSThread 経由 / issue #630 )。
+    // FSEvents が ready になるまで僅かに待つ。
     await sleepThreaded(.milliseconds(300))
 
     let testFile = tmpDir.appendingPathComponent("hello.txt")

--- a/apps/native/Tests/GozdCoreTests/FSWatcherTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSWatcherTests.swift
@@ -25,7 +25,11 @@ struct FSWatcherTests {
     let testFile = tmpDir.appendingPathComponent("hello.txt")
     try "hello".write(to: testFile, atomically: true, encoding: .utf8)
 
-    await waitUntil(timeout: .seconds(2), description: "hello.txt event") {
+    await waitUntil(
+      timeout: .seconds(2),
+      description: "hello.txt event",
+      lastObserved: { collector.snapshot().map(\.path).description }
+    ) {
       collector.snapshot().contains { $0.path.hasSuffix("hello.txt") }
     }
 
@@ -54,7 +58,11 @@ struct FSWatcherTests {
 
     try FileManager.default.removeItem(at: testFile)
 
-    await waitUntil(timeout: .seconds(2), description: "doomed.txt event") {
+    await waitUntil(
+      timeout: .seconds(2),
+      description: "doomed.txt event",
+      lastObserved: { collector.snapshot().map(\.path).description }
+    ) {
       collector.snapshot().contains { $0.path.hasSuffix("doomed.txt") }
     }
 
@@ -84,7 +92,11 @@ struct FSWatcherTests {
     let nestedFile = subDir.appendingPathComponent("nested.txt")
     try "nested".write(to: nestedFile, atomically: true, encoding: .utf8)
 
-    await waitUntil(timeout: .seconds(2), description: "nested.txt event") {
+    await waitUntil(
+      timeout: .seconds(2),
+      description: "nested.txt event",
+      lastObserved: { collector.snapshot().map(\.path).description }
+    ) {
       collector.snapshot().contains { $0.path.hasSuffix("nested.txt") }
     }
 

--- a/apps/native/Tests/GozdCoreTests/FSWatcherTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSWatcherTests.swift
@@ -19,14 +19,16 @@ struct FSWatcherTests {
     try watcher.start()
     defer { watcher.stop() }
 
-    // FSEvents が ready になるまで僅かに待つ。
-    try await Task.sleep(for: .milliseconds(300))
+    // FSEvents が ready になるまで僅かに待つ ( cooperative executor を踏まない
+    // dedicated NSThread 経由 / issue #630 )。
+    await sleepThreaded(.milliseconds(300))
 
     let testFile = tmpDir.appendingPathComponent("hello.txt")
     try "hello".write(to: testFile, atomically: true, encoding: .utf8)
 
-    // 0.05s latency + small margin
-    try await waitForEvent(collector, matching: { $0.path.hasSuffix("hello.txt") })
+    await waitUntil(timeout: .seconds(2), description: "hello.txt event") {
+      collector.snapshot().contains { $0.path.hasSuffix("hello.txt") }
+    }
 
     let events = collector.snapshot()
     #expect(events.contains { $0.path.hasSuffix("hello.txt") })
@@ -49,11 +51,13 @@ struct FSWatcherTests {
     try watcher.start()
     defer { watcher.stop() }
 
-    try await Task.sleep(for: .milliseconds(300))
+    await sleepThreaded(.milliseconds(300))
 
     try FileManager.default.removeItem(at: testFile)
 
-    try await waitForEvent(collector, matching: { $0.path.hasSuffix("doomed.txt") })
+    await waitUntil(timeout: .seconds(2), description: "doomed.txt event") {
+      collector.snapshot().contains { $0.path.hasSuffix("doomed.txt") }
+    }
 
     let events = collector.snapshot()
     #expect(events.contains { $0.path.hasSuffix("doomed.txt") })
@@ -76,12 +80,14 @@ struct FSWatcherTests {
     try watcher.start()
     defer { watcher.stop() }
 
-    try await Task.sleep(for: .milliseconds(300))
+    await sleepThreaded(.milliseconds(300))
 
     let nestedFile = subDir.appendingPathComponent("nested.txt")
     try "nested".write(to: nestedFile, atomically: true, encoding: .utf8)
 
-    try await waitForEvent(collector, matching: { $0.path.hasSuffix("nested.txt") })
+    await waitUntil(timeout: .seconds(2), description: "nested.txt event") {
+      collector.snapshot().contains { $0.path.hasSuffix("nested.txt") }
+    }
 
     let events = collector.snapshot()
     #expect(events.contains { $0.path.hasSuffix("nested.txt") })
@@ -98,18 +104,6 @@ private func makeTempDir() throws -> URL {
   try FileManager.default.createDirectory(at: raw, withIntermediateDirectories: true)
   let resolved = URL(fileURLWithPath: raw.path).resolvingSymlinksInPath()
   return resolved
-}
-
-private func waitForEvent(
-  _ collector: EventCollector,
-  timeout: Duration = .seconds(2),
-  matching predicate: @escaping (FSWatcher.Event) -> Bool
-) async throws {
-  let deadline = ContinuousClock.now.advanced(by: timeout)
-  while ContinuousClock.now < deadline {
-    if collector.snapshot().contains(where: predicate) { return }
-    try await Task.sleep(for: .milliseconds(50))
-  }
 }
 
 // 並行アクセス可能な event collector。Swift 6.2 のデフォルト strict concurrency

--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -194,10 +194,12 @@ struct PTYManagerTests {
     let exit = ExitCollector()
     let pty = PTYManager()
 
-    // /tmp はディレクトリで execute bit は付くが execve は EACCES を返す
+    // ディレクトリパスは execute bit が付いていても execve は EACCES を返す
     // （macOS execve(2): 「The new process file is not a regular file」も含めて EACCES）。
+    // `/tmp` 等の specific path に依存しないため testCwd ( NSTemporaryDirectory() ) を
+    // 流用する。
     try pty.spawn(
-      executable: "/tmp",
+      executable: testCwd,
       args: ["tmp"],
       env: ProcessInfo.processInfo.environment,
       cwd: testCwd,

--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -57,8 +57,9 @@ struct PTYManagerTests {
       onExit: { exit.set($0) }
     )
 
-    // tty が ready になるのを待つ。
-    try await Task.sleep(for: .milliseconds(150))
+    // tty が ready になるのを待つ ( CPty.c の ready pipe barrier を PTYManager 経由で
+    // 消費 )。経験的 sleep に頼らず、子が execve 段階に到達したことを構造的に確認する。
+    await pty.awaitReady()
 
     pty.write(Data("ping\n".utf8))
 

--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -57,8 +57,8 @@ struct PTYManagerTests {
       onExit: { exit.set($0) }
     )
 
-    // tty が ready になるのを待つ ( CPty.c の ready pipe barrier を PTYManager 経由で
-    // 消費 )。経験的 sleep に頼らず、子が execve 段階に到達したことを構造的に確認する。
+    // 子が execve 段階に到達するまで待つ ( CPty.c の ready pipe barrier を消費 )。
+    // 後段の write は ready 確定後にのみ意味を持つ。
     await pty.awaitReady()
 
     pty.write(Data("ping\n".utf8))

--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -23,7 +23,7 @@ struct PTYManagerTests {
       executable: "/bin/echo",
       args: ["echo", "hello"],
       env: ProcessInfo.processInfo.environment,
-      cwd: "/tmp",
+      cwd: testCwd,
       rows: 24,
       cols: 80,
       onData: { data.append($0) },
@@ -50,7 +50,7 @@ struct PTYManagerTests {
       executable: "/bin/cat",
       args: ["cat"],
       env: ProcessInfo.processInfo.environment,
-      cwd: "/tmp",
+      cwd: testCwd,
       rows: 24,
       cols: 80,
       onData: { data.append($0) },
@@ -89,7 +89,7 @@ struct PTYManagerTests {
       executable: "/bin/cat",
       args: ["cat"],
       env: ProcessInfo.processInfo.environment,
-      cwd: "/tmp",
+      cwd: testCwd,
       rows: 24,
       cols: 80,
       onData: { data.append($0) },
@@ -113,7 +113,7 @@ struct PTYManagerTests {
       executable: "/usr/bin/true",
       args: ["true"],
       env: ProcessInfo.processInfo.environment,
-      cwd: "/tmp",
+      cwd: testCwd,
       rows: 24,
       cols: 80,
       onData: { data.append($0) },
@@ -139,7 +139,7 @@ struct PTYManagerTests {
       executable: "/bin/sh",
       args: ["sh", "-c", "echo stderr-marker >&2"],
       env: ProcessInfo.processInfo.environment,
-      cwd: "/tmp",
+      cwd: testCwd,
       rows: 24,
       cols: 80,
       onData: { data.append($0) },
@@ -200,7 +200,7 @@ struct PTYManagerTests {
       executable: "/tmp",
       args: ["tmp"],
       env: ProcessInfo.processInfo.environment,
-      cwd: "/tmp",
+      cwd: testCwd,
       rows: 24,
       cols: 80,
       onData: { data.append($0) },
@@ -223,7 +223,7 @@ struct PTYManagerTests {
       executable: "/path/does/not/exist",
       args: ["nonexistent"],
       env: ProcessInfo.processInfo.environment,
-      cwd: "/tmp",
+      cwd: testCwd,
       rows: 24,
       cols: 80,
       onData: { data.append($0) },
@@ -409,6 +409,12 @@ private func expectedErrnoText(_ code: Int32) -> String {
 
 // `waitUntil` は `WaitUntil.swift` の共有実装 ( dedicated NSThread 上で polling loop を完結 )。
 // tick polling 履歴を保持し、timeout 時に Issue.record の message に inline する。
+
+// PTY spawn の cwd 引数に渡す「確定的に存在する dir」。`NSTemporaryDirectory()` は
+// macOS の per-user TMPDIR (`/var/folders/...`) を返し、グローバル `/tmp` と異なり
+// マルチユーザー環境 / サンドボックスでも衝突しない ( CLAUDE.md 規約「`/tmp` を
+// ハードコードしない、`NSTemporaryDirectory()` を使う」)。
+private let testCwd = NSTemporaryDirectory()
 
 private final class DataCollector: @unchecked Sendable {
   private let lock = NSLock()

--- a/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
@@ -23,7 +23,7 @@ struct PTYRegistryTests {
       executable: "/bin/echo",
       args: ["echo", "hello"],
       env: ProcessInfo.processInfo.environment,
-      cwd: "/tmp",
+      cwd: testCwd,
       rows: 24,
       cols: 80
     )
@@ -31,7 +31,7 @@ struct PTYRegistryTests {
       executable: "/bin/echo",
       args: ["echo", "world"],
       env: ProcessInfo.processInfo.environment,
-      cwd: "/tmp",
+      cwd: testCwd,
       rows: 24,
       cols: 80
     )
@@ -63,7 +63,7 @@ struct PTYRegistryTests {
       executable: "/bin/cat",
       args: ["cat"],
       env: ProcessInfo.processInfo.environment,
-      cwd: "/tmp",
+      cwd: testCwd,
       rows: 24,
       cols: 80
     )
@@ -112,7 +112,7 @@ struct PTYRegistryTests {
     var env = ProcessInfo.processInfo.environment
     env["GOZD_RESUME_CLAUDE_SESSION"] = "expected-sid-X"
     let id = try await registry.spawn(
-      executable: "/bin/cat", args: ["cat"], env: env, cwd: "/tmp", rows: 24, cols: 80
+      executable: "/bin/cat", args: ["cat"], env: env, cwd: testCwd, rows: 24, cols: 80
     )
     defer { Task { await registry.kill(id: id) } }
 
@@ -137,7 +137,7 @@ struct PTYRegistryTests {
     var env = ProcessInfo.processInfo.environment
     env["GOZD_RESUME_CLAUDE_SESSION"] = "expected-sid-X"
     let id = try await registry.spawn(
-      executable: "/bin/cat", args: ["cat"], env: env, cwd: "/tmp", rows: 24, cols: 80
+      executable: "/bin/cat", args: ["cat"], env: env, cwd: testCwd, rows: 24, cols: 80
     )
     defer { Task { await registry.kill(id: id) } }
 
@@ -165,7 +165,7 @@ struct PTYRegistryTests {
     var env = ProcessInfo.processInfo.environment
     env["GOZD_RESUME_CLAUDE_SESSION"] = "expected-sid-X"
     let id = try await registry.spawn(
-      executable: "/bin/cat", args: ["cat"], env: env, cwd: "/tmp", rows: 24, cols: 80
+      executable: "/bin/cat", args: ["cat"], env: env, cwd: testCwd, rows: 24, cols: 80
     )
     defer { Task { await registry.kill(id: id) } }
 
@@ -204,7 +204,7 @@ struct PTYRegistryConcurrentSpawnTests {
             executable: "/bin/echo",
             args: ["echo", "race"],
             env: ProcessInfo.processInfo.environment,
-            cwd: "/tmp",
+            cwd: testCwd,
             rows: 24,
             cols: 80
           )
@@ -237,6 +237,12 @@ struct PTYRegistryConcurrentSpawnTests {
 
 // `waitUntil` は `WaitUntil.swift` の共有実装 ( dedicated NSThread 上で polling loop を完結 )。
 // tick polling 履歴を保持し、timeout 時に Issue.record の message に inline する。
+
+// PTY spawn の cwd 引数に渡す「確定的に存在する dir」。`NSTemporaryDirectory()` は
+// macOS の per-user TMPDIR (`/var/folders/...`) を返し、グローバル `/tmp` と異なり
+// マルチユーザー環境 / サンドボックスでも衝突しない ( CLAUDE.md 規約「`/tmp` を
+// ハードコードしない、`NSTemporaryDirectory()` を使う」)。
+private let testCwd = NSTemporaryDirectory()
 
 private final class EventCollector: @unchecked Sendable {
   private let lock = NSLock()

--- a/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
@@ -69,19 +69,17 @@ struct PTYRegistryTests {
     )
     #expect(await registry.count() == 1)
 
-    try await Task.sleep(for: .milliseconds(100))
+    // spawn 自体が ready pipe barrier を消費しているため、kill 前の経験的 sleep は
+    // 構造的に不要 ( issue #630 )。
     await registry.kill(id: id)
 
     await waitUntil(timeout: .seconds(2)) {
       events.exitedIds().contains(id)
     }
-    // remove は exit handler 経由で `Task { await self.remove }` で発火するため、
-    // actor の serial execution に届くまで小さくポーリングする。
-    let deadline = ContinuousClock.now.advanced(by: .seconds(1))
-    while ContinuousClock.now < deadline {
-      if await registry.count() == 0 { break }
-      try await Task.sleep(for: .milliseconds(20))
-    }
+    // remove は exit handler 経由で `Task { await self.remove }` で発火する。
+    // actor 内の Continuation accessor で count==0 到達を構造的に待つ ( 手書き polling
+    // を撤去 / issue #630 )。
+    await registry.awaitEmpty()
     #expect(await registry.count() == 0)
   }
 

--- a/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
@@ -69,16 +69,13 @@ struct PTYRegistryTests {
     )
     #expect(await registry.count() == 1)
 
-    // spawn 自体が ready pipe barrier を消費しているため、kill 前の経験的 sleep は
-    // 構造的に不要 ( issue #630 )。
     await registry.kill(id: id)
 
     await waitUntil(timeout: .seconds(2)) {
       events.exitedIds().contains(id)
     }
     // remove は exit handler 経由で `Task { await self.remove }` で発火する。
-    // actor 内の Continuation accessor で count==0 到達を構造的に待つ ( 手書き polling
-    // を撤去 / issue #630 )。
+    // actor 内の Continuation accessor で count==0 到達を待つ。
     await registry.awaitEmpty()
     #expect(await registry.count() == 0)
   }
@@ -177,6 +174,62 @@ struct PTYRegistryTests {
     await registry.clearAssociations(for: id)
     let stillThere = await registry.consumeExpectedResumeSid(for: id)
     #expect(stillThere == "expected-sid-X")
+  }
+}
+
+// `PTYRegistry.spawn` は actor isolated method で内部に `await awaitReadyPipe(fd:)` を
+// 持つ。actor は `await` ごとに re-entrancy を許す (SE-0306) ため、id 採番 / `ptys[id]`
+// 登録 / `pidTracker` 加入は全て suspend point の **前** で完了する不変条件を持つ。
+// この suite はその不変条件が並列 spawn でも保たれることを直接 verify する。
+//
+// 親 suite `PTYRegistry` は `.serialized` で直列化されており、並列 spawn の race は
+// 構造的に踏めない。本 suite は default の parallel 実行に置き、`withThrowingTaskGroup`
+// で複数 spawn を同時発射した時の id 採番一意性を assert する。
+@Suite("PTYRegistry.ConcurrentSpawn")
+struct PTYRegistryConcurrentSpawnTests {
+  @Test("並列 spawn が一意な ptyId を採番し、並列 remove が actor 上で整合する")
+  func concurrentSpawnYieldsUniqueIds() async throws {
+    testTrace("started")
+    defer { testTrace("ended") }
+    let registry = PTYRegistry(
+      onText: { _, _ in },
+      onExit: { _, _ in }
+    )
+
+    let count = 8
+    let ids = try await withThrowingTaskGroup(of: UInt32.self) { group in
+      for _ in 0..<count {
+        group.addTask {
+          try await registry.spawn(
+            executable: "/bin/echo",
+            args: ["echo", "race"],
+            env: ProcessInfo.processInfo.environment,
+            cwd: "/tmp",
+            rows: 24,
+            cols: 80
+          )
+        }
+      }
+      var collected: [UInt32] = []
+      for try await id in group {
+        collected.append(id)
+      }
+      return collected
+    }
+
+    // 主観点: id 採番一意性 ( actor re-entrancy 経由の `ptys[id]` 上書き race の regression
+    // guard )。
+    #expect(ids.count == count)
+    #expect(
+      Set(ids).count == count,
+      "expected \(count) unique ids, got duplicates in \(ids.sorted())")
+
+    // 副観点: `/bin/echo` × 8 件は即時 _exit するため、8 つの consumer Task が並列に
+    // `remove(id:)` を actor に発射する。`awaitEmpty()` の Continuation flush が並列
+    // remove 経路でも `ptys.isEmpty` 確定後に 1 度だけ resume されることをここで合わせて
+    // 担保する ( single-pty の `cleanupOnKill` test では並列 remove を踏めない )。
+    await registry.awaitEmpty()
+    #expect(await registry.count() == 0)
   }
 }
 

--- a/apps/native/Tests/GozdCoreTests/RpcDispatcherTests.swift
+++ b/apps/native/Tests/GozdCoreTests/RpcDispatcherTests.swift
@@ -101,11 +101,7 @@ struct RpcDispatcherTests {
     killReq.ptyID = spawnResp.ptyID
     _ = try await dispatcher.dispatch(path: "/pty/kill", body: killReq.jsonUTF8Data())
 
-    let deadline = ContinuousClock.now.advanced(by: .seconds(2))
-    while ContinuousClock.now < deadline {
-      if exitFlag.isSet { break }
-      try await Task.sleep(for: .milliseconds(30))
-    }
+    await waitUntil(timeout: .seconds(2), description: "exitFlag is set") { exitFlag.isSet }
     #expect(exitFlag.isSet)
   }
 

--- a/apps/native/Tests/GozdCoreTests/RpcDispatcherTests.swift
+++ b/apps/native/Tests/GozdCoreTests/RpcDispatcherTests.swift
@@ -86,7 +86,7 @@ struct RpcDispatcherTests {
     )
 
     var spawnReq = Gozd_V1_PtySpawnRequest()
-    spawnReq.dir = "/tmp"
+    spawnReq.dir = testCwd
     spawnReq.executable = "/bin/cat"
     spawnReq.args = ["cat"]
     spawnReq.env = ProcessInfo.processInfo.environment
@@ -753,6 +753,12 @@ private func readGitForRpc(args: [String], cwd: String) async throws -> String {
 }
 
 // MARK: - Helpers
+
+// PTY spawn の cwd 引数に渡す「確定的に存在する dir」。`NSTemporaryDirectory()` は
+// macOS の per-user TMPDIR (`/var/folders/...`) を返し、グローバル `/tmp` と異なり
+// マルチユーザー環境 / サンドボックスでも衝突しない ( CLAUDE.md 規約「`/tmp` を
+// ハードコードしない、`NSTemporaryDirectory()` を使う」)。
+private let testCwd = NSTemporaryDirectory()
 
 private func makeTempDir() throws -> String {
   let raw = FileManager.default.temporaryDirectory

--- a/apps/native/Tests/GozdCoreTests/WaitUntil.swift
+++ b/apps/native/Tests/GozdCoreTests/WaitUntil.swift
@@ -116,3 +116,34 @@ private enum WaitResult {
   case resolved
   case timeout(elapsed: Duration, tickCount: Int, history: String)
 }
+
+// `Thread.sleep(forTimeInterval:)` を dedicated NSThread 上で 1 度だけ回し、cooperative
+// executor 経路を踏まずに「真に時間経過が意味を持つ」待機を実現する helper。
+//
+// 用途:
+// - FSEvents の debounce / kqueue 通知の propagation 待ち
+// - 「event 配送が暫く来ないこと」を verify する negative test (unwatch / unwatchAll 直後)
+//
+// 用途外: event / actor state の到達待ち。これらは production 側の barrier ( pipe
+// signaling / actor accessor ) で構造的に race を消すのが正攻法。`sleepThreaded` で
+// 時間を稼ぐと race を観測経路にすり替えるだけで flake が再生産される。
+//
+// 実装契約:
+// - `Thread { ... }.start()` で dedicated NSThread を立て、その上で `Thread.sleep`
+//   を 1 度だけ呼ぶ。Swift Concurrency の cooperative executor も GCD pool も触らない
+// - resume は sleep 終了時の 1 回のみ。cancel / throw 経路は持たない ( `waitUntil` と
+//   同じ設計判断 )。`Task.cancel` は無視する
+// - trace は出さない ( 1 回の sleep + resume で完結し、tick polling のような中間状態が
+//   無いため、`analyze-stall.sh` の解析対象にならない )
+func sleepThreaded(_ duration: Duration) async {
+  await withCheckedContinuation { continuation in
+    let thread = Thread {
+      let (seconds, attoseconds) = duration.components
+      let interval = Double(seconds) + Double(attoseconds) / 1.0e18
+      Thread.sleep(forTimeInterval: interval)
+      continuation.resume()
+    }
+    thread.name = "SleepThreaded"
+    thread.start()
+  }
+}

--- a/apps/native/Tests/GozdCoreTests/WaitUntil.swift
+++ b/apps/native/Tests/GozdCoreTests/WaitUntil.swift
@@ -42,9 +42,15 @@ import Testing
 // ( `mach_continuous_time` 基盤、suspend 中も進む ) と `Date` ( system clock、NTP 調整 ) を
 // 並列に記録する。稀な system clock 異常 ( NTP 巻き戻し / sleep wake 後の補正 ) の検知用。
 
+// `lastObserved` を指定すると timeout 時の `Issue.record` message に呼び出し結果を inline
+// する。Bool 履歴 ( `lastTicks` ) だけでは「条件が false」しか分からないため、collector
+// snapshot / counter 値 / state dump 等の補助情報を 1 行で残せる経路を用意する。
+// 評価は timeout 確定時の 1 度のみ ( polling 中には呼ばない )。
+
 func waitUntil(
   timeout: Duration,
   description: String = "condition",
+  lastObserved: (@Sendable () -> String)? = nil,
   _ condition: @escaping @Sendable () -> Bool,
   sourceLocation: SourceLocation = #_sourceLocation
 ) async {
@@ -92,11 +98,12 @@ func waitUntil(
   case .resolved:
     return
   case .timeout(let elapsed, let tickCount, let history):
+    let observedSuffix = lastObserved.map { " observed: \($0())" } ?? ""
     Issue.record(
       """
       waitUntil timed out after \(timeout) waiting for: \(description). \
       elapsed=\(elapsed) tickCount=\(tickCount). \
-      last ticks: [\(history)]
+      last ticks: [\(history)]\(observedSuffix)
       """,
       sourceLocation: sourceLocation)
   }


### PR DESCRIPTION
## 概要

`apps/native/Tests/GozdCoreTests/` 配下の生 `Task.sleep` を全 callsite で撤去し、cooperative-executor stall に起因する flake を構造的に根治する。残存 callsite を 1 つでも残すと別 test で同種 flake が無限再生産されるため、test infra の置換だけでなく production 側に「event 到達を構造的に signaling する API」を追加して race 自体を消す方針を取る。

## 背景

PR ( #625 ) で `WaitUntil` 本体のみ dedicated NSThread polling に切り替えたが、CI macOS-26 runner (run 26025564280 / 26029332080 / 26357231742) で以下の trace が観測された:

```text
[TEST-TRACE +4.183257875 test=writeRoundTrip()] waitUntil before-sleep tick=1
[TEST-TRACE +6.193379458 test=writeRoundTrip()] waitUntil after-sleep  tick=1   ← 2.01s stall
```

- `Task.sleep` だけが秒級 wake しない ( `Thread.sleep` 経路は 50ms 間隔で動く )
- timeout 直後の再 polling は即時 `result=true` を返す ( 観測対象は成立済、polling 経路だけが詰まっていた )

`Task.sleep` を経由する callsite が 1 つでも残る限り別 test で同種 flake が無限再生産される。残存 23 callsite のうち、event 待ち意図のものは production 側で race を構造的に消し、時間経過待ち意図のものだけ `sleepThreaded` ( dedicated NSThread の `Thread.sleep` ) に置換する。

issue は元々 3 件 ( #626 / #627 / #628 ) に分かれていたが root cause が同一で、partial 対応は「stall 経路を残す」「production API の中間状態を経由する」「flake 消滅の観測単位を分割する」三重の先送りに該当するため #630 で統合し単一 PR で扱う。

## 変更内容

### production: PTY ready barrier

- `gozd_pty_spawn` ( `apps/native/Sources/CPty/CPty.c` ) に親←子 ready pipe を組み込む。子は `login_tty` / `chdir` 完了後、execve 直前に 1 byte 書いて close。親は `out_ready_read_fd` を blocking read することで「子が execve 段階に到達した」ことを構造的に確認する
- C bridge の戻り値に `-3` ( pipe 作成失敗 ) を追加し、対応する `PTYError.readyPipeFailed(errno:)` を新設

### production: PTYManager

- `PTYManager.awaitReady() async` を追加 ( PTYManager 直接保持の非 actor caller 用 )
- `PTYManager.takeReadyPipeFd() -> Int32` を追加し、actor caller が non-Sendable な `pty` を sending せずに fd ( `Int32` ) だけ suspend 越しに保持する経路を提供
- 自由関数 `awaitReadyPipe(fd:)` を SSOT として配置し、dedicated NSThread 上で blocking read + close + Continuation resume の 3 段で完結させる ( cooperative executor / GCD pool / kqueue いずれの dispatch 経路にも乗せない )
- `readyPipeFd` を保持し、`deinit` で未消費分を必ず close ( fd リーク防止 )

### production: PTYRegistry

- `spawn` を `async throws` に変更。state mutation ( `nextId += 1` / `ptys[id] = pty` / `pidTracker.add` / consumer Task 起動 ) を **すべて await suspend point の前** に actor 排他区間で閉じる。最後に `await awaitReadyPipe(fd:)` で suspend し、actor re-entrancy ( SE-0306 ) 経由の concurrent spawn id 採番 race を構造的に防ぐ
- `awaitEmpty() async` accessor を追加。actor 内部で `CheckedContinuation` を保持し、`remove(id:)` で `ptys.isEmpty` 到達時に全 Continuation を flush。in-flight spawn 中の registry は `!ptys.isEmpty` を返す不変条件に合わせ即 return しない

### test infrastructure: WaitUntil

- `sleepThreaded(_ duration:)` async helper を追加。dedicated NSThread 上で `Thread.sleep(forTimeInterval:)` を 1 度だけ回し、debounce / propagation 待ち専用に使う
- `waitUntil` に `lastObserved: (() -> String)?` を追加し、timeout 時の `Issue.record` message に collector snapshot / counter 値を inline 出力 ( tick 履歴 ( true/false 列 ) だけでは表せない「何が来たか / 実値が幾つか」を 1 失敗ログから即座に判定可能 )

### test: callsite 置換 ( 全 23 件 )

- `PTYManagerTests.writeRoundTrip`: `Task.sleep(150ms)` → `pty.awaitReady()`
- `PTYRegistryTests.cleanupOnKill`: `Task.sleep(100ms)` → 構造的削除 ( spawn 自体が ready 待ち ) / `Task.sleep(20ms)` polling loop → `registry.awaitEmpty()`
- `RpcDispatcherTests`: `Task.sleep(30ms)` polling → `waitUntil`
- `FSWatcherTests` × 4: `sleepThreaded` + `waitUntil` に統合し、`waitForEvent` helper を撤去
- `FSWatchRegistryTests` × 16: 時間経過待ちは `sleepThreaded` に置換、`waitForEvent` / `waitForCount` helper 本体を `waitUntil` + `lastObserved` 経路に書き換え。`EventTimeout` struct は撤去

### test: race regression guard

- `PTYRegistry.ConcurrentSpawn` suite を `.serialized` 外で新設。`withThrowingTaskGroup` で 8 件並列 spawn を発射し、返り値 id 集合の一意性 ( `Set(ids).count == count` ) を `#expect` で固定。`/bin/echo` × 8 件の並列 `remove(id:)` 経路で `awaitEmpty()` の Continuation flush 整合性も同時に担保

## 確認事項

- [ ] swift build / swift test が全 294 テスト pass する ( ConcurrentSpawn 含む )
- [ ] 該当 suite ( `PTYManager` / `PTYRegistry` / `FSWatcher` / `FSWatchRegistry` / `RpcDispatcher` ) を **N 回連続 rerun** ( 最低 5 回 ) して 1 度も stall 由来 timeout が出ないこと。ローカルで 5 回連続 全 pass を確認済、CI 側で再確認が必要
- [ ] 実コード上の `Task.sleep` 残存 0 件 ( `grep -rn "Task.sleep" apps/native/Tests/GozdCoreTests/` のヒットがコメント文中のみであること )
- [ ] `PTYRegistry.spawn` の async 化に伴う caller 側 ( `RpcDispatcher` 等 ) の `await` 補完漏れがないこと
- [ ] `PTYRegistry.ConcurrentSpawn` test が並列 spawn の id 一意性を検出できる ( CI 上で `.serialized` を外した実行になっていること )
