### PR TITLE
feat(navigator): Files / Changes 行に右クリックメニューでファイルパス copy を追加

### DIFF
--- a/apps/renderer/src/features/changes/ChangesPane.vue
+++ b/apps/renderer/src/features/changes/ChangesPane.vue
@@ -23,8 +23,10 @@ summary 有効時は preview ペインに全変更の縦並び diff が表示さ
 
 <script setup lang="ts">
 import { tryCatch } from "@gozd/shared";
-import { ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import { useNotificationStore } from "../../shared/notification";
+import { useGitGraphStore } from "../git-graph";
+import { UNCOMMITTED_HASH } from "../worktree";
 import { buildChangesTree } from "./changesTree";
 import type { ChangesTreeNode } from "./changesTree";
 import ChangesTreeItem from "./ChangesTreeItem.vue";
@@ -38,6 +40,23 @@ const emit = defineEmits<{
 const notify = useNotificationStore();
 const changesStore = useChangesStore();
 const summaryStore = useChangesSummaryStore();
+const gitGraphStore = useGitGraphStore();
+
+/**
+ * 右クリックメニューに渡す commit hash。
+ *
+ * working tree 由来 (UNCOMMITTED_HASH 単独 / workingTreeOnly) のとき undefined を返し、
+ * メニュー側で file path のみを copy する経路に倒す。range mode で WT 端を含むケースでは
+ * selectedHash が UNCOMMITTED_HASH になるため compareHash 側を採用する。
+ */
+const contextMenuHash = computed<string | undefined>(() => {
+  if (gitGraphStore.workingTreeOnly) return undefined;
+  const sel = gitGraphStore.selectedHash;
+  if (sel !== UNCOMMITTED_HASH) return sel;
+  const cmp = gitGraphStore.compareHash;
+  if (cmp !== null && cmp !== UNCOMMITTED_HASH) return cmp;
+  return undefined;
+});
 
 /**
  * GitHub PR 風のディレクトリツリー（chain 圧縮済み）。
@@ -119,6 +138,7 @@ function onClickViewAll() {
         :node="node"
         :depth="0"
         :collapsed="collapsedFolders"
+        :commit-hash="contextMenuHash"
         @select="emit('select', $event)"
         @toggle-folder="toggleFolder"
       />

--- a/apps/renderer/src/features/changes/ChangesPane.vue
+++ b/apps/renderer/src/features/changes/ChangesPane.vue
@@ -23,10 +23,9 @@ summary 有効時は preview ペインに全変更の縦並び diff が表示さ
 
 <script setup lang="ts">
 import { tryCatch } from "@gozd/shared";
-import { computed, ref, watch } from "vue";
+import { ref, watch } from "vue";
 import { useNotificationStore } from "../../shared/notification";
-import { useGitGraphStore } from "../git-graph";
-import { UNCOMMITTED_HASH } from "../worktree";
+import type { FileContextMenuPayload } from "../navigator";
 import { buildChangesTree } from "./changesTree";
 import type { ChangesTreeNode } from "./changesTree";
 import ChangesTreeItem from "./ChangesTreeItem.vue";
@@ -35,38 +34,13 @@ import { useChangesSummaryStore } from "./useChangesSummaryStore";
 
 const emit = defineEmits<{
   select: [relPath: string];
-  /** 右クリック payload を NavigatorPane まで bubble する。本ペインは hash 解決のみ担当 */
-  contextMenu: [
-    payload: {
-      anchorEl: HTMLElement;
-      relPath: string;
-      commitHash?: string;
-      x: number;
-      y: number;
-    },
-  ];
+  /** 右クリック payload を NavigatorPane まで bubble する。hash 解決は navigator + store SSOT */
+  contextMenu: [payload: FileContextMenuPayload];
 }>();
 
 const notify = useNotificationStore();
 const changesStore = useChangesStore();
 const summaryStore = useChangesSummaryStore();
-const gitGraphStore = useGitGraphStore();
-
-/**
- * 右クリックメニューに渡す commit hash。
- *
- * - working tree (UNCOMMITTED_HASH 単独): undefined。menu 側で path のみ copy
- * - range mode (compareHash 非 null): undefined。複数 commit にまたがる diff を表示している
- *   ので、単一 hash で代表すると user に誤解 (「この hash 時点のファイル」) を与える。
- *   単一の代表 hash が必要なら git log per-file のような別経路を別 menu アクションとして
- *   将来用意する想定
- * - 単一 commit 選択: その hash。Filer の `snapshotHash` (= `selectedHash`) と同じ semantics
- */
-const contextMenuHash = computed<string | undefined>(() => {
-  if (gitGraphStore.isRangeMode) return undefined;
-  if (gitGraphStore.selectedHash === UNCOMMITTED_HASH) return undefined;
-  return gitGraphStore.selectedHash;
-});
 
 /**
  * GitHub PR 風のディレクトリツリー（chain 圧縮済み）。
@@ -148,7 +122,6 @@ function onClickViewAll() {
         :node="node"
         :depth="0"
         :collapsed="collapsedFolders"
-        :commit-hash="contextMenuHash"
         @select="emit('select', $event)"
         @toggle-folder="toggleFolder"
         @context-menu="(payload) => emit('contextMenu', payload)"

--- a/apps/renderer/src/features/changes/ChangesPane.vue
+++ b/apps/renderer/src/features/changes/ChangesPane.vue
@@ -35,6 +35,16 @@ import { useChangesSummaryStore } from "./useChangesSummaryStore";
 
 const emit = defineEmits<{
   select: [relPath: string];
+  /** 右クリック payload を NavigatorPane まで bubble する。本ペインは hash 解決のみ担当 */
+  contextMenu: [
+    payload: {
+      anchorEl: HTMLElement;
+      relPath: string;
+      commitHash?: string;
+      x: number;
+      y: number;
+    },
+  ];
 }>();
 
 const notify = useNotificationStore();
@@ -45,17 +55,17 @@ const gitGraphStore = useGitGraphStore();
 /**
  * 右クリックメニューに渡す commit hash。
  *
- * working tree 由来 (UNCOMMITTED_HASH 単独 / workingTreeOnly) のとき undefined を返し、
- * メニュー側で file path のみを copy する経路に倒す。range mode で WT 端を含むケースでは
- * selectedHash が UNCOMMITTED_HASH になるため compareHash 側を採用する。
+ * - working tree (UNCOMMITTED_HASH 単独): undefined。menu 側で path のみ copy
+ * - range mode (compareHash 非 null): undefined。複数 commit にまたがる diff を表示している
+ *   ので、単一 hash で代表すると user に誤解 (「この hash 時点のファイル」) を与える。
+ *   単一の代表 hash が必要なら git log per-file のような別経路を別 menu アクションとして
+ *   将来用意する想定
+ * - 単一 commit 選択: その hash。Filer の `snapshotHash` (= `selectedHash`) と同じ semantics
  */
 const contextMenuHash = computed<string | undefined>(() => {
-  if (gitGraphStore.workingTreeOnly) return undefined;
-  const sel = gitGraphStore.selectedHash;
-  if (sel !== UNCOMMITTED_HASH) return sel;
-  const cmp = gitGraphStore.compareHash;
-  if (cmp !== null && cmp !== UNCOMMITTED_HASH) return cmp;
-  return undefined;
+  if (gitGraphStore.isRangeMode) return undefined;
+  if (gitGraphStore.selectedHash === UNCOMMITTED_HASH) return undefined;
+  return gitGraphStore.selectedHash;
 });
 
 /**
@@ -141,6 +151,7 @@ function onClickViewAll() {
         :commit-hash="contextMenuHash"
         @select="emit('select', $event)"
         @toggle-folder="toggleFolder"
+        @context-menu="(payload) => emit('contextMenu', payload)"
       />
     </div>
   </div>

--- a/apps/renderer/src/features/changes/ChangesTreeItem.vue
+++ b/apps/renderer/src/features/changes/ChangesTreeItem.vue
@@ -71,24 +71,25 @@ function onChildToggle(fullPath: string) {
 }
 
 /**
- * 右クリック。
+ * 右クリック。file leaf / folder どちらも menu 対象にする。
  *
- * - file leaf: preventDefault + emit で navigator に bubble
- * - folder 行: chain 圧縮された presentation のため実体 path が unique に決まらない
- *   (`.github/workflows` 等の連結表記が 1 行)。Copy file path 経路に渡す path が曖昧に
- *   なるので menu を出さず OS 標準 menu に倒す。Filer の directory 行 (実体 path を持つ)
- *   とは対称ではない (Filer は menu 対象、Changes folder は対象外 — 責務の差)
+ * - file leaf: `change.newFilePath` を relPath に
+ * - folder: chain 圧縮の **最深** folder fullPath (`displayPath`) を relPath に。user が UI で
+ *   見ている folder 行 (例: `.github/workflows`) は実体として一意に決まる folder path を指す
+ *   ため、Copy file path として渡す path が曖昧になることはない。Filer の directory 行と
+ *   同じく menu 対象に揃える
  *
  * light-dismiss 回避 (pointerup 待機) は NavigatorPane が処理する責務。本 component は
  * payload を作って emit するだけ。
  */
 function onContextMenu(event: MouseEvent) {
-  if (props.node.kind !== "file") return;
   if (!(event.currentTarget instanceof HTMLElement)) return;
+  const relPath =
+    props.node.kind === "file" ? props.node.change.newFilePath : props.node.displayPath;
   event.preventDefault();
   emit("contextMenu", {
     anchorEl: event.currentTarget,
-    relPath: props.node.change.newFilePath,
+    relPath,
     x: event.clientX,
     y: event.clientY,
   });

--- a/apps/renderer/src/features/changes/ChangesTreeItem.vue
+++ b/apps/renderer/src/features/changes/ChangesTreeItem.vue
@@ -4,8 +4,10 @@ Recursive tree node for the changes pane. Renders folders (with collapse/expand)
 
 <script setup lang="ts">
 import type { GitFileChange } from "@gozd/proto";
+import { useEventListener } from "@vueuse/core";
 import { computed } from "vue";
 import { getFileIconUrl, getFolderIconUrl } from "../filer";
+import { useFileContextMenu } from "../navigator";
 import type { ChangesTreeNode } from "./changesTree";
 
 const props = defineProps<{
@@ -13,6 +15,8 @@ const props = defineProps<{
   depth: number;
   /** 折りたたまれているフォルダの fullPath 集合 */
   collapsed: Set<string>;
+  /** 右クリックメニューに渡す commit hash。working tree 由来なら undefined */
+  commitHash?: string;
 }>();
 
 const emit = defineEmits<{
@@ -62,15 +66,44 @@ function onChildSelect(relPath: string) {
 function onChildToggle(fullPath: string) {
   emit("toggleFolder", fullPath);
 }
+
+const { open: openContextMenu } = useFileContextMenu();
+
+// 右クリック経路は contextmenu の中で直接 showPopover すると、同サイクルの mousedown が
+// popover="auto" の light-dismiss を予約し、続く mouseup で消化されて即閉じる
+// (whatwg/html#10905)。次の pointerup を 1 回 capture once で待ってから open すれば
+// mousedown サイクルを抜けるため dismiss されない。
+function onContextMenu(event: MouseEvent) {
+  if (props.node.kind !== "file") return;
+  if (!(event.currentTarget instanceof HTMLElement)) return;
+  const node = props.node;
+  const anchor = event.currentTarget;
+  const x = event.clientX;
+  const y = event.clientY;
+  useEventListener(
+    window,
+    "pointerup",
+    () => {
+      openContextMenu(anchor, {
+        relPath: node.change.newFilePath,
+        commitHash: props.commitHash,
+        x,
+        y,
+      });
+    },
+    { once: true, capture: true },
+  );
+}
 </script>
 
 <template>
   <div>
     <button
       type="button"
-      class="flex w-full cursor-pointer items-center gap-1 px-1 py-0.5 text-left text-xs hover:bg-zinc-800/60"
+      class="flex w-full cursor-pointer items-center gap-1 px-1 py-0.5 text-left text-xs select-none hover:bg-zinc-800/60"
       :style="{ paddingLeft: `${depth * 12 + 8}px` }"
       @click="onClick"
+      @contextmenu.prevent="onContextMenu"
     >
       <template v-if="node.kind === 'folder'">
         <span
@@ -102,6 +135,7 @@ function onChildToggle(fullPath: string) {
         :node="child"
         :depth="depth + 1"
         :collapsed="collapsed"
+        :commit-hash="commitHash"
         @select="onChildSelect"
         @toggle-folder="onChildToggle"
       />

--- a/apps/renderer/src/features/changes/ChangesTreeItem.vue
+++ b/apps/renderer/src/features/changes/ChangesTreeItem.vue
@@ -55,7 +55,11 @@ const folderDisplayName = computed(() =>
   props.node.kind === "folder" ? props.node.displaySegments.join("/") : "",
 );
 
-function onClick() {
+function onClick(event: MouseEvent) {
+  // macOS の control+click は WebKit が button=0 + click event として dispatch するため、
+  // contextmenu と一緒に通常 click も発火する。control+click は context menu trigger の
+  // 意図なので toggle / select に倒さず contextmenu 経路に委譲する。
+  if (event.ctrlKey) return;
   if (props.node.kind === "folder") {
     emit("toggleFolder", props.node.anchorPath);
   } else {

--- a/apps/renderer/src/features/changes/ChangesTreeItem.vue
+++ b/apps/renderer/src/features/changes/ChangesTreeItem.vue
@@ -71,12 +71,16 @@ function onChildToggle(fullPath: string) {
 }
 
 /**
- * 右クリック。folder 行は preventDefault せず OS 標準の右クリック menu に倒す
- * (folder に対する gozd メニュー action が無いため、user の OS-level menu 期待を奪わない)。
- * file leaf のみ preventDefault + emit で navigator まで bubble する。
+ * 右クリック。
  *
- * 同サイクル open による light-dismiss 回避 / showPopover の defer は NavigatorPane が
- * setTimeout(0) で処理する責務。本 component は payload を作って emit するだけ。
+ * - file leaf: preventDefault + emit で navigator に bubble
+ * - folder 行: chain 圧縮された presentation のため実体 path が unique に決まらない
+ *   (`.github/workflows` 等の連結表記が 1 行)。Copy file path 経路に渡す path が曖昧に
+ *   なるので menu を出さず OS 標準 menu に倒す。Filer の directory 行 (実体 path を持つ)
+ *   とは対称ではない (Filer は menu 対象、Changes folder は対象外 — 責務の差)
+ *
+ * light-dismiss 回避 (pointerup 待機) は NavigatorPane が処理する責務。本 component は
+ * payload を作って emit するだけ。
  */
 function onContextMenu(event: MouseEvent) {
   if (props.node.kind !== "file") return;

--- a/apps/renderer/src/features/changes/ChangesTreeItem.vue
+++ b/apps/renderer/src/features/changes/ChangesTreeItem.vue
@@ -56,9 +56,11 @@ const folderDisplayName = computed(() =>
 );
 
 function onClick(event: MouseEvent) {
-  // macOS の control+click は WebKit が button=0 + click event として dispatch するため、
-  // contextmenu と一緒に通常 click も発火する。control+click は context menu trigger の
-  // 意図なので toggle / select に倒さず contextmenu 経路に委譲する。
+  // macOS の control+click は WebKit が button=0 + click event として dispatch する
+  // (webkit bugzilla 52174)。contextmenu と一緒に通常 click も発火するため、control+click
+  // は context menu trigger の意図として toggle / select には倒さず contextmenu 経路に委譲。
+  // gozd は macOS 専用 (root CLAUDE.md) なので ctrlKey === control+click と等価。cross-platform
+  // 対応する場合は OS 判定 (navigator.platform / userAgent) で macOS 経路に絞る必要がある。
   if (event.ctrlKey) return;
   if (props.node.kind === "folder") {
     emit("toggleFolder", props.node.anchorPath);

--- a/apps/renderer/src/features/changes/ChangesTreeItem.vue
+++ b/apps/renderer/src/features/changes/ChangesTreeItem.vue
@@ -4,10 +4,8 @@ Recursive tree node for the changes pane. Renders folders (with collapse/expand)
 
 <script setup lang="ts">
 import type { GitFileChange } from "@gozd/proto";
-import { useEventListener } from "@vueuse/core";
 import { computed } from "vue";
 import { getFileIconUrl, getFolderIconUrl } from "../filer";
-import { useFileContextMenu } from "../navigator";
 import type { ChangesTreeNode } from "./changesTree";
 
 const props = defineProps<{
@@ -22,6 +20,19 @@ const props = defineProps<{
 const emit = defineEmits<{
   select: [relPath: string];
   toggleFolder: [fullPath: string];
+  /**
+   * 右クリック payload を NavigatorPane まで bubble する。file leaf のみ発火する
+   * (folder 行は OS 標準の右クリック menu に倒すため preventDefault せず no-op)。
+   */
+  contextMenu: [
+    payload: {
+      anchorEl: HTMLElement;
+      relPath: string;
+      commitHash?: string;
+      x: number;
+      y: number;
+    },
+  ];
 }>();
 
 const CHANGE_COLOR_MAP: Record<GitFileChange["type"], string> = {
@@ -67,32 +78,25 @@ function onChildToggle(fullPath: string) {
   emit("toggleFolder", fullPath);
 }
 
-const { open: openContextMenu } = useFileContextMenu();
-
-// 右クリック経路は contextmenu の中で直接 showPopover すると、同サイクルの mousedown が
-// popover="auto" の light-dismiss を予約し、続く mouseup で消化されて即閉じる
-// (whatwg/html#10905)。次の pointerup を 1 回 capture once で待ってから open すれば
-// mousedown サイクルを抜けるため dismiss されない。
+/**
+ * 右クリック。folder 行は preventDefault せず OS 標準の右クリック menu に倒す
+ * (folder に対する gozd メニュー action が無いため、user の OS-level menu 期待を奪わない)。
+ * file leaf のみ preventDefault + emit で navigator まで bubble する。
+ *
+ * 同サイクル open による light-dismiss 回避 / showPopover の defer は NavigatorPane が
+ * setTimeout(0) で処理する責務。本 component は payload を作って emit するだけ。
+ */
 function onContextMenu(event: MouseEvent) {
   if (props.node.kind !== "file") return;
   if (!(event.currentTarget instanceof HTMLElement)) return;
-  const node = props.node;
-  const anchor = event.currentTarget;
-  const x = event.clientX;
-  const y = event.clientY;
-  useEventListener(
-    window,
-    "pointerup",
-    () => {
-      openContextMenu(anchor, {
-        relPath: node.change.newFilePath,
-        commitHash: props.commitHash,
-        x,
-        y,
-      });
-    },
-    { once: true, capture: true },
-  );
+  event.preventDefault();
+  emit("contextMenu", {
+    anchorEl: event.currentTarget,
+    relPath: props.node.change.newFilePath,
+    commitHash: props.commitHash,
+    x: event.clientX,
+    y: event.clientY,
+  });
 }
 </script>
 
@@ -103,7 +107,7 @@ function onContextMenu(event: MouseEvent) {
       class="flex w-full cursor-pointer items-center gap-1 px-1 py-0.5 text-left text-xs select-none hover:bg-zinc-800/60"
       :style="{ paddingLeft: `${depth * 12 + 8}px` }"
       @click="onClick"
-      @contextmenu.prevent="onContextMenu"
+      @contextmenu="onContextMenu"
     >
       <template v-if="node.kind === 'folder'">
         <span
@@ -138,6 +142,7 @@ function onContextMenu(event: MouseEvent) {
         :commit-hash="commitHash"
         @select="onChildSelect"
         @toggle-folder="onChildToggle"
+        @context-menu="(payload) => emit('contextMenu', payload)"
       />
     </template>
   </div>

--- a/apps/renderer/src/features/changes/ChangesTreeItem.vue
+++ b/apps/renderer/src/features/changes/ChangesTreeItem.vue
@@ -6,6 +6,7 @@ Recursive tree node for the changes pane. Renders folders (with collapse/expand)
 import type { GitFileChange } from "@gozd/proto";
 import { computed } from "vue";
 import { getFileIconUrl, getFolderIconUrl } from "../filer";
+import type { FileContextMenuPayload } from "../navigator";
 import type { ChangesTreeNode } from "./changesTree";
 
 const props = defineProps<{
@@ -13,8 +14,6 @@ const props = defineProps<{
   depth: number;
   /** 折りたたまれているフォルダの fullPath 集合 */
   collapsed: Set<string>;
-  /** 右クリックメニューに渡す commit hash。working tree 由来なら undefined */
-  commitHash?: string;
 }>();
 
 const emit = defineEmits<{
@@ -23,16 +22,9 @@ const emit = defineEmits<{
   /**
    * 右クリック payload を NavigatorPane まで bubble する。file leaf のみ発火する
    * (folder 行は OS 標準の右クリック menu に倒すため preventDefault せず no-op)。
+   * hash 解決は navigator が `useGitGraphStore.contextMenuHash` SSOT で行う。
    */
-  contextMenu: [
-    payload: {
-      anchorEl: HTMLElement;
-      relPath: string;
-      commitHash?: string;
-      x: number;
-      y: number;
-    },
-  ];
+  contextMenu: [payload: FileContextMenuPayload];
 }>();
 
 const CHANGE_COLOR_MAP: Record<GitFileChange["type"], string> = {
@@ -93,7 +85,6 @@ function onContextMenu(event: MouseEvent) {
   emit("contextMenu", {
     anchorEl: event.currentTarget,
     relPath: props.node.change.newFilePath,
-    commitHash: props.commitHash,
     x: event.clientX,
     y: event.clientY,
   });
@@ -139,7 +130,6 @@ function onContextMenu(event: MouseEvent) {
         :node="child"
         :depth="depth + 1"
         :collapsed="collapsed"
-        :commit-hash="commitHash"
         @select="onChildSelect"
         @toggle-folder="onChildToggle"
         @context-menu="(payload) => emit('contextMenu', payload)"

--- a/apps/renderer/src/features/changes/changesTree.test.ts
+++ b/apps/renderer/src/features/changes/changesTree.test.ts
@@ -6,53 +6,74 @@ function ch(newFilePath: string): GitFileChange {
   return { oldFilePath: newFilePath, newFilePath, type: "M" };
 }
 
-/**
- * `displayPath` は chain 圧縮された folder 行の copy 対象 path として user に直接見える値。
- * 右クリック menu の Copy file path で渡される relPath になるため、chain 圧縮ロジックの
- * 境界条件を踏むテストを用意する (圧縮しない / 1 段 / 多段 / file 混在 / root 直下 / sibling 2 つ)。
- */
-describe("buildChangesTree displayPath", () => {
-  test("圧縮なし: 子に複数 folder があるなら chain しない", () => {
-    const tree = buildChangesTree([ch("src/a.ts"), ch("src/b.ts"), ch("docs/c.md")]);
-    const docs = tree.find((n) => n.kind === "folder" && n.displaySegments[0] === "docs");
-    const src = tree.find((n) => n.kind === "folder" && n.displaySegments[0] === "src");
-    if (docs?.kind !== "folder" || src?.kind !== "folder") throw new Error("folder not found");
-    expect(docs.displayPath).toBe("docs");
-    expect(src.displayPath).toBe("src");
+describe("buildChangesTree", () => {
+  /**
+   * `displayPath` は chain 圧縮された folder 行の copy 対象 path として user に直接見える値。
+   * 右クリック menu の Copy file path で渡される relPath になるため、chain 圧縮ロジックの
+   * 境界条件を踏むテストを用意する。
+   */
+  describe("displayPath", () => {
+    test("圧縮なし: 子に複数 folder があるなら chain しない", () => {
+      const tree = buildChangesTree([ch("src/a.ts"), ch("src/b.ts"), ch("docs/c.md")]);
+      const docs = tree.find((n) => n.kind === "folder" && n.displaySegments[0] === "docs");
+      const src = tree.find((n) => n.kind === "folder" && n.displaySegments[0] === "src");
+      if (docs?.kind !== "folder" || src?.kind !== "folder") throw new Error("folder not found");
+      expect(docs.displayPath).toBe("docs");
+      expect(src.displayPath).toBe("src");
+    });
+
+    test("1 段 chain: 単独 folder の chain は最深 path を保持する", () => {
+      const tree = buildChangesTree([ch(".github/workflows/ci.yml")]);
+      const node = tree[0];
+      if (node?.kind !== "folder") throw new Error("folder expected");
+      expect(node.displaySegments).toEqual([".github", "workflows"]);
+      expect(node.anchorPath).toBe(".github");
+      expect(node.displayPath).toBe(".github/workflows");
+    });
+
+    test("多段 chain: 深い単独 folder の chain も最深 path を保持する", () => {
+      const tree = buildChangesTree([ch("a/b/c/d/file.ts"), ch("a/b/c/d/other.ts")]);
+      const node = tree[0];
+      if (node?.kind !== "folder") throw new Error("folder expected");
+      expect(node.displaySegments).toEqual(["a", "b", "c", "d"]);
+      expect(node.anchorPath).toBe("a");
+      expect(node.displayPath).toBe("a/b/c/d");
+    });
+
+    test("file 混在で chain 中断: file を含む段で chain 圧縮が止まる", () => {
+      const tree = buildChangesTree([ch("a/file.ts"), ch("a/b/other.ts")]);
+      const node = tree[0];
+      if (node?.kind !== "folder") throw new Error("folder expected");
+      // a に file (`a/file.ts`) と folder (`b`) があるため chain しない
+      expect(node.displaySegments).toEqual(["a"]);
+      expect(node.displayPath).toBe("a");
+    });
+
+    test("root 直下 folder: 単独 file しか無いなら chain せず folder のみ", () => {
+      const tree = buildChangesTree([ch("src/main.ts")]);
+      const node = tree[0];
+      if (node?.kind !== "folder") throw new Error("folder expected");
+      expect(node.displaySegments).toEqual(["src"]);
+      expect(node.displayPath).toBe("src");
+    });
   });
 
-  test("1 段 chain: 単独 folder の chain は最深 path を保持する", () => {
-    const tree = buildChangesTree([ch(".github/workflows/ci.yml")]);
-    const node = tree[0];
-    if (node?.kind !== "folder") throw new Error("folder expected");
-    expect(node.displaySegments).toEqual([".github", "workflows"]);
-    expect(node.anchorPath).toBe(".github");
-    expect(node.displayPath).toBe(".github/workflows");
-  });
+  /**
+   * 不正 path (空 segment / 重複 / 末尾 `/`) は silent 落としを避けて throw する契約。
+   * `ChangesPane.vue` 側で `tryCatch` + `notify.error` で受ける経路の trigger なので、
+   * 「不正入力で throw する」契約自体をテストで担保する。
+   */
+  describe("error contracts", () => {
+    test("重複 / (`a//b.ts`) は throw", () => {
+      expect(() => buildChangesTree([ch("a//b.ts")])).toThrow(/Invalid file path/);
+    });
 
-  test("多段 chain: 深い単独 folder の chain も最深 path を保持する", () => {
-    const tree = buildChangesTree([ch("a/b/c/d/file.ts"), ch("a/b/c/d/other.ts")]);
-    const node = tree[0];
-    if (node?.kind !== "folder") throw new Error("folder expected");
-    expect(node.displaySegments).toEqual(["a", "b", "c", "d"]);
-    expect(node.anchorPath).toBe("a");
-    expect(node.displayPath).toBe("a/b/c/d");
-  });
+    test("末尾 / (`a/b.ts/`) は throw", () => {
+      expect(() => buildChangesTree([ch("a/b.ts/")])).toThrow(/Invalid file path/);
+    });
 
-  test("file 混在で chain 中断: file を含む段で chain 圧縮が止まる", () => {
-    const tree = buildChangesTree([ch("a/file.ts"), ch("a/b/other.ts")]);
-    const node = tree[0];
-    if (node?.kind !== "folder") throw new Error("folder expected");
-    // a に file (`a/file.ts`) と folder (`b`) があるため chain しない
-    expect(node.displaySegments).toEqual(["a"]);
-    expect(node.displayPath).toBe("a");
-  });
-
-  test("root 直下 folder: 単独 file しか無いなら chain せず folder のみ", () => {
-    const tree = buildChangesTree([ch("src/main.ts")]);
-    const node = tree[0];
-    if (node?.kind !== "folder") throw new Error("folder expected");
-    expect(node.displaySegments).toEqual(["src"]);
-    expect(node.displayPath).toBe("src");
+    test("空 path は throw", () => {
+      expect(() => buildChangesTree([ch("")])).toThrow(/Invalid file path/);
+    });
   });
 });

--- a/apps/renderer/src/features/changes/changesTree.test.ts
+++ b/apps/renderer/src/features/changes/changesTree.test.ts
@@ -6,6 +6,11 @@ function ch(newFilePath: string): GitFileChange {
   return { oldFilePath: newFilePath, newFilePath, type: "M" };
 }
 
+/**
+ * `buildChangesTree` の責務別 spec。displayPath / error contracts など責務ごとに
+ * `describe` を nested で区切ることで、将来 `displaySegments` / `anchorPath` 等の境界
+ * テスト追加時に責務単位の grouping が維持できる構造にしている。
+ */
 describe("buildChangesTree", () => {
   /**
    * `displayPath` は chain 圧縮された folder 行の copy 対象 path として user に直接見える値。

--- a/apps/renderer/src/features/changes/changesTree.test.ts
+++ b/apps/renderer/src/features/changes/changesTree.test.ts
@@ -1,0 +1,58 @@
+import type { GitFileChange } from "@gozd/proto";
+import { describe, expect, test } from "bun:test";
+import { buildChangesTree } from "./changesTree";
+
+function ch(newFilePath: string): GitFileChange {
+  return { oldFilePath: newFilePath, newFilePath, type: "M" };
+}
+
+/**
+ * `displayPath` は chain 圧縮された folder 行の copy 対象 path として user に直接見える値。
+ * 右クリック menu の Copy file path で渡される relPath になるため、chain 圧縮ロジックの
+ * 境界条件を踏むテストを用意する (圧縮しない / 1 段 / 多段 / file 混在 / root 直下 / sibling 2 つ)。
+ */
+describe("buildChangesTree displayPath", () => {
+  test("圧縮なし: 子に複数 folder があるなら chain しない", () => {
+    const tree = buildChangesTree([ch("src/a.ts"), ch("src/b.ts"), ch("docs/c.md")]);
+    const docs = tree.find((n) => n.kind === "folder" && n.displaySegments[0] === "docs");
+    const src = tree.find((n) => n.kind === "folder" && n.displaySegments[0] === "src");
+    if (docs?.kind !== "folder" || src?.kind !== "folder") throw new Error("folder not found");
+    expect(docs.displayPath).toBe("docs");
+    expect(src.displayPath).toBe("src");
+  });
+
+  test("1 段 chain: 単独 folder の chain は最深 path を保持する", () => {
+    const tree = buildChangesTree([ch(".github/workflows/ci.yml")]);
+    const node = tree[0];
+    if (node?.kind !== "folder") throw new Error("folder expected");
+    expect(node.displaySegments).toEqual([".github", "workflows"]);
+    expect(node.anchorPath).toBe(".github");
+    expect(node.displayPath).toBe(".github/workflows");
+  });
+
+  test("多段 chain: 深い単独 folder の chain も最深 path を保持する", () => {
+    const tree = buildChangesTree([ch("a/b/c/d/file.ts"), ch("a/b/c/d/other.ts")]);
+    const node = tree[0];
+    if (node?.kind !== "folder") throw new Error("folder expected");
+    expect(node.displaySegments).toEqual(["a", "b", "c", "d"]);
+    expect(node.anchorPath).toBe("a");
+    expect(node.displayPath).toBe("a/b/c/d");
+  });
+
+  test("file 混在で chain 中断: file を含む段で chain 圧縮が止まる", () => {
+    const tree = buildChangesTree([ch("a/file.ts"), ch("a/b/other.ts")]);
+    const node = tree[0];
+    if (node?.kind !== "folder") throw new Error("folder expected");
+    // a に file (`a/file.ts`) と folder (`b`) があるため chain しない
+    expect(node.displaySegments).toEqual(["a"]);
+    expect(node.displayPath).toBe("a");
+  });
+
+  test("root 直下 folder: 単独 file しか無いなら chain せず folder のみ", () => {
+    const tree = buildChangesTree([ch("src/main.ts")]);
+    const node = tree[0];
+    if (node?.kind !== "folder") throw new Error("folder expected");
+    expect(node.displaySegments).toEqual(["src"]);
+    expect(node.displayPath).toBe("src");
+  });
+});

--- a/apps/renderer/src/features/changes/changesTree.ts
+++ b/apps/renderer/src/features/changes/changesTree.ts
@@ -14,6 +14,12 @@ export type ChangesTreeNode =
        * ユーザーが畳んだ状態を保てる。
        */
       anchorPath: string;
+      /**
+       * chain 圧縮の **最深** folder の fullPath。user が UI 上で見ている folder 行は
+       * この path を指す (例: `.github/workflows` 表示なら `.github/workflows`)。
+       * 右クリック menu で「この folder の path を copy」する経路で使う。
+       */
+      displayPath: string;
       children: ChangesTreeNode[];
     }
   | {
@@ -115,6 +121,7 @@ function collapseFolder(raw: RawFolder): ChangesTreeNode {
     kind: "folder",
     displaySegments,
     anchorPath: raw.fullPath,
+    displayPath: current.fullPath,
     children: finalizeChildren(current),
   };
 }

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -58,6 +58,7 @@
 import { tryCatch } from "@gozd/shared";
 import { computed, onMounted, ref, useTemplateRef, watch } from "vue";
 import { useNotificationStore } from "../../shared/notification";
+import type { FileContextMenuPayload } from "../navigator";
 import {
   resolveDirectoryGitChange,
   resolveFileGitChange,
@@ -118,16 +119,9 @@ const emit = defineEmits<{
   /**
    * 右クリック時に親に bubble する。NavigatorPane が popover singleton を open する責務を持つ。
    * 子 FileTreeItem からの emit もここで素通しで bubble する (再帰的に root pane まで上がる)。
+   * payload 型は navigator が SSOT として export (type-only import で依存方向は壊さない)。
    */
-  contextMenu: [
-    payload: {
-      anchorEl: HTMLElement;
-      relPath: string;
-      commitHash?: string;
-      x: number;
-      y: number;
-    },
-  ];
+  contextMenu: [payload: FileContextMenuPayload];
 }>();
 
 const notify = useNotificationStore();
@@ -396,21 +390,28 @@ function onChildSelect(childPath: string) {
 }
 
 /**
- * 右クリック。inertLeaf (submodule / snapshot symlink) は menu を開かず OS 標準の右クリック
- * menu に倒す (working tree に同名 file がある絶対パスを誤って copy 可能にする UI を構造的に
- * 排除する)。それ以外は preventDefault + emit で navigator まで bubble する。
+ * 右クリック。file leaf でかつ非 inert のときだけ menu を開く。
+ *
+ * - directory: 早期 return (folder は menu アクション無し、OS 標準右クリック menu に倒す)。
+ *   Changes 側 (folder で no-op) との対称性を取る
+ * - inert leaf (submodule / snapshot symlink): 早期 return (working tree に同名 file がある
+ *   絶対パスを誤って copy 可能にする UI を構造的に排除する)
+ * - 上記以外: preventDefault + emit で navigator まで bubble する
+ *
+ * commitHash は navigator が `useGitGraphStore.contextMenuHash` で SSOT 解決するため payload
+ * には乗せない (filer の `snapshotHash` は filer ツリー表示用なので copy 経路と分離する)。
  *
  * 同サイクル open による light-dismiss 回避 / showPopover の defer は NavigatorPane が
- * setTimeout(0) で処理する責務。本 component は payload を作って emit するだけ。
+ * 処理する責務。本 component は payload を作って emit するだけ。
  */
 function onContextMenu(event: MouseEvent) {
+  if (isDirectory.value) return;
   if (isInertLeaf.value) return;
   if (!(event.currentTarget instanceof HTMLElement)) return;
   event.preventDefault();
   emit("contextMenu", {
     anchorEl: event.currentTarget,
     relPath: props.path,
-    commitHash: props.snapshotHash,
     x: event.clientX,
     y: event.clientY,
   });

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -190,7 +190,11 @@ const iconUrl = computed(() => {
   return getFileIconUrl(props.name);
 });
 
-async function toggle() {
+async function toggle(event: MouseEvent) {
+  // macOS の control+click は WebKit が button=0 + click event として dispatch するため、
+  // contextmenu と一緒に通常 click も発火する。control+click は context menu trigger の
+  // 意図なので、folder の展開 / file の select には倒さず contextmenu 経路に委譲する。
+  if (event.ctrlKey) return;
   if (isDirectory.value) {
     expanded.value = !expanded.value;
     // 初回展開時のみ読み込む

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -390,13 +390,11 @@ function onChildSelect(childPath: string) {
 }
 
 /**
- * 右クリック。directory も含めて実体 path を持つ行は menu 対象にする。inert leaf のみ除外。
+ * 右クリック。directory / file どちらも実体 path を持つ行は menu 対象にする。inert leaf のみ除外。
  *
- * - directory: menu 対象 (実 filesystem path として絶対 path を copy する。Changes folder 行
- *   は presentation chain 圧縮で path が unique に決まらないため対象外という別責務)
+ * - directory / file: menu 対象 (実 filesystem path として絶対 path を copy する)
  * - inert leaf (submodule / snapshot symlink): 早期 return (snapshot 時点と working tree の
  *   実体が一致しないため、working tree の絶対 path を誤って copy 可能にする UI を排除)
- * - 上記以外: preventDefault + emit で navigator まで bubble する
  *
  * commitHash は navigator が `useGitGraphStore.contextMenuHash` で SSOT 解決するため payload
  * には乗せない (filer の `snapshotHash` は filer ツリー表示用なので copy 経路と分離する)。

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -56,10 +56,8 @@
 
 <script setup lang="ts">
 import { tryCatch } from "@gozd/shared";
-import { useEventListener } from "@vueuse/core";
 import { computed, onMounted, ref, useTemplateRef, watch } from "vue";
 import { useNotificationStore } from "../../shared/notification";
-import { useFileContextMenu } from "../navigator";
 import {
   resolveDirectoryGitChange,
   resolveFileGitChange,
@@ -117,12 +115,24 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   select: [path: string];
+  /**
+   * 右クリック時に親に bubble する。NavigatorPane が popover singleton を open する責務を持つ。
+   * 子 FileTreeItem からの emit もここで素通しで bubble する (再帰的に root pane まで上がる)。
+   */
+  contextMenu: [
+    payload: {
+      anchorEl: HTMLElement;
+      relPath: string;
+      commitHash?: string;
+      x: number;
+      y: number;
+    },
+  ];
 }>();
 
 const notify = useNotificationStore();
 const worktreeStore = useWorktreeStore();
 const filerEventStore = useFilerEventStore();
-const { open: openContextMenu } = useFileContextMenu();
 
 const isRoot = computed(() => isRootPath(props.path));
 const isDirectory = computed(() => props.kind === "directory");
@@ -385,28 +395,25 @@ function onChildSelect(childPath: string) {
   emit("select", childPath);
 }
 
-// 右クリック経路は contextmenu の中で直接 showPopover すると、同サイクルの mousedown が
-// popover="auto" の light-dismiss を予約し、続く mouseup で消化されて即閉じる
-// (whatwg/html#10905)。次の pointerup を 1 回 capture once で待ってから open すれば
-// mousedown サイクルを抜けるため dismiss されない。
+/**
+ * 右クリック。inertLeaf (submodule / snapshot symlink) は menu を開かず OS 標準の右クリック
+ * menu に倒す (working tree に同名 file がある絶対パスを誤って copy 可能にする UI を構造的に
+ * 排除する)。それ以外は preventDefault + emit で navigator まで bubble する。
+ *
+ * 同サイクル open による light-dismiss 回避 / showPopover の defer は NavigatorPane が
+ * setTimeout(0) で処理する責務。本 component は payload を作って emit するだけ。
+ */
 function onContextMenu(event: MouseEvent) {
+  if (isInertLeaf.value) return;
   if (!(event.currentTarget instanceof HTMLElement)) return;
-  const anchor = event.currentTarget;
-  const x = event.clientX;
-  const y = event.clientY;
-  useEventListener(
-    window,
-    "pointerup",
-    () => {
-      openContextMenu(anchor, {
-        relPath: props.path,
-        commitHash: props.snapshotHash,
-        x,
-        y,
-      });
-    },
-    { once: true, capture: true },
-  );
+  event.preventDefault();
+  emit("contextMenu", {
+    anchorEl: event.currentTarget,
+    relPath: props.path,
+    commitHash: props.snapshotHash,
+    x: event.clientX,
+    y: event.clientY,
+  });
 }
 </script>
 
@@ -425,7 +432,7 @@ function onContextMenu(event: MouseEvent) {
       :style="{ paddingLeft: `${depth * 16 + 4}px` }"
       :title="kind === 'submodule' ? 'submodule (not previewable)' : undefined"
       @click="toggle"
-      @contextmenu.prevent="onContextMenu"
+      @contextmenu="onContextMenu"
     >
       <!-- ディレクトリの展開/折りたたみアイコン -->
       <span
@@ -467,6 +474,7 @@ function onContextMenu(event: MouseEvent) {
         :depth="depth + 1"
         :selected-rel-path="selectedRelPath"
         @select="onChildSelect"
+        @context-menu="(payload) => emit('contextMenu', payload)"
       />
     </template>
   </div>

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -390,22 +390,21 @@ function onChildSelect(childPath: string) {
 }
 
 /**
- * 右クリック。file leaf でかつ非 inert のときだけ menu を開く。
+ * 右クリック。directory も含めて実体 path を持つ行は menu 対象にする。inert leaf のみ除外。
  *
- * - directory: 早期 return (folder は menu アクション無し、OS 標準右クリック menu に倒す)。
- *   Changes 側 (folder で no-op) との対称性を取る
- * - inert leaf (submodule / snapshot symlink): 早期 return (working tree に同名 file がある
- *   絶対パスを誤って copy 可能にする UI を構造的に排除する)
+ * - directory: menu 対象 (実 filesystem path として絶対 path を copy する。Changes folder 行
+ *   は presentation chain 圧縮で path が unique に決まらないため対象外という別責務)
+ * - inert leaf (submodule / snapshot symlink): 早期 return (snapshot 時点と working tree の
+ *   実体が一致しないため、working tree の絶対 path を誤って copy 可能にする UI を排除)
  * - 上記以外: preventDefault + emit で navigator まで bubble する
  *
  * commitHash は navigator が `useGitGraphStore.contextMenuHash` で SSOT 解決するため payload
  * には乗せない (filer の `snapshotHash` は filer ツリー表示用なので copy 経路と分離する)。
  *
- * 同サイクル open による light-dismiss 回避 / showPopover の defer は NavigatorPane が
- * 処理する責務。本 component は payload を作って emit するだけ。
+ * light-dismiss 回避 (pointerup 待機) は NavigatorPane が処理する責務。本 component は
+ * payload を作って emit するだけ。
  */
 function onContextMenu(event: MouseEvent) {
-  if (isDirectory.value) return;
   if (isInertLeaf.value) return;
   if (!(event.currentTarget instanceof HTMLElement)) return;
   event.preventDefault();

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -56,8 +56,10 @@
 
 <script setup lang="ts">
 import { tryCatch } from "@gozd/shared";
+import { useEventListener } from "@vueuse/core";
 import { computed, onMounted, ref, useTemplateRef, watch } from "vue";
 import { useNotificationStore } from "../../shared/notification";
+import { useFileContextMenu } from "../navigator";
 import {
   resolveDirectoryGitChange,
   resolveFileGitChange,
@@ -120,6 +122,7 @@ const emit = defineEmits<{
 const notify = useNotificationStore();
 const worktreeStore = useWorktreeStore();
 const filerEventStore = useFilerEventStore();
+const { open: openContextMenu } = useFileContextMenu();
 
 const isRoot = computed(() => isRootPath(props.path));
 const isDirectory = computed(() => props.kind === "directory");
@@ -381,6 +384,30 @@ watch(
 function onChildSelect(childPath: string) {
   emit("select", childPath);
 }
+
+// 右クリック経路は contextmenu の中で直接 showPopover すると、同サイクルの mousedown が
+// popover="auto" の light-dismiss を予約し、続く mouseup で消化されて即閉じる
+// (whatwg/html#10905)。次の pointerup を 1 回 capture once で待ってから open すれば
+// mousedown サイクルを抜けるため dismiss されない。
+function onContextMenu(event: MouseEvent) {
+  if (!(event.currentTarget instanceof HTMLElement)) return;
+  const anchor = event.currentTarget;
+  const x = event.clientX;
+  const y = event.clientY;
+  useEventListener(
+    window,
+    "pointerup",
+    () => {
+      openContextMenu(anchor, {
+        relPath: props.path,
+        commitHash: props.snapshotHash,
+        x,
+        y,
+      });
+    },
+    { once: true, capture: true },
+  );
+}
 </script>
 
 <template>
@@ -388,7 +415,7 @@ function onChildSelect(childPath: string) {
     <button
       v-if="!isRoot"
       ref="button"
-      class="flex w-full items-center gap-1 rounded-sm px-1 py-0.5 text-left text-sm hover:bg-zinc-700"
+      class="flex w-full items-center gap-1 rounded-sm px-1 py-0.5 text-left text-sm select-none hover:bg-zinc-700"
       :class="[
         selectedRelPath === path ? 'bg-zinc-700' : '',
         textColorClass,
@@ -398,6 +425,7 @@ function onChildSelect(childPath: string) {
       :style="{ paddingLeft: `${depth * 16 + 4}px` }"
       :title="kind === 'submodule' ? 'submodule (not previewable)' : undefined"
       @click="toggle"
+      @contextmenu.prevent="onContextMenu"
     >
       <!-- ディレクトリの展開/折りたたみアイコン -->
       <span

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -191,9 +191,11 @@ const iconUrl = computed(() => {
 });
 
 async function toggle(event: MouseEvent) {
-  // macOS の control+click は WebKit が button=0 + click event として dispatch するため、
-  // contextmenu と一緒に通常 click も発火する。control+click は context menu trigger の
-  // 意図なので、folder の展開 / file の select には倒さず contextmenu 経路に委譲する。
+  // macOS の control+click は WebKit が button=0 + click event として dispatch する
+  // (webkit bugzilla 52174)。contextmenu と一緒に通常 click も発火するため、control+click
+  // は context menu trigger の意図として toggle / select には倒さず contextmenu 経路に委譲。
+  // gozd は macOS 専用 (root CLAUDE.md) なので ctrlKey === control+click と等価。cross-platform
+  // 対応する場合は OS 判定 (navigator.platform / userAgent) で macOS 経路に絞る必要がある。
   if (event.ctrlKey) return;
   if (isDirectory.value) {
     expanded.value = !expanded.value;

--- a/apps/renderer/src/features/filer/FilerPane.vue
+++ b/apps/renderer/src/features/filer/FilerPane.vue
@@ -40,6 +40,7 @@ import { storeToRefs } from "pinia";
 import { computed, onUnmounted, watch } from "vue";
 import { onMessage } from "../../shared/rpc";
 import { useGitGraphStore } from "../git-graph";
+import type { FileContextMenuPayload } from "../navigator";
 import { UNCOMMITTED_HASH, useGitStatusStore, useWorktreeStore } from "../worktree";
 import FileTreeItem from "./FileTreeItem.vue";
 import type { FsChangePayload } from "./rpc";
@@ -48,19 +49,11 @@ import { useFilerEventStore } from "./useFilerEventStore";
 const emit = defineEmits<{
   select: [relPath: string];
   /**
-   * ファイル / フォルダ行で contextmenu が発火した時、配下から bubble してくる payload。
-   * NavigatorPane が受けて singleton popover を open する (依存方向を 1 方向に保つため、
-   * FilerPane は navigator を直接 import しない)。
+   * ファイル行で contextmenu が発火した時、配下から bubble してくる payload。
+   * NavigatorPane が受けて singleton popover を open する。type-only import で navigator
+   * から payload 型を持ってくるが、ランタイム依存は無いので 1 方向 (navigator → 子) を保つ。
    */
-  contextMenu: [
-    payload: {
-      anchorEl: HTMLElement;
-      relPath: string;
-      commitHash?: string;
-      x: number;
-      y: number;
-    },
-  ];
+  contextMenu: [payload: FileContextMenuPayload];
 }>();
 
 const worktreeStore = useWorktreeStore();

--- a/apps/renderer/src/features/filer/FilerPane.vue
+++ b/apps/renderer/src/features/filer/FilerPane.vue
@@ -47,6 +47,20 @@ import { useFilerEventStore } from "./useFilerEventStore";
 
 const emit = defineEmits<{
   select: [relPath: string];
+  /**
+   * ファイル / フォルダ行で contextmenu が発火した時、配下から bubble してくる payload。
+   * NavigatorPane が受けて singleton popover を open する (依存方向を 1 方向に保つため、
+   * FilerPane は navigator を直接 import しない)。
+   */
+  contextMenu: [
+    payload: {
+      anchorEl: HTMLElement;
+      relPath: string;
+      commitHash?: string;
+      x: number;
+      y: number;
+    },
+  ];
 }>();
 
 const worktreeStore = useWorktreeStore();
@@ -120,6 +134,7 @@ onUnmounted(() => {
         :depth="-1"
         :selected-rel-path="selectedRelPath"
         @select="(path: string) => emit('select', path)"
+        @context-menu="(payload) => emit('contextMenu', payload)"
       />
     </div>
   </div>

--- a/apps/renderer/src/features/filer/index.ts
+++ b/apps/renderer/src/features/filer/index.ts
@@ -1,4 +1,5 @@
 export { default as FilerPane } from "./FilerPane.vue";
+export { joinPath } from "./filerUtils";
 export { relDirOf } from "./relDirOf";
 export { rpcFsReadFile, rpcFsReadFileAbsolute } from "./rpc";
 export type { FsChangePayload } from "./rpc";

--- a/apps/renderer/src/features/filer/index.ts
+++ b/apps/renderer/src/features/filer/index.ts
@@ -1,5 +1,4 @@
 export { default as FilerPane } from "./FilerPane.vue";
-export { joinPath } from "./filerUtils";
 export { relDirOf } from "./relDirOf";
 export { rpcFsReadFile, rpcFsReadFileAbsolute } from "./rpc";
 export type { FsChangePayload } from "./rpc";

--- a/apps/renderer/src/features/git-graph/useGitGraphStore.ts
+++ b/apps/renderer/src/features/git-graph/useGitGraphStore.ts
@@ -142,6 +142,25 @@ export const useGitGraphStore = defineStore("gitGraph", () => {
     return result;
   });
 
+  /**
+   * Filer / Changes の右クリックメニューで copy する commit hash の SSOT。
+   *
+   * - range mode (compareHash 非 null): undefined。複数 commit にまたがる diff / snapshot を
+   *   単一 hash で代表すると user に誤解 (「この hash 時点」) を与えるため
+   * - 単一 commit (UNCOMMITTED_HASH 以外): その hash
+   * - working tree (UNCOMMITTED_HASH 単独): undefined
+   *
+   * Filer の snapshot tree 表示用 hash (`FilerPane.snapshotHash` = `selectedHash` で range mode
+   * でも commit hash を生かす) とは別概念。tree 表示は selectedHash 1 つに倒して見せる必要が
+   * あるが、copy 経路の「現在 user が見ているデータ全体を 1 hash で代表する」semantics は
+   * range mode で成立しないため undefined に倒す。
+   */
+  const contextMenuHash = computed<string | undefined>(() => {
+    if (isRangeMode.value) return undefined;
+    if (selectedHash.value === UNCOMMITTED_HASH) return undefined;
+    return selectedHash.value;
+  });
+
   function select(hash: string) {
     selectedHash.value = hash;
     compareHash.value = null;
@@ -173,6 +192,7 @@ export const useGitGraphStore = defineStore("gitGraph", () => {
     workingTreeOnly,
     rangeHashes,
     activeCommitHashes,
+    contextMenuHash,
     select,
     selectCompare,
     resetSelection,

--- a/apps/renderer/src/features/navigator/FileContextMenu.vue
+++ b/apps/renderer/src/features/navigator/FileContextMenu.vue
@@ -1,9 +1,9 @@
 <doc lang="md">
 ファイル行の右クリックメニュー。Copy file path アクションを表示する。
 
-copy する path は `useWorktreeStore.dir` (active worktree の絶対パス) と context の `relPath` を
-join した絶対パス。Filer / Changes はどちらも active worktree のみを表示するため、worktree dir
-は menu 側で読み取って組み立てる (call 側で組み立てて context に渡す経路を持たない)。
+copy する path は context に焼き付けられた `dir` (右クリック時の snapshot) と `relPath` を
+`joinAbsRel` で結合した絶対パス。defer 中 / menu 表示中に worktree が切り替わっても、その
+右クリック時点の dir / commitHash を一貫して使う (singleton store を読み直さない)。
 
 - working tree のファイル (commitHash 未指定): 絶対パスのみを copy
 - snapshot / commit 由来 (commitHash 指定): `${commitHash}\n${絶対パス}` を copy
@@ -15,12 +15,11 @@ state は `useFileContextMenu` (module singleton) 経由で開閉する。
 import { tryCatch } from "@gozd/shared";
 import { computed } from "vue";
 import { useNotificationStore } from "../../shared/notification";
-import { joinAbsRel, useWorktreeStore } from "../worktree";
+import { joinAbsRel } from "../worktree";
 import { useFileContextMenu } from "./useFileContextMenu";
 
 const { Popover, context, close } = useFileContextMenu();
 const notify = useNotificationStore();
-const worktreeStore = useWorktreeStore();
 
 // 右クリックでマウス座標 (context.x/y) が渡された場合はそれを優先。
 // ⋮ ボタン経路など座標未指定の場合は CSS Anchor Position で anchor 要素の bottom-left に出す。
@@ -39,12 +38,7 @@ const popoverStyle = computed(() => {
 
 async function handleCopyPath() {
   if (!context.value) return;
-  const { relPath, commitHash } = context.value;
-  const dir = worktreeStore.dir;
-  if (dir === undefined) {
-    notify.error("Failed to copy file path: no active worktree");
-    return;
-  }
+  const { dir, relPath, commitHash } = context.value;
   const absPath = joinAbsRel(dir, relPath);
   const text = commitHash === undefined ? absPath : `${commitHash}\n${absPath}`;
   close();

--- a/apps/renderer/src/features/navigator/FileContextMenu.vue
+++ b/apps/renderer/src/features/navigator/FileContextMenu.vue
@@ -1,14 +1,7 @@
 <doc lang="md">
-ファイル行の右クリックメニュー。Copy file path アクションを表示する。
-
-copy する path は context に焼き付けられた `dir` (右クリック時の snapshot) と `relPath` を
-`joinAbsRel` で結合した絶対パス。defer 中 / menu 表示中に worktree が切り替わっても、その
-右クリック時点の dir / commitHash を一貫して使う (singleton store を読み直さない)。
-
-- working tree のファイル (commitHash 未指定): 絶対パスのみを copy
-- snapshot / commit 由来 (commitHash 指定): `${commitHash}\n${絶対パス}` を copy
-
-state は `useFileContextMenu` (module singleton) 経由で開閉する。
+ファイル行の右クリックメニュー。Copy file path アクションを描画して clipboard に書き込む。
+context の組み立てと snapshot semantics、defer / disconnect ガード等の内部仕様は
+`useFileContextMenu.ts` の docstring を SSOT として参照する。
 </doc>
 
 <script setup lang="ts">

--- a/apps/renderer/src/features/navigator/FileContextMenu.vue
+++ b/apps/renderer/src/features/navigator/FileContextMenu.vue
@@ -15,8 +15,7 @@ state は `useFileContextMenu` (module singleton) 経由で開閉する。
 import { tryCatch } from "@gozd/shared";
 import { computed } from "vue";
 import { useNotificationStore } from "../../shared/notification";
-import { joinPath } from "../filer";
-import { useWorktreeStore } from "../worktree";
+import { joinAbsRel, useWorktreeStore } from "../worktree";
 import { useFileContextMenu } from "./useFileContextMenu";
 
 const { Popover, context, close } = useFileContextMenu();
@@ -46,9 +45,7 @@ async function handleCopyPath() {
     notify.error("Failed to copy file path: no active worktree");
     return;
   }
-  // filer の worktree-relative path 結合 SSOT を再利用。filer の root (relPath === "") は
-  // button を持たないため到達しない契約 (現状は relPath が常に非空で渡る)。
-  const absPath = joinPath(dir, relPath);
+  const absPath = joinAbsRel(dir, relPath);
   const text = commitHash === undefined ? absPath : `${commitHash}\n${absPath}`;
   close();
   // navigator.clipboard 参照時の同期 throw も拾うため async IIFE で Promise 化してから tryCatch に渡す

--- a/apps/renderer/src/features/navigator/FileContextMenu.vue
+++ b/apps/renderer/src/features/navigator/FileContextMenu.vue
@@ -1,0 +1,75 @@
+<doc lang="md">
+ファイル行の右クリックメニュー。Copy file path アクションを表示する。
+
+copy する path は `useWorktreeStore.dir` (active worktree の絶対パス) と context の `relPath` を
+join した絶対パス。Filer / Changes はどちらも active worktree のみを表示するため、worktree dir
+は menu 側で読み取って組み立てる (call 側で組み立てて context に渡す経路を持たない)。
+
+- working tree のファイル (commitHash 未指定): 絶対パスのみを copy
+- snapshot / commit 由来 (commitHash 指定): `${commitHash}\n${絶対パス}` を copy
+
+state は `useFileContextMenu` (module singleton) 経由で開閉する。
+</doc>
+
+<script setup lang="ts">
+import { tryCatch } from "@gozd/shared";
+import { computed } from "vue";
+import { useNotificationStore } from "../../shared/notification";
+import { useWorktreeStore } from "../worktree";
+import { useFileContextMenu } from "./useFileContextMenu";
+
+const { Popover, context, close } = useFileContextMenu();
+const notify = useNotificationStore();
+const worktreeStore = useWorktreeStore();
+
+// 右クリックでマウス座標 (context.x/y) が渡された場合はそれを優先。
+// ⋮ ボタン経路など座標未指定の場合は CSS Anchor Position で anchor 要素の bottom-left に出す。
+const popoverStyle = computed(() => {
+  const ctx = context.value;
+  if (ctx?.x !== undefined && ctx?.y !== undefined) {
+    return { position: "fixed", left: `${ctx.x}px`, top: `${ctx.y}px` };
+  }
+  return {
+    position: "fixed",
+    top: "anchor(bottom)",
+    left: "anchor(left)",
+    positionTryFallbacks: "flip-block, flip-inline",
+  };
+});
+
+async function handleCopyPath() {
+  if (!context.value) return;
+  const { relPath, commitHash } = context.value;
+  const dir = worktreeStore.dir;
+  if (dir === undefined) {
+    notify.error("Failed to copy file path: no active worktree");
+    return;
+  }
+  // relPath === "" は root を指す (現状の filer は root に button を描画しないので
+  // 到達しないが、構造的に dir をそのまま使う規律で寄せる)。
+  const absPath = relPath === "" ? dir : `${dir}/${relPath}`;
+  const text = commitHash === undefined ? absPath : `${commitHash}\n${absPath}`;
+  close();
+  // navigator.clipboard 参照時の同期 throw も拾うため async IIFE で Promise 化してから tryCatch に渡す
+  const result = await tryCatch((async () => navigator.clipboard.writeText(text))());
+  if (!result.ok) {
+    notify.error("Failed to copy file path", result.error);
+  }
+}
+</script>
+
+<template>
+  <Popover
+    class="m-0 min-w-36 rounded-lg border border-zinc-700 bg-zinc-900 py-1 text-sm text-zinc-200 shadow-lg"
+    :style="popoverStyle"
+  >
+    <button
+      v-if="context"
+      class="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-zinc-800"
+      @click="handleCopyPath"
+    >
+      <span class="icon-[lucide--copy] text-xs" />
+      Copy file path
+    </button>
+  </Popover>
+</template>

--- a/apps/renderer/src/features/navigator/FileContextMenu.vue
+++ b/apps/renderer/src/features/navigator/FileContextMenu.vue
@@ -15,6 +15,7 @@ state は `useFileContextMenu` (module singleton) 経由で開閉する。
 import { tryCatch } from "@gozd/shared";
 import { computed } from "vue";
 import { useNotificationStore } from "../../shared/notification";
+import { joinPath } from "../filer";
 import { useWorktreeStore } from "../worktree";
 import { useFileContextMenu } from "./useFileContextMenu";
 
@@ -45,9 +46,9 @@ async function handleCopyPath() {
     notify.error("Failed to copy file path: no active worktree");
     return;
   }
-  // relPath === "" は root を指す (現状の filer は root に button を描画しないので
-  // 到達しないが、構造的に dir をそのまま使う規律で寄せる)。
-  const absPath = relPath === "" ? dir : `${dir}/${relPath}`;
+  // filer の worktree-relative path 結合 SSOT を再利用。filer の root (relPath === "") は
+  // button を持たないため到達しない契約 (現状は relPath が常に非空で渡る)。
+  const absPath = joinPath(dir, relPath);
   const text = commitHash === undefined ? absPath : `${commitHash}\n${absPath}`;
   close();
   // navigator.clipboard 参照時の同期 throw も拾うため async IIFE で Promise 化してから tryCatch に渡す

--- a/apps/renderer/src/features/navigator/NavigatorPane.vue
+++ b/apps/renderer/src/features/navigator/NavigatorPane.vue
@@ -18,6 +18,7 @@ import { ChangesPane } from "../changes";
 import { FilerPane } from "../filer";
 import { ResizeHandle } from "../layout";
 import { usePreviewStore } from "../preview";
+import FileContextMenu from "./FileContextMenu.vue";
 
 const HANDLE_HEIGHT = 8;
 const FILER_MIN_HEIGHT = 100;
@@ -88,5 +89,8 @@ function onFileSelect(relPath: string) {
         <ChangesPane @select="onFileSelect" />
       </div>
     </template>
+
+    <!-- ファイル行の右クリックメニュー (Filer / Changes 共用) -->
+    <FileContextMenu />
   </div>
 </template>

--- a/apps/renderer/src/features/navigator/NavigatorPane.vue
+++ b/apps/renderer/src/features/navigator/NavigatorPane.vue
@@ -11,11 +11,7 @@ Filer（上）と Changes（下）を垂直分割で表示するコンテナ。
 
 ## 右クリックメニュー
 
-FilerPane / ChangesPane (および配下の TreeItem) から `contextMenu` event が bubble してくる。本ペインで singleton popover `useFileContextMenu` を open することで、依存方向を navigator → 子の 1 方向に保つ (子側は navigator を直接 import しない、または type-only import に限る)。
-
-open は VueUse `useTimeoutFn(_, 0)` で 1 task 分遅延させる。`popover="auto"` を contextmenu 同サイクル内で開くと mousedown が light-dismiss を予約し、続く mouseup で即閉じる挙動 (whatwg/html#10905) を回避するため。defer 経路は mouse / keyboard (Shift+F10) / programmatic dispatch のいずれにも非依存。`useTimeoutFn` は effect scope 連動なので unmount / HMR で pending な open が走り残らず、`start` は前の pending を cancel するので連打時は最後の右クリックだけが menu を開く (popover singleton の semantics と整合)。
-
-`dir` / `commitHash` は **右クリック時に snapshot** して popover context に焼き付ける。defer 中 / menu 表示中に worktree や commit 選択が切り替わっても、その右クリックで参照した当時の値を一貫して使う (defer 後に store を読み直すと「古い relPath + 新 dir」の race を生むため)。defer 完了時に anchor 元 component が unmount されていた (`anchorEl.isConnected === false`) ケースは debug log を残して open を skip する。
+FilerPane / ChangesPane (および配下の TreeItem) から `contextMenu` event を受けて singleton popover (`useFileContextMenu`) に橋渡しする。子側は navigator への直接依存を持たない (payload 型のみ type-only import) ため、依存方向は navigator → 子の 1 方向で閉じる。defer / snapshot / disconnect ガード等の内部仕様は `useFileContextMenu.ts` の docstring を SSOT として参照する。
 </doc>
 
 <script setup lang="ts">
@@ -78,9 +74,11 @@ const notification = useNotificationStore();
 /**
  * 右クリック → menu open までの 1 task 分の defer を effect scope 連動で行うキュー。
  *
- * `useTimeoutFn` の `start(req)` を呼ぶたびに前 pending を cancel して再 schedule する semantics。
- * 連打時は最後の右クリックだけが menu を開く挙動になり、popover singleton の openState
- * 上書き semantics と整合する。unmount / HMR では scope dispose で pending が自動 clear される。
+ * `useTimeoutFn` の `start(req)` を呼ぶたびに前 pending を **無音で cancel** して再 schedule する
+ * semantics。連打時は最後の右クリックだけが menu を開く挙動になり、popover singleton の openState
+ * 上書き semantics (最後の値だけが意味を持つ) と整合する。cancel を log しないのは意図的:
+ * user 連打のたびに console を汚すノイズになるため、観察可能性より signal-to-noise を優先する。
+ * unmount / HMR では scope dispose で pending が自動 clear される。
  */
 const { start: deferOpenMenu } = useTimeoutFn(
   (req: FileContextMenuPayload, dirSnapshot: string, hashSnapshot: string | undefined) => {
@@ -111,7 +109,10 @@ const { start: deferOpenMenu } = useTimeoutFn(
  * - `dir` / `commitHash` は **本関数の同期実行時点** で snapshot する。defer 中に worktree
  *   切替 / commit 選択切替が起きても、その右クリック時点の値を popover context に焼き付ける
  *   ことで「古い relPath + 新 dir」「古い anchor + 新 hash」の race を構造的に排除する
- * - dir 未設定 (起動初期 / 全 repo 閉鎖直後) では menu を出さず debug log
+ * - `dir` 未設定 (起動初期 / 全 repo 閉鎖直後) では menu を出さず debug log。FilerPane は
+ *   `v-if="!dir"` で "waiting for open command..." を出してツリー自体を描画しないため、user
+ *   操作経路ではこの分岐に到達しない (defensive)。観測対象が user 不可視の異常系なので
+ *   `info` toast ではなく `debug` のまま (toast にすると正常状態と区別しにくい)
  */
 function onFileContextMenu(req: FileContextMenuPayload) {
   const dirSnapshot = worktreeStore.dir;

--- a/apps/renderer/src/features/navigator/NavigatorPane.vue
+++ b/apps/renderer/src/features/navigator/NavigatorPane.vue
@@ -11,11 +11,11 @@ Filer（上）と Changes（下）を垂直分割で表示するコンテナ。
 
 ## 右クリックメニュー
 
-FilerPane / ChangesPane (および配下の TreeItem) から `contextMenu` event を受けて singleton popover (`useFileContextMenu`) に橋渡しする。子側は navigator への直接依存を持たない (payload 型のみ type-only import) ため、依存方向は navigator → 子の 1 方向で閉じる。defer / snapshot / disconnect ガード等の内部仕様は `useFileContextMenu.ts` の docstring を SSOT として参照する。
+FilerPane / ChangesPane (および配下の TreeItem) から `contextMenu` event を受けて singleton popover (`useFileContextMenu`) に橋渡しする。子側は navigator への直接依存を持たない (payload 型のみ type-only import) ため、依存方向は navigator → 子の 1 方向で閉じる。pointerup once-capture による light-dismiss 回避 / dir / hash snapshot / disconnect ガード等の内部仕様は `useFileContextMenu.ts` の docstring を SSOT として参照する。
 </doc>
 
 <script setup lang="ts">
-import { useElementSize, useTimeoutFn } from "@vueuse/core";
+import { useElementSize, useEventListener } from "@vueuse/core";
 import { ref, useTemplateRef, watch } from "vue";
 import { useNotificationStore } from "../../shared/notification";
 import { useRepoStore } from "../../shared/repo";
@@ -71,44 +71,68 @@ const gitGraphStore = useGitGraphStore();
 const worktreeStore = useWorktreeStore();
 const notification = useNotificationStore();
 
+type PendingOpen = {
+  payload: FileContextMenuPayload;
+  dir: string;
+  hash: string | undefined;
+};
+
 /**
- * 右クリック → menu open までの 1 task 分の defer を effect scope 連動で行うキュー。
- *
- * `useTimeoutFn` の `start(req)` を呼ぶたびに前 pending を **無音で cancel** して再 schedule する
- * semantics。連打時は最後の右クリックだけが menu を開く挙動になり、popover singleton の openState
- * 上書き semantics (最後の値だけが意味を持つ) と整合する。cancel を log しないのは意図的:
+ * 右クリックで積まれる pending open。次の `pointerup` で処理して open する。
+ * 連打時は最後の右クリックが pending を上書き (popover singleton の openState 上書き
+ * semantics と整合 — 最後の値だけが意味を持つ)。cancel を log しないのは意図的:
  * user 連打のたびに console を汚すノイズになるため、観察可能性より signal-to-noise を優先する。
- * unmount / HMR では scope dispose で pending が自動 clear される。
  */
-const { start: deferOpenMenu } = useTimeoutFn(
-  (req: FileContextMenuPayload, dirSnapshot: string, hashSnapshot: string | undefined) => {
-    if (!req.anchorEl.isConnected) {
+const pendingOpen = ref<PendingOpen | null>(null);
+
+/**
+ * window 全体に常設する `pointerup` capture listener。pending が積まれていれば消化して open する。
+ *
+ * **不変条件 (実装変更時に必読)**:
+ * - `setTimeout(0)` / `requestAnimationFrame` / `queueMicrotask` 等の task / microtask defer は
+ *   WebKit (WebPage) の `popover="auto"` light-dismiss を **抜けない** (実機検証済)。続く mouseup が
+ *   popover に到達して即 dismiss される (whatwg/html#10905)
+ * - `pointerup` を `capture: true` で window に貼ると、popover が show される **前** に listener が
+ *   pointerup を消化する → 続く mouseup は popover open 前の press cycle として扱われ
+ *   light-dismiss の対象外になる。`{ capture: true }` を外したり、pointerdown / mousedown 経路に
+ *   変えてはならない
+ * - keyboard 経路 (Shift+F10 / Apps key) と programmatic dispatch は pointerup が発火しないため
+ *   menu は開かない。本 PR の責務外で、将来 keyboard ショートカット要件が発生したら別経路
+ *   ([docs/keybinding.md](../../../../../docs/keybinding.md)) で menu を開く
+ *
+ * `useEventListener` を setup 直下で呼ぶことで effect scope に紐付き、unmount / HMR で自動 cleanup
+ * される (handler 内で呼ぶと scope に登録されず leak する)。
+ */
+useEventListener(
+  window,
+  "pointerup",
+  () => {
+    const pending = pendingOpen.value;
+    if (!pending) return;
+    pendingOpen.value = null;
+    if (!pending.payload.anchorEl.isConnected) {
       notification.debug("[FileContextMenu] anchor disconnected before open, skipping", {
-        relPath: req.relPath,
+        relPath: pending.payload.relPath,
       });
       return;
     }
-    openFileContextMenu(req.anchorEl, {
-      dir: dirSnapshot,
-      relPath: req.relPath,
-      commitHash: hashSnapshot,
-      x: req.x,
-      y: req.y,
+    openFileContextMenu(pending.payload.anchorEl, {
+      dir: pending.dir,
+      relPath: pending.payload.relPath,
+      commitHash: pending.hash,
+      x: pending.payload.x,
+      y: pending.payload.y,
     });
   },
-  0,
-  { immediate: false },
+  { capture: true },
 );
 
 /**
- * 配下から bubble してくる contextmenu request を受けて popover singleton を open する。
+ * 配下から bubble してくる contextmenu request を pending に積む。
  *
- * - 同サイクル内の `showPopover` は `popover="auto"` の light-dismiss を続く mouseup が消化して
- *   即閉じるため (whatwg/html#10905)、`useTimeoutFn` で 1 task 分 defer する。入力種別
- *   (mouse / keyboard / programmatic) 非依存
- * - `dir` / `commitHash` は **本関数の同期実行時点** で snapshot する。defer 中に worktree
- *   切替 / commit 選択切替が起きても、その右クリック時点の値を popover context に焼き付ける
- *   ことで「古い relPath + 新 dir」「古い anchor + 新 hash」の race を構造的に排除する
+ * - `dir` / `commitHash` は **本関数の同期実行時点** で snapshot する。pointerup 待機中に
+ *   worktree 切替 / commit 選択切替が起きても、その右クリック時点の値を popover context に
+ *   焼き付けることで「古い relPath + 新 dir」「古い anchor + 新 hash」の race を構造的に排除する
  * - `dir` 未設定 (起動初期 / 全 repo 閉鎖直後) では menu を出さず debug log。FilerPane は
  *   `v-if="!dir"` で "waiting for open command..." を出してツリー自体を描画しないため、user
  *   操作経路ではこの分岐に到達しない (defensive)。観測対象が user 不可視の異常系なので
@@ -120,8 +144,11 @@ function onFileContextMenu(req: FileContextMenuPayload) {
     notification.debug("[FileContextMenu] no active worktree, skipping", { relPath: req.relPath });
     return;
   }
-  const hashSnapshot = gitGraphStore.contextMenuHash;
-  deferOpenMenu(req, dirSnapshot, hashSnapshot);
+  pendingOpen.value = {
+    payload: req,
+    dir: dirSnapshot,
+    hash: gitGraphStore.contextMenuHash,
+  };
 }
 </script>
 

--- a/apps/renderer/src/features/navigator/NavigatorPane.vue
+++ b/apps/renderer/src/features/navigator/NavigatorPane.vue
@@ -106,7 +106,12 @@ const pendingOpen = ref<PendingOpen | null>(null);
 useEventListener(
   window,
   "pointerup",
-  () => {
+  (event) => {
+    // 右クリック (button=2) 由来の pointerup のみを処理する。window 全体に常設しているため、
+    // 別 pane の左クリックや middle click も pointerup を発火させるが、それらで pending を
+    // 消化すると「Filer 行を右クリック → 他所を左 click → 別場所で menu が開く」race が
+    // 起きる。button 判定で右クリック release だけに絞り込めば構造的に排除できる。
+    if (event.button !== 2) return;
     const pending = pendingOpen.value;
     if (!pending) return;
     pendingOpen.value = null;

--- a/apps/renderer/src/features/navigator/NavigatorPane.vue
+++ b/apps/renderer/src/features/navigator/NavigatorPane.vue
@@ -18,23 +18,17 @@ open は `setTimeout(open, 0)` で 1 task 分遅延させる。`popover="auto"` 
 
 <script setup lang="ts">
 import { useElementSize } from "@vueuse/core";
-import { ref, useTemplateRef, watch } from "vue";
+import { onScopeDispose, ref, useTemplateRef, watch } from "vue";
+import { useNotificationStore } from "../../shared/notification";
 import { useRepoStore } from "../../shared/repo";
 import { ChangesPane } from "../changes";
 import { FilerPane } from "../filer";
+import { useGitGraphStore } from "../git-graph";
 import { ResizeHandle } from "../layout";
 import { usePreviewStore } from "../preview";
 import FileContextMenu from "./FileContextMenu.vue";
 import { useFileContextMenu } from "./useFileContextMenu";
-
-/** contextmenu event payload (FilerPane / ChangesPane から bubble してくる) */
-type FileContextMenuRequest = {
-  anchorEl: HTMLElement;
-  relPath: string;
-  commitHash?: string;
-  x: number;
-  y: number;
-};
+import type { FileContextMenuPayload } from "./useFileContextMenu";
 
 const HANDLE_HEIGHT = 8;
 const FILER_MIN_HEIGHT = 100;
@@ -74,19 +68,52 @@ function onFileSelect(relPath: string) {
 }
 
 const { open: openFileContextMenu } = useFileContextMenu();
+const gitGraphStore = useGitGraphStore();
+const notification = useNotificationStore();
 
-// contextmenu の発火サイクル (mousedown → contextmenu → mouseup) を 1 task 分抜けてから
-// showPopover を呼ぶ。同サイクル内 open は whatwg/html#10905 で続く mouseup が light-dismiss
-// として消化される。setTimeout(0) は入力種別 (マウス / キーボード / programmatic) 非依存。
-function onFileContextMenu(req: FileContextMenuRequest) {
-  setTimeout(() => {
+/**
+ * defer 中の timer 集合。setup scope dispose (unmount / HMR) で全部 clearTimeout する。
+ * 生 setTimeout は global timer queue に逃げて component lifecycle と切り離されるため、
+ * pending な open が unmount 後に走るのを構造的に防ぐ (CLAUDE.md 規約: listener / timer は
+ * 必ず scope に紐付ける)。
+ */
+const pendingOpenTimers = new Set<ReturnType<typeof setTimeout>>();
+onScopeDispose(() => {
+  for (const t of pendingOpenTimers) clearTimeout(t);
+  pendingOpenTimers.clear();
+});
+
+/**
+ * 配下から bubble してくる contextmenu request を受けて popover singleton を open する。
+ *
+ * - contextmenu の発火サイクル (mousedown → contextmenu → mouseup) を 1 task 分抜けてから
+ *   showPopover を呼ぶ。同サイクル内 open は whatwg/html#10905 で続く mouseup が
+ *   light-dismiss として消化される。setTimeout(0) は入力種別 (mouse / keyboard / programmatic)
+ *   非依存
+ * - commitHash は `useGitGraphStore.contextMenuHash` (SSOT) から解決する。range mode は
+ *   undefined、UNCOMMITTED_HASH のときも undefined、それ以外で selectedHash。child pane に
+ *   hash 解決を分散させないことで Filer / Changes 同 file の copy 結果非対称を防ぐ
+ * - defer 中に anchor 元 component が unmount された (dir 切替・`:key="dir"` 再マウント) ケース
+ *   では `anchorEl.isConnected` が false になる。silent drop せず debug log を残して open を
+ *   スキップする (observability 規約)
+ */
+function onFileContextMenu(req: FileContextMenuPayload) {
+  const timer = setTimeout(() => {
+    pendingOpenTimers.delete(timer);
+    if (!req.anchorEl.isConnected) {
+      notification.debug("[FileContextMenu] anchor disconnected before open, skipping", {
+        relPath: req.relPath,
+      });
+      return;
+    }
     openFileContextMenu(req.anchorEl, {
       relPath: req.relPath,
-      commitHash: req.commitHash,
+      commitHash: gitGraphStore.contextMenuHash,
       x: req.x,
       y: req.y,
     });
   }, 0);
+  pendingOpenTimers.add(timer);
 }
 </script>
 

--- a/apps/renderer/src/features/navigator/NavigatorPane.vue
+++ b/apps/renderer/src/features/navigator/NavigatorPane.vue
@@ -96,6 +96,9 @@ const pendingOpen = ref<PendingOpen | null>(null);
  *   pointerup を消化する → 続く mouseup は popover open 前の press cycle として扱われ
  *   light-dismiss の対象外になる。`{ capture: true }` を外したり、pointerdown / mousedown 経路に
  *   変えてはならない
+ * - `event.button === 2` のような button filter を入れてはならない。macOS WebKit は control+click
+ *   を button=0 として dispatch する (bugzilla 52174) ため、control+click 経由の native context
+ *   menu 経路で menu が開かなくなる
  * - keyboard 経路 (Shift+F10 / Apps key) と programmatic dispatch は pointerup が発火しないため
  *   menu は開かない。本 PR の責務外で、将来 keyboard ショートカット要件が発生したら別経路
  *   ([docs/keybinding.md](../../../../../docs/keybinding.md)) で menu を開く
@@ -106,12 +109,13 @@ const pendingOpen = ref<PendingOpen | null>(null);
 useEventListener(
   window,
   "pointerup",
-  (event) => {
-    // 右クリック (button=2) 由来の pointerup のみを処理する。window 全体に常設しているため、
-    // 別 pane の左クリックや middle click も pointerup を発火させるが、それらで pending を
-    // 消化すると「Filer 行を右クリック → 他所を左 click → 別場所で menu が開く」race が
-    // 起きる。button 判定で右クリック release だけに絞り込めば構造的に排除できる。
-    if (event.button !== 2) return;
+  () => {
+    // `event.button` で右クリック (=2) のみに絞らない理由: macOS WebKit は control + click を
+    // **button=0** として dispatch する (webkit bugzilla 52174, "RESOLVED INVALID" だが挙動は
+    // 残っている)。button 絞り込みを入れると macOS native の context menu 経路 (control+click)
+    // で menu が開かなくなる。pending ref そのものが「直前に contextmenu があった」flag を
+    // 兼ねるため、最初の pointerup で消化 + null 化する設計で十分。多ボタン同時押し race
+    // (右クリック保持中に別所で左 click) は edge case として受容する
     const pending = pendingOpen.value;
     if (!pending) return;
     pendingOpen.value = null;

--- a/apps/renderer/src/features/navigator/NavigatorPane.vue
+++ b/apps/renderer/src/features/navigator/NavigatorPane.vue
@@ -8,6 +8,12 @@ Filer（上）と Changes（下）を垂直分割で表示するコンテナ。
 - git リポジトリでない場合は Filer のみ表示
 - FilerPane の reveal は worktreeStore.revealVersion を内部で購読しているため props 経由不要
 - FilerPane / ChangesPane の `select` emit はどちらも user-initiated select として `previewStore.requestSelect` を呼ぶ。同一パス再選択でのトグル close / summary 抜けの意思決定は preview store 側に集約されている（[docs/preview.md](../../../../../docs/preview.md) の決定表を参照）
+
+## 右クリックメニュー
+
+FilerPane / ChangesPane (および配下の TreeItem) から `contextMenu` event が bubble してくる。本ペインで singleton popover `useFileContextMenu` を open することで、依存方向を navigator → 子の 1 方向に保つ (子側は navigator を直接 import しない)。
+
+open は `setTimeout(open, 0)` で 1 task 分遅延させる。`popover="auto"` を contextmenu 同サイクル内で開くと mousedown が light-dismiss を予約し、続く mouseup で即閉じる挙動 (whatwg/html#10905) を回避するため。setTimeout 経路は mouse / keyboard (Shift+F10) / programmatic dispatch のいずれにも非依存に動く。
 </doc>
 
 <script setup lang="ts">
@@ -19,6 +25,16 @@ import { FilerPane } from "../filer";
 import { ResizeHandle } from "../layout";
 import { usePreviewStore } from "../preview";
 import FileContextMenu from "./FileContextMenu.vue";
+import { useFileContextMenu } from "./useFileContextMenu";
+
+/** contextmenu event payload (FilerPane / ChangesPane から bubble してくる) */
+type FileContextMenuRequest = {
+  anchorEl: HTMLElement;
+  relPath: string;
+  commitHash?: string;
+  x: number;
+  y: number;
+};
 
 const HANDLE_HEIGHT = 8;
 const FILER_MIN_HEIGHT = 100;
@@ -56,6 +72,22 @@ function getFilerHeight(): number {
 function onFileSelect(relPath: string) {
   previewStore.requestSelect({ kind: "worktreeRelative", relPath });
 }
+
+const { open: openFileContextMenu } = useFileContextMenu();
+
+// contextmenu の発火サイクル (mousedown → contextmenu → mouseup) を 1 task 分抜けてから
+// showPopover を呼ぶ。同サイクル内 open は whatwg/html#10905 で続く mouseup が light-dismiss
+// として消化される。setTimeout(0) は入力種別 (マウス / キーボード / programmatic) 非依存。
+function onFileContextMenu(req: FileContextMenuRequest) {
+  setTimeout(() => {
+    openFileContextMenu(req.anchorEl, {
+      relPath: req.relPath,
+      commitHash: req.commitHash,
+      x: req.x,
+      y: req.y,
+    });
+  }, 0);
+}
 </script>
 
 <template>
@@ -72,7 +104,7 @@ function onFileSelect(relPath: string) {
         </span>
       </div>
       <div class="min-h-0 flex-1 overflow-hidden">
-        <FilerPane @select="onFileSelect" />
+        <FilerPane @select="onFileSelect" @context-menu="onFileContextMenu" />
       </div>
     </div>
 
@@ -86,7 +118,7 @@ function onFileSelect(relPath: string) {
         :get-before-size="getFilerHeight"
       />
       <div class="shrink-0 overflow-hidden" :style="{ height: `${changesHeight}px` }">
-        <ChangesPane @select="onFileSelect" />
+        <ChangesPane @select="onFileSelect" @context-menu="onFileContextMenu" />
       </div>
     </template>
 

--- a/apps/renderer/src/features/navigator/NavigatorPane.vue
+++ b/apps/renderer/src/features/navigator/NavigatorPane.vue
@@ -11,14 +11,16 @@ Filer（上）と Changes（下）を垂直分割で表示するコンテナ。
 
 ## 右クリックメニュー
 
-FilerPane / ChangesPane (および配下の TreeItem) から `contextMenu` event が bubble してくる。本ペインで singleton popover `useFileContextMenu` を open することで、依存方向を navigator → 子の 1 方向に保つ (子側は navigator を直接 import しない)。
+FilerPane / ChangesPane (および配下の TreeItem) から `contextMenu` event が bubble してくる。本ペインで singleton popover `useFileContextMenu` を open することで、依存方向を navigator → 子の 1 方向に保つ (子側は navigator を直接 import しない、または type-only import に限る)。
 
-open は `setTimeout(open, 0)` で 1 task 分遅延させる。`popover="auto"` を contextmenu 同サイクル内で開くと mousedown が light-dismiss を予約し、続く mouseup で即閉じる挙動 (whatwg/html#10905) を回避するため。setTimeout 経路は mouse / keyboard (Shift+F10) / programmatic dispatch のいずれにも非依存に動く。
+open は VueUse `useTimeoutFn(_, 0)` で 1 task 分遅延させる。`popover="auto"` を contextmenu 同サイクル内で開くと mousedown が light-dismiss を予約し、続く mouseup で即閉じる挙動 (whatwg/html#10905) を回避するため。defer 経路は mouse / keyboard (Shift+F10) / programmatic dispatch のいずれにも非依存。`useTimeoutFn` は effect scope 連動なので unmount / HMR で pending な open が走り残らず、`start` は前の pending を cancel するので連打時は最後の右クリックだけが menu を開く (popover singleton の semantics と整合)。
+
+`dir` / `commitHash` は **右クリック時に snapshot** して popover context に焼き付ける。defer 中 / menu 表示中に worktree や commit 選択が切り替わっても、その右クリックで参照した当時の値を一貫して使う (defer 後に store を読み直すと「古い relPath + 新 dir」の race を生むため)。defer 完了時に anchor 元 component が unmount されていた (`anchorEl.isConnected === false`) ケースは debug log を残して open を skip する。
 </doc>
 
 <script setup lang="ts">
-import { useElementSize } from "@vueuse/core";
-import { onScopeDispose, ref, useTemplateRef, watch } from "vue";
+import { useElementSize, useTimeoutFn } from "@vueuse/core";
+import { ref, useTemplateRef, watch } from "vue";
 import { useNotificationStore } from "../../shared/notification";
 import { useRepoStore } from "../../shared/repo";
 import { ChangesPane } from "../changes";
@@ -26,6 +28,7 @@ import { FilerPane } from "../filer";
 import { useGitGraphStore } from "../git-graph";
 import { ResizeHandle } from "../layout";
 import { usePreviewStore } from "../preview";
+import { useWorktreeStore } from "../worktree";
 import FileContextMenu from "./FileContextMenu.vue";
 import { useFileContextMenu } from "./useFileContextMenu";
 import type { FileContextMenuPayload } from "./useFileContextMenu";
@@ -69,37 +72,18 @@ function onFileSelect(relPath: string) {
 
 const { open: openFileContextMenu } = useFileContextMenu();
 const gitGraphStore = useGitGraphStore();
+const worktreeStore = useWorktreeStore();
 const notification = useNotificationStore();
 
 /**
- * defer 中の timer 集合。setup scope dispose (unmount / HMR) で全部 clearTimeout する。
- * 生 setTimeout は global timer queue に逃げて component lifecycle と切り離されるため、
- * pending な open が unmount 後に走るのを構造的に防ぐ (CLAUDE.md 規約: listener / timer は
- * 必ず scope に紐付ける)。
- */
-const pendingOpenTimers = new Set<ReturnType<typeof setTimeout>>();
-onScopeDispose(() => {
-  for (const t of pendingOpenTimers) clearTimeout(t);
-  pendingOpenTimers.clear();
-});
-
-/**
- * 配下から bubble してくる contextmenu request を受けて popover singleton を open する。
+ * 右クリック → menu open までの 1 task 分の defer を effect scope 連動で行うキュー。
  *
- * - contextmenu の発火サイクル (mousedown → contextmenu → mouseup) を 1 task 分抜けてから
- *   showPopover を呼ぶ。同サイクル内 open は whatwg/html#10905 で続く mouseup が
- *   light-dismiss として消化される。setTimeout(0) は入力種別 (mouse / keyboard / programmatic)
- *   非依存
- * - commitHash は `useGitGraphStore.contextMenuHash` (SSOT) から解決する。range mode は
- *   undefined、UNCOMMITTED_HASH のときも undefined、それ以外で selectedHash。child pane に
- *   hash 解決を分散させないことで Filer / Changes 同 file の copy 結果非対称を防ぐ
- * - defer 中に anchor 元 component が unmount された (dir 切替・`:key="dir"` 再マウント) ケース
- *   では `anchorEl.isConnected` が false になる。silent drop せず debug log を残して open を
- *   スキップする (observability 規約)
+ * `useTimeoutFn` の `start(req)` を呼ぶたびに前 pending を cancel して再 schedule する semantics。
+ * 連打時は最後の右クリックだけが menu を開く挙動になり、popover singleton の openState
+ * 上書き semantics と整合する。unmount / HMR では scope dispose で pending が自動 clear される。
  */
-function onFileContextMenu(req: FileContextMenuPayload) {
-  const timer = setTimeout(() => {
-    pendingOpenTimers.delete(timer);
+const { start: deferOpenMenu } = useTimeoutFn(
+  (req: FileContextMenuPayload, dirSnapshot: string, hashSnapshot: string | undefined) => {
     if (!req.anchorEl.isConnected) {
       notification.debug("[FileContextMenu] anchor disconnected before open, skipping", {
         relPath: req.relPath,
@@ -107,13 +91,36 @@ function onFileContextMenu(req: FileContextMenuPayload) {
       return;
     }
     openFileContextMenu(req.anchorEl, {
+      dir: dirSnapshot,
       relPath: req.relPath,
-      commitHash: gitGraphStore.contextMenuHash,
+      commitHash: hashSnapshot,
       x: req.x,
       y: req.y,
     });
-  }, 0);
-  pendingOpenTimers.add(timer);
+  },
+  0,
+  { immediate: false },
+);
+
+/**
+ * 配下から bubble してくる contextmenu request を受けて popover singleton を open する。
+ *
+ * - 同サイクル内の `showPopover` は `popover="auto"` の light-dismiss を続く mouseup が消化して
+ *   即閉じるため (whatwg/html#10905)、`useTimeoutFn` で 1 task 分 defer する。入力種別
+ *   (mouse / keyboard / programmatic) 非依存
+ * - `dir` / `commitHash` は **本関数の同期実行時点** で snapshot する。defer 中に worktree
+ *   切替 / commit 選択切替が起きても、その右クリック時点の値を popover context に焼き付ける
+ *   ことで「古い relPath + 新 dir」「古い anchor + 新 hash」の race を構造的に排除する
+ * - dir 未設定 (起動初期 / 全 repo 閉鎖直後) では menu を出さず debug log
+ */
+function onFileContextMenu(req: FileContextMenuPayload) {
+  const dirSnapshot = worktreeStore.dir;
+  if (dirSnapshot === undefined) {
+    notification.debug("[FileContextMenu] no active worktree, skipping", { relPath: req.relPath });
+    return;
+  }
+  const hashSnapshot = gitGraphStore.contextMenuHash;
+  deferOpenMenu(req, dirSnapshot, hashSnapshot);
 }
 </script>
 

--- a/apps/renderer/src/features/navigator/NavigatorPane.vue
+++ b/apps/renderer/src/features/navigator/NavigatorPane.vue
@@ -99,6 +99,11 @@ const pendingOpen = ref<PendingOpen | null>(null);
  * - `event.button === 2` のような button filter を入れてはならない。macOS WebKit は control+click
  *   を button=0 として dispatch する (bugzilla 52174) ため、control+click 経由の native context
  *   menu 経路で menu が開かなくなる
+ * - `pointerdown` で pending を reset する経路を追加してはならない。右クリック → contextmenu →
+ *   同 mouse の pointerup → pending 消化 → open という物理順序で、`onFileContextMenu` で
+ *   pending を積む **前** に右クリックの pointerdown が既に走り終わっている。pointerdown で
+ *   reset すると pending を積んだ瞬間に消える経路はないものの、左 click 直後の pointerdown と
+ *   交錯すると pending が即消えて menu が開かなくなる事故源になる
  * - keyboard 経路 (Shift+F10 / Apps key) と programmatic dispatch は pointerup が発火しないため
  *   menu は開かない。本 PR の責務外で、将来 keyboard ショートカット要件が発生したら別経路
  *   ([docs/keybinding.md](../../../../../docs/keybinding.md)) で menu を開く

--- a/apps/renderer/src/features/navigator/NavigatorPane.vue
+++ b/apps/renderer/src/features/navigator/NavigatorPane.vue
@@ -99,11 +99,12 @@ const pendingOpen = ref<PendingOpen | null>(null);
  * - `event.button === 2` のような button filter を入れてはならない。macOS WebKit は control+click
  *   を button=0 として dispatch する (bugzilla 52174) ため、control+click 経由の native context
  *   menu 経路で menu が開かなくなる
- * - `pointerdown` で pending を reset する経路を追加してはならない。右クリック → contextmenu →
- *   同 mouse の pointerup → pending 消化 → open という物理順序で、`onFileContextMenu` で
- *   pending を積む **前** に右クリックの pointerdown が既に走り終わっている。pointerdown で
- *   reset すると pending を積んだ瞬間に消える経路はないものの、左 click 直後の pointerdown と
- *   交錯すると pending が即消えて menu が開かなくなる事故源になる
+ * - `pointerdown` で pending を reset する経路を追加してはならない。右クリック sequence
+ *   (pointerdown → contextmenu → pointerup) では右ボタン pointerdown が `onFileContextMenu`
+ *   の pending 積みより前に終わるため、pointerdown reset を入れても右クリック単体では
+ *   破綻しない。しかし pending が積まれた状態で **別経路の pointerdown** (例: 左 click) が
+ *   来ると pending を即消去してしまい、本来意図した次の pointerup での消化が起きなくなる。
+ *   状態遷移を pointerup のみで完結させる現設計を維持すること
  * - keyboard 経路 (Shift+F10 / Apps key) と programmatic dispatch は pointerup が発火しないため
  *   menu は開かない。本 PR の責務外で、将来 keyboard ショートカット要件が発生したら別経路
  *   ([docs/keybinding.md](../../../../../docs/keybinding.md)) で menu を開く

--- a/apps/renderer/src/features/navigator/index.ts
+++ b/apps/renderer/src/features/navigator/index.ts
@@ -1,1 +1,2 @@
 export { default as NavigatorPane } from "./NavigatorPane.vue";
+export type { FileContextMenuPayload } from "./useFileContextMenu";

--- a/apps/renderer/src/features/navigator/index.ts
+++ b/apps/renderer/src/features/navigator/index.ts
@@ -1,2 +1,1 @@
 export { default as NavigatorPane } from "./NavigatorPane.vue";
-export { useFileContextMenu } from "./useFileContextMenu";

--- a/apps/renderer/src/features/navigator/index.ts
+++ b/apps/renderer/src/features/navigator/index.ts
@@ -1,1 +1,2 @@
 export { default as NavigatorPane } from "./NavigatorPane.vue";
+export { useFileContextMenu } from "./useFileContextMenu";

--- a/apps/renderer/src/features/navigator/useFileContextMenu.ts
+++ b/apps/renderer/src/features/navigator/useFileContextMenu.ts
@@ -29,6 +29,11 @@
  *
  * 開く直前に anchor 元 component が unmount された (dir 切替・`:key="dir"` 再マウント) ケースは
  * `anchorEl.isConnected` で検出し、debug log を残して open を skip する。
+ *
+ * 不変条件の重複: 上記 light-dismiss 不変条件 (defer 不可 / pointerup capture を変えない /
+ * keyboard 経路は責務外) は `NavigatorPane.vue` の `useEventListener` 呼び出し直上の docstring
+ * にも記載されている (実装変更時に直近で必ず読まれる位置に再掲することで回帰防止する設計)。
+ * 仕様を変える際は両者を必ず同時に更新する責務がある。
  */
 import { usePopover } from "../../shared/popover";
 

--- a/apps/renderer/src/features/navigator/useFileContextMenu.ts
+++ b/apps/renderer/src/features/navigator/useFileContextMenu.ts
@@ -22,6 +22,26 @@
  */
 import { usePopover } from "../../shared/popover";
 
+/**
+ * 子 pane (FilerPane / ChangesPane / TreeItem) が contextmenu event で navigator まで bubble
+ * させる payload の SSOT。各 pane の emit 定義はこの型を `import type` で参照することで、
+ * 同 shape を重複定義する事故を防ぐ。type-only import なので runtime 依存は無く、
+ * 依存方向 (navigator → 子) は壊れない。
+ *
+ * commitHash は payload に乗せず NavigatorPane が `useGitGraphStore.contextMenuHash` で
+ * SSOT 解決する (Filer の snapshot tree 表示用 hash と copy 用 hash が別 semantics のため、
+ * 子 pane に hash 解決責務を分散させない)。
+ */
+export type FileContextMenuPayload = {
+  /** popover の anchor。CSS Anchor Position の anchor 元として使う */
+  anchorEl: HTMLElement;
+  /** worktree 相対パス */
+  relPath: string;
+  /** contextmenu イベント時のマウス座標 (`position: fixed; left/top` 用) */
+  x: number;
+  y: number;
+};
+
 type FileContextMenuContext = {
   /** worktree 相対パス */
   relPath: string;

--- a/apps/renderer/src/features/navigator/useFileContextMenu.ts
+++ b/apps/renderer/src/features/navigator/useFileContextMenu.ts
@@ -1,24 +1,28 @@
 /**
  * Filer / Changes のファイル行の右クリックメニュー (module singleton)。
  *
- * NavigatorPane が `open(anchorEl, { relPath, commitHash, x, y })` を呼び、FileContextMenu.vue が
- * context を購読して描画する。FilerPane / ChangesPane (および配下の TreeItem) は navigator を
+ * NavigatorPane が `open(anchorEl, { dir, relPath, commitHash, x, y })` を呼び、FileContextMenu.vue
+ * が context を購読して描画する。FilerPane / ChangesPane (および配下の TreeItem) は navigator を
  * 直接 import せず、`@contextMenu` event の bubble だけを担当する (依存方向を navigator → 子の
  * 1 方向に保つため)。
  *
- * relPath は worktree 相対パス。メニュー側で active worktree dir と join して絶対パスに展開し、
- * その絶対パスを clipboard に書く。commitHash は working tree のとき undefined、snapshot /
- * commit 由来のとき hash 値。メニュー側はこの discriminator を見て copy 文字列の組み立てを切り
- * 替える (working: 絶対パスのみ / commit 由来: `${hash}\n${絶対パス}`)。
+ * `dir` / `commitHash` は **右クリック時点で navigator が snapshot** して context に焼き付ける。
+ * defer 中 / メニュー表示中に worktree や commit 選択が切り替わっても、その右クリックで参照した
+ * 当時の値を一貫して使う (defer 後に singleton store を読み直すと「古い relPath + 新 dir」の
+ * 不整合 race が起きるため)。
+ *
+ * メニュー側は `joinAbsRel(dir, relPath)` で絶対 path に展開し、`commitHash === undefined` なら
+ * 絶対 path のみ、定義されていれば `${hash}\n${絶対 path}` を clipboard に書く。
  *
  * x / y は contextmenu イベント時のマウス座標。指定時はメニュー側で `position: fixed; left/top`
  * を使い、undefined なら CSS Anchor Position で anchor 要素基準で出す (将来の menu 起動経路用)。
  *
- * NavigatorPane は `setTimeout(open, 0)` で open を 1 task 分遅延させる責務を持つ。`popover="auto"`
- * を contextmenu 同サイクル内で開くと mousedown が light-dismiss を予約し続く mouseup で即閉じる
- * (whatwg/html#10905) ため、現在の mousedown task を抜けてから showPopover を発火させる。
- * setTimeout 経路はマウス / キーボード (Shift+F10) / programmatic dispatch のいずれにも非依存に
- * 動く (pointerup 待機経路はマウス右クリックに限定されるため採用しない)。
+ * NavigatorPane は VueUse `useTimeoutFn` で 0ms の defer を効果 scope 連動で行う。同サイクル内
+ * open は `popover="auto"` の light-dismiss を mouseup で消化されて即閉じる (whatwg/html#10905)
+ * ため、現在の mousedown task を抜けてから showPopover を発火する。defer 経路はマウス /
+ * keyboard (Shift+F10) / programmatic dispatch のいずれにも非依存。defer 中に anchor 元
+ * component が unmount された (dir 切替・`:key="dir"` 再マウント) ケースは `anchorEl.isConnected`
+ * で検出し、debug log を残して open を skip する。
  */
 import { usePopover } from "../../shared/popover";
 
@@ -43,9 +47,11 @@ export type FileContextMenuPayload = {
 };
 
 type FileContextMenuContext = {
+  /** 右クリック時に snapshot した worktree dir (絶対パス) */
+  dir: string;
   /** worktree 相対パス */
   relPath: string;
-  /** snapshot / commit 由来のとき commit hash。working tree なら undefined */
+  /** 右クリック時に snapshot した commit hash。working tree なら undefined */
   commitHash?: string;
   /** contextmenu イベント時のマウス座標。指定時は anchor() より優先 */
   x?: number;

--- a/apps/renderer/src/features/navigator/useFileContextMenu.ts
+++ b/apps/renderer/src/features/navigator/useFileContextMenu.ts
@@ -1,22 +1,24 @@
 /**
  * Filer / Changes のファイル行の右クリックメニュー (module singleton)。
  *
- * 親側 (FileTreeItem / ChangesTreeItem) から `open(anchorEl, { relPath, commitHash, x, y })` を
- * 呼び、NavigatorPane に置いた FileContextMenu.vue が context を購読して描画する。
+ * NavigatorPane が `open(anchorEl, { relPath, commitHash, x, y })` を呼び、FileContextMenu.vue が
+ * context を購読して描画する。FilerPane / ChangesPane (および配下の TreeItem) は navigator を
+ * 直接 import せず、`@contextMenu` event の bubble だけを担当する (依存方向を navigator → 子の
+ * 1 方向に保つため)。
  *
  * relPath は worktree 相対パス。メニュー側で active worktree dir と join して絶対パスに展開し、
- * その絶対パスを clipboard に書く。
+ * その絶対パスを clipboard に書く。commitHash は working tree のとき undefined、snapshot /
+ * commit 由来のとき hash 値。メニュー側はこの discriminator を見て copy 文字列の組み立てを切り
+ * 替える (working: 絶対パスのみ / commit 由来: `${hash}\n${絶対パス}`)。
  *
- * commitHash は working tree のとき undefined、snapshot / commit 由来のとき hash 値。
- * メニュー側はこの discriminator を見て copy 文字列の組み立てを切り替える。
+ * x / y は contextmenu イベント時のマウス座標。指定時はメニュー側で `position: fixed; left/top`
+ * を使い、undefined なら CSS Anchor Position で anchor 要素基準で出す (将来の menu 起動経路用)。
  *
- * x / y は右クリック時のマウス座標。指定時はメニュー側で `position: fixed; left/top` を使い、
- * undefined なら CSS Anchor Position で anchor 要素基準で出す (⋮ ボタン経由など)。
- *
- * 右クリック経路は呼び出し側で「contextmenu の preventDefault + 次の pointerup を 1 回
- * capture once で待つ」処理を行ってから open する責務がある (whatwg/html#10905 の
- * light-dismiss を回避するため。`popover="auto"` の dismiss が mousedown 時点で予約され
- * mouseup で消化される問題)。
+ * NavigatorPane は `setTimeout(open, 0)` で open を 1 task 分遅延させる責務を持つ。`popover="auto"`
+ * を contextmenu 同サイクル内で開くと mousedown が light-dismiss を予約し続く mouseup で即閉じる
+ * (whatwg/html#10905) ため、現在の mousedown task を抜けてから showPopover を発火させる。
+ * setTimeout 経路はマウス / キーボード (Shift+F10) / programmatic dispatch のいずれにも非依存に
+ * 動く (pointerup 待機経路はマウス右クリックに限定されるため採用しない)。
  */
 import { usePopover } from "../../shared/popover";
 
@@ -25,7 +27,7 @@ type FileContextMenuContext = {
   relPath: string;
   /** snapshot / commit 由来のとき commit hash。working tree なら undefined */
   commitHash?: string;
-  /** 右クリックで開いた場合のマウス座標。指定時は anchor() より優先 */
+  /** contextmenu イベント時のマウス座標。指定時は anchor() より優先 */
   x?: number;
   y?: number;
 };

--- a/apps/renderer/src/features/navigator/useFileContextMenu.ts
+++ b/apps/renderer/src/features/navigator/useFileContextMenu.ts
@@ -1,0 +1,41 @@
+/**
+ * Filer / Changes のファイル行の右クリックメニュー (module singleton)。
+ *
+ * 親側 (FileTreeItem / ChangesTreeItem) から `open(anchorEl, { relPath, commitHash, x, y })` を
+ * 呼び、NavigatorPane に置いた FileContextMenu.vue が context を購読して描画する。
+ *
+ * relPath は worktree 相対パス。メニュー側で active worktree dir と join して絶対パスに展開し、
+ * その絶対パスを clipboard に書く。
+ *
+ * commitHash は working tree のとき undefined、snapshot / commit 由来のとき hash 値。
+ * メニュー側はこの discriminator を見て copy 文字列の組み立てを切り替える。
+ *
+ * x / y は右クリック時のマウス座標。指定時はメニュー側で `position: fixed; left/top` を使い、
+ * undefined なら CSS Anchor Position で anchor 要素基準で出す (⋮ ボタン経由など)。
+ *
+ * 右クリック経路は呼び出し側で「contextmenu の preventDefault + 次の pointerup を 1 回
+ * capture once で待つ」処理を行ってから open する責務がある (whatwg/html#10905 の
+ * light-dismiss を回避するため。`popover="auto"` の dismiss が mousedown 時点で予約され
+ * mouseup で消化される問題)。
+ */
+import { usePopover } from "../../shared/popover";
+
+type FileContextMenuContext = {
+  /** worktree 相対パス */
+  relPath: string;
+  /** snapshot / commit 由来のとき commit hash。working tree なら undefined */
+  commitHash?: string;
+  /** 右クリックで開いた場合のマウス座標。指定時は anchor() より優先 */
+  x?: number;
+  y?: number;
+};
+
+const popover = usePopover<FileContextMenuContext>();
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => popover.stop());
+}
+
+export function useFileContextMenu() {
+  return popover;
+}

--- a/apps/renderer/src/features/navigator/useFileContextMenu.ts
+++ b/apps/renderer/src/features/navigator/useFileContextMenu.ts
@@ -7,9 +7,8 @@
  * 1 方向に保つため)。
  *
  * `dir` / `commitHash` は **右クリック時点で navigator が snapshot** して context に焼き付ける。
- * defer 中 / メニュー表示中に worktree や commit 選択が切り替わっても、その右クリックで参照した
- * 当時の値を一貫して使う (defer 後に singleton store を読み直すと「古い relPath + 新 dir」の
- * 不整合 race が起きるため)。
+ * 後で worktree や commit 選択が切り替わっても、その右クリックで参照した当時の値を一貫して使う
+ * (open 後に singleton store を読み直すと「古い relPath + 新 dir」の不整合 race が起きるため)。
  *
  * メニュー側は `joinAbsRel(dir, relPath)` で絶対 path に展開し、`commitHash === undefined` なら
  * 絶対 path のみ、定義されていれば `${hash}\n${絶対 path}` を clipboard に書く。
@@ -17,12 +16,19 @@
  * x / y は contextmenu イベント時のマウス座標。指定時はメニュー側で `position: fixed; left/top`
  * を使い、undefined なら CSS Anchor Position で anchor 要素基準で出す (将来の menu 起動経路用)。
  *
- * NavigatorPane は VueUse `useTimeoutFn` で 0ms の defer を効果 scope 連動で行う。同サイクル内
- * open は `popover="auto"` の light-dismiss を mouseup で消化されて即閉じる (whatwg/html#10905)
- * ため、現在の mousedown task を抜けてから showPopover を発火する。defer 経路はマウス /
- * keyboard (Shift+F10) / programmatic dispatch のいずれにも非依存。defer 中に anchor 元
- * component が unmount された (dir 切替・`:key="dir"` 再マウント) ケースは `anchorEl.isConnected`
- * で検出し、debug log を残して open を skip する。
+ * NavigatorPane は `pointerup` capture listener を setup 直下に常設し、子 pane から bubble する
+ * contextmenu event を `pending` ref に積んで次の pointerup で showPopover する。**`setTimeout(0)`
+ * / `requestAnimationFrame` 等の defer は WebKit (WebPage) の `popover="auto"` light-dismiss を
+ * 抜けない** (whatwg/html#10905、実機検証で確認)。続く mouseup が popover に到達して即 dismiss
+ * されるため、`pointerup` が popover の show 前に消化されることで mouseup の dismiss 対象外に
+ * 倒す。`{ capture: true }` を外したり pointerdown / mousedown 経路に変えてはならない。
+ *
+ * 副作用: keyboard 経路 (Shift+F10 / Apps key) と programmatic dispatch は pointerup が発火
+ * しないため menu を開かない。本 PR の責務外で、将来 keyboard ショートカット要件が発生したら
+ * keybinding システム ([docs/keybinding.md](../../../../docs/keybinding.md)) 経由で別途用意する。
+ *
+ * 開く直前に anchor 元 component が unmount された (dir 切替・`:key="dir"` 再マウント) ケースは
+ * `anchorEl.isConnected` で検出し、debug log を残して open を skip する。
  */
 import { usePopover } from "../../shared/popover";
 

--- a/apps/renderer/src/features/worktree/index.ts
+++ b/apps/renderer/src/features/worktree/index.ts
@@ -1,6 +1,7 @@
 export { UNCOMMITTED_HASH } from "./constants";
 export { generateTimestamp } from "./generateTimestamp";
 export {
+  joinAbsRel,
   normalizeAbsolute,
   normalizePathTarget,
   normalizeRelative,

--- a/apps/renderer/src/features/worktree/pathUtils.test.ts
+++ b/apps/renderer/src/features/worktree/pathUtils.test.ts
@@ -110,4 +110,20 @@ describe("joinAbsRel", () => {
   test("relPath が空のとき dir をそのまま返す (末尾 / を作らない)", () => {
     expect(joinAbsRel("/Users/foo/repo", "")).toBe("/Users/foo/repo");
   });
+
+  test("dir に末尾 / があっても二重 / を作らない", () => {
+    expect(joinAbsRel("/abs/dir/", "rel")).toBe("/abs/dir/rel");
+  });
+
+  test("dir に複数末尾 / があっても 1 個まで畳む", () => {
+    expect(joinAbsRel("/abs/dir///", "rel")).toBe("/abs/dir/rel");
+  });
+
+  test("dir が root / のとき strip 後も root として扱う", () => {
+    expect(joinAbsRel("/", "rel")).toBe("/rel");
+  });
+
+  test("dir が root / で relPath 空のとき / を返す", () => {
+    expect(joinAbsRel("/", "")).toBe("/");
+  });
 });

--- a/apps/renderer/src/features/worktree/pathUtils.test.ts
+++ b/apps/renderer/src/features/worktree/pathUtils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  joinAbsRel,
   normalizeAbsolute,
   normalizeRelative,
   type PathTarget,
@@ -94,5 +95,19 @@ describe("pathTargetEquals", () => {
   test("異 kind は path が同名でも false", () => {
     expect(pathTargetEquals(rel("a.md"), abs("/a.md"))).toBe(false);
     expect(pathTargetEquals(abs("/a.md"), rel("a.md"))).toBe(false);
+  });
+});
+
+describe("joinAbsRel", () => {
+  test("dir + relPath を / で結合する", () => {
+    expect(joinAbsRel("/Users/foo/repo", "src/main.ts")).toBe("/Users/foo/repo/src/main.ts");
+  });
+
+  test("relPath が深いネストでも結合する", () => {
+    expect(joinAbsRel("/abs/dir", "a/b/c/d.ts")).toBe("/abs/dir/a/b/c/d.ts");
+  });
+
+  test("relPath が空のとき dir をそのまま返す (末尾 / を作らない)", () => {
+    expect(joinAbsRel("/Users/foo/repo", "")).toBe("/Users/foo/repo");
   });
 });

--- a/apps/renderer/src/features/worktree/pathUtils.ts
+++ b/apps/renderer/src/features/worktree/pathUtils.ts
@@ -111,16 +111,17 @@ function normalizeAbsolute(absPath: string): string {
 export { normalizeAbsolute, normalizeRelative };
 
 /**
- * worktree の絶対 dir と worktree 相対 path を結合して絶対 path を返す純粋関数。
- * 「右クリックメニューの Copy file path」「外部表示用 path 組み立て」など、絶対 dir +
- * 相対 path → 絶対 path の用途で SSOT として使う。
+ * 絶対 dir と worktree 相対 path を結合して絶対 path を返す純粋関数。
  *
- * filer の `joinPath` (worktree 相対 + 子名) とは責務が別 (こちらは絶対 + 相対)。
- *
- * `relPath === ""` のとき dir をそのまま返す (末尾 `/` を作らない)。filer の root 行は
- * button を持たないため到達しない契約だが、defensive に処理する。
+ * 入力 invariants:
+ * - `dir` は絶対 path だが末尾 `/` の有無は不問 (Swift `URL.path` 経由で trailing slash が
+ *   付くケースに備え、内部で 1 個以上の末尾 `/` を strip する)
+ * - `dir === "/"` は root を表し、strip 後の "" を再度 "/" に戻す
+ * - `relPath` は worktree 相対 path (先頭 `/` 無し)。空文字なら dir そのものを返す
+ *   (末尾 `/` を作らない)
  */
 export function joinAbsRel(dir: string, relPath: string): string {
-  if (relPath === "") return dir;
-  return `${dir}/${relPath}`;
+  const trimmedDir = dir.replace(/\/+$/, "");
+  if (relPath === "") return trimmedDir === "" ? "/" : trimmedDir;
+  return `${trimmedDir}/${relPath}`;
 }

--- a/apps/renderer/src/features/worktree/pathUtils.ts
+++ b/apps/renderer/src/features/worktree/pathUtils.ts
@@ -109,3 +109,18 @@ function normalizeAbsolute(absPath: string): string {
 }
 
 export { normalizeAbsolute, normalizeRelative };
+
+/**
+ * worktree の絶対 dir と worktree 相対 path を結合して絶対 path を返す純粋関数。
+ * 「右クリックメニューの Copy file path」「外部表示用 path 組み立て」など、絶対 dir +
+ * 相対 path → 絶対 path の用途で SSOT として使う。
+ *
+ * filer の `joinPath` (worktree 相対 + 子名) とは責務が別 (こちらは絶対 + 相対)。
+ *
+ * `relPath === ""` のとき dir をそのまま返す (末尾 `/` を作らない)。filer の root 行は
+ * button を持たないため到達しない契約だが、defensive に処理する。
+ */
+export function joinAbsRel(dir: string, relPath: string): string {
+  if (relPath === "") return dir;
+  return `${dir}/${relPath}`;
+}


### PR DESCRIPTION
## 概要

Filer (Files) / Changes パネルの行に右クリック / control+click でメニューを追加し、ファイルやフォルダの絶対パスを clipboard に copy できるようにする。snapshot / commit 選択中は `{commit hash}\n{絶対パス}` の 2 行形式で copy する。

## 背景

これまで「いま見ているファイルやフォルダの絶対パスを別ツールに貼りたい」「過去 commit のあるファイル参照を hash 付きで控えたい」という日常的な copy 要求に応える手段がなかった。Filer / Changes はどちらも active worktree の行を表示しているので、両方の行に統一的な右クリック経路を追加するのが自然な置き場所になる。

設計判断の過程で実機検証と設計レビューを通じて見つかった構造的制約、そのリファクタの経緯:

- **light-dismiss 回避**: `popover="auto"` を contextmenu 同サイクル内で `showPopover` すると mousedown が light-dismiss を予約し、続く mouseup で即閉じる ( whatwg/html issue 10905 )。`setTimeout(0)` / `requestAnimationFrame` 等の defer は WebKit (WebPage) では light-dismiss を抜けないことが実機で判明したため、`pointerup` capture listener を NavigatorPane の setup 直下に常設し、子から bubble する contextmenu event を pending ref に積んで次の pointerup で showPopover する経路にした
- **macOS control+click 対応**: WebKit は control+click を `button=0` + click event として dispatch する ( webkit bugzilla 52174 ) ため、contextmenu と通常 click の両方が発火する。click handler 側で `event.ctrlKey` 早期 return することで folder の展開 / file の select 経路を抑止し、contextmenu 経路のみが動くようにした
- **依存方向の整理**: 右クリックメニューを `src/shared/` に置こうとすると `isolateModules` lint に引っかかるため、`features/navigator/` に閉じ込め、子 pane (FilerPane / ChangesPane / TreeItem) は contextMenu event を bubble で navigator まで上げる構造に倒した。子は payload 型のみ type-only import で受け、runtime 依存は navigator → 子の 1 方向に保つ
- **race の排除**: defer 中に worktree や commit 選択が切り替わる race を排除するため `dir` と `commitHash` は **右クリック時に snapshot** して popover context に焼き付け、menu 側は live store を読み直さない
- **Filer / Changes 対称性**: commit hash 解決は `useGitGraphStore.contextMenuHash` の SSOT に集約 (range mode は undefined、UNCOMMITTED_HASH も undefined、それ以外で selectedHash)。両 pane で同 file の copy 結果が非対称にならないよう統一

## 変更内容

### 新規モジュール ( features/navigator/ )

- `useFileContextMenu.ts` — `usePopover<{ dir, relPath, commitHash?, x?, y? }>()` の module singleton。`FileContextMenuPayload` (子から bubble する event payload 型) を SSOT として export。docstring に light-dismiss 回避の不変条件 ( `setTimeout` / `rAF` / `queueMicrotask` 不可、`{ capture: true }` 外すな、`event.button` で filter するな、`pointerdown` で reset するな ) を集約
- `FileContextMenu.vue` — Copy file path 1 アクションのポップオーバー。context の `dir` (右クリック時 snapshot) と `relPath` を `joinAbsRel` で結合した絶対パスを clipboard に書く。`commitHash` 指定時は `{hash}\n{abs path}` 形式

### NavigatorPane

- 末尾に `<FileContextMenu />` を 1 個マウント (singleton state)
- `useEventListener(window, "pointerup", ..., { capture: true })` を setup 直下で 1 度だけ登録 (effect scope 連動で auto cleanup)
- `pendingOpen` ref に dir / hash を snapshot で積み、pointerup で消化 + null 化 (連打時は最後の右クリックだけが menu を開く)
- `anchorEl.isConnected` で defer 中 unmount race をガード

### Filer

- `FileTreeItem.vue`: 行 button に `@contextmenu` を追加し、inertLeaf (submodule / snapshot symlink) 以外で preventDefault + emit。`toggle` 内で `event.ctrlKey` 早期 return (control+click で folder 展開を抑止)
- `FilerPane.vue`: 配下から bubble してくる contextMenu を NavigatorPane に bubble
- `select-none` で右クリック時のテキスト選択を抑制

### Changes

- `ChangesTreeItem.vue`: file leaf / folder どちらも menu 対象。folder は chain 圧縮の最深 fullPath ( `displayPath` ) を relPath に。`onClick` 内で `event.ctrlKey` 早期 return
- `ChangesPane.vue`: contextMenu を NavigatorPane に bubble
- `select-none` でテキスト選択抑制

### Git graph store

- `useGitGraphStore.contextMenuHash` (computed) を追加。「右クリックで copy する commit hash」の SSOT。range mode は undefined、UNCOMMITTED_HASH も undefined、それ以外で selectedHash

### Changes tree

- `ChangesTreeNode.folder` に `displayPath` (chain 圧縮の最深 folder fullPath) を追加。chain 圧縮された `.github/workflows` のような行でも 1 つの実体 path に決まるため menu 対象にできる
- `changesTree.test.ts` 新規追加 — `displayPath` の境界 5 ケース (圧縮なし / 1 段 / 多段 / file 混在 / root 直下) と throw 契約 3 ケース (重複 `/` / 末尾 `/` / 空 path) を覆う

### Worktree pathUtils

- `joinAbsRel(dir, relPath)` を追加。絶対 dir + worktree 相対 path → 絶対 path の SSOT
- dir 末尾 `/` (Swift `URL.path` 経由) を defensive strip、`dir === "/"` の root ケースも safe に処理
- `pathUtils.test.ts` に境界テスト 4 件追加

### Type / 依存方向

- `FileContextMenuPayload` は navigator が SSOT として export、子 pane は `import type` で参照 (type-only import なので runtime 依存は navigator → 子の 1 方向で閉じる)

## 確認事項

- [ ] Files / Changes のファイル行を右クリック → menu がカーソル位置に開く
- [ ] Filer の directory 行 / Changes の folder 行を右クリック → menu が開き、Copy file path で folder の絶対 path が copy される
- [ ] working tree 中で Copy file path → 絶対パスのみ copy される
- [ ] git-graph で過去 commit を選んだ状態で Filer / Changes 双方から Copy → `{hash}\n{abs path}` が copy される
- [ ] range mode (shift+click) で Changes から Copy → path のみ copy される (multi-commit を単一 hash で代表しない)
- [ ] 右クリック時にテキスト選択が発生しない
- [ ] macOS control+click でも menu が開く (button=0 経路、bugzilla 52174 対応)
- [ ] macOS control+click で folder が開閉しない (click 経路は ctrlKey で早期 return)
- [ ] submodule / snapshot symlink を右クリック → gozd menu が開かず OS 標準 menu が出る
- [ ] 右クリック直後に worktree 切替ショートカット → menu が右クリック時点の dir / hash で開く (snapshot 化が効いていること)
