### PR TITLE
fix(lefthook): renderer group の親 glob 除去で docs-only commit を通す

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ import { useTerminalStore } from "../terminal/useTerminalStore";
 - `pnpm dev` — renderer（Vite HMR）と native（Swift app）を `pnpm --parallel --filter @gozd/renderer --filter @gozd/native dev` で同時起動
 - `pnpm build` — 全パッケージをビルド（stable 環境の `.app` を生成）
 
-全体チェックはルートの `pnpm typecheck:all` / `lint:all` / `test:all` を使う。各 workspace の同名スクリプトを一括実行する。
+全チェックはルートの `pnpm run test:all` / `pnpm run typecheck:all` で行う。pnpm 11 は `pnpm run` 実行時に node_modules を自動インストールするため、事前の手動 install は不要。
 
 - import の整理（未使用 import の削除、並び替え）は commit 時に lint が自動実行する。手動で整理しない
 

--- a/apps/renderer/CLAUDE.md
+++ b/apps/renderer/CLAUDE.md
@@ -1,3 +1,7 @@
+## 検証コマンド
+
+- package 単位の検証は `pnpm run test` / `pnpm run typecheck`
+
 ## エラーハンドリング
 
 - 例外処理では必ず `useNotificationStore` の `error(message, cause?)` / `info(message, cause?)` でトースト通知する。`console.error` で握りつぶさない

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -59,10 +59,14 @@ pre-commit:
             stage_fixed: true
 
           # apps/renderer: .ts は oxlint、.vue は eslint。oxfmt は全ファイルに適用
-          # 同一ファイルへの競合を避けるため piped で直列実行
+          # 同一ファイルへの競合を避けるため piped で直列実行。
+          # 親 group には glob を置かない: lefthook の group は親 glob と子 glob を
+          # OR（和集合）で連結するため、親 glob は子を絞り込めず追加にしかならない。
+          # 親 glob があると .md/.css 単独 commit でも oxlint(.ts)/eslint(.vue) が
+          # 対象外ファイルを受け取り「No files found to lint」で落ちる。
+          # 子ごとに glob を持たせて振り分けを完結させる。
           - name: renderer
             root: apps/renderer/
-            glob: "**/*.{ts,vue,css,md}"
             group:
               piped: true
               jobs:
@@ -74,7 +78,10 @@ pre-commit:
                   glob: "**/*.vue"
                   run: pnpm exec eslint -c eslint.config.fix.ts --no-warn-ignored --cache --fix {staged_files}
                   stage_fixed: true
+                # oxfmt は対象拡張子を明示。glob 無しだと .json/.svg/.png まで
+                # 受けて exit 2 で落ちるため {ts,vue,css,md} に限定する。
                 - name: oxfmt
+                  glob: "**/*.{ts,vue,css,md}"
                   run: pnpm exec oxfmt {staged_files}
                   stage_fixed: true
 


### PR DESCRIPTION
## 概要

`apps/renderer` 配下の `.md` / `.css` **だけ**を含む commit が pre-commit hook で `No files found to lint` (exit 1) で落ちる問題を修正する。あわせて検証で使うコマンドを CLAUDE.md に明文化する。

## 背景

セッションログ表示改善 PR の作業中、`apps/renderer/CLAUDE.md` だけを編集した commit が pre-commit で落ちた。spike と lefthook v2.1.8 のソース確認で原因を特定した。

- `scope.extend` (`internal/run/controller/scope.go`) が子ジョブの glob を親 glob に `slices.Concat` で**連結**する
- `byGlob` (`internal/run/controller/filter/filter.go`) は複数 glob を**和集合 (OR)** で評価する

結果、group の子 glob は親 glob を**絞り込めず追加にしかならない**。`renderer` 親の `glob: "**/*.{ts,vue,css,md}"` に対し子 `oxlint` の `glob: "**/*.ts"` は OR されるため、`.md` 単独 staged でも `oxlint` がそれを受け取り、非 lint ファイルとして落ちる。

spike 結果:

- 非 piped の `oxlint-root` (glob `*.ts`) は root `.md` 単独で正しくスキップ
- piped の `renderer > oxlint` (glob `**/*.ts`) は renderer `.md` 単独で `.md` を受け取り落ちる

## 変更内容

### lefthook.yml: renderer 親 group の glob 除去 + oxfmt 子に glob 明示

親 group の glob を除去し、`oxfmt` 子に対象拡張子 glob を持たせる。親が空なら子 glob がそのまま効き (`oxlint`=.ts / `eslint`=.vue)、`oxfmt` も `{ts,vue,css,md}` に限定される。

修正後の振り分け (spike 全拡張子マトリクスで実証):

- `ts` → oxlint + oxfmt / `vue` → eslint + oxfmt / `css`・`md` → oxfmt のみ
- `json` / `svg` / `txt` / `png` → renderer グループのジョブに拾われない (元の親 glob と同じ挙動 = リグレッションなし)

> [!NOTE]
> 「親 glob 除去 + oxfmt 子も glob 無し」案は不可。`oxfmt` が `.json` / `.svg` / `.png` まで受けて exit 2 で落ちる (spike で確認)。

本 PR の `apps/renderer/CLAUDE.md` 変更 (`.md` 単独) が pre-commit を通過することで、修正対象のシナリオを実証している。

### CLAUDE.md: 検証コマンドの明文化

- root: 全チェックは `pnpm run test:all` / `pnpm run typecheck:all`。pnpm 11 は `pnpm run` 実行時に node_modules を自動インストールするため事前の手動 install は不要
- `apps/renderer`: package 単位は `pnpm run test` / `pnpm run typecheck`

## 確認事項

- [ ] `apps/renderer/CLAUDE.md` だけの commit が pre-commit を通る (本 PR で実証済み)
- [ ] `.ts` / `.vue` commit で oxlint / eslint / oxfmt が従来通り走る
- [ ] `apps/renderer` 配下の `.json` / `.svg` 等が oxfmt に拾われない
