### PR TITLE
feat(git-graph): pin HEAD to the leftmost lane

### DIFF
--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -6,7 +6,7 @@ Git commit graph showing the current worktree branch and the default branch.
 - Working Tree row: sticky header outside scroll area, with status icons and dot on lane 0
 - Connector line: dashed SVG path from lane 0 top to HEAD lane (straight if same lane, Bézier curve otherwise)
 - Scrollable commit list: HTML rows for commit data + SVG overlay for graph lines and dots
-- Graph layout reserves lane 0 for the Working Tree connector; commit lanes start from lane 1
+- HEAD is pinned to the leftmost lane (lane 0) so it aligns under the Working Tree dot and the connector stays vertical. Diverged branches ordered above HEAD are pushed to lanes ≥ 1. The pinning only applies when HEAD is a graph tip not already at the top; see `graphLayout.ts` for the condition
 - CommitDetailPane is shown as a toggleable right pane inside the graph
 - Commits are stored in `useGitGraphStore` and shared with ChangesPane
 
@@ -126,19 +126,16 @@ function findHeadCommit(rawCommits: GitCommit[]): GitCommit | undefined {
   return rawCommits.find((c) => c.refs.includes("HEAD"));
 }
 
-/** Working Tree 接続用に左端 1 レーンを確保 */
-const RESERVED_LANES = 1;
-
 function recomputeLayout() {
   layout.value = computeGraphLayout(commits.value, {
-    reservedLanes: RESERVED_LANES,
+    headHash: findHeadCommit(commits.value)?.hash,
   });
 }
 
 /** HEAD ノードのレーン番号。接続線の描画に使用 */
 const headLane = computed(() => {
   const node = layout.value.nodes.find((n) => n.commit.refs.includes("HEAD"));
-  return node?.lane ?? RESERVED_LANES;
+  return node?.lane ?? 0;
 });
 
 // 以下 3 つの「前回値」は **active worktree dir に対する不変条件** として保持する。

--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -6,7 +6,7 @@ Git commit graph showing the current worktree branch and the default branch.
 - Working Tree row: sticky header outside scroll area, with status icons and dot on lane 0
 - Connector line: dashed SVG path from lane 0 top to HEAD lane (straight if same lane, Bézier curve otherwise)
 - Scrollable commit list: HTML rows for commit data + SVG overlay for graph lines and dots
-- HEAD is pinned to the leftmost lane (lane 0) so it aligns under the Working Tree dot and the connector stays vertical. Diverged branches ordered above HEAD are pushed to lanes ≥ 1. The pinning only applies when HEAD is a graph tip not already at the top; see `graphLayout.ts` for the condition
+- HEAD is pinned to the leftmost lane (lane 0) so it aligns under the Working Tree dot. When HEAD is not the topmost commit, lane 0 is reserved as an empty channel above HEAD so the connector descends without crossing other lanes; commits above HEAD (diverged branches, or HEAD's own children in a detached-HEAD view) are pushed to lanes ≥ 1 and HEAD's children merge back into lane 0 at HEAD's row. See `graphLayout.ts` for the lane assignment
 - CommitDetailPane is shown as a toggleable right pane inside the graph
 - Commits are stored in `useGitGraphStore` and shared with ChangesPane
 

--- a/apps/renderer/src/features/git-graph/graphLayout.test.ts
+++ b/apps/renderer/src/features/git-graph/graphLayout.test.ts
@@ -41,12 +41,78 @@ describe("computeGraphLayout の HEAD 最左固定", () => {
     expect(lanes.get("base")).toBe(0);
   });
 
-  test("HEAD がグラフ内に子を持つ (= tip でない) 場合は固定しない", () => {
-    // c0 が c1 (HEAD) を parent に持つ。HEAD は祖先側なので最左固定すると線が壊れる。
-    // 通常の貪欲割り当てに倒し、c0 と同じ lane を共有する。
+  test("HEAD がグラフ内に子を持つ (= 非 tip) 場合も最左に固定し子を合流させる", () => {
+    // c0 が c1 (HEAD) を parent に持つ。HEAD の子 c0 は lane 0 を予約のため lane 1 以降に置かれ、
+    // c1 (HEAD) 行で lane 0 へ合流する。detached HEAD で子孫が表示されるケースに相当。
     const commits = [commit("c0", ["c1"]), commit("c1", ["c2"], ["HEAD"]), commit("c2", [])];
     const lanes = laneByHash(computeGraphLayout(commits, { headHash: "c1" }));
-    expect(lanes.get("c1")).toBe(lanes.get("c0"));
+    expect(lanes.get("c1")).toBe(0);
+    expect(lanes.get("c0")).toBeGreaterThan(0);
+  });
+
+  test("HEAD 到達前の merge コミットの 2nd parent が予約 lane 0 を奪わない", () => {
+    // 上枝が内部 merge を持ち、HEAD (h0) は tip。merge (m) は headRow より前の行。
+    // m の 2nd parent (u2) が lane 0 を取ると h0 が最左を確保できないため、
+    // findEmptyLane の minLane=1 により u2 は lane 1 以降へ追いやられる必要がある。
+    //   u0 → m ┬─ u1 ┐
+    //          └─ u2 ┤
+    //   h0 ─────────┤
+    //            base┘
+    const commits = [
+      commit("u0", ["m"]),
+      commit("m", ["u1", "u2"]),
+      commit("u1", ["base"]),
+      commit("h0", ["base"], ["HEAD"]),
+      commit("u2", ["base"]),
+      commit("base", []),
+    ];
+    const lanes = laneByHash(computeGraphLayout(commits, { headHash: "h0" }));
+    expect(lanes.get("h0")).toBe(0);
+    // merge の 2nd parent は予約 lane 0 を避けて右へ配置される
+    expect(lanes.get("u2")).toBeGreaterThan(0);
+    expect(lanes.get("base")).toBe(0);
+  });
+
+  test("HEAD 自身が merge コミットの tip でも最左 lane に固定する", () => {
+    //   o0 → o1 ┐
+    //   m(HEAD)─┼─ a ┐
+    //           └─ b ┤
+    //            base┘
+    const commits = [
+      commit("o0", ["o1"]),
+      commit("o1", ["base"]),
+      commit("m", ["a", "b"], ["HEAD"]),
+      commit("a", ["base"]),
+      commit("b", ["base"]),
+      commit("base", []),
+    ];
+    const lanes = laneByHash(computeGraphLayout(commits, { headHash: "m" }));
+    expect(lanes.get("m")).toBe(0);
+    expect(lanes.get("o0")).toBeGreaterThan(0);
+  });
+
+  test("非 tip な HEAD に複数の子がある場合も lane 0 に固定し全子を合流させる", () => {
+    // a/b が h (HEAD) を parent に持つ (h は 2 つの子を持つ非 tip)。
+    //   a ┐ b ┐
+    //     ├───┤
+    //   h(HEAD)┘ → c
+    const commits = [
+      commit("a", ["h"]),
+      commit("b", ["h"]),
+      commit("h", ["c"], ["HEAD"]),
+      commit("c", []),
+    ];
+    const lanes = laneByHash(computeGraphLayout(commits, { headHash: "h" }));
+    expect(lanes.get("h")).toBe(0);
+    expect(lanes.get("a")).toBeGreaterThan(0);
+    expect(lanes.get("b")).toBeGreaterThan(0);
+    expect(lanes.get("c")).toBe(0);
+  });
+
+  test("headHash が表示集合に存在しない (maxCount 打ち切り等) 場合は従来レイアウト", () => {
+    const commits = [commit("c0", ["c1"]), commit("c1", [])];
+    const lanes = laneByHash(computeGraphLayout(commits, { headHash: "missing" }));
+    expect(lanes.get("c0")).toBe(0);
   });
 
   test("headHash 未指定なら従来どおり先頭コミットが最左", () => {

--- a/apps/renderer/src/features/git-graph/graphLayout.test.ts
+++ b/apps/renderer/src/features/git-graph/graphLayout.test.ts
@@ -1,0 +1,57 @@
+import type { GitCommit } from "@gozd/proto";
+import { describe, expect, test } from "bun:test";
+import { computeGraphLayout } from "./graphLayout";
+
+/** テスト用 commit を最小フィールドで生成する */
+function commit(hash: string, parents: string[], refs: string[] = []): GitCommit {
+  return { hash, shortHash: hash, parents, author: "", date: 0, message: "", body: "", refs };
+}
+
+/** hash → lane の引きやすいマップに変換する */
+function laneByHash(layout: ReturnType<typeof computeGraphLayout>): Map<string, number> {
+  return new Map(layout.nodes.map((n) => [n.commit.hash, n.lane]));
+}
+
+describe("computeGraphLayout の HEAD 最左固定", () => {
+  test("HEAD が表示順の先頭なら最左 lane (0) に置く", () => {
+    const commits = [commit("c0", ["c1"], ["HEAD"]), commit("c1", ["c2"]), commit("c2", [])];
+    const lanes = laneByHash(computeGraphLayout(commits, { headHash: "c0" }));
+    expect(lanes.get("c0")).toBe(0);
+  });
+
+  test("分岐により他枝が HEAD より上に並んでも HEAD を最左に固定する", () => {
+    // o0/o1: origin 側の分岐コミット (HEAD より新しく表示順で上)
+    // h0: HEAD (tip)。base が共通祖先
+    //   o0 → o1 ┐
+    //           ├→ base
+    //   h0 ─────┘
+    const commits = [
+      commit("o0", ["o1"]),
+      commit("o1", ["base"]),
+      commit("h0", ["base"], ["HEAD"]),
+      commit("base", []),
+    ];
+    const lanes = laneByHash(computeGraphLayout(commits, { headHash: "h0" }));
+    // HEAD は予約された最左 lane (0) に固定される
+    expect(lanes.get("h0")).toBe(0);
+    // 上に並ぶ origin 枝は右側へ追いやられる
+    expect(lanes.get("o0")).toBeGreaterThan(0);
+    expect(lanes.get("o1")).toBeGreaterThan(0);
+    // 共通祖先は HEAD 系統に合流して最左に戻る
+    expect(lanes.get("base")).toBe(0);
+  });
+
+  test("HEAD がグラフ内に子を持つ (= tip でない) 場合は固定しない", () => {
+    // c0 が c1 (HEAD) を parent に持つ。HEAD は祖先側なので最左固定すると線が壊れる。
+    // 通常の貪欲割り当てに倒し、c0 と同じ lane を共有する。
+    const commits = [commit("c0", ["c1"]), commit("c1", ["c2"], ["HEAD"]), commit("c2", [])];
+    const lanes = laneByHash(computeGraphLayout(commits, { headHash: "c1" }));
+    expect(lanes.get("c1")).toBe(lanes.get("c0"));
+  });
+
+  test("headHash 未指定なら従来どおり先頭コミットが最左", () => {
+    const commits = [commit("c0", ["c1"]), commit("c1", [])];
+    const lanes = laneByHash(computeGraphLayout(commits, {}));
+    expect(lanes.get("c0")).toBe(0);
+  });
+});

--- a/apps/renderer/src/features/git-graph/graphLayout.ts
+++ b/apps/renderer/src/features/git-graph/graphLayout.ts
@@ -67,13 +67,27 @@ interface LaneState {
 }
 
 /**
- * @param reservedLanes 左端に確保する空きレーン数。全ノード・ラインの lane が右にシフトされる
+ * @param headHash HEAD コミットの hash。指定すると HEAD を最左 lane (lane 0) に固定する
  */
-export function computeGraphLayout(commits: GitCommit[], { reservedLanes = 0 } = {}): GraphLayout {
+export function computeGraphLayout(
+  commits: GitCommit[],
+  { headHash }: { headHash?: string } = {},
+): GraphLayout {
   const commitIndexMap = new Map<string, number>();
   for (let i = 0; i < commits.length; i++) {
     commitIndexMap.set(commits[i].hash, i);
   }
+
+  // HEAD を最左 lane に固定するための予約判定。
+  // - row 0 が HEAD の通常ケース (headRow === 0) は貪欲割り当てで既に最左なので予約不要
+  // - HEAD がグラフ内に子 (HEAD を parent に持つ commit) を持つ場合、lane を強制すると
+  //   子からの接続線が壊れる。この場合は通常レイアウトに倒す
+  // 上記以外 (HEAD が tip かつ表示順で先頭でない = 分岐により他枝が上に並ぶ) のときだけ、
+  // HEAD 到達前は lane 0 を空けて予約し、HEAD 行で lane 0 に固定する。
+  const headRow = headHash === undefined ? -1 : (commitIndexMap.get(headHash) ?? -1);
+  const headIsTip =
+    headHash !== undefined && headRow >= 0 && !commits.some((c) => c.parents.includes(headHash));
+  const reserveHeadLane = headRow > 0 && headIsTip;
 
   const activeLanes: (LaneState | undefined)[] = [];
   let nextColor = 0;
@@ -97,11 +111,18 @@ export function computeGraphLayout(commits: GitCommit[], { reservedLanes = 0 } =
     let lane: number;
     let color: number;
 
+    // HEAD 到達前は lane 0 を予約 (空き探索の下限を 1 に上げる) し、HEAD に確保しておく
+    const minLane = reserveHeadLane && row < headRow ? 1 : 0;
+
     if (matchingLanes.length > 0) {
       lane = matchingLanes[0];
       color = activeLanes[lane]!.color;
+    } else if (reserveHeadLane && row === headRow) {
+      // 予約しておいた最左 lane に HEAD を固定する
+      lane = 0;
+      color = nextColor++;
     } else {
-      lane = findEmptyLane(activeLanes);
+      lane = findEmptyLane(activeLanes, minLane);
       color = nextColor++;
     }
 
@@ -169,7 +190,7 @@ export function computeGraphLayout(commits: GitCommit[], { reservedLanes = 0 } =
 
       const existingLane = activeLanes.findIndex((l) => l?.hash === parentHash);
       if (existingLane === -1) {
-        const mergeLane = findEmptyLane(activeLanes);
+        const mergeLane = findEmptyLane(activeLanes, minLane);
         const mergeColor = nextColor++;
         // originLane を設定して、次の行で斜めセグメントを生成
         activeLanes[mergeLane] = { hash: parentHash, color: mergeColor, originLane: lane };
@@ -177,24 +198,20 @@ export function computeGraphLayout(commits: GitCommit[], { reservedLanes = 0 } =
     }
 
     maxLanes = Math.max(maxLanes, countActive(activeLanes));
-    nodes.push({ commit, lane: lane + reservedLanes, color });
+    nodes.push({ commit, lane, color });
   }
 
-  if (reservedLanes > 0) {
-    for (const seg of lines) {
-      seg.x1 += reservedLanes;
-      seg.x2 += reservedLanes;
-    }
-  }
-
-  return { nodes, lines, maxLanes: Math.max(maxLanes, 1) + reservedLanes };
+  return { nodes, lines, maxLanes: Math.max(maxLanes, 1) };
 }
 
-function findEmptyLane(lanes: (LaneState | undefined)[]): number {
-  for (let i = 0; i < lanes.length; i++) {
+/**
+ * @param minLane 探索を開始する最小 lane。HEAD 予約中は 1 を渡して lane 0 を温存する
+ */
+function findEmptyLane(lanes: (LaneState | undefined)[], minLane = 0): number {
+  for (let i = minLane; i < lanes.length; i++) {
     if (lanes[i] === undefined) return i;
   }
-  return lanes.length;
+  return Math.max(lanes.length, minLane);
 }
 
 function countActive(lanes: (LaneState | undefined)[]): number {

--- a/apps/renderer/src/features/git-graph/graphLayout.ts
+++ b/apps/renderer/src/features/git-graph/graphLayout.ts
@@ -67,7 +67,8 @@ interface LaneState {
 }
 
 /**
- * @param headHash HEAD コミットの hash。指定すると HEAD を最左 lane (lane 0) に固定する
+ * @param headHash HEAD コミットの hash。指定すると HEAD を最左 lane (lane 0) に固定する。
+ *   HEAD が表示順で先頭でないときは lane 0 を空きチャンネルとして予約し、子があれば lane 0 へ合流させる
  */
 export function computeGraphLayout(
   commits: GitCommit[],
@@ -79,15 +80,12 @@ export function computeGraphLayout(
   }
 
   // HEAD を最左 lane に固定するための予約判定。
-  // - row 0 が HEAD の通常ケース (headRow === 0) は貪欲割り当てで既に最左なので予約不要
-  // - HEAD がグラフ内に子 (HEAD を parent に持つ commit) を持つ場合、lane を強制すると
-  //   子からの接続線が壊れる。この場合は通常レイアウトに倒す
-  // 上記以外 (HEAD が tip かつ表示順で先頭でない = 分岐により他枝が上に並ぶ) のときだけ、
-  // HEAD 到達前は lane 0 を空けて予約し、HEAD 行で lane 0 に固定する。
+  // HEAD が表示順で先頭 (headRow === 0) なら貪欲割り当てで既に最左なので予約不要。
+  // それ以外 (HEAD より上に他コミットが並ぶ) のときは、HEAD 到達前の行で lane 0 を
+  // 空けて予約し、HEAD 行で lane 0 に固定する。HEAD がグラフ内に子を持つ (= 非 tip) 場合も、
+  // 子の各レーンを HEAD 行で lane 0 へ合流させることで lane を壊さず固定できる。
   const headRow = headHash === undefined ? -1 : (commitIndexMap.get(headHash) ?? -1);
-  const headIsTip =
-    headHash !== undefined && headRow >= 0 && !commits.some((c) => c.parents.includes(headHash));
-  const reserveHeadLane = headRow > 0 && headIsTip;
+  const reserveHeadLane = headRow > 0;
 
   const activeLanes: (LaneState | undefined)[] = [];
   let nextColor = 0;
@@ -114,13 +112,14 @@ export function computeGraphLayout(
     // HEAD 到達前は lane 0 を予約 (空き探索の下限を 1 に上げる) し、HEAD に確保しておく
     const minLane = reserveHeadLane && row < headRow ? 1 : 0;
 
-    if (matchingLanes.length > 0) {
+    if (reserveHeadLane && row === headRow) {
+      // 予約しておいた最左 lane に HEAD を固定する。HEAD に子がある (matchingLanes あり) 場合も
+      // ここを優先し、子の各レーンを下の合流処理で lane 0 へ寄せる。色は最初の子レーンを継ぐ
+      lane = 0;
+      color = matchingLanes.length > 0 ? activeLanes[matchingLanes[0]]!.color : nextColor++;
+    } else if (matchingLanes.length > 0) {
       lane = matchingLanes[0];
       color = activeLanes[lane]!.color;
-    } else if (reserveHeadLane && row === headRow) {
-      // 予約しておいた最左 lane に HEAD を固定する
-      lane = 0;
-      color = nextColor++;
     } else {
       lane = findEmptyLane(activeLanes, minLane);
       color = nextColor++;
@@ -144,8 +143,9 @@ export function computeGraphLayout(
           });
           // originLane をクリア（最初の1セグメントだけ斜め）
           state.originLane = undefined;
-        } else if (matchingLanes.length > 1 && matchingLanes.includes(i) && i !== lane) {
+        } else if (matchingLanes.includes(i) && i !== lane) {
           // 合流: このレーンからメインレーンへの斜め線
+          // (HEAD 固定では lane=0 が matchingLanes に含まれないため、子レーンすべてが対象)
           lines.push({
             x1: i,
             y1: row - 1,
@@ -169,10 +169,10 @@ export function computeGraphLayout(
     }
 
     // --- Phase 2: 合流レーンを解放 ---
-    if (matchingLanes.length > 1) {
-      for (let k = 1; k < matchingLanes.length; k++) {
-        activeLanes[matchingLanes[k]] = undefined;
-      }
+    // この行のレーン (lane) 以外の matching を解放する。通常は matchingLanes[0] === lane なので
+    // [1..] を解放。HEAD 固定では lane=0 が matchingLanes に含まれないため全 matching を解放する。
+    for (const ml of matchingLanes) {
+      if (ml !== lane) activeLanes[ml] = undefined;
     }
 
     // --- Phase 3: このコミットのレーン状態を更新 ---


### PR DESCRIPTION
## 概要

git graph で現在の HEAD を常に最左レーンに表示するようにした。あわせて、これまで混線回避のために確保していた Working Tree 用の左 1 レーン分のずらし (`reservedLanes`) を撤去した。HEAD が表示順で先頭でない場合（分岐・detached HEAD 等）も、lane 0 を空きチャンネルとして予約して HEAD を最左に固定する。

## 背景

git log はデフォルトで日付順に並ぶため、origin が分岐して HEAD より新しいコミットが上に並ぶと、その分岐コミットが lane 0 を先取りし、HEAD が lane 1 以降へ押し出されていた。現在位置である HEAD が画面の左端にいないと、どれが自分の作業中の系統か直感的に分かりづらい。

HEAD のレーンが不定だったため、Working Tree → HEAD の接続線が混線しないよう左端 1 レーンを予約して全コミットを右へずらしていた。HEAD が最左に確定すれば、この予約は不要になり Working Tree ドットと HEAD が縦に揃う。

当初は HEAD が tip（表示集合に子を持たない）のときだけ最左固定する実装にしたが、detached HEAD で子孫コミットが表示されるケースでは HEAD が内側レーンに残り、Working Tree のダッシュ線が他レーンの dot/線と重なることが分かった。これは撤去した `reservedLanes` が防いでいた混線そのものの再発だったため、非 tip な HEAD も最左固定する方式に変更した。

## 変更内容

### HEAD の最左固定 ( graphLayout.ts )

- `computeGraphLayout` に `headHash` オプションを追加
- HEAD が表示順で先頭でないとき (`headRow > 0`)、HEAD 到達前の行は空きレーン探索の下限を 1 に上げて lane 0 を空きチャンネルとして温存し、HEAD 行で lane 0 に固定する
- HEAD がグラフ内に子を持つ（非 tip、detached HEAD で子孫が表示される等）場合も、HEAD 行で子の各レーンを lane 0 へ合流（merge 曲線）させることでレーンを壊さず最左に固定する
- 分岐した他枝は lane 1 以降へ追いやられ、共通祖先 (merge-base) で lane 0 へ合流するため、HEAD 系統が最左の幹になる

### 合流ロジックの一般化 ( graphLayout.ts )

- 合流セグメント条件から `matchingLanes.length > 1` を外し `i !== lane` のみとする。HEAD 固定では lane 0 が matching に含まれず子が 1 つでも寄せる必要があるため、通常 merge と同一ロジックに統一
- Phase 2 のレーン解放を「`lane` 以外の全 matching」に変更

### Working Tree レーンずらしの撤去 ( graphLayout.ts / GitGraphPane.vue )

- HEAD が lane 0 に来るため `reservedLanes` (左 1 列確保) とそれに伴う lane シフトをすべて削除
- Working Tree ドット (lane 0) と HEAD ドットが縦に揃い、接続線が垂直直線になる

### テスト ( graphLayout.test.ts )

- 先頭 HEAD / 分岐 tip / 非 tip（単一子・複数子）/ HEAD 到達前 merge の 2nd parent / HEAD 自身が merge / headHash 不在 / headHash 未指定 の 8 ケースでレーン割り当てを固定

## 確認事項

- [x] 通常の worktree (分岐なし) で HEAD が最左・Working Tree と縦に揃って表示される
- [x] origin が分岐している worktree で HEAD が最左に固定され、他枝が右側へ分かれて共通祖先で合流する
- [x] detached HEAD で子孫が表示されるケースでも HEAD が最左に来て、コネクタが他レーンと被らない
