### PR TITLE
feat(session-log): render rewind branches with inline per-node selector

### DIFF
--- a/apps/renderer/src/features/sidebar/SessionLogDialog.vue
+++ b/apps/renderer/src/features/sidebar/SessionLogDialog.vue
@@ -27,6 +27,10 @@ subagent が居て軸を引けるときだけタイムラインを出す。subag
   取得し、各 entry を `parseSessionLog` で transcript 化して保持する。`entries[0]` が main、
   残りが subagents。subagent タブを選ぶと右ペインの transcript が切り替わる
 - 取得失敗 / 未発見 / 空ログはそれぞれ明示メッセージを出す (fallback で握り潰さない)
+- rewind があるセッションはデフォルトで最新枝だけを表示する。分岐点に出る branch セレクタを
+  クリックすると `branchSelections` (tabId → branchKey → childUuid) を更新し、`parsedSessions`
+  computed がそのバージョンへ再 parse する。選択はライブ refresh を跨いで保持し、別セッション
+  load でクリアする
 
 ## ライブ更新
 
@@ -45,6 +49,7 @@ import { onMessage } from "../../shared/rpc";
 import type { FsChangePayload } from "../filer";
 import { rpcClaudeSessionLog, rpcFsUnwatch, rpcFsWatch } from "./rpc";
 import {
+  type BranchSelection,
   buildSubagentLinks,
   buildTimelineTracks,
   groupByWorkflow,
@@ -84,16 +89,54 @@ interface SessionTab {
   workflowRunId: string;
   // workflow の表示名 (グループ見出し)。非 workflow subagent / main は空文字。
   workflowName: string;
+  // 生 JSONL。parse は branchSelections 依存の computed (parsedSessions) で行う。
+  content: string;
+}
+// parse 済みタブ。content + そのタブの branch 選択から parsed を導出した派生型。
+interface ParsedSessionTab extends SessionTab {
   parsed: ParsedSessionLog;
 }
 const sessions = ref<SessionTab[]>([]);
-// entries[0] が main。subagents はそれ以降。
-const mainSession = computed<SessionTab | undefined>(() =>
-  sessions.value.find((s) => s.kind === "main"),
+
+// rewind 分岐の選択状態。tabId (session_id / agent_id) → そのタブの BranchSelection
+// (branchKey → 選択 childUuid)。未選択の分岐点は parseSessionLog 側が最新枝にフォールバックする。
+// ライブ refresh を跨いで保持し (キーが安定なら選択が残る)、別セッション load でクリアする。
+const branchSelections = ref<Map<string, BranchSelection>>(new Map());
+
+// content + branch 選択から各タブを parse する。selection 変更で該当バージョンへ再構築される。
+const parsedSessions = computed<ParsedSessionTab[]>(() =>
+  sessions.value.map((s) => ({
+    ...s,
+    parsed: parseSessionLog(s.content, branchSelections.value.get(s.id)),
+  })),
 );
-const subagents = computed<SessionTab[]>(() => sessions.value.filter((s) => s.kind !== "main"));
+
+// 分岐セレクタのクリック: そのタブの branchKey を指定 childUuid に切り替える (枝の差し替え)。
+// reactivity のため Map は複製して差し替える。併せて該当ペインを選択枝の先頭 (ts) へ寄せる:
+// 枝切替は parsed を差し替えるため Transcript の parsed watch が走るが、scrollTarget を立てて
+// おくとボトム追従を抑止して分岐点位置を保てる。scrollTarget は scrollNonce で必ず変化させ、
+// 同 ts への連続切替でも子の watch を発火させる。
+function selectBranch(tabId: string, branchKey: string, childUuid: string, ts: string) {
+  const next = new Map(branchSelections.value);
+  const inner = new Map(next.get(tabId) ?? []);
+  inner.set(branchKey, childUuid);
+  next.set(tabId, inner);
+  branchSelections.value = next;
+
+  const target = { ts, nonce: ++scrollNonce };
+  if (tabId === mainSession.value?.id) mainScrollTarget.value = target;
+  else subScrollTarget.value = target;
+}
+
+// entries[0] が main。subagents はそれ以降。
+const mainSession = computed<ParsedSessionTab | undefined>(() =>
+  parsedSessions.value.find((s) => s.kind === "main"),
+);
+const subagents = computed<ParsedSessionTab[]>(() =>
+  parsedSessions.value.filter((s) => s.kind !== "main"),
+);
 // Task ツール subagent (workflowRunId 空)。横断タイムラインで main の次に並べる。
-const plainSubagents = computed<SessionTab[]>(() =>
+const plainSubagents = computed<ParsedSessionTab[]>(() =>
   subagents.value.filter((s) => s.workflowRunId === ""),
 );
 // workflow agent は workflowRunId でグループ化する (出現順保持)。タイムラインのトラック順
@@ -103,7 +146,7 @@ const workflowGroups = computed(() => groupByWorkflow(subagents.value));
 
 // 右ペインに出す subagent。subagent が 1 つでもあれば先頭を初期選択する。
 const activeSubId = ref<string | undefined>(undefined);
-const activeSub = computed<SessionTab | undefined>(() =>
+const activeSub = computed<ParsedSessionTab | undefined>(() =>
   subagents.value.find((s) => s.id === activeSubId.value),
 );
 
@@ -156,7 +199,7 @@ const playheadMs = computed<number | undefined>(() => {
 
 // 1 セッション → 1 session トラック。生存期間は sessionTimeRange (純関数) が events の
 // min/max ts から算出。
-function toTimelineSession(s: SessionTab): TimelineSession {
+function toTimelineSession(s: ParsedSessionTab): TimelineSession {
   return { id: s.id, label: s.label, events: s.parsed.events };
 }
 
@@ -236,7 +279,7 @@ function toSessionTab(entry: {
     name: entry.name,
     workflowRunId: entry.workflowRunId,
     workflowName: entry.workflowName,
-    parsed: parseSessionLog(entry.content),
+    content: entry.content,
   };
 }
 
@@ -246,6 +289,8 @@ async function load(sessionId: string) {
   errorMessage.value = undefined;
   notFound.value = false;
   sessions.value = [];
+  // 別セッションの分岐選択は引き継がない (tabId が変わるため意味を持たない)。
+  branchSelections.value = new Map();
   activeSubId.value = undefined;
   subScrollTarget.value = undefined;
   mainScrollTarget.value = undefined;
@@ -454,6 +499,9 @@ function onDialogClick(event: MouseEvent) {
           class="min-w-0 flex-1"
           @open-subagent="openSubagent"
           @current-ts="onMainCurrentTs"
+          @select-branch="
+            selectBranch(mainSession.id, $event.branchKey, $event.childUuid, $event.ts)
+          "
         />
 
         <!-- 右: 選択中の subagent (あれば横並び)。scrollTo で呼び出し時刻へ同期する。 -->
@@ -466,6 +514,7 @@ function onDialogClick(event: MouseEvent) {
           :session-key="activeSub.id"
           :scroll-to="subScrollTarget"
           class="min-w-0 flex-1 border-l border-zinc-800"
+          @select-branch="selectBranch(activeSub.id, $event.branchKey, $event.childUuid, $event.ts)"
         />
       </div>
     </div>

--- a/apps/renderer/src/features/sidebar/SessionLogTranscript.vue
+++ b/apps/renderer/src/features/sidebar/SessionLogTranscript.vue
@@ -18,6 +18,8 @@ tool は LINE に対応物が無いため、中央寄せの控えめなシステ
 
 - 吹き出し (user / assistant / image) は常時表示、システム行 (thinking / tool) のみ
   `<details>` のネイティブ開閉に委ね、Vue 側に per-event の ref を持たない
+- rewind 分岐は `branch` イベントとして中央寄せのセレクタ行で出す。番号は古い順 (最新が最大)、
+  選択中の枝をハイライトし、他をクリックで `select-branch` を emit して親に枝の切り替えを委ねる
 - scroll-spy は `IntersectionObserver`。純 CSS の scroll marker / `:target-current` は
   WebKit (Safari 26 / macOS 26) 未対応のため使えない。チャット行の最外要素に `data-ev`
   を残し、user / assistant 行を index で観測して topmost の ts を `current-ts` に出す
@@ -73,6 +75,9 @@ const emit = defineEmits<{
   // topmost に見えている会話イベントの ts。親 (SessionLogDialog) が横断タイムラインの
   // playhead 位置に使う。スクロールに追従して発火する。
   (e: "current-ts", ts: string): void;
+  // rewind 分岐セレクタのクリック。親がそのタブの branch 選択を更新して transcript を
+  // 該当バージョンへ再構築する。ts は選択枝先頭の時刻で、切替後にその分岐点へ寄せるのに使う。
+  (e: "select-branch", payload: { branchKey: string; childUuid: string; ts: string }): void;
 }>();
 
 const notify = useNotificationStore();
@@ -340,6 +345,10 @@ watch(
     const wasAtBottom = computeAtBottom();
     await nextTick();
     setupObserver();
+    // 明示スクロール (時刻ジャンプ / rewind 枝切替) が保留中ならボトム追従しない。枝切替は
+    // parsed を差し替えるためこの watch が走るが、ライブ追記と違い分岐点へ寄せたい。scrollTo
+    // watch (この watch より先に登録) が pendingScrollTs を同期セットするため、ここで見て回避する。
+    if (pendingScrollTs !== undefined) return;
     // ボトムにいたら追従、離れていたら通知ボタンを出して位置を保つ。離れている間は
     // 保留中の追従要求もクリアし、後から markdown 描画が来てもボトムへ引き戻さない。
     if (wasAtBottom) {
@@ -425,9 +434,42 @@ onBeforeUnmount(teardownObserver);
     <!-- トランスクリプト本文 (LINE 風チャット)。現在地は横断タイムラインの playhead が示す -->
     <div v-else ref="contentRef" class="min-h-0 flex-1 space-y-3 overflow-y-auto px-4 py-3">
       <template v-for="(ev, i) in parsed.events" :key="`${sessionKey}:${i}`">
+        <!-- rewind 分岐セレクタ: ここで会話が枝分かれした。番号は古い順 (最新が最大)。
+               選択中の枝をハイライトし、他をクリックでその枝へ切り替える。捨て枝が
+               存在することの可視化と、過去バージョンの閲覧を兼ねる。 -->
+        <div
+          v-if="ev.kind === 'branch'"
+          :data-ev="i"
+          class="mx-auto flex w-fit max-w-[85%] scroll-mt-2 flex-wrap items-center justify-center gap-1.5 py-1 text-[11px] text-zinc-500"
+        >
+          <span class="icon-[lucide--git-branch] size-3.5 shrink-0" />
+          <button
+            v-for="opt in ev.options"
+            :key="opt.childUuid"
+            type="button"
+            class="flex max-w-[200px] items-center gap-1 rounded-full border px-2 py-0.5"
+            :class="
+              opt.childUuid === ev.selectedChildUuid
+                ? 'border-green-700 bg-green-800 text-green-50'
+                : 'border-zinc-700 text-zinc-400 hover:bg-white/5 hover:text-zinc-200'
+            "
+            :title="opt.lead"
+            @click="
+              emit('select-branch', {
+                branchKey: ev.branchKey,
+                childUuid: opt.childUuid,
+                ts: opt.ts,
+              })
+            "
+          >
+            <span class="shrink-0 tabular-nums">#{{ opt.index }}</span>
+            <span v-if="opt.lead !== ''" class="min-w-0 truncate">{{ opt.lead }}</span>
+          </button>
+        </div>
+
         <!-- thinking / tool: 中央寄せの控えめなシステム行 (デフォルト閉じ) -->
         <details
-          v-if="ev.kind === 'thinking' || ev.kind === 'tool'"
+          v-else-if="ev.kind === 'thinking' || ev.kind === 'tool'"
           :data-ev="i"
           :open="defaultOpen(ev.kind)"
           class="scroll-mt-2"

--- a/apps/renderer/src/features/sidebar/SessionLogTranscript.vue
+++ b/apps/renderer/src/features/sidebar/SessionLogTranscript.vue
@@ -226,6 +226,13 @@ function jumpToLatest() {
 // その場合 pendingScrollTs を宙に残さないよう初回適用直後にクリアする (rendered が永遠に
 // 発火しないため、補正経路だけに掃除を任せられない)。
 let pendingScrollTs: string | undefined;
+
+// 次の parsed watch で 1 度だけボトム追従を抑止するフラグ。明示スクロール (時刻ジャンプ /
+// rewind 枝切替) は parsed を差し替えるが分岐点 / seek 位置を保ちたい。pendingScrollTs を
+// 抑止判定に使うと markdown 補正用に残った値が後続のライブ refresh のボトム追従まで誤抑止する
+// (rendered 不発火で残るケース)。抑止は scrollTo watch が立てて parsed watch が 1 回で消す
+// 専用フラグに分離し、pendingScrollTs (補正用) の生存と切り離す。
+let bottomFollowSkipOnce = false;
 const hasMarkdownEvent = (): boolean => props.parsed.events.some((ev) => ev.kind === "assistant");
 
 function applyScroll(ts: string) {
@@ -249,6 +256,9 @@ watch(
   () => props.scrollTo,
   (next) => {
     if (next === undefined) return;
+    // 同 tick で起きる parsed 差し替え (枝切替) のボトム追従を 1 回だけ抑止する。この watch は
+    // parsed watch より先に登録されるため、同期でフラグを立てれば後続の parsed watch が見られる。
+    bottomFollowSkipOnce = true;
     void scrollToTarget(next.ts);
   },
 );
@@ -345,10 +355,13 @@ watch(
     const wasAtBottom = computeAtBottom();
     await nextTick();
     setupObserver();
-    // 明示スクロール (時刻ジャンプ / rewind 枝切替) が保留中ならボトム追従しない。枝切替は
-    // parsed を差し替えるためこの watch が走るが、ライブ追記と違い分岐点へ寄せたい。scrollTo
-    // watch (この watch より先に登録) が pendingScrollTs を同期セットするため、ここで見て回避する。
-    if (pendingScrollTs !== undefined) return;
+    // 明示スクロール (時刻ジャンプ / rewind 枝切替) 由来の parsed 差し替えならボトム追従しない。
+    // 枝切替はこの watch を走らせるが、ライブ追記と違い分岐点 / seek 位置へ寄せたい。scrollTo
+    // watch (この watch より先に登録) が同期で立てたフラグを 1 回で消費して回避する。
+    if (bottomFollowSkipOnce) {
+      bottomFollowSkipOnce = false;
+      return;
+    }
     // ボトムにいたら追従、離れていたら通知ボタンを出して位置を保つ。離れている間は
     // 保留中の追従要求もクリアし、後から markdown 描画が来てもボトムへ引き戻さない。
     if (wasAtBottom) {

--- a/apps/renderer/src/features/sidebar/sessionLog.test.ts
+++ b/apps/renderer/src/features/sidebar/sessionLog.test.ts
@@ -525,6 +525,152 @@ describe("parseSessionLog", () => {
     ]);
   });
 
+  test("rewind: 分岐の親が透過ノード (system) でも会話的親 (直前の assistant) を branchKey にする", () => {
+    // 実ログ形: user → assistant → system → system → user×2。turn 境界の system を跨いで
+    // 会話的親 a1 を branchKey に解決できることを踏む。
+    const log = parseSessionLog(
+      jsonl(
+        {
+          type: "user",
+          uuid: "u1",
+          parentUuid: null,
+          timestamp: TS,
+          message: { role: "user", content: "?" },
+        },
+        {
+          type: "assistant",
+          uuid: "a1",
+          parentUuid: "u1",
+          timestamp: TS,
+          message: { role: "assistant", content: [{ type: "text", text: "どうぞ" }] },
+        },
+        { type: "system", uuid: "s1", parentUuid: "a1", timestamp: TS },
+        { type: "system", uuid: "s2", parentUuid: "s1", timestamp: TS },
+        {
+          type: "user",
+          uuid: "b1",
+          parentUuid: "s2",
+          timestamp: TS,
+          message: { role: "user", content: "週末の天気は？" },
+        },
+        {
+          type: "user",
+          uuid: "b2",
+          parentUuid: "s2",
+          timestamp: TS,
+          message: { role: "user", content: "昨日の天気は？" },
+        },
+      ),
+    );
+    expect(log.events).toEqual([
+      { kind: "user", text: "?", ts: TS },
+      { kind: "assistant", text: "どうぞ", ts: TS },
+      {
+        kind: "branch",
+        ts: TS,
+        branchKey: "a1",
+        selectedChildUuid: "b2",
+        options: [
+          { childUuid: "b1", index: 1, lead: "週末の天気は？", ts: TS },
+          { childUuid: "b2", index: 2, lead: "昨日の天気は？", ts: TS },
+        ],
+      },
+      { kind: "user", text: "昨日の天気は？", ts: TS },
+    ]);
+  });
+
+  // ネスト分岐: 最新枝 (b2) の配下でさらに rewind して 2 段目の分岐が生じる。
+  const nestedLog = () =>
+    jsonl(
+      {
+        type: "user",
+        uuid: "u1",
+        parentUuid: null,
+        timestamp: TS,
+        message: { role: "user", content: "?" },
+      },
+      {
+        type: "assistant",
+        uuid: "a1",
+        parentUuid: "u1",
+        timestamp: TS,
+        message: { role: "assistant", content: [{ type: "text", text: "どうぞ" }] },
+      },
+      {
+        type: "user",
+        uuid: "b1",
+        parentUuid: "a1",
+        timestamp: TS,
+        message: { role: "user", content: "外側の旧枝" },
+      },
+      {
+        type: "user",
+        uuid: "b2",
+        parentUuid: "a1",
+        timestamp: TS,
+        message: { role: "user", content: "外側の新枝" },
+      },
+      {
+        type: "assistant",
+        uuid: "a2",
+        parentUuid: "b2",
+        timestamp: TS,
+        message: { role: "assistant", content: [{ type: "text", text: "了解" }] },
+      },
+      {
+        type: "user",
+        uuid: "c1",
+        parentUuid: "a2",
+        timestamp: TS,
+        message: { role: "user", content: "内側の旧枝" },
+      },
+      {
+        type: "user",
+        uuid: "c2",
+        parentUuid: "a2",
+        timestamp: TS,
+        message: { role: "user", content: "内側の新枝" },
+      },
+    );
+
+  test("rewind: ネスト分岐はデフォルトで両段とも最新枝を辿り branch を 2 つ出す", () => {
+    const log = parseSessionLog(nestedLog());
+    const branches = log.events.filter((e) => e.kind === "branch");
+    expect(branches).toEqual([
+      {
+        kind: "branch",
+        ts: TS,
+        branchKey: "a1",
+        selectedChildUuid: "b2",
+        options: [
+          { childUuid: "b1", index: 1, lead: "外側の旧枝", ts: TS },
+          { childUuid: "b2", index: 2, lead: "外側の新枝", ts: TS },
+        ],
+      },
+      {
+        kind: "branch",
+        ts: TS,
+        branchKey: "a2",
+        selectedChildUuid: "c2",
+        options: [
+          { childUuid: "c1", index: 1, lead: "内側の旧枝", ts: TS },
+          { childUuid: "c2", index: 2, lead: "内側の新枝", ts: TS },
+        ],
+      },
+    ]);
+    const userTexts = log.events.filter((e) => e.kind === "user").map((e) => e.text);
+    expect(userTexts).toEqual(["?", "外側の新枝", "内側の新枝"]);
+  });
+
+  test("rewind: 外側で旧枝を選ぶと内側の分岐は経路から外れ消える (分岐はノード単位で独立)", () => {
+    const log = parseSessionLog(nestedLog(), new Map([["a1", "b1"]]));
+    const branches = log.events.filter((e) => e.kind === "branch");
+    // 外側 a1 のみ。b1 配下に分岐は無いので内側 branch は出ない。
+    expect(branches.map((b) => (b.kind === "branch" ? b.branchKey : ""))).toEqual(["a1"]);
+    const userTexts = log.events.filter((e) => e.kind === "user").map((e) => e.text);
+    expect(userTexts).toEqual(["?", "外側の旧枝"]);
+  });
+
   test("base64 image block を data URL の image イベントにする", () => {
     const log = parseSessionLog(
       jsonl({

--- a/apps/renderer/src/features/sidebar/sessionLog.test.ts
+++ b/apps/renderer/src/features/sidebar/sessionLog.test.ts
@@ -525,10 +525,9 @@ describe("parseSessionLog", () => {
     ]);
   });
 
-  test("rewind: 分岐点と prompt の間に透過ノード (system) があっても 2 prompt の共有親で検出する", () => {
-    // 実ログ形: user → assistant → system → system → user×2。rewind は同一 parentUuid で fork
-    // するため 2 つの prompt は直接の親 s2 を共有する。branchKey はその共有親 s2 になり、間の
-    // system は表示されず (skipped)、prompt 検出には影響しない。
+  test("rewind: 分岐の親が透過ノード (system) でも会話的親 (直前の assistant) を branchKey にする", () => {
+    // 実ログ形: user → assistant → system → system → user×2。turn 境界の system を透過して
+    // 会話的親 a1 を branchKey に解決できることを踏む。間の system は表示されず (skipped)。
     const log = parseSessionLog(
       jsonl(
         {
@@ -569,7 +568,7 @@ describe("parseSessionLog", () => {
       {
         kind: "branch",
         ts: TS,
-        branchKey: "s2",
+        branchKey: "a1",
         selectedChildUuid: "b2",
         options: [
           { childUuid: "b1", index: 1, lead: "週末の天気は？", ts: TS },
@@ -578,6 +577,64 @@ describe("parseSessionLog", () => {
       },
       { kind: "user", text: "昨日の天気は？", ts: TS },
     ]);
+  });
+
+  test("rewind: 2 つの prompt の直接親が異なっても (attachment vs system) 会話的親で 1 分岐に束ねる", () => {
+    // 実ログ形 (05b08da3): assistant 応答後に rewind した 2 つの prompt が、一方は attachment、
+    // 他方は system を直接親に持ち、直接 parentUuid は異なる。会話的親 a1 で束ねないと分岐が
+    // 検出されず両 prompt が表示される (= 旧枝混入。本 PR が直す症状の再発)。
+    const log = parseSessionLog(
+      jsonl(
+        {
+          type: "user",
+          uuid: "u1",
+          parentUuid: null,
+          timestamp: TS,
+          message: { role: "user", content: "?" },
+        },
+        {
+          type: "assistant",
+          uuid: "a1",
+          parentUuid: "u1",
+          timestamp: TS,
+          message: { role: "assistant", content: [{ type: "text", text: "どうぞ" }] },
+        },
+        // 旧枝: prompt b1 の直接親は attachment
+        { type: "attachment", uuid: "att1", parentUuid: "a1", timestamp: TS },
+        {
+          type: "user",
+          uuid: "b1",
+          parentUuid: "att1",
+          timestamp: TS,
+          message: { role: "user", content: "旧" },
+        },
+        // 新枝: prompt b2 の直接親は system
+        { type: "system", uuid: "sys1", parentUuid: "a1", timestamp: TS },
+        {
+          type: "user",
+          uuid: "b2",
+          parentUuid: "sys1",
+          timestamp: TS,
+          message: { role: "user", content: "新" },
+        },
+      ),
+    );
+    const branches = log.events.filter((e) => e.kind === "branch");
+    expect(branches).toEqual([
+      {
+        kind: "branch",
+        ts: TS,
+        branchKey: "a1",
+        selectedChildUuid: "b2",
+        options: [
+          { childUuid: "b1", index: 1, lead: "旧", ts: TS },
+          { childUuid: "b2", index: 2, lead: "新", ts: TS },
+        ],
+      },
+    ]);
+    // 旧枝 b1 は表示されず、新枝 b2 のみ。
+    const userTexts = log.events.filter((e) => e.kind === "user").map((e) => e.text);
+    expect(userTexts).toEqual(["?", "新"]);
   });
 
   test("並列 tool 呼び出しは分岐にならず全 tool を表示する (偽分岐の回帰防止)", () => {

--- a/apps/renderer/src/features/sidebar/sessionLog.test.ts
+++ b/apps/renderer/src/features/sidebar/sessionLog.test.ts
@@ -525,9 +525,10 @@ describe("parseSessionLog", () => {
     ]);
   });
 
-  test("rewind: 分岐の親が透過ノード (system) でも会話的親 (直前の assistant) を branchKey にする", () => {
-    // 実ログ形: user → assistant → system → system → user×2。turn 境界の system を跨いで
-    // 会話的親 a1 を branchKey に解決できることを踏む。
+  test("rewind: 分岐点と prompt の間に透過ノード (system) があっても 2 prompt の共有親で検出する", () => {
+    // 実ログ形: user → assistant → system → system → user×2。rewind は同一 parentUuid で fork
+    // するため 2 つの prompt は直接の親 s2 を共有する。branchKey はその共有親 s2 になり、間の
+    // system は表示されず (skipped)、prompt 検出には影響しない。
     const log = parseSessionLog(
       jsonl(
         {
@@ -568,7 +569,7 @@ describe("parseSessionLog", () => {
       {
         kind: "branch",
         ts: TS,
-        branchKey: "a1",
+        branchKey: "s2",
         selectedChildUuid: "b2",
         options: [
           { childUuid: "b1", index: 1, lead: "週末の天気は？", ts: TS },
@@ -576,6 +577,92 @@ describe("parseSessionLog", () => {
         ],
       },
       { kind: "user", text: "昨日の天気は？", ts: TS },
+    ]);
+  });
+
+  test("並列 tool 呼び出しは分岐にならず全 tool を表示する (偽分岐の回帰防止)", () => {
+    // 実ログ形: 1 ターンで 2 tool を呼ぶと tool_use t1 が「次の tool_use t2」と「自身の
+    // tool_result r1」の 2 子を持つ。これは rewind ではない。子 2 つを分岐とみなすと本流
+    // (t2 以降) を捨て枝として落とすため、tool_use / tool_result は分岐候補から外す。
+    const log = parseSessionLog(
+      jsonl(
+        {
+          type: "user",
+          uuid: "u1",
+          parentUuid: null,
+          timestamp: TS,
+          message: { role: "user", content: "調べて" },
+        },
+        {
+          type: "assistant",
+          uuid: "a1",
+          parentUuid: "u1",
+          timestamp: TS,
+          message: {
+            role: "assistant",
+            content: [{ type: "tool_use", id: "t1", name: "Bash", input: { command: "ls" } }],
+          },
+        },
+        {
+          type: "assistant",
+          uuid: "a2",
+          parentUuid: "a1",
+          timestamp: TS,
+          message: {
+            role: "assistant",
+            content: [{ type: "tool_use", id: "t2", name: "Read", input: { file: "x" } }],
+          },
+        },
+        {
+          type: "user",
+          uuid: "r1",
+          parentUuid: "a1",
+          timestamp: TS,
+          message: {
+            role: "user",
+            content: [{ type: "tool_result", tool_use_id: "t1", content: "out1" }],
+          },
+        },
+        {
+          type: "user",
+          uuid: "r2",
+          parentUuid: "a2",
+          timestamp: TS,
+          message: {
+            role: "user",
+            content: [{ type: "tool_result", tool_use_id: "t2", content: "out2" }],
+          },
+        },
+        {
+          type: "assistant",
+          uuid: "a3",
+          parentUuid: "r2",
+          timestamp: TS,
+          message: { role: "assistant", content: [{ type: "text", text: "終わり" }] },
+        },
+      ),
+    );
+    // 分岐は発生しない。両 tool が結果付きで表示され、本流の text も残る。
+    expect(log.events.some((e) => e.kind === "branch")).toBe(false);
+    expect(log.events).toEqual([
+      { kind: "user", text: "調べて", ts: TS },
+      {
+        kind: "tool",
+        name: "Bash",
+        input: { command: "ls" },
+        toolUseId: "t1",
+        ts: TS,
+        result: { text: "out1", isError: false },
+      },
+      {
+        kind: "tool",
+        name: "Read",
+        input: { file: "x" },
+        toolUseId: "t2",
+        ts: TS,
+        result: { text: "out2", isError: false },
+      },
+      { kind: "assistant", text: "終わり", ts: TS },
     ]);
   });
 

--- a/apps/renderer/src/features/sidebar/sessionLog.test.ts
+++ b/apps/renderer/src/features/sidebar/sessionLog.test.ts
@@ -399,7 +399,130 @@ describe("parseSessionLog", () => {
     const log = parseSessionLog(`${valid}\n{ broken json`);
     expect(log.events).toEqual([{ kind: "user", text: "ok", ts: TS }]);
     expect(log.malformed).toBe(1);
-    expect(log.totalLines).toBe(2);
+    // totalLines は表示した (live な) 行数。parse 不能行は uuid 不明で枝に帰属できないため
+    // malformed に計上して totalLines からは外す (= live 1 行のみ)。
+    expect(log.totalLines).toBe(1);
+  });
+
+  // rewind 分岐: assistant 応答 (a1) を親に user プロンプトが 2 つ (旧 b1 / 新 b2) 生える。
+  // append-only なので b2 が最新。デフォルトは最新枝 (b2) を表示し、その直前に branch を挿す。
+  const rewindLog = () =>
+    jsonl(
+      {
+        type: "user",
+        uuid: "u1",
+        parentUuid: null,
+        timestamp: TS,
+        message: { role: "user", content: "?" },
+      },
+      {
+        type: "assistant",
+        uuid: "a1",
+        parentUuid: "u1",
+        timestamp: TS,
+        message: { role: "assistant", content: [{ type: "text", text: "どうぞ" }] },
+      },
+      // 旧枝 (rewind で捨てられた)
+      {
+        type: "user",
+        uuid: "b1",
+        parentUuid: "a1",
+        timestamp: TS,
+        message: { role: "user", content: "週末の天気は？" },
+      },
+      {
+        type: "assistant",
+        uuid: "c1",
+        parentUuid: "b1",
+        timestamp: TS,
+        message: { role: "assistant", content: [{ type: "text", text: "週末は雨" }] },
+      },
+      // 新枝 (最新)
+      {
+        type: "user",
+        uuid: "b2",
+        parentUuid: "a1",
+        timestamp: TS,
+        message: { role: "user", content: "昨日の天気は？" },
+      },
+      {
+        type: "assistant",
+        uuid: "c2",
+        parentUuid: "b2",
+        timestamp: TS,
+        message: { role: "assistant", content: [{ type: "text", text: "昨日は晴れ" }] },
+      },
+    );
+
+  test("rewind: デフォルトは最新枝を表示し直前に branch セレクタを挿す (捨て枝は出さない)", () => {
+    const log = parseSessionLog(rewindLog());
+    expect(log.events).toEqual([
+      { kind: "user", text: "?", ts: TS },
+      { kind: "assistant", text: "どうぞ", ts: TS },
+      {
+        kind: "branch",
+        ts: TS,
+        branchKey: "a1",
+        selectedChildUuid: "b2",
+        options: [
+          { childUuid: "b1", index: 1, lead: "週末の天気は？", ts: TS },
+          { childUuid: "b2", index: 2, lead: "昨日の天気は？", ts: TS },
+        ],
+      },
+      { kind: "user", text: "昨日の天気は？", ts: TS },
+      { kind: "assistant", text: "昨日は晴れ", ts: TS },
+    ]);
+  });
+
+  test("rewind: selection で旧枝を選ぶとその枝に差し替わる", () => {
+    const log = parseSessionLog(rewindLog(), new Map([["a1", "b1"]]));
+    expect(log.events).toEqual([
+      { kind: "user", text: "?", ts: TS },
+      { kind: "assistant", text: "どうぞ", ts: TS },
+      {
+        kind: "branch",
+        ts: TS,
+        branchKey: "a1",
+        selectedChildUuid: "b1",
+        options: [
+          { childUuid: "b1", index: 1, lead: "週末の天気は？", ts: TS },
+          { childUuid: "b2", index: 2, lead: "昨日の天気は？", ts: TS },
+        ],
+      },
+      { kind: "user", text: "週末の天気は？", ts: TS },
+      { kind: "assistant", text: "週末は雨", ts: TS },
+    ]);
+  });
+
+  test("rewind: 存在しない childUuid 指定は最新枝にフォールバック", () => {
+    const log = parseSessionLog(rewindLog(), new Map([["a1", "nonexistent"]]));
+    const userTexts = log.events.filter((e) => e.kind === "user").map((e) => e.text);
+    expect(userTexts).toEqual(["?", "昨日の天気は？"]);
+  });
+
+  test("rewind 無し (uuid の 1 本道) は全件表示で branch を挿さない", () => {
+    const log = parseSessionLog(
+      jsonl(
+        {
+          type: "user",
+          uuid: "u1",
+          parentUuid: null,
+          timestamp: TS,
+          message: { role: "user", content: "やあ" },
+        },
+        {
+          type: "assistant",
+          uuid: "a1",
+          parentUuid: "u1",
+          timestamp: TS,
+          message: { role: "assistant", content: [{ type: "text", text: "こんにちは" }] },
+        },
+      ),
+    );
+    expect(log.events).toEqual([
+      { kind: "user", text: "やあ", ts: TS },
+      { kind: "assistant", text: "こんにちは", ts: TS },
+    ]);
   });
 
   test("base64 image block を data URL の image イベントにする", () => {

--- a/apps/renderer/src/features/sidebar/sessionLog.ts
+++ b/apps/renderer/src/features/sidebar/sessionLog.ts
@@ -341,12 +341,44 @@ export function parseSessionLog(jsonl: string, selection?: BranchSelection): Par
   }
 
   // --- フェーズ 2: rewind 木を構築し、捨て枝 (非選択候補のサブツリー) を刈る ---
-  // parentUuid → 子 LogNode[] (出現順)。uuid を持つレコードのみ木に参加する。
+  // uuid → LogNode と parentUuid → 子 LogNode[] (出現順)。前者は会話的親の遡上、後者は
+  // サブツリー prune に使う。uuid を持つレコードのみ木に参加する。
+  const byUuid = new Map<string, LogNode>();
   const childrenByParent = new Map<string, LogNode[]>();
   for (const node of nodes) {
     if (node.uuid === "") continue;
+    byUuid.set(node.uuid, node);
     const arr = childrenByParent.get(node.parentUuid);
     if (arr === undefined) childrenByParent.set(node.parentUuid, [node]);
+    else arr.push(node);
+  }
+
+  // 分岐候補ノードの「会話的親」= parentUuid を遡り最初に出会う分岐候補ノードの uuid。無ければ ""。
+  // attachment / system / tool_use / tool_result 等の非候補ノードを透過する。rewind 候補は同一の
+  // 直接親を共有するとは限らない (枝ごとに異なる透過ノードが分岐点と prompt の間に挟まりうる。実ログ
+  // で確認済み: 一方の prompt の親が attachment、他方が system で、共通祖先が会話的親の assistant)。
+  // 会話的親で揃えて初めて同一分岐点として検出できる。
+  const convAncestor = (node: LogNode): string => {
+    let cur = node.parentUuid;
+    const guard = new Set<string>(); // 循環参照ガード (信頼境界外データ)
+    while (cur !== "" && !guard.has(cur)) {
+      guard.add(cur);
+      const p = byUuid.get(cur);
+      if (p === undefined) return ""; // 親不在 (fork コピー / 欠落) は ROOT 扱いで遡上打ち切り
+      if (isBranchCandidate(p.raw)) return cur;
+      cur = p.parentUuid;
+    }
+    return "";
+  };
+
+  // 会話的親 uuid ("" = ROOT) → 分岐候補の子 LogNode[] (出現順)。同一会話的親に候補が 2 つ以上
+  // 並ぶ箇所が rewind 分岐。tool_use / tool_result は候補でないため並列 tool の DAG は分岐にならない。
+  const convChildren = new Map<string, LogNode[]>();
+  for (const node of nodes) {
+    if (node.uuid === "" || !isBranchCandidate(node.raw)) continue;
+    const key = convAncestor(node);
+    const arr = convChildren.get(key);
+    if (arr === undefined) convChildren.set(key, [node]);
     else arr.push(node);
   }
 
@@ -365,15 +397,14 @@ export function parseSessionLog(jsonl: string, selection?: BranchSelection): Par
     }
   };
 
-  // 分岐点を検出する。同一親に分岐候補が 2 つ以上並ぶ箇所が rewind 分岐。非選択候補のサブツリーを
+  // 分岐点を検出する。同一会話的親に分岐候補が 2 つ以上並ぶ箇所が rewind 分岐。非選択候補のサブツリーを
   // 刈り、選択枝の先頭に branch イベントを用意する。処理順は結果に影響しない (各分岐点は独立に
   // 自分の非選択候補だけを刈り、pruned は冪等な集合のため)。
-  for (const [parent, kids] of childrenByParent) {
-    const candidates = kids.filter((k) => isBranchCandidate(k.raw));
+  for (const [ancestor, candidates] of convChildren) {
     if (candidates.length < 2) continue;
     // 選択: selection 指定が候補にあればそれ、無ければ最新 (出現順で最後)。
     let selected = candidates[candidates.length - 1];
-    const sel = selection?.get(parent);
+    const sel = selection?.get(ancestor);
     if (sel !== undefined) {
       const found = candidates.find((c) => c.uuid === sel);
       if (found !== undefined) selected = found;
@@ -384,7 +415,7 @@ export function parseSessionLog(jsonl: string, selection?: BranchSelection): Par
     branchAtChild.set(selected.uuid, {
       kind: "branch",
       ts: selected.raw.timestamp ?? "",
-      branchKey: parent,
+      branchKey: ancestor,
       selectedChildUuid: selected.uuid,
       options: candidates.map((c, i) => ({
         childUuid: c.uuid,

--- a/apps/renderer/src/features/sidebar/sessionLog.ts
+++ b/apps/renderer/src/features/sidebar/sessionLog.ts
@@ -21,10 +21,15 @@
 //
 // rewind 対応: Claude Code の JSONL は append-only で、rewind しても旧レコードを消さず過去の
 // uuid を parentUuid に指して新レコードを追記する。このため uuid/parentUuid は木 (DAG) を成し、
-// 行を逐次読むと捨てられた枝も混ざる。parseSessionLog は会話ノード (user 非meta / assistant) で
-// 木を組み、各分岐点で「選択中 (未選択なら最新) の子」へ下る 1 本道だけをイベント化する。
-// 分岐点 (会話子が 2 つ以上) では選択枝の先頭に branch イベントを挿し、UI でセレクタを出す。
+// 行を逐次読むと捨てられた枝も混ざる。parseSessionLog は全レコードをファイル順に出しつつ、
+// 捨てられた rewind 枝だけを刈る。分岐点 (同一親に分岐候補が 2 つ以上) で選択中 (未指定なら最新)
+// 以外の候補のサブツリーを除外し、選択枝の先頭に branch イベントを挿して UI でセレクタを出す。
 // rewind は会話木の任意のノードで独立に起きるため、分岐は session 単位ではなくノード単位で扱う。
+//
+// 分岐候補は「実発話 user / text・thinking を持つ assistant」に限定する。並列 tool 呼び出しは
+// 1 つの tool_use が「次の tool_use」と「自身の tool_result」の 2 子を持つ DAG を作るが、これは
+// rewind ではない。子 2 つを機械的に分岐とみなすと本流を捨て枝として落とすため、tool_use /
+// tool_result を候補から外して誤検出を防ぐ (詳細は isBranchCandidate)。
 
 import { tryCatch } from "@gozd/shared";
 
@@ -235,39 +240,49 @@ function toolResultText(content: string | ContentBlock[]): string {
     .join("\n");
 }
 
-/** branchKey (分岐点の会話ノード uuid) → 選択した childUuid。未指定の分岐点は最新枝を採る。 */
+/** branchKey (分岐点 = 候補が共有する親 uuid) → 選択した childUuid。未指定の分岐点は最新枝を採る。 */
 export type BranchSelection = Map<string, string>;
 
-/** parse 済みの 1 行 (会話木の構築に使う最小情報)。 */
+/** parse 済みの 1 行 (rewind 木の構築に使う最小情報)。 */
 interface LogNode {
   raw: RawLine;
   uuid: string; // raw.uuid ?? "" (uuid 無し = 木に参加しない古いログ / 注入レコード)
   parentUuid: string; // raw.parentUuid ?? ""
-  isConv: boolean; // 会話を進めるノード (user 非meta / assistant) か
 }
 
 // 分岐選択肢の lead テキストの最大長。これを超えたら省略記号で切る。
 const LEAD_MAX = 80;
 
 /**
- * 会話を進めるノードか。assistant と「表示対象の user」のみ。attachment / system / isMeta user /
- * 注入 user (system-reminder 等で始まる string) は透過ノード (会話を進めず、rewind 分岐の主体に
- * もならない)。
+ * rewind 分岐の候補ノードか。「同一親に 2 つ以上並ぶと rewind 分岐」とみなせるのは、実発話 user
+ * (text / image を持つ。tool_result / 注入 / meta を除く) と、text / thinking を持つ assistant
+ * (応答の起点。tool_use のみのレコードを除く) だけ。
  *
- * 節点判定はフェーズ 3 の表示判定 (userTextOf) と同一基準にする。基準がずれると、表示されない
- * 注入 user が木の節点になり、同一会話的親に実発話と並んだとき偽の分岐点を生む (選んでも本文は
- * 空、lead も空)。string content は userTextOf で表示可否を判定し、array content (tool_result /
- * image / text) は会話イベントとして必ず節点にする。
+ * これを限定しないと並列 tool 呼び出しの DAG を分岐と誤検出する。Claude Code は 1 ターンで複数
+ * tool を呼ぶと、ある tool_use レコードが「次の tool_use」と「自身の tool_result」の 2 子を持つ
+ * 構造を書く。これは rewind ではないが、子 2 つを機械的に分岐とみなすと本流を捨て枝として落とし、
+ * デフォルト表示から tool 呼び出しが大量に消える。tool_use / tool_result はこの定義で候補から
+ * 外れるため、tool の連鎖は分岐にならない。真の rewind は実発話 / 応答が同一親に複数並ぶ場合のみ。
  */
-function isConvNode(raw: RawLine): boolean {
-  if (raw.type === "assistant") return true;
-  if (raw.type !== "user" || raw.isMeta === true) return false;
+function isBranchCandidate(raw: RawLine): boolean {
   const content = raw.message?.content;
-  if (typeof content === "string") return userTextOf(content) !== undefined;
-  return true;
+  if (raw.type === "user") {
+    if (raw.isMeta === true) return false;
+    if (typeof content === "string") return userTextOf(content) !== undefined;
+    if (Array.isArray(content)) return content.some((b) => b.type === "text" || b.type === "image");
+    return false;
+  }
+  if (raw.type === "assistant" && Array.isArray(content)) {
+    return content.some(
+      (b) =>
+        (b.type === "text" && b.text !== "") ||
+        (b.type === "thinking" && b.thinking !== undefined && b.thinking !== ""),
+    );
+  }
+  return false;
 }
 
-/** 会話ノードの先頭テキスト (分岐選択肢の識別ラベル)。空なら "" 。LEAD_MAX で切る。 */
+/** 分岐候補ノードの先頭テキスト (選択肢の識別ラベル)。空なら "" 。LEAD_MAX で切る。 */
 function nodeLeadText(raw: RawLine): string {
   const content = raw.message?.content;
   let text = "";
@@ -285,70 +300,6 @@ function nodeLeadText(raw: RawLine): string {
   return text.length > LEAD_MAX ? `${text.slice(0, LEAD_MAX)}…` : text;
 }
 
-/** カーソルパス算出の結果。live な会話 uuid 集合と、各枝先頭に挿す branch イベント。 */
-interface LiveBranchResult {
-  // 表示する会話ノードの uuid 集合 (root から各分岐点で選択した子へ下る 1 本道)。
-  liveConv: Set<string>;
-  // 選択中の枝の先頭 childUuid → その直前に挿入する branch イベント。
-  branchAtChild: Map<string, Extract<TranscriptEvent, { kind: "branch" }>>;
-}
-
-/**
- * 会話木を辿り、表示する 1 本道 (カーソルパス) を決める。
- *
- * rewind は会話木の任意のノードで独立に起きる。各分岐点で「選択中の子」を辿り、未選択なら
- * 最新 (出現順で最後 = append-only で最後に追記された枝) を採る。これを root から leaf まで
- * 繰り返した経路が表示対象。分岐点 (会話子が 2 つ以上) では枝先頭に branch イベントを挿す。
- *
- * - byUuid: uuid → LogNode (uuid を持つノードのみ)。透過ノードの会話的親を辿るのに使う。
- * - convChildren: convParent uuid ("" = ROOT) → 会話子 LogNode[] (出現順)。
- */
-function computeLiveBranch(
-  byUuid: Map<string, LogNode>,
-  convChildren: Map<string, LogNode[]>,
-  selection: BranchSelection | undefined,
-): LiveBranchResult {
-  const liveConv = new Set<string>();
-  const branchAtChild = new Map<string, Extract<TranscriptEvent, { kind: "branch" }>>();
-  // 信頼境界外データの循環参照で無限ループしないためのガード。
-  const visited = new Set<string>();
-
-  let parent = "";
-  while (true) {
-    const kids = convChildren.get(parent);
-    if (kids === undefined || kids.length === 0) break;
-    // 選択: selection 指定が kids にあればそれ、無ければ最新 (出現順で最後)。
-    let selected = kids[kids.length - 1];
-    const sel = selection?.get(parent);
-    if (sel !== undefined) {
-      const found = kids.find((k) => k.uuid === sel);
-      if (found !== undefined) selected = found;
-    }
-    if (visited.has(selected.uuid)) break;
-    visited.add(selected.uuid);
-    liveConv.add(selected.uuid);
-
-    // 会話子が 2 つ以上ならここが分岐点。選択枝の先頭に branch セレクタを挿す。
-    if (kids.length >= 2) {
-      branchAtChild.set(selected.uuid, {
-        kind: "branch",
-        ts: selected.raw.timestamp ?? "",
-        branchKey: parent,
-        selectedChildUuid: selected.uuid,
-        options: kids.map((k, i) => ({
-          childUuid: k.uuid,
-          index: i + 1, // 古い順 1 始まり (最新が最大番号)
-          lead: nodeLeadText(k.raw),
-          ts: k.raw.timestamp ?? "",
-        })),
-      });
-    }
-    parent = selected.uuid;
-  }
-
-  return { liveConv, branchAtChild };
-}
-
 /**
  * 生 JSONL を transcript に変換する。
  *
@@ -356,9 +307,11 @@ function computeLiveBranch(
  * 現れる tool_result を tool_use_id で引き当てて同じイベントに result を充填する。これで
  * 「コマンド + 実行結果」が 1 ブロックに畳まれ、時系列上の位置も保たれる。
  *
- * rewind 対応: uuid/parentUuid の会話木を辿り、各分岐点で選択中 (未選択なら最新) の枝だけを
- * 表示する。`selection` で分岐点ごとに別の枝を選べる。uuid を持たないレコード (古いログ /
- * 注入) は木に参加せず常に表示するため、rewind が無いログの挙動は不変。
+ * rewind 対応: 全レコードをファイル順に表示しつつ、捨てられた rewind 枝だけを刈る。分岐点
+ * (同一親に分岐候補が 2 つ以上) で選択中 (未指定なら最新) 以外の候補のサブツリーを除外する。
+ * `selection` で分岐点ごとに別の枝を選べる。並列 tool の DAG は分岐候補にならないため落とさない。
+ * uuid を持たないレコード (古いログ / 注入) は木に参加せず常に表示するため、rewind が無いログの
+ * 挙動は不変。
  */
 export function parseSessionLog(jsonl: string, selection?: BranchSelection): ParsedSessionLog {
   const events: TranscriptEvent[] = [];
@@ -370,9 +323,8 @@ export function parseSessionLog(jsonl: string, selection?: BranchSelection): Par
   let skipped = 0;
   let emptyThinking = 0;
 
-  // --- フェーズ 1: 全行を parse して LogNode に正規化する (会話木の素材) ---
+  // --- フェーズ 1: 全行を parse して LogNode に正規化する (rewind 木の素材) ---
   const nodes: LogNode[] = [];
-  const byUuid = new Map<string, LogNode>();
   for (const line of jsonl.split("\n")) {
     if (line.trim() === "") continue;
     const parsed = tryCatch(() => JSON.parse(line) as RawLine);
@@ -381,55 +333,72 @@ export function parseSessionLog(jsonl: string, selection?: BranchSelection): Par
       continue;
     }
     const raw = parsed.value;
-    const node: LogNode = {
+    nodes.push({
       raw,
       uuid: raw.uuid ?? "",
       parentUuid: typeof raw.parentUuid === "string" ? raw.parentUuid : "",
-      isConv: isConvNode(raw),
-    };
-    if (node.uuid !== "") byUuid.set(node.uuid, node);
-    nodes.push(node);
+    });
   }
 
-  // --- フェーズ 2: 会話木を構築し、表示するカーソルパスを決める ---
-  // 透過ノード (attachment / system 等) を遡って最初に出会う会話ノード uuid。無ければ "" (ROOT)。
-  const convAncestor = (node: LogNode): string => {
-    let cur = node.parentUuid;
-    const guard = new Set<string>(); // 循環参照ガード (信頼境界外データ)
-    while (cur !== "" && !guard.has(cur)) {
-      guard.add(cur);
-      const p = byUuid.get(cur);
-      // 親不在 (fork コピー / 途中欠落) はそこで遡上を打ち切り ROOT 扱いにする。
-      if (p === undefined) return "";
-      if (p.isConv) return cur;
-      cur = p.parentUuid;
-    }
-    return "";
-  };
-  // convParent uuid ("" = ROOT) → 会話子 LogNode[] (出現順)。分岐は uuid ベースでのみ起きるため
-  // uuid を持つ会話ノードだけを節点にする (uuid 無し会話ノードは木外 = 常に表示)。
-  const convChildren = new Map<string, LogNode[]>();
+  // --- フェーズ 2: rewind 木を構築し、捨て枝 (非選択候補のサブツリー) を刈る ---
+  // parentUuid → 子 LogNode[] (出現順)。uuid を持つレコードのみ木に参加する。
+  const childrenByParent = new Map<string, LogNode[]>();
   for (const node of nodes) {
-    if (!node.isConv || node.uuid === "") continue;
-    const cp = convAncestor(node);
-    const arr = convChildren.get(cp);
-    if (arr === undefined) convChildren.set(cp, [node]);
+    if (node.uuid === "") continue;
+    const arr = childrenByParent.get(node.parentUuid);
+    if (arr === undefined) childrenByParent.set(node.parentUuid, [node]);
     else arr.push(node);
   }
-  const { liveConv, branchAtChild } = computeLiveBranch(byUuid, convChildren, selection);
 
-  // 表示対象 (live) か。uuid 無しは木外で常に表示。会話ノードは liveConv 帰属で、透過ノードは
-  // 会話的親が live かで決める (捨て枝に付随する attachment 等を除外する)。
-  const isLive = (node: LogNode): boolean => {
-    if (node.uuid === "") return true;
-    if (node.isConv) return liveConv.has(node.uuid);
-    const cp = convAncestor(node);
-    return cp === "" || liveConv.has(cp);
+  // 選択枝先頭の childUuid → 直前に挿す branch イベント。
+  const branchAtChild = new Map<string, Extract<TranscriptEvent, { kind: "branch" }>>();
+  // 捨て枝 (非選択候補) のサブツリーに属する uuid。表示から除外する。
+  const pruned = new Set<string>();
+  // uuid のサブツリー (自身 + 全子孫) を pruned に入れる。循環 / 既訪問はガードする。
+  const pruneSubtree = (rootUuid: string) => {
+    const stack: string[] = [rootUuid];
+    while (stack.length > 0) {
+      const u = stack.pop();
+      if (u === undefined || pruned.has(u)) continue;
+      pruned.add(u);
+      for (const child of childrenByParent.get(u) ?? []) stack.push(child.uuid);
+    }
   };
 
-  // --- フェーズ 3: カーソルパス上の行だけをイベント化する ---
+  // 分岐点を検出する。同一親に分岐候補が 2 つ以上並ぶ箇所が rewind 分岐。非選択候補のサブツリーを
+  // 刈り、選択枝の先頭に branch イベントを用意する。処理順は結果に影響しない (各分岐点は独立に
+  // 自分の非選択候補だけを刈り、pruned は冪等な集合のため)。
+  for (const [parent, kids] of childrenByParent) {
+    const candidates = kids.filter((k) => isBranchCandidate(k.raw));
+    if (candidates.length < 2) continue;
+    // 選択: selection 指定が候補にあればそれ、無ければ最新 (出現順で最後)。
+    let selected = candidates[candidates.length - 1];
+    const sel = selection?.get(parent);
+    if (sel !== undefined) {
+      const found = candidates.find((c) => c.uuid === sel);
+      if (found !== undefined) selected = found;
+    }
+    for (const cand of candidates) {
+      if (cand.uuid !== selected.uuid) pruneSubtree(cand.uuid);
+    }
+    branchAtChild.set(selected.uuid, {
+      kind: "branch",
+      ts: selected.raw.timestamp ?? "",
+      branchKey: parent,
+      selectedChildUuid: selected.uuid,
+      options: candidates.map((c, i) => ({
+        childUuid: c.uuid,
+        index: i + 1, // 古い順 1 始まり (最新が最大番号)
+        lead: nodeLeadText(c.raw),
+        ts: c.raw.timestamp ?? "",
+      })),
+    });
+  }
+
+  // --- フェーズ 3: 捨て枝以外をファイル順にイベント化する ---
+  // pruned は uuid を持つレコードのみ含む。uuid 無し (古いログ / 注入) は常に表示される。
   for (const node of nodes) {
-    if (!isLive(node)) continue;
+    if (pruned.has(node.uuid)) continue;
     totalLines++;
     // この行が分岐の選択枝の先頭なら、直前に branch セレクタを挿す。
     const branch = branchAtChild.get(node.uuid);

--- a/apps/renderer/src/features/sidebar/sessionLog.ts
+++ b/apps/renderer/src/features/sidebar/sessionLog.ts
@@ -18,6 +18,13 @@
 // 平文の無い thinking (最新モデルの暗号化 signature のみ / フィールド欠落) も載せないが、
 // これは非会話レコードではなく会話イベントの一種なので skipped と混ぜず emptyThinking に
 // 別集計する。footer は両者を別ラベルで示し、件数の意味を 1:1 に保つ。
+//
+// rewind 対応: Claude Code の JSONL は append-only で、rewind しても旧レコードを消さず過去の
+// uuid を parentUuid に指して新レコードを追記する。このため uuid/parentUuid は木 (DAG) を成し、
+// 行を逐次読むと捨てられた枝も混ざる。parseSessionLog は会話ノード (user 非meta / assistant) で
+// 木を組み、各分岐点で「選択中 (未選択なら最新) の子」へ下る 1 本道だけをイベント化する。
+// 分岐点 (会話子が 2 つ以上) では選択枝の先頭に branch イベントを挿し、UI でセレクタを出す。
+// rewind は会話木の任意のノードで独立に起きるため、分岐は session 単位ではなくノード単位で扱う。
 
 import { tryCatch } from "@gozd/shared";
 
@@ -99,6 +106,13 @@ interface RawLine {
   attachment?: RawAttachment;
   // CLI / hook が注入したシステム由来レコード。ユーザー発話ではないので transcript に載せない。
   isMeta?: boolean;
+  // レコードの一意 id と親 id。Claude Code は append-only に書き、rewind 時は過去の uuid を
+  // parentUuid に指して新レコードを追記する (旧枝は消さない)。このため uuid/parentUuid の木に
+  // 分岐が生じ、「現在の会話」は tip から遡る 1 本道になる。rewind 検出の唯一の情報源。
+  // 古いログ / 注入レコードは uuid を持たない (型で排除できないため optional)。parentUuid は
+  // ルートで null になりうる。
+  uuid?: string;
+  parentUuid?: string | null;
 }
 
 // harness / CLI が user role で注入するラッパーで始まる string。これらはユーザーの
@@ -149,6 +163,18 @@ function userTextOf(text: string): string | undefined {
   return text;
 }
 
+/** rewind 分岐の 1 選択肢。`index` は古い順 1 始まり (最新が最大番号)。 */
+interface BranchOption {
+  // この枝の先頭会話ノードの uuid。selection マップのキー兼選択値。
+  childUuid: string;
+  // 表示番号。出現順 (= 古い順) に 1, 2, 3 …。最新枝が最大番号。
+  index: number;
+  // 枝を識別するための先頭テキスト (この枝の最初のプロンプト / 応答の冒頭)。
+  lead: string;
+  // この枝の先頭会話ノードの timestamp。
+  ts: string;
+}
+
 /** transcript の 1 ブロック。discriminated union (kind で分岐) */
 export type TranscriptEvent =
   | { kind: "user"; text: string; ts: string }
@@ -162,11 +188,22 @@ export type TranscriptEvent =
       ts: string;
       result: { text: string; isError: boolean } | undefined;
     }
-  | { kind: "image"; ts: string; src: string | undefined };
+  | { kind: "image"; ts: string; src: string | undefined }
+  // rewind 分岐点。選択中の枝の先頭会話ノードの直前に挿入する。UI はここにセレクタを出し、
+  // 別の枝を選ぶと selection が更新され transcript が再構築される。
+  | {
+      kind: "branch";
+      ts: string;
+      // 分岐点の会話ノード uuid (この枝群の共通の親)。selection マップのキー。
+      branchKey: string;
+      // 現在描画中の枝の childUuid。
+      selectedChildUuid: string;
+      options: BranchOption[];
+    };
 
 export interface ParsedSessionLog {
   events: TranscriptEvent[];
-  /** 読んだ JSONL 行数 */
+  /** 表示した (live な) JSONL 行数。rewind で選ばれなかった枝の行は含まない */
   totalLines: number;
   /** JSON parse に失敗した行数 (末尾の追記途中行など) */
   malformed: number;
@@ -198,14 +235,125 @@ function toolResultText(content: string | ContentBlock[]): string {
     .join("\n");
 }
 
+/** branchKey (分岐点の会話ノード uuid) → 選択した childUuid。未指定の分岐点は最新枝を採る。 */
+export type BranchSelection = Map<string, string>;
+
+/** parse 済みの 1 行 (会話木の構築に使う最小情報)。 */
+interface LogNode {
+  raw: RawLine;
+  uuid: string; // raw.uuid ?? "" (uuid 無し = 木に参加しない古いログ / 注入レコード)
+  parentUuid: string; // raw.parentUuid ?? ""
+  isConv: boolean; // 会話を進めるノード (user 非meta / assistant) か
+}
+
+// 分岐選択肢の lead テキストの最大長。これを超えたら省略記号で切る。
+const LEAD_MAX = 80;
+
+/**
+ * 会話を進めるノードか。user(非meta) / assistant のみ。attachment / system / 注入 user は
+ * 透過ノード (会話を進めず、rewind 分岐の主体にもならない)。rewind は実ユーザー発話 / 応答の
+ * 分岐としてのみ起きるため、この 2 種だけを木の節点とする。
+ */
+function isConvNode(raw: RawLine): boolean {
+  if (raw.type === "assistant") return true;
+  if (raw.type === "user") return raw.isMeta !== true;
+  return false;
+}
+
+/** 会話ノードの先頭テキスト (分岐選択肢の識別ラベル)。空なら "" 。LEAD_MAX で切る。 */
+function nodeLeadText(raw: RawLine): string {
+  const content = raw.message?.content;
+  let text = "";
+  if (typeof content === "string") {
+    text = (raw.type === "user" ? userTextOf(content) : content) ?? "";
+  } else if (Array.isArray(content)) {
+    for (const block of content) {
+      if (block.type === "text") {
+        text = block.text;
+        break;
+      }
+    }
+  }
+  text = text.trim();
+  return text.length > LEAD_MAX ? `${text.slice(0, LEAD_MAX)}…` : text;
+}
+
+/** カーソルパス算出の結果。live な会話 uuid 集合と、各枝先頭に挿す branch イベント。 */
+interface LiveBranchResult {
+  // 表示する会話ノードの uuid 集合 (root から各分岐点で選択した子へ下る 1 本道)。
+  liveConv: Set<string>;
+  // 選択中の枝の先頭 childUuid → その直前に挿入する branch イベント。
+  branchAtChild: Map<string, Extract<TranscriptEvent, { kind: "branch" }>>;
+}
+
+/**
+ * 会話木を辿り、表示する 1 本道 (カーソルパス) を決める。
+ *
+ * rewind は会話木の任意のノードで独立に起きる。各分岐点で「選択中の子」を辿り、未選択なら
+ * 最新 (出現順で最後 = append-only で最後に追記された枝) を採る。これを root から leaf まで
+ * 繰り返した経路が表示対象。分岐点 (会話子が 2 つ以上) では枝先頭に branch イベントを挿す。
+ *
+ * - byUuid: uuid → LogNode (uuid を持つノードのみ)。透過ノードの会話的親を辿るのに使う。
+ * - convChildren: convParent uuid ("" = ROOT) → 会話子 LogNode[] (出現順)。
+ */
+function computeLiveBranch(
+  byUuid: Map<string, LogNode>,
+  convChildren: Map<string, LogNode[]>,
+  selection: BranchSelection | undefined,
+): LiveBranchResult {
+  const liveConv = new Set<string>();
+  const branchAtChild = new Map<string, Extract<TranscriptEvent, { kind: "branch" }>>();
+  // 信頼境界外データの循環参照で無限ループしないためのガード。
+  const visited = new Set<string>();
+
+  let parent = "";
+  while (true) {
+    const kids = convChildren.get(parent);
+    if (kids === undefined || kids.length === 0) break;
+    // 選択: selection 指定が kids にあればそれ、無ければ最新 (出現順で最後)。
+    let selected = kids[kids.length - 1];
+    const sel = selection?.get(parent);
+    if (sel !== undefined) {
+      const found = kids.find((k) => k.uuid === sel);
+      if (found !== undefined) selected = found;
+    }
+    if (visited.has(selected.uuid)) break;
+    visited.add(selected.uuid);
+    liveConv.add(selected.uuid);
+
+    // 会話子が 2 つ以上ならここが分岐点。選択枝の先頭に branch セレクタを挿す。
+    if (kids.length >= 2) {
+      branchAtChild.set(selected.uuid, {
+        kind: "branch",
+        ts: selected.raw.timestamp ?? "",
+        branchKey: parent,
+        selectedChildUuid: selected.uuid,
+        options: kids.map((k, i) => ({
+          childUuid: k.uuid,
+          index: i + 1, // 古い順 1 始まり (最新が最大番号)
+          lead: nodeLeadText(k.raw),
+          ts: k.raw.timestamp ?? "",
+        })),
+      });
+    }
+    parent = selected.uuid;
+  }
+
+  return { liveConv, branchAtChild };
+}
+
 /**
  * 生 JSONL を transcript に変換する。
  *
  * tool_use は出現位置 (assistant ブロック直後) に tool イベントを置き、後続の user 行に
  * 現れる tool_result を tool_use_id で引き当てて同じイベントに result を充填する。これで
  * 「コマンド + 実行結果」が 1 ブロックに畳まれ、時系列上の位置も保たれる。
+ *
+ * rewind 対応: uuid/parentUuid の会話木を辿り、各分岐点で選択中 (未選択なら最新) の枝だけを
+ * 表示する。`selection` で分岐点ごとに別の枝を選べる。uuid を持たないレコード (古いログ /
+ * 注入) は木に参加せず常に表示するため、rewind が無いログの挙動は不変。
  */
-export function parseSessionLog(jsonl: string): ParsedSessionLog {
+export function parseSessionLog(jsonl: string, selection?: BranchSelection): ParsedSessionLog {
   const events: TranscriptEvent[] = [];
   // tool_use_id → 生成済み tool イベント。後続の tool_result を充填する。
   const toolById = new Map<string, Extract<TranscriptEvent, { kind: "tool" }>>();
@@ -215,17 +363,72 @@ export function parseSessionLog(jsonl: string): ParsedSessionLog {
   let skipped = 0;
   let emptyThinking = 0;
 
-  const lines = jsonl.split("\n");
-  for (const line of lines) {
+  // --- フェーズ 1: 全行を parse して LogNode に正規化する (会話木の素材) ---
+  const nodes: LogNode[] = [];
+  const byUuid = new Map<string, LogNode>();
+  for (const line of jsonl.split("\n")) {
     if (line.trim() === "") continue;
-    totalLines++;
-
     const parsed = tryCatch(() => JSON.parse(line) as RawLine);
     if (!parsed.ok) {
       malformed++;
       continue;
     }
     const raw = parsed.value;
+    const node: LogNode = {
+      raw,
+      uuid: raw.uuid ?? "",
+      parentUuid: typeof raw.parentUuid === "string" ? raw.parentUuid : "",
+      isConv: isConvNode(raw),
+    };
+    if (node.uuid !== "") byUuid.set(node.uuid, node);
+    nodes.push(node);
+  }
+
+  // --- フェーズ 2: 会話木を構築し、表示するカーソルパスを決める ---
+  // 透過ノード (attachment / system 等) を遡って最初に出会う会話ノード uuid。無ければ "" (ROOT)。
+  const convAncestor = (node: LogNode): string => {
+    let cur = node.parentUuid;
+    const guard = new Set<string>(); // 循環参照ガード (信頼境界外データ)
+    while (cur !== "" && !guard.has(cur)) {
+      guard.add(cur);
+      const p = byUuid.get(cur);
+      // 親不在 (fork コピー / 途中欠落) はそこで遡上を打ち切り ROOT 扱いにする。
+      if (p === undefined) return "";
+      if (p.isConv) return cur;
+      cur = p.parentUuid;
+    }
+    return "";
+  };
+  // convParent uuid ("" = ROOT) → 会話子 LogNode[] (出現順)。分岐は uuid ベースでのみ起きるため
+  // uuid を持つ会話ノードだけを節点にする (uuid 無し会話ノードは木外 = 常に表示)。
+  const convChildren = new Map<string, LogNode[]>();
+  for (const node of nodes) {
+    if (!node.isConv || node.uuid === "") continue;
+    const cp = convAncestor(node);
+    const arr = convChildren.get(cp);
+    if (arr === undefined) convChildren.set(cp, [node]);
+    else arr.push(node);
+  }
+  const { liveConv, branchAtChild } = computeLiveBranch(byUuid, convChildren, selection);
+
+  // 表示対象 (live) か。uuid 無しは木外で常に表示。会話ノードは liveConv 帰属で、透過ノードは
+  // 会話的親が live かで決める (捨て枝に付随する attachment 等を除外する)。
+  const isLive = (node: LogNode): boolean => {
+    if (node.uuid === "") return true;
+    if (node.isConv) return liveConv.has(node.uuid);
+    const cp = convAncestor(node);
+    return cp === "" || liveConv.has(cp);
+  };
+
+  // --- フェーズ 3: カーソルパス上の行だけをイベント化する ---
+  for (const node of nodes) {
+    if (!isLive(node)) continue;
+    totalLines++;
+    // この行が分岐の選択枝の先頭なら、直前に branch セレクタを挿す。
+    const branch = branchAtChild.get(node.uuid);
+    if (branch !== undefined) events.push(branch);
+
+    const raw = node.raw;
     const ts = raw.timestamp ?? "";
 
     // CLI / hook 注入のシステムレコードはユーザー発話ではないので会話に載せない。

--- a/apps/renderer/src/features/sidebar/sessionLog.ts
+++ b/apps/renderer/src/features/sidebar/sessionLog.ts
@@ -250,14 +250,21 @@ interface LogNode {
 const LEAD_MAX = 80;
 
 /**
- * 会話を進めるノードか。user(非meta) / assistant のみ。attachment / system / 注入 user は
- * 透過ノード (会話を進めず、rewind 分岐の主体にもならない)。rewind は実ユーザー発話 / 応答の
- * 分岐としてのみ起きるため、この 2 種だけを木の節点とする。
+ * 会話を進めるノードか。assistant と「表示対象の user」のみ。attachment / system / isMeta user /
+ * 注入 user (system-reminder 等で始まる string) は透過ノード (会話を進めず、rewind 分岐の主体に
+ * もならない)。
+ *
+ * 節点判定はフェーズ 3 の表示判定 (userTextOf) と同一基準にする。基準がずれると、表示されない
+ * 注入 user が木の節点になり、同一会話的親に実発話と並んだとき偽の分岐点を生む (選んでも本文は
+ * 空、lead も空)。string content は userTextOf で表示可否を判定し、array content (tool_result /
+ * image / text) は会話イベントとして必ず節点にする。
  */
 function isConvNode(raw: RawLine): boolean {
   if (raw.type === "assistant") return true;
-  if (raw.type === "user") return raw.isMeta !== true;
-  return false;
+  if (raw.type !== "user" || raw.isMeta === true) return false;
+  const content = raw.message?.content;
+  if (typeof content === "string") return userTextOf(content) !== undefined;
+  return true;
 }
 
 /** 会話ノードの先頭テキスト (分岐選択肢の識別ラベル)。空なら "" 。LEAD_MAX で切る。 */


### PR DESCRIPTION
## 概要

セッションログビューアで rewind されたセッションを正しく扱えるようにする。これまで rewind しても捨てられた旧枝が最新枝に混ざって表示されていた。本 PR では会話を `uuid`/`parentUuid` の木として扱い、デフォルトで最新枝だけを表示しつつ、分岐点ごとにインラインのセレクタを出して過去の枝を選んで閲覧できるようにする。

## 背景

Claude Code のセッションログ (JSONL) は append-only で、rewind しても旧レコードを削除しない。過去のレコードの `uuid` を `parentUuid` に指して新レコードを追記するため、ログは線形ではなく木 (DAG) を成す。旧実装の `parseSessionLog` は JSONL を 1 行ずつ逐次読みし `uuid`/`parentUuid` を見ていなかったため、捨てられた枝も含めた全レコードが時系列に並んでいた。

レビュー過程で 2 つの重大な問題が判明し、実ログ corpus (約 1150 ファイル) で実証して修正した。

- **並列 tool 呼び出しの偽分岐**: Claude Code は 1 ターンで複数 tool を呼ぶと、ある tool_use レコードが「次の tool_use」と「自身の tool_result」の 2 子を持つ DAG を書く。これを分岐と誤検出すると本流が捨て枝として落ち、tool 呼び出しと結果が大量に消える (実ログで 36 tool 中 33 が消失)。
- **透過ノード経由 rewind の取りこぼし**: rewind の複数候補は同一の直接親を共有するとは限らず、枝ごとに異なる透過ノード (一方は attachment、他方は system) が分岐点と prompt の間に挟まる実ログがある。直接親でグループ化すると分岐を検出できず旧枝が混ざる。

## 変更内容

### 会話木モデルと分岐検出 ( sessionLog.ts )

- `parseSessionLog(jsonl, selection?)` に拡張。全レコードをファイル順に表示しつつ、捨てられた rewind 枝 (非選択候補のサブツリー) だけを刈る prune モデルにする
- 分岐候補を「実発話 user (text/image を持つ。tool_result・注入・meta を除く) / text・thinking を持つ assistant (tool_use のみのレコードを除く)」に限定する。tool_use / tool_result は候補にならないため並列 tool の DAG は分岐にならない
- 分岐候補を `convAncestor` (attachment/system/tool 等の非候補ノードを透過して最初に出会う分岐候補) でグループ化する。同一会話的親に候補が 2 つ以上並ぶ箇所を rewind 分岐とし、その会話的親を branchKey にする
- 分岐点では選択中 (未指定なら最新) 以外の候補のサブツリーを除外し、選択枝の先頭に `branch` イベントを挿す。番号は古い順 1 始まり (最新が最大)
- `uuid` を持たない古いレコード / 注入は木に参加せず常に表示するため、rewind が無いログの挙動は不変

### 分岐セレクタ UI ( SessionLogTranscript.vue / SessionLogDialog.vue )

- `branch` イベントを中央寄せのセレクタ行で描画する。選択中の枝をハイライトし、他をクリックで `select-branch` を emit する
- `SessionLogDialog` は `branchSelections` ( tabId → branchKey → childUuid ) を持ち、`parsedSessions` computed が selection 依存で再 parse する。選択はライブ refresh を跨いで保持し、別セッション load でクリアする

### スクロール位置の保持

- 枝切替は `parsed` を差し替えるため `parsed` watch のボトム追従が誤発火し分岐点を見失う問題があった。枝切替を時刻ジャンプとして扱い、専用フラグ `bottomFollowSkipOnce` で 1 回だけボトム追従を抑止して選択枝の先頭 (分岐点) へ寄せる。markdown 高さ補正用の `pendingScrollTs` とは切り離し、補正値が残ってもライブ追従を誤抑止しない

### テスト

- rewind の分岐検出・selection 切替・ネスト分岐・透過ノード経由・直接親が異なる rewind・並列 tool の非分岐 (回帰防止) を追加

## 確認事項

- [x] rewind があるセッションでデフォルトが最新枝のみになる ( 実ログ 48324169 / 05b08da3 で検証 )
- [x] 並列 tool セッションで tool 呼び出しが消えない ( 実ログ a350ac80 で 36/36 表示を確認 )
- [ ] **スクロール挙動の再確認 (要実機)**: 「最新枝で分岐点までスクロール → #1 に切替 → #2 に戻す」で分岐点位置が保たれる ( bottom に飛ばない )。スクロール抑止を `bottomFollowSkipOnce` に作り替えたため、初回確認時の実装から変わっている
