### PR TITLE
fix(git-graph): pin HEAD lane to a reserved fixed color

### DIFF
--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -4,7 +4,7 @@ Git commit graph showing the current worktree branch and the default branch.
 ## Structure
 
 - Working Tree row: sticky header outside scroll area, with status icons and dot on lane 0
-- Connector line: dashed SVG path from lane 0 top to HEAD lane (straight if same lane, Bézier curve otherwise)
+- Connector line: dashed SVG path straight down lane 0 from the top to the HEAD row (HEAD is always on lane 0, so no curve is needed)
 - Scrollable commit list: HTML rows for commit data + SVG overlay for graph lines and dots
 - HEAD is pinned to the leftmost lane (lane 0) so it aligns under the Working Tree dot. When HEAD is not the topmost commit, lane 0 is reserved as an empty channel above HEAD so the connector descends without crossing other lanes; commits above HEAD (diverged branches, or HEAD's own children in a detached-HEAD view) are pushed to lanes ≥ 1 and HEAD's children merge back into lane 0 at HEAD's row. See `graphLayout.ts` for the lane assignment
 - HEAD also gets a reserved fixed color (`HEAD_COLOR`) in `graphLayout.ts`, so lane 0 (the current branch line) is always the same color regardless of draw order; other lanes are numbered from 1 to avoid the clash. The Working Tree dot/connector read the HEAD node's color (`headColor`) so they match HEAD instead of being hardcoded
@@ -521,29 +521,14 @@ function rowY(row: number): number {
 
 /**
  * Working Tree 固定行 → HEAD コミットへの接続ダッシュ線パス。
- * lane 0 を垂直に降りて、HEAD の1行上からベジェ曲線で HEAD レーンへ合流する。
- * HEAD が row 0 の場合は直接接続する。
+ * HEAD は表示集合内では常に lane 0 に固定されるため、lane 0 上端から HEAD 行まで降りる垂直直線になる。
  */
 const connectorPath = computed(() => {
   const head = headNode.value;
   if (head === undefined) return "";
 
   const x0 = laneX(0);
-  const xHead = laneX(head.node.lane);
-  const headIndex = head.index;
-  const headY = rowY(headIndex);
-
-  // HEAD が lane 0 にいる場合: 垂直直線のみ
-  if (x0 === xHead) {
-    return `M${x0},0L${x0},${headY}`;
-  }
-
-  // lane 0 を垂直に降りて、HEAD の1行上からベジェ曲線で合流。
-  // HEAD が row 0 の場合は turnY = 0 となり、垂直部分なしで直接カーブする。
-  const turnY = headIndex > 0 ? rowY(headIndex - 1) : 0;
-  const span = headY - turnY;
-  const d = span * 0.8;
-  return `M${x0},0L${x0},${turnY}C${x0},${turnY + d} ${xHead},${headY - d} ${xHead},${headY}`;
+  return `M${x0},0L${x0},${rowY(head.index)}`;
 });
 
 /** ブランチの色パレット */
@@ -723,10 +708,10 @@ function selectedIndex(): number {
 
 /** 選択を Uncommitted Changes に戻し、HEAD コミット付近にスクロール */
 function scrollHeadIntoView() {
-  const index = layout.value.nodes.findIndex((n) => n.commit.refs.includes("HEAD"));
-  if (index === -1) return;
+  const head = headNode.value;
+  if (head === undefined) return;
   gitGraphStore.resetSelection();
-  scrollToCenter(index);
+  scrollToCenter(head.index);
 }
 
 /** 指定行をビューポート中央にスクロール */

--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -7,6 +7,7 @@ Git commit graph showing the current worktree branch and the default branch.
 - Connector line: dashed SVG path from lane 0 top to HEAD lane (straight if same lane, Bézier curve otherwise)
 - Scrollable commit list: HTML rows for commit data + SVG overlay for graph lines and dots
 - HEAD is pinned to the leftmost lane (lane 0) so it aligns under the Working Tree dot. When HEAD is not the topmost commit, lane 0 is reserved as an empty channel above HEAD so the connector descends without crossing other lanes; commits above HEAD (diverged branches, or HEAD's own children in a detached-HEAD view) are pushed to lanes ≥ 1 and HEAD's children merge back into lane 0 at HEAD's row. See `graphLayout.ts` for the lane assignment
+- HEAD also gets a reserved fixed color (`HEAD_COLOR`) in `graphLayout.ts`, so lane 0 (the current branch line) is always the same color regardless of draw order; other lanes are numbered from 1 to avoid the clash. The Working Tree dot/connector read the HEAD node's color (`headColor`) so they match HEAD instead of being hardcoded
 - CommitDetailPane is shown as a toggleable right pane inside the graph
 - Commits are stored in `useGitGraphStore` and shared with ChangesPane
 
@@ -132,11 +133,23 @@ function recomputeLayout() {
   });
 }
 
-/** HEAD ノードのレーン番号。接続線の描画に使用 */
-const headLane = computed(() => {
-  const node = layout.value.nodes.find((n) => n.commit.refs.includes("HEAD"));
-  return node?.lane ?? 0;
+/**
+ * refs に "HEAD" を持つ表示中ノードとその行番号。
+ * Working Tree 行の接続線・色、HEAD レーン番号の単一導出元 (SSOT)。
+ */
+const headNode = computed(() => {
+  const index = layout.value.nodes.findIndex((n) => n.commit.refs.includes("HEAD"));
+  if (index === -1) return undefined;
+  return { node: layout.value.nodes[index], index };
 });
+
+/**
+ * HEAD ノードの色インデックス。Working Tree のドット/接続線を HEAD レーンと同色に揃える。
+ * HEAD は lane 0 上で HEAD コミットの真上に乗る存在なので、HEAD が tip で
+ * teal 以外の色になっても Working Tree 側を追従させて色の食い違いを防ぐ。
+ * HEAD 不在時は colorFor(0) = teal にフォールバックする。
+ */
+const headColor = computed(() => headNode.value?.node.color ?? 0);
 
 // 以下 3 つの「前回値」は **active worktree dir に対する不変条件** として保持する。
 // 全 worktree watch / 全 worktree push 設計では、別 worktree の
@@ -512,11 +525,12 @@ function rowY(row: number): number {
  * HEAD が row 0 の場合は直接接続する。
  */
 const connectorPath = computed(() => {
-  const x0 = laneX(0);
-  const xHead = laneX(headLane.value);
-  const headIndex = layout.value.nodes.findIndex((n) => n.commit.refs.includes("HEAD"));
-  if (headIndex === -1) return "";
+  const head = headNode.value;
+  if (head === undefined) return "";
 
+  const x0 = laneX(0);
+  const xHead = laneX(head.node.lane);
+  const headIndex = head.index;
   const headY = rowY(headIndex);
 
   // HEAD が lane 0 にいる場合: 垂直直線のみ
@@ -1058,8 +1072,8 @@ const isWorkingTreeActive = computed(
               :cx="laneX(0)"
               :cy="ROW_HEIGHT / 2"
               :r="isWorkingTreeActive ? DOT_RADIUS + 1 : DOT_RADIUS"
-              :fill="isWorkingTreeActive ? '#4ec9b0' : '#1c1c1c'"
-              stroke="#4ec9b0"
+              :fill="isWorkingTreeActive ? colorFor(headColor) : '#1c1c1c'"
+              :stroke="colorFor(headColor)"
               stroke-width="2"
             />
             <line
@@ -1067,7 +1081,7 @@ const isWorkingTreeActive = computed(
               :y1="ROW_HEIGHT / 2 + DOT_RADIUS"
               :x2="laneX(0)"
               :y2="ROW_HEIGHT"
-              stroke="#4ec9b0"
+              :stroke="colorFor(headColor)"
               stroke-width="2"
               stroke-dasharray="4 2"
             />
@@ -1102,7 +1116,7 @@ const isWorkingTreeActive = computed(
                 v-if="connectorPath"
                 :d="connectorPath"
                 fill="none"
-                stroke="#4ec9b0"
+                :stroke="colorFor(headColor)"
                 stroke-width="2"
                 stroke-dasharray="4 2"
               />

--- a/apps/renderer/src/features/git-graph/graphLayout.test.ts
+++ b/apps/renderer/src/features/git-graph/graphLayout.test.ts
@@ -141,6 +141,17 @@ describe("computeGraphLayout の HEAD 最左固定", () => {
     expect(colors.get("c0")).toBe(HEAD_COLOR);
   });
 
+  test("非 tip な HEAD でも固定色 (HEAD_COLOR) を割り当て、子は別色・親系統は同色になる", () => {
+    // c0 が c1 (HEAD) を parent に持つ非 tip 構成。isHead && matchingLanes あり経路を踏む。
+    // 子 c0 は lane 1 へ追いやられ別色、HEAD は色 0、HEAD の first parent c2 は lane 0 の色 0 を継ぐ。
+    const commits = [commit("c0", ["c1"]), commit("c1", ["c2"], ["HEAD"]), commit("c2", [])];
+    const colors = colorByHash(computeGraphLayout(commits, { headHash: "c1" }));
+    expect(colors.get("c1")).toBe(HEAD_COLOR);
+    expect(colors.get("c0")).not.toBe(HEAD_COLOR);
+    // HEAD の親系統は lane 0 = current branch の線なので HEAD と同色
+    expect(colors.get("c2")).toBe(HEAD_COLOR);
+  });
+
   test("HEAD 不在なら色 0 を予約せず先頭コミットが色 0 を取る", () => {
     const commits = [commit("c0", ["c1"]), commit("c1", [])];
     const colors = colorByHash(computeGraphLayout(commits, { headHash: "missing" }));

--- a/apps/renderer/src/features/git-graph/graphLayout.test.ts
+++ b/apps/renderer/src/features/git-graph/graphLayout.test.ts
@@ -12,6 +12,14 @@ function laneByHash(layout: ReturnType<typeof computeGraphLayout>): Map<string, 
   return new Map(layout.nodes.map((n) => [n.commit.hash, n.lane]));
 }
 
+/** hash → color の引きやすいマップに変換する */
+function colorByHash(layout: ReturnType<typeof computeGraphLayout>): Map<string, number> {
+  return new Map(layout.nodes.map((n) => [n.commit.hash, n.color]));
+}
+
+/** HEAD 専用に予約する色インデックス (graphLayout.ts の HEAD_COLOR と一致) */
+const HEAD_COLOR = 0;
+
 describe("computeGraphLayout の HEAD 最左固定", () => {
   test("HEAD が表示順の先頭なら最左 lane (0) に置く", () => {
     const commits = [commit("c0", ["c1"], ["HEAD"]), commit("c1", ["c2"]), commit("c2", [])];
@@ -107,6 +115,36 @@ describe("computeGraphLayout の HEAD 最左固定", () => {
     expect(lanes.get("a")).toBeGreaterThan(0);
     expect(lanes.get("b")).toBeGreaterThan(0);
     expect(lanes.get("c")).toBe(0);
+  });
+
+  test("HEAD には固定色 (HEAD_COLOR) を割り当て、上に並ぶ他枝には別色を割り当てる", () => {
+    // バグ再現形: HEAD が tip で、上に divergent な origin 枝が並ぶ。
+    // 先着順採番だと origin が色 0 を取り HEAD が色 1 になり、Working Tree (常に色 0) と
+    // 食い違う。HEAD_COLOR 予約により HEAD=0 / origin≠0 になることを確認する。
+    const commits = [
+      commit("o0", ["o1"]),
+      commit("o1", ["base"]),
+      commit("h0", ["base"], ["HEAD"]),
+      commit("base", []),
+    ];
+    const colors = colorByHash(computeGraphLayout(commits, { headHash: "h0" }));
+    expect(colors.get("h0")).toBe(HEAD_COLOR);
+    expect(colors.get("o0")).not.toBe(HEAD_COLOR);
+    expect(colors.get("o1")).not.toBe(HEAD_COLOR);
+    // 共通祖先は HEAD 系統 (lane 0) に合流するので HEAD と同色になる
+    expect(colors.get("base")).toBe(HEAD_COLOR);
+  });
+
+  test("HEAD が表示先頭でも固定色 (HEAD_COLOR) を割り当てる", () => {
+    const commits = [commit("c0", ["c1"], ["HEAD"]), commit("c1", ["c2"]), commit("c2", [])];
+    const colors = colorByHash(computeGraphLayout(commits, { headHash: "c0" }));
+    expect(colors.get("c0")).toBe(HEAD_COLOR);
+  });
+
+  test("HEAD 不在なら色 0 を予約せず先頭コミットが色 0 を取る", () => {
+    const commits = [commit("c0", ["c1"]), commit("c1", [])];
+    const colors = colorByHash(computeGraphLayout(commits, { headHash: "missing" }));
+    expect(colors.get("c0")).toBe(0);
   });
 
   test("headHash が表示集合に存在しない (maxCount 打ち切り等) 場合は従来レイアウト", () => {

--- a/apps/renderer/src/features/git-graph/graphLayout.ts
+++ b/apps/renderer/src/features/git-graph/graphLayout.ts
@@ -66,9 +66,15 @@ interface LaneState {
   originLane?: number;
 }
 
+/** HEAD レーン専用に予約する色インデックス。lane 0 = current branch の線を常にこの色で示し、
+ *  Working Tree 行のドット/接続線と色を揃える。他レーンは 1 以降を採番して衝突を避ける。 */
+const HEAD_COLOR = 0;
+
 /**
- * @param headHash HEAD コミットの hash。指定すると HEAD を最左 lane (lane 0) に固定する。
- *   HEAD が表示順で先頭でないときは lane 0 を空きチャンネルとして予約し、子があれば lane 0 へ合流させる
+ * @param headHash HEAD コミットの hash。指定すると HEAD を最左 lane (lane 0) に固定し、
+ *   色も HEAD_COLOR (0) に固定する。HEAD が表示順で先頭でないときは lane 0 を空きチャンネルとして
+ *   予約し、子があれば lane 0 へ合流させる。HEAD が表示集合に存在する間は他レーンの採番を 1 から
+ *   始めて HEAD_COLOR の衝突を避ける
  */
 export function computeGraphLayout(
   commits: GitCommit[],
@@ -88,7 +94,9 @@ export function computeGraphLayout(
   const reserveHeadLane = headRow > 0;
 
   const activeLanes: (LaneState | undefined)[] = [];
-  let nextColor = 0;
+  // HEAD が表示集合内にあるなら色 0 は HEAD 専用に予約し、他レーンは 1 から採番する。
+  // HEAD 不在 (headRow < 0) なら予約不要なので従来どおり 0 から採番する。
+  let nextColor = headRow >= 0 ? 1 : 0;
   let maxLanes = 0;
 
   const nodes: GraphNode[] = [];
@@ -109,14 +117,18 @@ export function computeGraphLayout(
     let lane: number;
     let color: number;
 
+    const isHead = row === headRow;
     // HEAD 到達前は lane 0 を予約 (空き探索の下限を 1 に上げる) し、HEAD に確保しておく
     const minLane = reserveHeadLane && row < headRow ? 1 : 0;
 
-    if (reserveHeadLane && row === headRow) {
-      // 予約しておいた最左 lane に HEAD を固定する。HEAD に子がある (matchingLanes あり) 場合も
-      // ここを優先し、子の各レーンを下の合流処理で lane 0 へ寄せる。色は最初の子レーンを継ぐ
-      lane = 0;
-      color = matchingLanes.length > 0 ? activeLanes[matchingLanes[0]]!.color : nextColor++;
+    if (isHead) {
+      // HEAD は常に最左 lane (lane 0) と固定色 (HEAD_COLOR) に置く。
+      // 予約中 (headRow > 0) は確保済みの lane 0、HEAD が表示先頭 (headRow === 0) なら
+      // 貪欲割り当てでも lane 0 になる。子がある (matchingLanes あり) 場合も lane 0 を優先し、
+      // 子の各レーンを下の合流処理で lane 0 へ寄せる。色は子に追従せず HEAD_COLOR に固定して
+      // lane 0 = current branch の線を常に同色にし、Working Tree 行と揃える
+      lane = reserveHeadLane ? 0 : findEmptyLane(activeLanes, minLane);
+      color = HEAD_COLOR;
     } else if (matchingLanes.length > 0) {
       lane = matchingLanes[0];
       color = activeLanes[lane]!.color;


### PR DESCRIPTION
## 概要

Git Graph で Working Tree のドット（teal）と HEAD コミットのドット（blue 等）の色が食い違うバグを修正する。HEAD レーン（lane 0 = current branch の線）に専用の固定色を予約し、Working Tree のドット/接続線をその色に追従させることで、両者を常に同色で揃える。

## 背景

HEAD を最左レーン（lane 0）に固定する変更を入れたが、色の割り当ては別ロジックのままだった。色採番はグラフを上から走査して先着順に `nextColor++` する方式で、HEAD かどうかを考慮していなかった。

その結果、HEAD が tip で、HEAD 行より上に divergent なコミット（`origin/main` 等）が並ぶケースでは、上の枝が先に色 0（teal）を奪い、HEAD は後着で色 1（blue）になっていた。Working Tree のドット/接続線は `#4ec9b0`（teal）をハードコードしていたため、「Working Tree=teal / HEAD=blue」で色が食い違っていた。

当初は Working Tree を HEAD の色に追従させる対症療法を検討したが、先着順採番という根本原因が残るため、レイアウト側で HEAD の色自体を固定する方針に切り替えた。

## 変更内容

### graphLayout.ts（色採番）

- HEAD 専用に色インデックス `HEAD_COLOR = 0` を予約。HEAD は子の色を継がず常にこの色に固定し、lane 0 = current branch の線を常に同色にする
- HEAD が表示集合に存在する間は他レーンの採番を `1` から開始し、teal の衝突を防ぐ。HEAD 不在時は従来どおり `0` から採番
- lane/color 割り当てを `isHead` 判定に統一（従来の `reserveHeadLane && row === headRow` 分岐を一般化）

### GitGraphPane.vue（描画）

- HEAD ノード探索を `headNode` computed に SSOT 化（従来 `headLane`・`connectorPath`・`scrollHeadIntoView`・色ロジックで分散して探索していた）
- Working Tree のドット fill/stroke・ダッシュ線・接続線パスのハードコード `#4ec9b0` を `colorFor(headColor)` に置換し、HEAD ノードの実際の色に追従させる
- HEAD は表示集合内では常に lane 0 に固定されるため、`connectorPath` の到達不能なベジェ合流分岐を削除し垂直直線のみに単純化（lane 固定を導入した前段コミット時点で dead code 化していた）
- `<doc>` ブロックを実態に合わせて更新（色予約と Working Tree 追従の挙動を追記、接続線がベジェではなく常に垂直直線である旨に修正）

### graphLayout.test.ts

- `colorByHash` ヘルパーを追加
- HEAD の色固定を検証するケースを追加: バグ再現形（tip HEAD の上に origin 枝が並ぶ）で HEAD=0 / origin≠0、HEAD 表示先頭でも 0、非 tip HEAD（子を持つ）で HEAD=0 / 子≠0 / HEAD の親系統=0 継承、HEAD 不在では予約しないこと

## 今回含めない点

### 今回は対応しない

- `colorFor` は `COLORS`（8 色）を `% length` で巡回するため、HEAD を除く同時表示レーンが 8 本に達すると色 8 が wrap（8 % 8 = 0）して teal に戻り HEAD と衝突しうる。これは色予約の導入前から存在する wraparound の制約で、実用域（数本のレーン）では発生しないため今回は対象外とする

## 確認事項

- [ ] tip HEAD の上に `origin/main` 等の divergent なコミットが並ぶケースで、HEAD・lane 0 の縦線・Working Tree のドット/接続線がすべて同色（teal）で揃うこと
- [ ] HEAD が表示先頭のケース、HEAD が非 tip（子を持つ detached HEAD）のケースでもレーン・色が破綻しないこと
