### PR TITLE
refactor(test): replace callback polling with AsyncStream barriers

### DIFF
--- a/apps/native/Tests/GozdCoreTests/FSWatcherTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSWatcherTests.swift
@@ -25,6 +25,8 @@ struct FSWatcherTests {
     let testFile = tmpDir.appendingPathComponent("hello.txt")
     try "hello".write(to: testFile, atomically: true, encoding: .utf8)
 
+    // FSEvents kqueue 経路で SUT 側に callback accessor が無い (event は handler への
+    // push 配信のみ)。WaitUntil.swift 規律「使用可: OS event の到達待ち」に該当。
     await waitUntil(
       timeout: .seconds(2),
       description: "hello.txt event",
@@ -58,6 +60,8 @@ struct FSWatcherTests {
 
     try FileManager.default.removeItem(at: testFile)
 
+    // FSEvents kqueue 経路で SUT 側に callback accessor が無い。
+    // WaitUntil.swift 規律「使用可: OS event の到達待ち」に該当。
     await waitUntil(
       timeout: .seconds(2),
       description: "doomed.txt event",
@@ -92,6 +96,8 @@ struct FSWatcherTests {
     let nestedFile = subDir.appendingPathComponent("nested.txt")
     try "nested".write(to: nestedFile, atomically: true, encoding: .utf8)
 
+    // FSEvents kqueue 経路で SUT 側に callback accessor が無い。
+    // WaitUntil.swift 規律「使用可: OS event の到達待ち」に該当。
     await waitUntil(
       timeout: .seconds(2),
       description: "nested.txt event",

--- a/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYManagerTests.swift
@@ -5,18 +5,21 @@ import Testing
 
 // `.serialized` で直列実行する（issue #556 観測項目 4）。並列実行下では複数の PTY が
 // 同時刻に spawn され、CI trace 上で pid 多重化が起きる。`resizeIsSafe` のような
-// timeout 系 flake が再発した時、「どの pid を見ていたのか」をテスト失敗時刻と
-// 一致する spawn pid から目で突き合わせるしか手段が無くなる。
-// 本 suite は ローカル swift test 実測で 1 秒未満、CI macos-26 でも秒オーダー内に収まる
-// ことを想定。直列化による性能劣化は許容範囲。
-@Suite("PTYManager", .serialized)
+// flake が再発した時、「どの pid を見ていたのか」をテスト失敗時刻と一致する spawn pid から
+// 目で突き合わせるしか手段が無くなる。test 自体の決定性は AsyncStream-based barrier で
+// 確保するため CPU 競合を理由とした直列化ではないが、trace 解析容易性のために維持する。
+//
+// `.timeLimit(.minutes(1))` は production 側 bug (AsyncStream.exit が永久に来ない deadlock
+// 等) で test が永久 hang するのを test framework 経由の fail に倒す breaker。個別 test に
+// 経験則 timeout (`.seconds(2)` / `.seconds(3)`) を撒くのは percentile based 確率設計で
+// flake = 0 要件と矛盾するため、suite 単位 1 段に集約する (issue #710 系譜)。
+@Suite("PTYManager", .serialized, .timeLimit(.minutes(1)))
 struct PTYManagerTests {
   @Test("子プロセスの stdout を受け取り、正常終了 (.exited(0)) を検知する")
   func receivesOutputAndExit() async throws {
     testTrace("started")
     defer { testTrace("ended") }
-    let data = DataCollector()
-    let exit = ExitCollector()
+    let bridge = PTYEventBridge()
     let pty = PTYManager()
 
     try pty.spawn(
@@ -26,24 +29,22 @@ struct PTYManagerTests {
       cwd: testCwd,
       rows: 24,
       cols: 80,
-      onData: { data.append($0) },
-      onExit: { exit.set($0) }
+      onData: bridge.onData,
+      onExit: bridge.onExit
     )
 
-    await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
-
+    let (data, reason) = await bridge.consumeUntilExit()
     // pty (tty mode) は ONLCR で \n を \r\n に変換する。
-    let text = String(decoding: data.snapshot(), as: UTF8.self)
+    let text = String(decoding: data, as: UTF8.self)
     #expect(text.contains("hello"))
-    #expect(exit.snapshot() == .exited(code: 0))
+    #expect(reason == .exited(code: 0))
   }
 
   @Test("write した内容を子プロセス経由で読み戻せる（cat エコー）")
   func writeRoundTrip() async throws {
     testTrace("started")
     defer { testTrace("ended") }
-    let data = DataCollector()
-    let exit = ExitCollector()
+    let bridge = PTYEventBridge()
     let pty = PTYManager()
 
     try pty.spawn(
@@ -53,8 +54,8 @@ struct PTYManagerTests {
       cwd: testCwd,
       rows: 24,
       cols: 80,
-      onData: { data.append($0) },
-      onExit: { exit.set($0) }
+      onData: bridge.onData,
+      onExit: bridge.onExit
     )
 
     // 子が execve 段階に到達するまで待つ ( CPty.c の ready pipe barrier を消費 )。
@@ -63,17 +64,28 @@ struct PTYManagerTests {
 
     pty.write(Data("ping\n".utf8))
 
-    await waitUntil(timeout: .seconds(2)) {
-      String(decoding: data.snapshot(), as: UTF8.self).contains("ping")
+    // data event を順に観察し、"ping" 到達で kill → exit event 到達でループ終了。
+    // polling は介在せず production の AsyncStream FIFO が決定的に駆動する。
+    var data = Data()
+    var reason: PTYExitReason?
+    var killed = false
+    for await event in bridge.stream {
+      switch event {
+      case .data(let chunk):
+        data.append(chunk)
+        if !killed && String(decoding: data, as: UTF8.self).contains("ping") {
+          pty.kill()
+          killed = true
+        }
+      case .exit(let r):
+        reason = r
+      }
     }
 
-    pty.kill()
-    await waitUntil(timeout: .seconds(2)) { exit.snapshot() != nil }
-
-    if case .signaled(let sig, _) = exit.snapshot() {
+    if case .signaled(let sig, _) = reason {
       #expect(sig == SIGHUP)
     } else {
-      Issue.record("expected SIGHUP signaled exit, got \(String(describing: exit.snapshot()))")
+      Issue.record("expected SIGHUP signaled exit, got \(String(describing: reason))")
     }
   }
 
@@ -83,8 +95,7 @@ struct PTYManagerTests {
     defer { testTrace("ended") }
     let pty = PTYManager()
     pty.resize(rows: 30, cols: 100)  // fd 未確立: no-op
-    let data = DataCollector()
-    let exit = ExitCollector()
+    let bridge = PTYEventBridge()
     try pty.spawn(
       executable: "/bin/cat",
       args: ["cat"],
@@ -92,21 +103,20 @@ struct PTYManagerTests {
       cwd: testCwd,
       rows: 24,
       cols: 80,
-      onData: { data.append($0) },
-      onExit: { exit.set($0) }
+      onData: bridge.onData,
+      onExit: bridge.onExit
     )
     pty.resize(rows: 40, cols: 120)
     pty.kill()
-    await waitUntil(timeout: .seconds(2)) { exit.snapshot() != nil }
-    #expect(exit.snapshot() != nil)
+    let (_, reason) = await bridge.consumeUntilExit()
+    #expect(reason != nil)
   }
 
   @Test("0 byte 出力で正常終了する child (/usr/bin/true) でも onExit が発火する")
   func zeroByteOutput() async throws {
     testTrace("started")
     defer { testTrace("ended") }
-    let data = DataCollector()
-    let exit = ExitCollector()
+    let bridge = PTYEventBridge()
     let pty = PTYManager()
 
     try pty.spawn(
@@ -116,23 +126,21 @@ struct PTYManagerTests {
       cwd: testCwd,
       rows: 24,
       cols: 80,
-      onData: { data.append($0) },
-      onExit: { exit.set($0) }
+      onData: bridge.onData,
+      onExit: bridge.onExit
     )
 
-    await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
-
+    let (_, reason) = await bridge.consumeUntilExit()
     // /usr/bin/true は何も出力せず exit 0 で終わる。
     // tty mode で promptless なので、データは 0 byte または echo 由来の数 byte のみ。
-    #expect(exit.snapshot() == .exited(code: 0))
+    #expect(reason == .exited(code: 0))
   }
 
   @Test("stderr のみに書く child の出力も master fd から読める")
   func stderrIsCapturedThroughSlave() async throws {
     testTrace("started")
     defer { testTrace("ended") }
-    let data = DataCollector()
-    let exit = ExitCollector()
+    let bridge = PTYEventBridge()
     let pty = PTYManager()
 
     try pty.spawn(
@@ -142,25 +150,23 @@ struct PTYManagerTests {
       cwd: testCwd,
       rows: 24,
       cols: 80,
-      onData: { data.append($0) },
-      onExit: { exit.set($0) }
+      onData: bridge.onData,
+      onExit: bridge.onExit
     )
 
-    await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
-
+    let (data, reason) = await bridge.consumeUntilExit()
     // login_tty で slave fd は stdin/stdout/stderr すべてに dup2 されているため
     // stderr 出力も master 経由で観測できる。
-    let text = String(decoding: data.snapshot(), as: UTF8.self)
+    let text = String(decoding: data, as: UTF8.self)
     #expect(text.contains("stderr-marker"))
-    #expect(exit.snapshot() == .exited(code: 0))
+    #expect(reason == .exited(code: 0))
   }
 
   @Test("存在しない cwd を指定すると exited(code: 124) を返す (chdir 失敗)")
   func chdirFailureReportedAsExit124() async throws {
     testTrace("started")
     defer { testTrace("ended") }
-    let data = DataCollector()
-    let exit = ExitCollector()
+    let bridge = PTYEventBridge()
     let pty = PTYManager()
 
     // 実行時に確実に存在しないパスを動的生成。固定文字列ハードコードだと
@@ -178,20 +184,19 @@ struct PTYManagerTests {
       cwd: nonexistentCwd,
       rows: 24,
       cols: 80,
-      onData: { data.append($0) },
-      onExit: { exit.set($0) }
+      onData: bridge.onData,
+      onExit: bridge.onExit
     )
 
-    await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
-    #expect(exit.snapshot() == .exited(code: 124))
+    let (_, reason) = await bridge.consumeUntilExit()
+    #expect(reason == .exited(code: 124))
   }
 
   @Test("ディレクトリを executable に指定すると exited(code: 126) を返す (execve EACCES)")
   func execveEACCESReportedAsExit126() async throws {
     testTrace("started")
     defer { testTrace("ended") }
-    let data = DataCollector()
-    let exit = ExitCollector()
+    let bridge = PTYEventBridge()
     let pty = PTYManager()
 
     // ディレクトリパスは execute bit が付いていても execve は EACCES を返す
@@ -205,20 +210,19 @@ struct PTYManagerTests {
       cwd: testCwd,
       rows: 24,
       cols: 80,
-      onData: { data.append($0) },
-      onExit: { exit.set($0) }
+      onData: bridge.onData,
+      onExit: bridge.onExit
     )
 
-    await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
-    #expect(exit.snapshot() == .exited(code: 126))
+    let (_, reason) = await bridge.consumeUntilExit()
+    #expect(reason == .exited(code: 126))
   }
 
   @Test("実行できないパス (/path/does/not/exist) は exited(code: 127) を返す")
   func execveENOENTReportedAsExit127() async throws {
     testTrace("started")
     defer { testTrace("ended") }
-    let data = DataCollector()
-    let exit = ExitCollector()
+    let bridge = PTYEventBridge()
     let pty = PTYManager()
 
     try pty.spawn(
@@ -228,14 +232,13 @@ struct PTYManagerTests {
       cwd: testCwd,
       rows: 24,
       cols: 80,
-      onData: { data.append($0) },
-      onExit: { exit.set($0) }
+      onData: bridge.onData,
+      onExit: bridge.onExit
     )
 
-    await waitUntil(timeout: .seconds(3)) { exit.snapshot() != nil }
-
+    let (_, reason) = await bridge.consumeUntilExit()
     // POSIX shell 慣例 / CPty.c の child で execve ENOENT → _exit(127)。
-    #expect(exit.snapshot() == .exited(code: 127))
+    #expect(reason == .exited(code: 127))
   }
 
   @Test("PTYError の description は `PTYError.<case>(errno=<n> <strerror>)` 形式で完全一致する")
@@ -409,45 +412,64 @@ private func expectedErrnoText(_ code: Int32) -> String {
 
 // MARK: - Helpers
 
-// `waitUntil` は `WaitUntil.swift` の共有実装 ( dedicated NSThread 上で polling loop を完結 )。
-// tick polling 履歴を保持し、timeout 時に Issue.record の message に inline する。
-
 // PTY spawn の cwd 引数に渡す「確定的に存在する dir」。`NSTemporaryDirectory()` は
 // macOS の per-user TMPDIR (`/var/folders/...`) を返し、グローバル `/tmp` と異なり
 // マルチユーザー環境 / サンドボックスでも衝突しない ( CLAUDE.md 規約「`/tmp` を
 // ハードコードしない、`NSTemporaryDirectory()` を使う」)。
 private let testCwd = NSTemporaryDirectory()
 
-private final class DataCollector: @unchecked Sendable {
-  private let lock = NSLock()
-  private var data = Data()
-
-  func append(_ chunk: Data) {
-    lock.lock()
-    defer { lock.unlock() }
-    data.append(chunk)
-  }
-
-  func snapshot() -> Data {
-    lock.lock()
-    defer { lock.unlock() }
-    return data
-  }
+private enum PTYTestEvent: Sendable {
+  case data(Data)
+  case exit(PTYExitReason)
 }
 
-private final class ExitCollector: @unchecked Sendable {
-  private let lock = NSLock()
-  private var reason: PTYExitReason?
+/// PTYManager.spawn の `onData` / `onExit` callback を AsyncStream に直結する test 用 bridge。
+///
+/// 設計目的:
+///   - 過去設計 (DataCollector / ExitCollector + NSLock + waitUntil polling) は
+///     production callback を mutable snapshot に変換し、50ms tick で polling する経路。
+///     issue #710 で 2.13s flake が観測された確率的設計
+///   - 本 bridge は production callback を AsyncStream に直結し、`for await` で順序保証
+///     付きに observe する。polling 0 段、timeout 0 段で決定的に駆動される
+///   - 永久 suspend (production 側 bug) は suite trait `.timeLimit(.minutes(1))` が breaker
+///     として吸収する。個別 test に経験則 timeout を撒かない (flake = 0 設計)
+///
+/// 公開 closure (`onData` / `onExit`) は `@Sendable` で `spawn` に直接渡せる。
+/// continuation を init 内で生成して closure に capture することで `@unchecked Sendable`
+/// を回避する (CLAUDE.md 規約)。
+///
+/// **単一 consumer 契約**: `stream` は 1 度だけ iterate すること (`for await` または
+/// `consumeUntilExit()` 1 回)。AsyncStream は single-consumer 契約のため 2 度目の iteration
+/// は未定義動作 (Apple Doc: "iterating an `AsyncStream` more than once results in undefined
+/// behavior")。本 bridge を使う test は spawn → 1 度 consume → assertion の単線フロー
+/// 専用で、複数 phase の event 観察には別 bridge インスタンスを使う。
+private final class PTYEventBridge: Sendable {
+  let onData: @Sendable (Data) -> Void
+  let onExit: @Sendable (PTYExitReason) -> Void
+  let stream: AsyncStream<PTYTestEvent>
 
-  func set(_ value: PTYExitReason) {
-    lock.lock()
-    defer { lock.unlock() }
-    reason = value
+  init() {
+    let (stream, continuation) = AsyncStream<PTYTestEvent>.makeStream()
+    self.stream = stream
+    self.onData = { continuation.yield(.data($0)) }
+    self.onExit = { reason in
+      continuation.yield(.exit(reason))
+      // exit 受信時に AsyncStream を finish。これにより `for await` が決定的に終了する。
+      continuation.finish()
+    }
   }
 
-  func snapshot() -> PTYExitReason? {
-    lock.lock()
-    defer { lock.unlock() }
-    return reason
+  /// data event を accumulate しつつ exit event 到達でループ終了する短縮 helper。
+  /// 中間 interaction (kill / write) を伴わない簡単な test 用。
+  func consumeUntilExit() async -> (Data, PTYExitReason?) {
+    var data = Data()
+    var reason: PTYExitReason?
+    for await event in stream {
+      switch event {
+      case .data(let chunk): data.append(chunk)
+      case .exit(let r): reason = r
+      }
+    }
+    return (data, reason)
   }
 }

--- a/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PTYRegistryTests.swift
@@ -5,19 +5,19 @@ import Testing
 
 // `.serialized` で直列実行する（issue #556 観測項目 4）。
 // PTYManagerTests と同様、複数 PTY の並列 spawn を構造的に消すことで再発時の
-// trace 解析（pid と test の対応復元）を容易にする。
-// PTY を spawn する suite を跨いだ並列実行も避けるため、両 suite を揃って直列化する。
-@Suite("PTYRegistry", .serialized)
+// trace 解析（pid と test の対応復元）を容易にする。test 自体の決定性は AsyncStream-based
+// barrier で確保するため CPU 競合を理由とした直列化ではないが、trace 解析容易性のために維持する。
+//
+// `.timeLimit(.minutes(1))` は production 側 bug (AsyncStream.exit が永久に来ない deadlock
+// 等) で test が永久 hang するのを test framework 経由の fail に倒す breaker (issue #710 系譜)。
+@Suite("PTYRegistry", .serialized, .timeLimit(.minutes(1)))
 struct PTYRegistryTests {
   @Test("spawn は連番の ptyId を返し、onText / onExit が ID 付きで配送される")
   func spawnAndExitDispatch() async throws {
     testTrace("started")
     defer { testTrace("ended") }
-    let events = EventCollector()
-    let registry = PTYRegistry(
-      onText: { id, text in events.appendText(id: id, text: text) },
-      onExit: { id, reason in events.appendExit(id: id, reason: reason) }
-    )
+    let bridge = PTYRegistryEventBridge()
+    let registry = PTYRegistry(onText: bridge.onText, onExit: bridge.onExit)
 
     let id1 = try await registry.spawn(
       executable: "/bin/echo",
@@ -41,23 +41,19 @@ struct PTYRegistryTests {
     // test である本 test の副次 assertion に統合した（PR #597 review feedback）。
     #expect(id2 == id1 + 1)
 
-    await waitUntil(timeout: .seconds(3)) {
-      events.exitedIds().contains(id1) && events.exitedIds().contains(id2)
-    }
-
-    #expect(events.textFor(id: id1).contains("hello"))
-    #expect(events.textFor(id: id2).contains("world"))
+    // 両 PTY の exit event 到達まで決定的に待つ。AsyncStream FIFO が production の
+    // text/exit 順序を保つため polling 不要。
+    let (texts, _) = await bridge.consumeUntilExitedIds([id1, id2])
+    #expect((texts[id1] ?? "").contains("hello"))
+    #expect((texts[id2] ?? "").contains("world"))
   }
 
   @Test("kill 後に PTY が registry から自動削除される")
   func cleanupOnKill() async throws {
     testTrace("started")
     defer { testTrace("ended") }
-    let events = EventCollector()
-    let registry = PTYRegistry(
-      onText: { id, text in events.appendText(id: id, text: text) },
-      onExit: { id, reason in events.appendExit(id: id, reason: reason) }
-    )
+    let bridge = PTYRegistryEventBridge()
+    let registry = PTYRegistry(onText: bridge.onText, onExit: bridge.onExit)
 
     let id = try await registry.spawn(
       executable: "/bin/cat",
@@ -71,9 +67,8 @@ struct PTYRegistryTests {
 
     await registry.kill(id: id)
 
-    await waitUntil(timeout: .seconds(2)) {
-      events.exitedIds().contains(id)
-    }
+    // exit event 到達まで決定的に待つ。
+    _ = await bridge.consumeUntilExitedIds([id])
     // remove は exit handler 経由で `Task { await self.remove }` で発火する。
     // actor 内の Continuation accessor で count==0 到達を待つ。
     await registry.awaitEmpty()
@@ -84,11 +79,8 @@ struct PTYRegistryTests {
   func unknownIdIsNoop() async {
     testTrace("started")
     defer { testTrace("ended") }
-    let events = EventCollector()
-    let registry = PTYRegistry(
-      onText: { id, text in events.appendText(id: id, text: text) },
-      onExit: { id, reason in events.appendExit(id: id, reason: reason) }
-    )
+    let bridge = PTYRegistryEventBridge()
+    let registry = PTYRegistry(onText: bridge.onText, onExit: bridge.onExit)
 
     await registry.write(id: 9999, data: Data("ping\n".utf8))
     await registry.resize(id: 9999, rows: 50, cols: 100)
@@ -103,11 +95,8 @@ struct PTYRegistryTests {
   func expectedResumeSidPopulatedFromEnv() async throws {
     testTrace("started")
     defer { testTrace("ended") }
-    let events = EventCollector()
-    let registry = PTYRegistry(
-      onText: { id, text in events.appendText(id: id, text: text) },
-      onExit: { id, reason in events.appendExit(id: id, reason: reason) }
-    )
+    let bridge = PTYRegistryEventBridge()
+    let registry = PTYRegistry(onText: bridge.onText, onExit: bridge.onExit)
 
     var env = ProcessInfo.processInfo.environment
     env["GOZD_RESUME_CLAUDE_SESSION"] = "expected-sid-X"
@@ -128,11 +117,8 @@ struct PTYRegistryTests {
   func consumeExpectedSidAlwaysConsumes() async throws {
     testTrace("started")
     defer { testTrace("ended") }
-    let events = EventCollector()
-    let registry = PTYRegistry(
-      onText: { id, text in events.appendText(id: id, text: text) },
-      onExit: { id, reason in events.appendExit(id: id, reason: reason) }
-    )
+    let bridge = PTYRegistryEventBridge()
+    let registry = PTYRegistry(onText: bridge.onText, onExit: bridge.onExit)
 
     var env = ProcessInfo.processInfo.environment
     env["GOZD_RESUME_CLAUDE_SESSION"] = "expected-sid-X"
@@ -156,11 +142,8 @@ struct PTYRegistryTests {
   func clearAssociationsLeavesExpectedSid() async throws {
     testTrace("started")
     defer { testTrace("ended") }
-    let events = EventCollector()
-    let registry = PTYRegistry(
-      onText: { id, text in events.appendText(id: id, text: text) },
-      onExit: { id, reason in events.appendExit(id: id, reason: reason) }
-    )
+    let bridge = PTYRegistryEventBridge()
+    let registry = PTYRegistry(onText: bridge.onText, onExit: bridge.onExit)
 
     var env = ProcessInfo.processInfo.environment
     env["GOZD_RESUME_CLAUDE_SESSION"] = "expected-sid-X"
@@ -182,10 +165,11 @@ struct PTYRegistryTests {
 // 登録 / `pidTracker` 加入は全て suspend point の **前** で完了する不変条件を持つ。
 // この suite はその不変条件が並列 spawn でも保たれることを直接 verify する。
 //
-// 親 suite `PTYRegistry` は `.serialized` で直列化されており、並列 spawn の race は
-// 構造的に踏めない。本 suite は default の parallel 実行に置き、`withThrowingTaskGroup`
-// で複数 spawn を同時発射した時の id 採番一意性を assert する。
-@Suite("PTYRegistry.ConcurrentSpawn")
+// **suite 自体は `.serialized`**: 並列 spawn race を発火させる責務は test 内 `withThrowingTaskGroup`
+// で 8 件を同時発射することが担っており、suite を並列実行に置く意義は無い (issue #710 系譜:
+// suite 間並列を消して trace 解析容易性を上げる)。
+// `.timeLimit(.minutes(1))` は production 側 deadlock 検出用 breaker。
+@Suite("PTYRegistry.ConcurrentSpawn", .serialized, .timeLimit(.minutes(1)))
 struct PTYRegistryConcurrentSpawnTests {
   @Test("並列 spawn が一意な ptyId を採番し、並列 remove が actor 上で整合する")
   func concurrentSpawnYieldsUniqueIds() async throws {
@@ -235,41 +219,61 @@ struct PTYRegistryConcurrentSpawnTests {
 
 // MARK: - Helpers
 
-// `waitUntil` は `WaitUntil.swift` の共有実装 ( dedicated NSThread 上で polling loop を完結 )。
-// tick polling 履歴を保持し、timeout 時に Issue.record の message に inline する。
-
 // PTY spawn の cwd 引数に渡す「確定的に存在する dir」。`NSTemporaryDirectory()` は
 // macOS の per-user TMPDIR (`/var/folders/...`) を返し、グローバル `/tmp` と異なり
 // マルチユーザー環境 / サンドボックスでも衝突しない ( CLAUDE.md 規約「`/tmp` を
 // ハードコードしない、`NSTemporaryDirectory()` を使う」)。
 private let testCwd = NSTemporaryDirectory()
 
-private final class EventCollector: @unchecked Sendable {
-  private let lock = NSLock()
-  private var textMap: [UInt32: String] = [:]
-  private var exits: [UInt32: PTYExitReason] = [:]
+private enum PTYRegistryTestEvent: Sendable {
+  case text(UInt32, String)
+  case exit(UInt32, PTYExitReason)
+}
 
-  func appendText(id: UInt32, text: String) {
-    lock.lock()
-    defer { lock.unlock() }
-    textMap[id, default: ""].append(text)
+/// PTYRegistry の `onText` / `onExit` callback を AsyncStream に直結する test 用 bridge。
+///
+/// 設計目的:
+///   - 過去設計 (EventCollector + NSLock + waitUntil polling) は production callback を
+///     mutable snapshot に変換し、50ms tick で polling する確率的経路 (issue #710 系譜)
+///   - 本 bridge は production callback を AsyncStream に直結し、`consumeUntilExitedIds`
+///     で「N 件の id が exit するまで」を決定的に待つ。polling 0 段、timeout 0 段
+///   - 永久 suspend は suite trait `.timeLimit(.minutes(1))` が breaker として吸収する
+///
+/// **単一 consumer 契約**: `stream` は 1 度だけ iterate すること (`consumeUntilExitedIds`
+/// 1 回 または `for await` 1 回)。AsyncStream は single-consumer 契約のため 2 度目の
+/// iteration は未定義動作 (Apple Doc: "iterating an `AsyncStream` more than once results
+/// in undefined behavior")。複数 phase の event 観察には別 bridge インスタンスを使う。
+private final class PTYRegistryEventBridge: Sendable {
+  let onText: @Sendable (UInt32, String) -> Void
+  let onExit: @Sendable (UInt32, PTYExitReason) -> Void
+  let stream: AsyncStream<PTYRegistryTestEvent>
+
+  init() {
+    let (stream, continuation) = AsyncStream<PTYRegistryTestEvent>.makeStream()
+    self.stream = stream
+    self.onText = { continuation.yield(.text($0, $1)) }
+    self.onExit = { continuation.yield(.exit($0, $1)) }
+    // continuation.finish() はここでは呼ばない (複数 PTY の exit を順に受ける)。
+    // consumeUntilExitedIds が break で iteration を終了する。
   }
 
-  func appendExit(id: UInt32, reason: PTYExitReason) {
-    lock.lock()
-    defer { lock.unlock() }
-    exits[id] = reason
-  }
-
-  func textFor(id: UInt32) -> String {
-    lock.lock()
-    defer { lock.unlock() }
-    return textMap[id] ?? ""
-  }
-
-  func exitedIds() -> Set<UInt32> {
-    lock.lock()
-    defer { lock.unlock() }
-    return Set(exits.keys)
+  /// 指定された id 全てが exit するまで event を accumulate する。
+  /// 戻り値は (id → 累積 text, id → exit reason)。
+  func consumeUntilExitedIds(_ targetIds: [UInt32])
+    async -> (texts: [UInt32: String], exits: [UInt32: PTYExitReason])
+  {
+    let targetSet = Set(targetIds)
+    var texts: [UInt32: String] = [:]
+    var exits: [UInt32: PTYExitReason] = [:]
+    for await event in stream {
+      switch event {
+      case .text(let id, let text):
+        texts[id, default: ""].append(text)
+      case .exit(let id, let reason):
+        exits[id] = reason
+      }
+      if targetSet.isSubset(of: Set(exits.keys)) { break }
+    }
+    return (texts, exits)
   }
 }

--- a/apps/native/Tests/GozdCoreTests/RpcDispatcherTests.swift
+++ b/apps/native/Tests/GozdCoreTests/RpcDispatcherTests.swift
@@ -4,7 +4,15 @@ import Testing
 
 @testable import GozdCore
 
-@Suite("RpcDispatcher")
+// `.serialized`: 並列実行下の trace 解析容易性 (issue #556 観測項目 4、PTYManager /
+// PTYRegistry suite と整合)。test 自体の決定性は AsyncStream-based barrier で確保するため
+// 並列 CPU 競合を理由とした追加では無いが、PTY を spawn する suite を揃って直列化する。
+// `.timeLimit(.minutes(1))`: production 側 bug (AsyncStream.exit が永久に来ない deadlock 等)
+// で test が永久 hang するのを test framework 経由の fail に倒す breaker。個別 test に
+// 経験則 timeout (`.seconds(2)` / `.seconds(3)`) を撒くのは percentile based 確率設計で
+// flake = 0 要件と矛盾するため、suite 単位 1 段に集約する。.minutes(1) は Swift Testing
+// の最小粒度。
+@Suite("RpcDispatcher", .serialized, .timeLimit(.minutes(1)))
 struct RpcDispatcherTests {
   @Test("/echo は EchoRequest を受けて EchoResponse を返す")
   func echo() async throws {
@@ -78,11 +86,21 @@ struct RpcDispatcherTests {
     let dir = try makeTempDir()
     defer { try? FileManager.default.removeItem(at: URL(fileURLWithPath: dir)) }
 
-    let exitFlag = ExitFlag()
+    // production 側 PTYRegistry consumer Task が AsyncStream.exit event を受けて
+    // onPtyExit callback を発火する。test 側はその callback を AsyncStream に直結し、
+    // `for await` で順序保証付きに observe する。`waitUntil` polling は介在しない:
+    //   - 過去設計: callback → NSLock + Bool ExitFlag → 50ms tick polling → 2s timeout
+    //     (issue #710 で 2.13s 観測の flake 経路)
+    //   - 本設計: callback → AsyncStream.yield → for await で suspend (timeout 不要)
+    // 永久 suspend は suite trait `.timeLimit(.minutes(1))` が breaker として吸収する。
+    let (exitEvents, exitContinuation) = AsyncStream<(UInt32, PTYExitReason)>.makeStream()
     let dispatcher = RpcDispatcher(
       configDir: dir,
       onPtyText: { _, _ in },
-      onPtyExit: { _, _ in exitFlag.signal() }
+      onPtyExit: { id, reason in
+        exitContinuation.yield((id, reason))
+        exitContinuation.finish()
+      }
     )
 
     var spawnReq = Gozd_V1_PtySpawnRequest()
@@ -101,8 +119,15 @@ struct RpcDispatcherTests {
     killReq.ptyID = spawnResp.ptyID
     _ = try await dispatcher.dispatch(path: "/pty/kill", body: killReq.jsonUTF8Data())
 
-    await waitUntil(timeout: .seconds(2), description: "exitFlag is set") { exitFlag.isSet }
-    #expect(exitFlag.isSet)
+    var iterator = exitEvents.makeAsyncIterator()
+    let observed = await iterator.next()
+    let (exitedId, reason) = try #require(observed)
+    #expect(exitedId == spawnResp.ptyID)
+    if case .signaled(let signal, _) = reason {
+      #expect(signal == SIGHUP)
+    } else {
+      Issue.record("expected SIGHUP signaled exit, got \(reason)")
+    }
   }
 
   @Test("/claudeSession/removeByPty: expected resume sid 残留時に task の dead session を片付ける (resume 失敗検出)")
@@ -516,21 +541,25 @@ struct RpcDispatcherTests {
     let dir = try makeTempDir()
     defer { try? FileManager.default.removeItem(at: URL(fileURLWithPath: dir)) }
 
-    let captured = HookCapture()
+    let (hookStream, hookContinuation) = AsyncStream<Gozd_V1_HookMessage>.makeStream()
     let dispatcher = RpcDispatcher(
       configDir: dir,
       onPtyText: { _, _ in },
       onPtyExit: { _, _ in },
-      onHook: { hook in captured.set(hook) },
+      onHook: { hook in
+        hookContinuation.yield(hook)
+        hookContinuation.finish()
+      },
       onOpen: { _ in }
     )
 
     let line = Data(#"{"hook":{"event":"session-start","ptyId":42}}"#.utf8)
     try await dispatcher.handleSocketMessage(line)
 
-    let h = captured.value
-    #expect(h?.event == "session-start")
-    #expect(h?.ptyID == 42)
+    var iterator = hookStream.makeAsyncIterator()
+    let h = try #require(await iterator.next())
+    #expect(h.event == "session-start")
+    #expect(h.ptyID == 42)
   }
 
   @Test("handleSocketMessage は OpenMessage を decode して onOpen に渡す")
@@ -538,19 +567,24 @@ struct RpcDispatcherTests {
     let dir = try makeTempDir()
     defer { try? FileManager.default.removeItem(at: URL(fileURLWithPath: dir)) }
 
-    let captured = OpenCapture()
+    let (openStream, openContinuation) = AsyncStream<String>.makeStream()
     let dispatcher = RpcDispatcher(
       configDir: dir,
       onPtyText: { _, _ in },
       onPtyExit: { _, _ in },
       onHook: { _ in },
-      onOpen: { path in captured.set(path) }
+      onOpen: { path in
+        openContinuation.yield(path)
+        openContinuation.finish()
+      }
     )
 
     let line = Data(#"{"open":{"targetPath":"/Users/me/repo"}}"#.utf8)
     try await dispatcher.handleSocketMessage(line)
 
-    #expect(captured.value == "/Users/me/repo")
+    var iterator = openStream.makeAsyncIterator()
+    let captured = try #require(await iterator.next())
+    #expect(captured == "/Users/me/repo")
   }
 
   @Test("handleSocketMessage は oneof 未指定で SocketDecodeError.emptyOneof を throw")
@@ -745,47 +779,3 @@ private func makeTempDir() throws -> String {
   return URL(fileURLWithPath: raw.path).resolvingSymlinksInPath().path
 }
 
-private final class ExitFlag: @unchecked Sendable {
-  private let lock = NSLock()
-  private var flag = false
-  func signal() {
-    lock.lock()
-    defer { lock.unlock() }
-    flag = true
-  }
-  var isSet: Bool {
-    lock.lock()
-    defer { lock.unlock() }
-    return flag
-  }
-}
-
-private final class HookCapture: @unchecked Sendable {
-  private let lock = NSLock()
-  private var stored: Gozd_V1_HookMessage?
-  func set(_ h: Gozd_V1_HookMessage) {
-    lock.lock()
-    defer { lock.unlock() }
-    stored = h
-  }
-  var value: Gozd_V1_HookMessage? {
-    lock.lock()
-    defer { lock.unlock() }
-    return stored
-  }
-}
-
-private final class OpenCapture: @unchecked Sendable {
-  private let lock = NSLock()
-  private var stored: String?
-  func set(_ s: String) {
-    lock.lock()
-    defer { lock.unlock() }
-    stored = s
-  }
-  var value: String? {
-    lock.lock()
-    defer { lock.unlock() }
-    return stored
-  }
-}

--- a/apps/native/Tests/GozdCoreTests/SocketServerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/SocketServerTests.swift
@@ -4,7 +4,10 @@ import Testing
 
 @testable import GozdCore
 
-@Suite("SocketServer")
+// `.timeLimit(.minutes(1))` は production 側 bug (SocketServer の listener が起動しない
+// deadlock 等) で test が永久 hang するのを test framework 経由の fail に倒す breaker。
+// 個別 test の経験則 timeout を排し suite 単位 1 段に集約 (issue #710 系譜)。
+@Suite("SocketServer", .timeLimit(.minutes(1)))
 struct SocketServerTests {
   @Test("単一の NDJSON 行を受信できる")
   func receivesSingleLine() async throws {
@@ -13,17 +16,18 @@ struct SocketServerTests {
     let path = makeSocketPath()
     defer { unlink(path) }
 
-    let messages = MessageCollector()
+    let bridge = SocketMessageBridge()
     let server = SocketServer(socketPath: path)
-    try server.start { data in messages.append(data) }
+    try server.start(onMessage: bridge.onMessage)
     defer { server.stop() }
 
+    // socket file 出現待ち = kqueue / syscall 経路で SUT 側に callback accessor が無い。
+    // WaitUntil.swift 規律「使用可: OS event の到達待ち」に該当 (issue #710 系譜)。
     await waitUntil(timeout: .seconds(2)) { fileExists(path) }
 
     try sendOverUnixSocket(path: path, data: Data(#"{"type":"ping"}\#n"#.utf8))
 
-    await waitUntil(timeout: .seconds(2)) { messages.snapshot().count == 1 }
-    let received = messages.snapshot()
+    let received = await bridge.collect(count: 1)
     #expect(received.count == 1)
     #expect(String(decoding: received[0], as: UTF8.self) == #"{"type":"ping"}"#)
   }
@@ -35,11 +39,12 @@ struct SocketServerTests {
     let path = makeSocketPath()
     defer { unlink(path) }
 
-    let messages = MessageCollector()
+    let bridge = SocketMessageBridge()
     let server = SocketServer(socketPath: path)
-    try server.start { data in messages.append(data) }
+    try server.start(onMessage: bridge.onMessage)
     defer { server.stop() }
 
+    // socket file 出現待ち (上の test と同じ規律)。
     await waitUntil(timeout: .seconds(2)) { fileExists(path) }
 
     let payload = Data(
@@ -51,8 +56,7 @@ struct SocketServerTests {
       """.utf8)
     try sendOverUnixSocket(path: path, data: payload)
 
-    await waitUntil(timeout: .seconds(2)) { messages.snapshot().count == 3 }
-    let received = messages.snapshot().map { String(decoding: $0, as: UTF8.self) }
+    let received = await bridge.collect(count: 3).map { String(decoding: $0, as: UTF8.self) }
     #expect(received == [#"{"i":1}"#, #"{"i":2}"#, #"{"i":3}"#])
   }
 
@@ -63,11 +67,12 @@ struct SocketServerTests {
     let path = makeSocketPath()
     defer { unlink(path) }
 
-    let messages = MessageCollector()
+    let bridge = SocketMessageBridge()
     let server = SocketServer(socketPath: path)
-    try server.start { data in messages.append(data) }
+    try server.start(onMessage: bridge.onMessage)
     defer { server.stop() }
 
+    // socket file 出現待ち (上の test と同じ規律)。
     await waitUntil(timeout: .seconds(2)) { fileExists(path) }
 
     try await withThrowingTaskGroup(of: Void.self) { group in
@@ -79,8 +84,8 @@ struct SocketServerTests {
       try await group.waitForAll()
     }
 
-    await waitUntil(timeout: .seconds(3)) { messages.snapshot().count == 5 }
-    let received = Set(messages.snapshot().map { String(decoding: $0, as: UTF8.self) })
+    let received = Set(
+      await bridge.collect(count: 5).map { String(decoding: $0, as: UTF8.self) })
     let expected: Set<String> = (0..<5).map { #"{"i":\#($0)}"# }.reduce(into: Set()) {
       $0.insert($1)
     }
@@ -176,19 +181,37 @@ private func sendOverUnixSocket(path: String, data: Data) throws {
   }
 }
 
-private final class MessageCollector: @unchecked Sendable {
-  private let lock = NSLock()
-  private var messages: [Data] = []
+/// SocketServer の message callback を AsyncStream に直結する test 用 bridge。
+///
+/// 設計目的:
+///   - 過去設計 (MessageCollector + NSLock + waitUntil polling) は production callback を
+///     mutable snapshot に変換し、50ms tick で polling する確率的経路
+///   - 本 bridge は callback を AsyncStream に直結し、`collect(count:)` で N 件到達まで
+///     決定的に await する。polling 0 段、timeout 0 段
+///   - 永久 suspend は suite trait `.timeLimit(.minutes(1))` が breaker として吸収する
+///
+/// **単一 consumer 契約**: `stream` は 1 度だけ iterate すること (`collect(count:)` 1 回
+/// または `for await` 1 回)。AsyncStream は single-consumer 契約のため 2 度目の iteration
+/// は未定義動作 (Apple Doc: "iterating an `AsyncStream` more than once results in undefined
+/// behavior")。複数 phase の message 観察には別 bridge インスタンスを使う。
+private final class SocketMessageBridge: Sendable {
+  let onMessage: @Sendable (Data) -> Void
+  let stream: AsyncStream<Data>
 
-  func append(_ data: Data) {
-    lock.lock()
-    defer { lock.unlock() }
-    messages.append(data)
+  init() {
+    let (stream, continuation) = AsyncStream<Data>.makeStream()
+    self.stream = stream
+    self.onMessage = { continuation.yield($0) }
+    // continuation.finish() は collect 側で打ち切る (server は test 終了まで生きる)。
   }
 
-  func snapshot() -> [Data] {
-    lock.lock()
-    defer { lock.unlock() }
-    return messages
+  /// 指定件数の message が到達するまで `for await` で待つ。順序は callback 配送順と一致。
+  func collect(count: Int) async -> [Data] {
+    var collected: [Data] = []
+    for await data in stream {
+      collected.append(data)
+      if collected.count >= count { break }
+    }
+    return collected
   }
 }

--- a/apps/native/Tests/GozdCoreTests/WaitUntil.swift
+++ b/apps/native/Tests/GozdCoreTests/WaitUntil.swift
@@ -5,7 +5,35 @@ import Testing
 
 // `condition()` が true になるまで小さくポーリングで待つ test 共有 helper。
 //
-// 実装契約:
+// ## 用途規律 (issue #710 系譜)
+//
+// **使用可: SUT 側に async barrier (AsyncStream / actor accessor / continuation) を生やせない
+// OS event の到達待ち**
+//   - FSEvents kqueue 経路 (FSWatcher / FSWatchRegistry の event propagation 待ち)
+//   - socket file の出現待ち (SocketServer の listener bind 確認)
+//   - `sleepThreaded` と組み合わせた negative test (event が **来ないこと** の verify)
+//
+// **使用不可: SUT 側に AsyncStream / callback accessor を持てる event 観察**
+//   - PTY exit 観察 (`PTYManager.spawn` の onExit callback / `PTYRegistry` の onExit callback)
+//     → test 側 AsyncStream.makeStream() を callback に直結する (PTYEventBridge / PTYRegistryEventBridge
+//     パターン、PTYManagerTests / PTYRegistryTests / RpcDispatcherTests 参照)
+//   - hook message / socket message 観察
+//     → 同じく test 側 AsyncStream.makeStream() で callback bridge
+//   - actor accessor で待てる状態到達 (`PTYRegistry.awaitEmpty()` 等の SUT API)
+//
+// 使用不可カテゴリに本 helper を当てると、`callback → NSLock + Bool snapshot → 50ms tick polling →
+// 経験則 timeout (2-3 秒)` という確率的 bridge が test に混入し、CI runner 負荷分布の長尾で
+// flake する (issue #710: 2.13 秒で 2 秒 timeout を割った flake)。
+//
+// **規律確認のチェックリスト**:
+//   - その event は SUT 側で同期 callback / yield / actor accessor 経由で観測できないか?
+//   - できるなら AsyncStream.makeStream() + `for await` に置き換える (polling 0 段、timeout 0 段)
+//   - permanent suspend (production bug) は suite-level `.timeLimit(.minutes(1))` trait が breaker
+//
+// 既存 callsite は kqueue / FSEvents 経路に限定して残っており、各 callsite で本規律のどの
+// カテゴリに該当するかを 1 行で justify するコメントを付ける。
+//
+// ## 実装契約:
 //
 // - polling loop ( condition 評価 / trace 出力 / `Thread.sleep(forTimeInterval:)` ) は
 //   `Thread { ... }.start()` で立てた **dedicated NSThread** 上で完結する。Swift Concurrency


### PR DESCRIPTION
## 概要

PTY / Socket / Hook 経路の test を callback polling から AsyncStream barrier ベースに再設計し、CI macOS-26 runner で flake していた test を構造的に解消する。SUT (PTYRegistry / PTYManager / SocketServer / RpcDispatcher) は一切変更していない。

## 背景

( #710 ) で `RpcDispatcherTests.ptyLifecycle` が CI macOS-26 runner で `waitUntil(timeout: .seconds(2))` の 2 秒 timeout を 2.13 秒で割って fail した。原因は過去の根治対象 ( #420 ) / ( #449 ) / ( #545 ) / ( #550 ) / ( #565 ) / ( #567 ) / ( #625 ) / ( #632 ) のいずれにも該当せず、純粋に「production の SIGHUP → exit handler 鎖の所要時間が CI 並列負荷下で 2 秒を超えた」現象だった。

最初は `.serialized` 1 行で `RpcDispatcher` suite の並列を消す対症療法を試みたが、対話で以下が論点になった:

- timeout を上げる / `.serialized` を当てる発想は percentile を下げる確率設計で、`flake = 0` を test 設計目標とする方針と矛盾する
- production の `AsyncStream<PTYEvent>` という正規 channel が既にあるにもかかわらず、test 経路だけ `callback → NSLock + Bool snapshot → 50ms tick polling → 経験則 timeout` という 5 段の確率的 bridge を介していた
- 現代の Swift Testing ベストプラクティス (Apple Doc / Donny Wals / Matt Massicotte / Rachel Brindle) は polling を最後の手段と扱い、callback / continuation / AsyncStream で待てる経路は必ずそちらに置き換える

flake を確率事象ではなく構造事象として消すため、production callback を test 側 `AsyncStream.makeStream()` に直結する Massicotte パターンへ全面移行した。production SUT 側 accessor 追加案も検討したが、 production callback contract を変えずに test 側だけで同等の決定論を獲得できるため不採用にした。

## 変更内容

### test 設計の構造改修

- production callback (`onText` / `onExit` / `onMessage` / `onHook` / `onOpen`) を `AsyncStream.makeStream()` の continuation に直結し、`for await` で順序保証付きに observe する bridge クラス (`PTYEventBridge` / `PTYRegistryEventBridge` / `SocketMessageBridge`) を導入
- 既存の `@unchecked Sendable` collector 7 class (`ExitFlag` / `DataCollector` / `ExitCollector` / `EventCollector` / `HookCapture` / `OpenCapture` / `MessageCollector`) を撤去
- 各 bridge は `final class Sendable` で CLAUDE.md の「`@unchecked Sendable` を機械的に使わない」規律と整合
- 各 bridge に「単一 consumer 契約」doc を Apple Doc 引用付きで明記

### timeout 集約

- 個別 test の `waitUntil(timeout: .seconds(2))` / `.seconds(3)` を event 観察用途では全撤去
- `RpcDispatcher` / `PTYManager` / `PTYRegistry` / `PTYRegistry.ConcurrentSpawn` / `SocketServer` の 5 suite に `.timeLimit(.minutes(1))` を suite-level breaker として付与 (production deadlock のみ catch、`.minutes(1)` は Swift Testing の最小粒度)
- `PTYRegistry.ConcurrentSpawn` を `.serialized` に揃え (test 内 `withThrowingTaskGroup` で並列 race を発火させる責務は維持される)

### WaitUntil 用途規律 SSOT

- `WaitUntil.swift` 冒頭に「使用可 / 使用不可」カテゴリの doc を明文化
  - 使用可: kqueue / FSEvents / socket file 出現待ち / `sleepThreaded` 併用の negative test
  - 使用不可: SUT 側に AsyncStream / callback accessor を持てる event 観察 (PTY exit / hook / actor accessor 待ち)
- 残った 8 callsite (SocketServerTests 3 / FSWatcherTests 3 / FSWatchRegistryTests wrapper 経由 2) すべてに「どのカテゴリに該当するか」の justify コメントを 1-2 行で付与

## 確認事項

- [ ] PTY 系 test (`PTYManagerTests` / `PTYRegistryTests` / `RpcDispatcherTests.ptyLifecycle`) が CI macOS-26 runner で複数回 green であること
- [ ] SUT 側 (`apps/native/Sources/GozdCore/PTYRegistry.swift` / `PTYManager.swift` / `SocketServer.swift` / `RpcDispatcher.swift`) に diff が無いこと
- [ ] `WaitUntil` の残 callsite 全てに justify コメントがあること (`grep -rn "await waitUntil" apps/native/Tests/`)
- [ ] `@unchecked Sendable` な test collector が test target に残っていないこと
