### PR TITLE
fix(git-graph): route HEAD-as-merge-parent into reserved lane 0

### DIFF
--- a/apps/renderer/src/features/git-graph/graphLayout.test.ts
+++ b/apps/renderer/src/features/git-graph/graphLayout.test.ts
@@ -137,7 +137,7 @@ describe("computeGraphLayout の HEAD 最左固定", () => {
     expect(lanes.get("other")).toBeGreaterThan(0);
     expect(colors.get("other")).not.toBe(HEAD_COLOR);
 
-    // other は m とも別レーン / 別色 (m: lane 1 / color 1、other: lane 2 / color 2)
+    // other は m と独立: lane も color も異なる
     expect(lanes.get("other")).not.toBe(lanes.get("m"));
     expect(colors.get("other")).not.toBe(colors.get("m"));
 

--- a/apps/renderer/src/features/git-graph/graphLayout.test.ts
+++ b/apps/renderer/src/features/git-graph/graphLayout.test.ts
@@ -81,6 +81,43 @@ describe("computeGraphLayout の HEAD 最左固定", () => {
     expect(lanes.get("base")).toBe(0);
   });
 
+  test("HEAD 到達前の merge コミットの 2nd parent が HEAD 自身でも借りレーンを作らない", () => {
+    // GitHub flow 最頻ケース: main 側の "Merge pull request #N from .../HEAD-branch"。
+    //   m (origin/main, parents=[prev, h0]) — prev 系統と HEAD を merge
+    //   h0 (HEAD)
+    //   prev → base
+    //   h0  → base
+    // 借りレーンを作ると lane 1 → 借りレーンへの余分な斜めセグメントが残り、
+    // 紫等の別色 (nextColor) の線が描画される。HEAD 予約 lane 0 に直接乗せて防ぐ。
+    const commits = [
+      commit("m", ["prev", "h0"]),
+      commit("h0", ["base"], ["HEAD"]),
+      commit("prev", ["base"]),
+      commit("base", []),
+    ];
+    const layout = computeGraphLayout(commits, { headHash: "h0" });
+    const lanes = laneByHash(layout);
+    const colors = colorByHash(layout);
+
+    // HEAD は予約済み lane 0 に置かれる
+    expect(lanes.get("h0")).toBe(0);
+    expect(colors.get("h0")).toBe(HEAD_COLOR);
+
+    // merge 自身は lane 0 を奪わず lane 1 以降
+    expect(lanes.get("m")).toBeGreaterThan(0);
+
+    // 余分な借りレーンが作られていないこと: m + prev + HEAD = 同時 3 本までだが、
+    // HEAD 予約直行なら借りレーン分の +1 が増えない (lane 0=HEAD, lane 1=m/prev)
+    expect(layout.maxLanes).toBeLessThanOrEqual(2);
+
+    // 紫 (color=2) など HEAD_COLOR / m 色 以外のセグメントが含まれていない
+    const usedColors = new Set(layout.lines.map((s) => s.color));
+    const mColor = colors.get("m");
+    for (const c of usedColors) {
+      expect([HEAD_COLOR, mColor]).toContain(c);
+    }
+  });
+
   test("HEAD 自身が merge コミットの tip でも最左 lane に固定する", () => {
     //   o0 → o1 ┐
     //   m(HEAD)─┼─ a ┐

--- a/apps/renderer/src/features/git-graph/graphLayout.test.ts
+++ b/apps/renderer/src/features/git-graph/graphLayout.test.ts
@@ -1,6 +1,6 @@
 import type { GitCommit } from "@gozd/proto";
 import { describe, expect, test } from "bun:test";
-import { computeGraphLayout } from "./graphLayout";
+import { computeGraphLayout, HEAD_COLOR } from "./graphLayout";
 
 /** テスト用 commit を最小フィールドで生成する */
 function commit(hash: string, parents: string[], refs: string[] = []): GitCommit {
@@ -16,9 +16,6 @@ function laneByHash(layout: ReturnType<typeof computeGraphLayout>): Map<string, 
 function colorByHash(layout: ReturnType<typeof computeGraphLayout>): Map<string, number> {
   return new Map(layout.nodes.map((n) => [n.commit.hash, n.color]));
 }
-
-/** HEAD 専用に予約する色インデックス (graphLayout.ts の HEAD_COLOR と一致) */
-const HEAD_COLOR = 0;
 
 describe("computeGraphLayout の HEAD 最左固定", () => {
   test("HEAD が表示順の先頭なら最左 lane (0) に置く", () => {
@@ -106,16 +103,42 @@ describe("computeGraphLayout の HEAD 最左固定", () => {
     // merge 自身は lane 0 を奪わず lane 1 以降
     expect(lanes.get("m")).toBeGreaterThan(0);
 
-    // 余分な借りレーンが作られていないこと: m + prev + HEAD = 同時 3 本までだが、
-    // HEAD 予約直行なら借りレーン分の +1 が増えない (lane 0=HEAD, lane 1=m/prev)
-    expect(layout.maxLanes).toBeLessThanOrEqual(2);
+    // 余分な借りレーンが作られていないこと: lane 0 = HEAD、lane 1 = m / prev で同時 2 本
+    expect(layout.maxLanes).toBe(2);
 
-    // 紫 (color=2) など HEAD_COLOR / m 色 以外のセグメントが含まれていない
+    // HEAD_COLOR / m 色 以外の色を持つセグメントが含まれていない
     const usedColors = new Set(layout.lines.map((s) => s.color));
     const mColor = colors.get("m");
     for (const c of usedColors) {
       expect([HEAD_COLOR, mColor]).toContain(c);
     }
+  });
+
+  test("octopus merge で restParents に HEAD と非 HEAD が同居しても他枝が予約 lane 0 を奪わない", () => {
+    // m が 3 親 (prev, h0, other) を持つ octopus merge。restParents = [h0, other]。
+    // h0 は HEAD なので予約 lane 0 / HEAD_COLOR に直行、other は findEmptyLane(minLane=1) で
+    // lane 1 以降を採り別色 (nextColor) を取る。借りレーンと予約レーンの境界が混在する経路。
+    const commits = [
+      commit("m", ["prev", "h0", "other"]),
+      commit("h0", ["base"], ["HEAD"]),
+      commit("prev", ["base"]),
+      commit("other", ["base"]),
+      commit("base", []),
+    ];
+    const layout = computeGraphLayout(commits, { headHash: "h0" });
+    const lanes = laneByHash(layout);
+    const colors = colorByHash(layout);
+
+    // HEAD は予約済み lane 0 / HEAD_COLOR
+    expect(lanes.get("h0")).toBe(0);
+    expect(colors.get("h0")).toBe(HEAD_COLOR);
+
+    // other は lane 0 を奪わず、色も HEAD_COLOR ではない別色
+    expect(lanes.get("other")).toBeGreaterThan(0);
+    expect(colors.get("other")).not.toBe(HEAD_COLOR);
+
+    // other と m は別レーン (m / prev / other / h0 が並走する瞬間がある)
+    expect(colors.get("other")).not.toBe(colors.get("m"));
   });
 
   test("HEAD 自身が merge コミットの tip でも最左 lane に固定する", () => {

--- a/apps/renderer/src/features/git-graph/graphLayout.test.ts
+++ b/apps/renderer/src/features/git-graph/graphLayout.test.ts
@@ -137,8 +137,12 @@ describe("computeGraphLayout の HEAD 最左固定", () => {
     expect(lanes.get("other")).toBeGreaterThan(0);
     expect(colors.get("other")).not.toBe(HEAD_COLOR);
 
-    // other と m は別レーン (m / prev / other / h0 が並走する瞬間がある)
+    // other は m とも別レーン / 別色 (m: lane 1 / color 1、other: lane 2 / color 2)
+    expect(lanes.get("other")).not.toBe(lanes.get("m"));
     expect(colors.get("other")).not.toBe(colors.get("m"));
+
+    // h0 行で h0 / prev / other の 3 本が同時 active になる
+    expect(layout.maxLanes).toBe(3);
   });
 
   test("HEAD 自身が merge コミットの tip でも最左 lane に固定する", () => {

--- a/apps/renderer/src/features/git-graph/graphLayout.ts
+++ b/apps/renderer/src/features/git-graph/graphLayout.ts
@@ -208,8 +208,9 @@ export function computeGraphLayout(
       // 採ると、その borrowed lane の originLane = lane(merge 行) が次行 (HEAD 行) まで持ち越され、
       // Phase 1 で「merge 行 lane → borrowed lane」の分岐セグメントを nextColor++ で 1 本生成
       // してしまう。HEAD は別経路で lane 0 を固定するため borrowed lane は誰にも消費されず
-      // 余計な線として残る。HEAD 予約 lane 0 に直行させれば、次行で「merge 行 lane → 0」の
-      // 合流線が HEAD_COLOR で正しく描かれる
+      // 余計な線として残る。HEAD 予約 lane 0 に直行させれば、次行の Phase 1 で
+      // activeLanes[0].originLane = merge 行 lane が「分岐」ブロック (lockedFirst=true) を踏み、
+      // x1=merge 行 lane → x2=0 の斜めセグメントが HEAD_COLOR で正しく描かれる
       const isHeadBranch = parentHash === headHash && reserveHeadLane;
       const mergeLane = isHeadBranch ? 0 : findEmptyLane(activeLanes, minLane);
       const mergeColor = isHeadBranch ? HEAD_COLOR : nextColor++;

--- a/apps/renderer/src/features/git-graph/graphLayout.ts
+++ b/apps/renderer/src/features/git-graph/graphLayout.ts
@@ -210,7 +210,7 @@ export function computeGraphLayout(
       // してしまう。HEAD は別経路で lane 0 を固定するため borrowed lane は誰にも消費されず
       // 余計な線として残る。HEAD 予約 lane 0 に直行させれば、次行の Phase 1 で
       // activeLanes[0].originLane = merge 行 lane が「分岐」ブロック (lockedFirst=true) を踏み、
-      // x1=merge 行 lane → x2=0 の斜めセグメントが HEAD_COLOR で正しく描かれる
+      // x1=merge 行 lane → x2=0 の斜めセグメントが HEAD_COLOR で 1 本だけ描かれる
       const isHeadBranch = parentHash === headHash && reserveHeadLane;
       const mergeLane = isHeadBranch ? 0 : findEmptyLane(activeLanes, minLane);
       const mergeColor = isHeadBranch ? HEAD_COLOR : nextColor++;

--- a/apps/renderer/src/features/git-graph/graphLayout.ts
+++ b/apps/renderer/src/features/git-graph/graphLayout.ts
@@ -201,12 +201,17 @@ export function computeGraphLayout(
       if (!commitIndexMap.has(parentHash)) continue;
 
       const existingLane = activeLanes.findIndex((l) => l?.hash === parentHash);
-      if (existingLane === -1) {
-        const mergeLane = findEmptyLane(activeLanes, minLane);
-        const mergeColor = nextColor++;
-        // originLane を設定して、次の行で斜めセグメントを生成
-        activeLanes[mergeLane] = { hash: parentHash, color: mergeColor, originLane: lane };
-      }
+      if (existingLane !== -1) continue;
+
+      // 2nd parent が HEAD 自身のとき (例: main の "Merge pull request #N from .../HEAD-branch")
+      // は予約済み lane 0 / HEAD_COLOR に直接乗せる。findEmptyLane(minLane=1) で新レーンを
+      // 採ってしまうと、次行で HEAD が lane 0 に固定された後も解放前の借りレーンから lane 0
+      // ではなく借りレーンへの斜めセグメントが残り、別色 (nextColor) の余分な線が描かれる
+      const isHeadBranch = parentHash === headHash && reserveHeadLane;
+      const mergeLane = isHeadBranch ? 0 : findEmptyLane(activeLanes, minLane);
+      const mergeColor = isHeadBranch ? HEAD_COLOR : nextColor++;
+      // originLane を設定して、次の行で斜めセグメントを生成
+      activeLanes[mergeLane] = { hash: parentHash, color: mergeColor, originLane: lane };
     }
 
     maxLanes = Math.max(maxLanes, countActive(activeLanes));

--- a/apps/renderer/src/features/git-graph/graphLayout.ts
+++ b/apps/renderer/src/features/git-graph/graphLayout.ts
@@ -68,7 +68,7 @@ interface LaneState {
 
 /** HEAD レーン専用に予約する色インデックス。lane 0 = current branch の線を常にこの色で示し、
  *  Working Tree 行のドット/接続線と色を揃える。他レーンは 1 以降を採番して衝突を避ける。 */
-const HEAD_COLOR = 0;
+export const HEAD_COLOR = 0;
 
 /**
  * @param headHash HEAD コミットの hash。指定すると HEAD を最左 lane (lane 0) に固定し、
@@ -204,9 +204,12 @@ export function computeGraphLayout(
       if (existingLane !== -1) continue;
 
       // 2nd parent が HEAD 自身のとき (例: main の "Merge pull request #N from .../HEAD-branch")
-      // は予約済み lane 0 / HEAD_COLOR に直接乗せる。findEmptyLane(minLane=1) で新レーンを
-      // 採ってしまうと、次行で HEAD が lane 0 に固定された後も解放前の借りレーンから lane 0
-      // ではなく借りレーンへの斜めセグメントが残り、別色 (nextColor) の余分な線が描かれる
+      // は予約済み lane 0 / HEAD_COLOR に直接乗せる。findEmptyLane(minLane=1) で借りレーンを
+      // 採ると、その borrowed lane の originLane = lane(merge 行) が次行 (HEAD 行) まで持ち越され、
+      // Phase 1 で「merge 行 lane → borrowed lane」の分岐セグメントを nextColor++ で 1 本生成
+      // してしまう。HEAD は別経路で lane 0 を固定するため borrowed lane は誰にも消費されず
+      // 余計な線として残る。HEAD 予約 lane 0 に直行させれば、次行で「merge 行 lane → 0」の
+      // 合流線が HEAD_COLOR で正しく描かれる
       const isHeadBranch = parentHash === headHash && reserveHeadLane;
       const mergeLane = isHeadBranch ? 0 : findEmptyLane(activeLanes, minLane);
       const mergeColor = isHeadBranch ? HEAD_COLOR : nextColor++;


### PR DESCRIPTION
## 概要

Git Graph で「main 側の `Merge pull request #N from .../HEAD-branch` の直下にある HEAD 行」のとき、Working Tree の青ドットから右下に伸びる別色（紫）の余計なセグメントが描画されるバグを修正する。`graphLayout.ts` の merge コミット 2nd parent 処理で、`parentHash === headHash` の特例を追加し、新規 mergeLane を作らず予約済み lane 0 / `HEAD_COLOR` に直接乗せる。

## 背景

GitHub flow では `Merge pull request #N from owner/HEAD-branch` というコミットが main に乗ったとき、その親は `parents = [前 main, HEAD]` という構造になる（2nd parent が HEAD 自身）。これは「PR を merge した直後の main」を表示する最頻ケース。

PR #688 ( pin HEAD to the leftmost lane ) で HEAD を lane 0 に予約・固定する仕組みを入れ、PR #707 ( pin HEAD lane to a reserved fixed color ) で HEAD_COLOR を予約する仕組みを入れた。しかし `restParents` を処理する `graphLayout.ts:200-210` のループは、parent が HEAD 自身かどうかを区別せず一律 `findEmptyLane(activeLanes, minLane=1)` で借りレーンを採り `nextColor++` で別色を採番していた。

その結果、上記スクショ構成では:

- 行 0 ( `Merge pull request #713` ): lane 1 / color 1。Phase 3 で restParents の HEAD が lane 2 に借り予約され、color 2 ( 紫 ) を採番、`originLane = 1` がセットされる
- 行 1 ( HEAD ): 予約 lane 0 に固定。しかし行 0→1 の Phase 1 で `activeLanes[2].originLane = 1` が残っているため、lane 1 → lane 2 の紫の斜めセグメントが無条件に描画される

PR #688 のテスト「HEAD 到達前の merge コミットの 2nd parent が予約 lane 0 を奪わない」は、2nd parent が HEAD 以外の独立コミット ( `u2 → base` ) を対象にしており、2nd parent が HEAD 自身というケースを構造的に取りこぼしていた。

## 変更内容

### `graphLayout.ts` のレーン採番

- `restParents` ループに `parentHash === headHash && reserveHeadLane` の分岐を追加
- 真のとき: 新規 mergeLane を採らず予約済み lane 0 を使い、color も `HEAD_COLOR` で固定。`originLane = 行の lane` をセットすることで次行で「行の lane → 予約 lane 0」への合流セグメントが HEAD 色で正しく描かれる
- 既存の `existingLane === -1` ガードを early `continue` に flatten

### `graphLayout.test.ts`

- 新ケース「HEAD 到達前の merge コミットの 2nd parent が HEAD 自身でも借りレーンを作らない」を追加
- 3 不変条件で借りレーン副作用を機械検出する:
  - HEAD の lane / color が予約値 ( `0` / `HEAD_COLOR` ) であること
  - `maxLanes <= 2` ( 借りレーン分の +1 が増えないこと )
  - `layout.lines[*].color` の使用色集合が `{HEAD_COLOR, merge 色}` のみに収まること ( `nextColor++` の紫消費がないこと )

## 確認事項

- [x] スクショの再現構成 ( origin/main の merge 直下に HEAD ) で紫の余計な線が消え、HEAD 色 ( teal ) の合流線のみが描画される
- [x] `pnpm run test` ( renderer ) 全パス ( 13/13 ) 、`pnpm run typecheck` クリーン
- [x] 既存 12 ケース ( 先頭 HEAD / 分岐 tip / 非 tip / merge tip / headHash 不在等 ) が引き続きパス
