### PR TITLE
fix(popover): correct flip behavior at viewport bottom

### DIFF
--- a/apps/renderer/src/features/git-graph/CommitContextMenu.vue
+++ b/apps/renderer/src/features/git-graph/CommitContextMenu.vue
@@ -24,9 +24,8 @@ const popoverStyle = computed(() => {
   }
   return {
     position: "fixed",
-    top: "anchor(bottom)",
-    left: "anchor(left)",
-    positionTryFallbacks: "flip-block, flip-inline",
+    positionArea: "block-end span-inline-end",
+    positionTryFallbacks: "flip-block, flip-inline, flip-block flip-inline",
   };
 });
 

--- a/apps/renderer/src/features/navigator/FileContextMenu.vue
+++ b/apps/renderer/src/features/navigator/FileContextMenu.vue
@@ -23,9 +23,8 @@ const popoverStyle = computed(() => {
   }
   return {
     position: "fixed",
-    top: "anchor(bottom)",
-    left: "anchor(left)",
-    positionTryFallbacks: "flip-block, flip-inline",
+    positionArea: "block-end span-inline-end",
+    positionTryFallbacks: "flip-block, flip-inline, flip-block flip-inline",
   };
 });
 

--- a/apps/renderer/src/features/preview/BlamePopover.vue
+++ b/apps/renderer/src/features/preview/BlamePopover.vue
@@ -71,8 +71,7 @@ function isHistoryDisabled(): boolean {
     popover="auto"
     class="m-0 w-104 max-w-[90vw] rounded-lg border border-zinc-700 bg-zinc-900 text-sm text-zinc-200 shadow-xl"
     :style="{
-      top: 'anchor(bottom)',
-      left: 'anchor(left)',
+      positionArea: 'block-end span-inline-end',
     }"
     @toggle="onToggle"
   >
@@ -208,6 +207,9 @@ function isHistoryDisabled(): boolean {
 <style scoped>
 [popover] {
   position: fixed;
-  position-try-fallbacks: flip-block, flip-inline;
+  position-try-fallbacks:
+    flip-block,
+    flip-inline,
+    flip-block flip-inline;
 }
 </style>

--- a/apps/renderer/src/features/sidebar/TaskMenu.vue
+++ b/apps/renderer/src/features/sidebar/TaskMenu.vue
@@ -52,9 +52,8 @@ function handleRemove() {
     class="m-0 min-w-36 rounded-lg border border-zinc-700 bg-zinc-900 py-1 text-sm text-zinc-200 shadow-lg"
     :style="{
       position: 'fixed',
-      top: 'anchor(bottom)',
-      left: 'anchor(left)',
-      positionTryFallbacks: 'flip-block, flip-inline',
+      positionArea: 'block-end span-inline-end',
+      positionTryFallbacks: 'flip-block, flip-inline, flip-block flip-inline',
     }"
   >
     <template v-if="context">

--- a/apps/renderer/src/features/sidebar/WorktreeMenu.vue
+++ b/apps/renderer/src/features/sidebar/WorktreeMenu.vue
@@ -26,9 +26,8 @@ function handleRemove() {
     class="m-0 min-w-36 rounded-lg border border-zinc-700 bg-zinc-900 py-1 text-sm text-zinc-200 shadow-lg"
     :style="{
       position: 'fixed',
-      top: 'anchor(bottom)',
-      left: 'anchor(left)',
-      positionTryFallbacks: 'flip-block, flip-inline',
+      positionArea: 'block-end span-inline-end',
+      positionTryFallbacks: 'flip-block, flip-inline, flip-block flip-inline',
     }"
   >
     <button

--- a/apps/renderer/src/features/sidebar/features/worktree/TaskRow.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/TaskRow.vue
@@ -174,7 +174,7 @@ function onRowDblClick() {
     <button
       type="button"
       aria-label="Open task menu"
-      class="absolute top-1/2 right-1 grid size-5 -translate-y-1/2 place-items-center rounded-sm bg-zinc-800 text-zinc-300 opacity-0 shadow-md ring-1 ring-zinc-700 transition-opacity duration-100 group-focus-within/task:opacity-100 group-hover/task:opacity-100 hover:bg-zinc-700 hover:text-zinc-100"
+      class="absolute inset-y-0 right-1 my-auto grid size-5 place-items-center rounded-sm bg-zinc-800 text-zinc-300 opacity-0 shadow-md ring-1 ring-zinc-700 transition-opacity duration-100 group-focus-within/task:opacity-100 group-hover/task:opacity-100 hover:bg-zinc-700 hover:text-zinc-100"
       @click="onMenuClick"
     >
       <span class="icon-[lucide--ellipsis-vertical] text-xs" />

--- a/apps/renderer/src/features/sidebar/features/worktree/WtCard.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/WtCard.vue
@@ -157,7 +157,7 @@ function onHeaderClick() {
         v-if="canRemove"
         type="button"
         aria-label="Open menu"
-        class="absolute top-1/2 right-1 grid size-5 -translate-y-1/2 place-items-center rounded-sm bg-zinc-800 text-zinc-300 opacity-0 shadow-md ring-1 ring-zinc-700 transition-opacity duration-100 group-focus-within/wt:opacity-100 group-hover/wt:opacity-100 hover:bg-zinc-700 hover:text-zinc-100"
+        class="absolute inset-y-0 right-1 my-auto grid size-5 place-items-center rounded-sm bg-zinc-800 text-zinc-300 opacity-0 shadow-md ring-1 ring-zinc-700 transition-opacity duration-100 group-focus-within/wt:opacity-100 group-hover/wt:opacity-100 hover:bg-zinc-700 hover:text-zinc-100"
         @click="onMenuClick"
       >
         <span class="icon-[lucide--ellipsis-vertical] text-xs" />


### PR DESCRIPTION
## 概要

サイドバーの wt / task メニュー (TaskMenu / WorktreeMenu) を画面下端の行で ⋮ ボタンから開くと、menu が anchor (⋮ ボタン) の近傍に出ず **画面上端の遠く** に表示される問題を修正する。

## 背景

画面下端の wt 行で ⋮ を押すと menu が画面上端付近に飛んで表示される、という挙動が観測された。

調査の過程で原因が 2 つの独立した不具合の連結であることが判明した。

第 1 の不具合は popover の配置式に `top: anchor(bottom); left: anchor(left)` + `position-try-fallbacks: flip-block` を使っていた点。`flip-block` try-tactic は spec normative では「block 軸の property 値 swap」しか規定がなく、`anchor()` 関数引数 (`bottom` → `top`) の mirror は implementation-defined。spike 検証 (3 案比較) で `top: anchor(bottom)` + `flip-block` は flip 発火時に menu が viewport top 0 / 高さ 0 で描画される empirical な壊れ方をすることを確認した。一方 `position-area: block-end span-inline-end` + `flip-block` は `block-end` ↔ `block-start` の keyword swap で spec 確定領域、flip 時に menu が正しく anchor の上に配置される。

第 2 の不具合は anchor 元 ⋮ ボタンの中央配置に `top-1/2 -translate-y-1/2` を使っていた点。`transform: translate` は layout box を動かさず paint のみ平行移動するため、`anchor()` 関数は **translate 前の layout 位置** を参照して解決する。視覚位置 (translate 後) と anchor 解決位置がボタン高さの半分ずれ、通常配置では「anchor 下端 → menu 上端」の不要なスキマとして、flip 配置では「anchor 上端 → menu 下端」の重なりとして観測された。

## 変更内容

### popover の配置式

TaskMenu / WorktreeMenu / FileContextMenu / CommitContextMenu / BlamePopover の `:style` を `top: anchor(bottom); left: anchor(left)` から `position-area: block-end span-inline-end` に変更。`position-try-fallbacks` も `flip-block, flip-inline, flip-block flip-inline` の 3 段に揃え、角 (右下 / 左下) で詰むケースの fallback を追加した。

### anchor 元 ⋮ ボタンの中央配置

TaskRow.vue / WtCard.vue の ⋮ ボタンの class を `top-1/2 -translate-y-1/2` から `inset-y-0 my-auto` に変更。auto margin centering により layout box 自体が中央に位置し、`anchor()` 解決位置と視覚位置が一致する。

## 確認事項

- [ ] サイドバーで画面下方の task / wt 行で ⋮ を押すと menu が画面上端の遠くに飛ばず anchor の真上に出る
- [ ] サイドバーで画面上方の task / wt 行で ⋮ を押すと anchor の真下に menu が出る
- [ ] BlamePopover (CodePreview の行番号クリック) で画面下方の行を開いた時に同様に anchor の上に出る
