### PR TITLE
fix(git-graph): keep graph SVG above commit row background via stacking layer split

### DIFF
--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -517,10 +517,17 @@ const LANE_WIDTH = 16;
 const ROW_HEIGHT = 24;
 const DOT_RADIUS = 4;
 const GRAPH_PADDING_X = 12;
+/** col 1 (graph 列) の右側に確保する HEAD marker `→` 用余白 (px)。
+ * marker は col 2 (description 列) の左外側に absolute 配置されるため、SVG が描く
+ * lane / dot と marker の x 帯が物理的に重ならない width をここで予約する。
+ * 内訳: marker glyph ~14 + col 2 との margin 4 + 安全余白 2 = 20。
+ * これを GRAPH_PADDING_X (12) のままにすると `maxLanes === 1` で
+ * marker と lane 0 dot の x 帯が衝突する。 */
+const HEAD_MARKER_RIGHT_PADDING = 20;
 
-/** Graph 列の幅 */
+/** Graph 列の幅。右側は HEAD marker 分の余白を確保する。 */
 const graphColumnWidth = computed(
-  () => GRAPH_PADDING_X + layout.value.maxLanes * LANE_WIDTH + GRAPH_PADDING_X,
+  () => GRAPH_PADDING_X + layout.value.maxLanes * LANE_WIDTH + HEAD_MARKER_RIGHT_PADDING,
 );
 
 /** グラフ全体の SVG 高さ */
@@ -1152,11 +1159,15 @@ const isWorkingTreeActive = computed(
               />
             </svg>
 
-            <!-- Commit table rows: Working Tree 行と同じ grid template を引いて columns を揃える。 -->
+            <!-- Commit table rows: Working Tree 行と同じ grid template を引いて columns を揃える。
+                 row には `position` を付けない (非 positioned = stacking layer 3)。兄弟の overlay
+                 SVG は positioned absolute (layer 6) なので、CSS の painting order により z-index
+                 を一切使わずに SVG が row 背景の上に描かれる。`relative` を足すと row が layer 6
+                 に上がり、tree order で後発の row 背景が先発の SVG を塗りつぶす不具合が再発する。 -->
             <div
               v-for="node in layout.nodes"
               :key="node.commit.hash"
-              class="_graph-row relative grid items-center text-xs"
+              class="_graph-row grid items-center text-xs"
               :class="rowHighlightClass(node.commit.hash)"
               :style="{
                 gridTemplateColumns: 'var(--graph-cols)',
@@ -1165,24 +1176,28 @@ const isWorkingTreeActive = computed(
               @click="onRowClick(node.commit.hash, $event)"
               @contextmenu="onCommitContextMenu(node.commit.hash, $event)"
             >
-              <!-- col 1 (graph): SVG が absolute で覆うので空セル -->
+              <!-- col 1 (graph): SVG が absolute で覆うので空セル。
+                   右側に HEAD_MARKER_RIGHT_PADDING ぶんの余白を持ち、marker は col 2 から
+                   この余白領域に飛び出して配置される (= 旧視覚位置: graph 列の右端)。 -->
               <div />
 
-              <!-- HEAD marker: グラフ列の右端に absolute 配置。レイアウトに影響しない -->
-              <span
-                v-if="hasHead(node.commit.refs)"
-                class="absolute text-warning-text"
-                :style="{
-                  left: `${graphColumnWidth}px`,
-                  transform: 'translateX(calc(-100% - 4px))',
-                }"
-                title="HEAD"
-              >
-                →
-              </span>
-
-              <!-- col 2 (description) -->
-              <div class="flex min-w-0 items-center gap-1 truncate pr-2">
+              <!-- col 2 (description)。
+                   `relative` を持つが background クラスは持たないので、SVG 覆い問題は起きない
+                   (row のように `relative` + 背景の組合せで初めて SVG を覆う)。
+                   HEAD marker は本要素を containing block として left 外側に absolute 配置し、
+                   col 1 右端の予約余白 (HEAD_MARKER_RIGHT_PADDING) に視覚的に乗せる。 -->
+              <div class="relative flex min-w-0 items-center gap-1 truncate pr-2">
+                <!-- HEAD marker: col 2 の左外側に absolute 配置。
+                     `right-full` で marker の右端を col 2 の左端に合わせ、`mr-1` (4px) で
+                     col 2 との隙間を作る。col 1 の右余白 (HEAD_MARKER_RIGHT_PADDING = 20px) 内に
+                     収まるため SVG が描く lane / dot と x 帯が重ならない。 -->
+                <span
+                  v-if="hasHead(node.commit.refs)"
+                  class="absolute right-full mr-1 text-warning-text"
+                  title="HEAD"
+                >
+                  →
+                </span>
                 <span
                   v-if="isMergeCommit(node.commit)"
                   class="icon-[lucide--git-merge] size-3.5 shrink-0 text-foreground-low"


### PR DESCRIPTION
## 概要

Git Graph 画面で commit 行を hover / 選択したときに、行背景色がブランチグラフのドット・線を塗りつぶしてしまう不具合を、z-index を一切使わずに CSS の自然な painting order で解消する。HEAD marker `→` の視覚位置は旧仕様 ( graph 列の右端 ) を維持する。

## 背景

Working Tree 行は hover / 選択時にもグラフが正常に描画されるが、commit 行ではグラフが塗りつぶされていた。

原因は CSS の painting order ( W3C CSS 2.1 Appendix E ):

- commit 行は `relative` (positioned, z-auto) → CSS stacking layer 6
- overlay SVG は `absolute` (positioned, z-auto) → CSS stacking layer 6
- 同一 layer 内では tree order で後発が描画される → DOM 順で後発の commit 行が、先発の SVG を覆う

最初の試行で overlay SVG に `z-10`、HEAD marker に `z-20` を付けたが、これは新たな regression を生む:

- `<div class="relative">` / `_graph-row` はいずれも z-auto で stacking context を作らない
- 子要素の z-index が scrollContainer 階層まで「flat に露出」する
- 結果、sticky な Working Tree 行 ( z-10 ) と marker ( z-20 ) が同一 stacking context で直接比較されてしまい、HEAD commit が sticky 下を通過する瞬間に marker `→` が Working Tree 行を貫通する

z-index に依存しない構造修正に切り替えた:

- 非 positioned ( layer 3 ) と positioned ( layer 6 ) は z-index 抜きで自動的に順序づけられる
- commit 行と SVG が違う layer に居れば、stacking 競合自体が発生しない
- HEAD marker は visual 位置を維持するため、background を持たない col 2 div に `relative` を付けて containing block にし、左外側に absolute 配置する

「`relative` を付けると SVG を覆う」のは「**背景を持つ**要素に `relative` を付けた」ときだけ ( = 元の row の状況 )。背景を持たない要素に `relative` を付けても、layer 6 で paint されるのは content だけで SVG を覆わない。これが本修正の核心。

## 変更内容

### `apps/renderer/src/features/git-graph/GitGraphPane.vue`

#### commit 行を非 positioned に倒す

- commit 行の `relative` を削除し、非 positioned ( layer 3 ) にする
- overlay SVG ( layer 6 ) が z-index ゼロで自動的に row 背景の上に描画される

#### HEAD marker を col 2 の `relative` containing block に absolute 配置

- col 2 ( description 列 ) の `<div>` に `relative` を追加 ( background クラスを持たないため SVG 覆い問題は起きない )
- HEAD marker `→` を `class="absolute right-full mr-1"` で col 2 の左外側に配置し、視覚位置は旧仕様 ( graph 列の右端 ) を維持する
- `right-full` ( = `right: 100%` ) で marker の右端を col 2 の左端に合わせ、`mr-1` ( 4px ) で隙間を確保

#### col 1 の右側に marker 用余白を予約

- `HEAD_MARKER_RIGHT_PADDING = 20` を追加し、`graphColumnWidth` の右側 padding を `GRAPH_PADDING_X` から差し替える
- marker glyph (~14px) + col 2 との margin (4px) + 安全余白 (2px) = 20px
- これを `GRAPH_PADDING_X` (12) のままにすると、`maxLanes === 1` で lane 0 dot ( x=16-24 ) と marker ( x ~22-36 ) の x 帯が衝突する

#### コメント

- 各箇所に「なぜこの構造か」「なぜ z-index を使わないか」「なぜ `relative` を付けてよい / よくないか」を残し、将来 row に `relative` を不用意に足す変更が来たときに即座に気付ける守りにする

## 確認事項

- [ ] commit 行を hover してもブランチグラフのドット・線が見える
- [ ] commit 行を選択 ( `bg-primary-subtle` ) してもグラフが塗りつぶされない
- [ ] 範囲選択 ( shift+click ) でも同様にグラフが見える
- [ ] Working Tree 行の挙動が回帰していない
- [ ] HEAD commit 行を Working Tree 行 ( sticky ) の下にスクロールしても `→` marker が貫通しない
- [ ] HEAD commit 行で `→` marker が **graph 列の右端** ( 旧位置と同じ ) に表示される
- [ ] `maxLanes === 1` の repo ( 単一ブランチ ) でも marker と lane 0 dot が衝突しない
- [ ] `maxLanes >= 2` の repo でも marker の右余白が広すぎないか確認
- [ ] commit 行のクリック / 右クリックメニュー ( Reset mixed ) が従来通り動作する
