### PR TITLE
feat(session-preview): toggle popover close on same bubble re-click

### DIFF
--- a/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
+++ b/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
@@ -34,8 +34,7 @@ sub overlay の先頭に `subagentTabLabel` 由来の subagent ラベル (Task /
 各 bubble クリックで HTML Popover API ベースの全文ポップオーバーを開く。Popover は
 `shared/popover` の `usePopover` を per-instance で使い、anchor は被クリック bubble。
 CSS anchor positioning (`positionArea` + `positionTryFallbacks`) で画面端に押し出された
-ときは反対側へ flip する。開いている bubble を再クリックすると `usePopover` の `toggle`
-経由で閉じる (同 anchor 判定で hidePopover + openState clear)。
+ときは反対側へ flip する。同じ bubble を再クリックすると閉じる (トグル)。
 </doc>
 
 <script setup lang="ts">
@@ -191,14 +190,13 @@ const subMessages = computed<PreviewMessage[]>(() => collectMessages(subEvents.v
 // PreviewMessage を context にそのまま渡し、popover 側は kind / text しか参照しない
 // (ts は無視される)。型を分けず 1 つにまとめて conversion を消す。
 // per-instance: コンポーネント unmount で effect scope が自動破棄されるため stop 不要。
-// 開いている bubble を再クリックしたら閉じる動作にするため `toggle` を使う。
 const {
   Popover: PreviewPopover,
   context: previewContext,
   toggle: togglePreviewPopover,
 } = usePopover<PreviewMessage>();
 
-function openPreview(event: MouseEvent, msg: PreviewMessage) {
+function togglePreview(event: MouseEvent, msg: PreviewMessage) {
   const anchor = event.currentTarget;
   if (!(anchor instanceof HTMLElement)) return;
   togglePreviewPopover(anchor, msg);
@@ -240,7 +238,7 @@ const hasSub = computed(() => subMessages.value.length > 0);
             : 'bg-chat-incoming text-chat-incoming-text'
         "
         :title="msg.text"
-        @click="openPreview($event, msg)"
+        @click="togglePreview($event, msg)"
       >
         <span class="line-clamp-2">{{ msg.text }}</span>
       </button>
@@ -280,7 +278,7 @@ const hasSub = computed(() => subMessages.value.length > 0);
                 : 'bg-chat-incoming text-chat-incoming-text'
             "
             :title="msg.text"
-            @click="openPreview($event, msg)"
+            @click="togglePreview($event, msg)"
           >
             <span class="line-clamp-2">{{ msg.text }}</span>
           </button>

--- a/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
+++ b/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
@@ -34,7 +34,8 @@ sub overlay の先頭に `subagentTabLabel` 由来の subagent ラベル (Task /
 各 bubble クリックで HTML Popover API ベースの全文ポップオーバーを開く。Popover は
 `shared/popover` の `usePopover` を per-instance で使い、anchor は被クリック bubble。
 CSS anchor positioning (`positionArea` + `positionTryFallbacks`) で画面端に押し出された
-ときは反対側へ flip する。
+ときは反対側へ flip する。開いている bubble を再クリックすると `usePopover` の `toggle`
+経由で閉じる (同 anchor 判定で hidePopover + openState clear)。
 </doc>
 
 <script setup lang="ts">
@@ -190,16 +191,17 @@ const subMessages = computed<PreviewMessage[]>(() => collectMessages(subEvents.v
 // PreviewMessage を context にそのまま渡し、popover 側は kind / text しか参照しない
 // (ts は無視される)。型を分けず 1 つにまとめて conversion を消す。
 // per-instance: コンポーネント unmount で effect scope が自動破棄されるため stop 不要。
+// 開いている bubble を再クリックしたら閉じる動作にするため `toggle` を使う。
 const {
   Popover: PreviewPopover,
   context: previewContext,
-  open: openPreviewPopover,
+  toggle: togglePreviewPopover,
 } = usePopover<PreviewMessage>();
 
 function openPreview(event: MouseEvent, msg: PreviewMessage) {
   const anchor = event.currentTarget;
   if (!(anchor instanceof HTMLElement)) return;
-  openPreviewPopover(anchor, msg);
+  togglePreviewPopover(anchor, msg);
 }
 
 // sub overlay の折り畳み状態。`<details>` の `open` 属性を SSOT にすると subagent

--- a/apps/renderer/src/shared/popover/usePopover.ts
+++ b/apps/renderer/src/shared/popover/usePopover.ts
@@ -96,14 +96,16 @@ export function usePopover<T>(): UsePopoverResult<T> {
     // 同 anchor の再 click 経路: mousedown で light-dismiss が popover を閉じ、続く click が
     // この関数を呼ぶが、@toggle "closed" は task-queued のため openState はまだ直前 anchor を
     // 保持している。ここで openState を undefined に倒すと、後続の queued @toggle "closed" は
-    // 既に undefined を再代入する no-op になり、結果として popover は閉じたまま残る。
+    // `:popover-open` が false の分岐で `openState.value = undefined` を再代入する no-op になり、
+    // 結果として popover は閉じたまま残る。close 後に show を続けないため `suppressNextCloseEmit`
+    // は立てない (立てると onToggle 側で 1 回 skip が消費され、本来の next close が誤検出される)。
     // hidePopover() は light-dismiss 済みなら no-op、未 dismiss なら冪等に閉じる保険。
     if (openState.value?.anchorEl === anchorEl) {
       openState.value = undefined;
       popoverRef.value?.hidePopover();
       return;
     }
-    openState.value = { anchorEl, context: value };
+    open(anchorEl, value);
   }
 
   function close(): void {

--- a/apps/renderer/src/shared/popover/usePopover.ts
+++ b/apps/renderer/src/shared/popover/usePopover.ts
@@ -62,6 +62,13 @@ interface UsePopoverResult<T> {
   context: ComputedRef<T | undefined>;
   /** anchorEl の直下に popover を開き、context を template に渡す */
   open: (anchorEl: HTMLElement, context: T) => void;
+  /**
+   * 同じ anchorEl で open 中なら閉じ、そうでなければ open する。click で開いた anchor を
+   * 再 click したときの「トグル close」用。light-dismiss が click より先に走るケースでも、
+   * @toggle "closed" は task-queued なので、click ハンドラ実行時点では `openState` が
+   * まだ直前 anchor を保持している → 同期的に同 anchor 判定できる。
+   */
+  toggle: (anchorEl: HTMLElement, context: T) => void;
   /** popover を閉じる。@toggle 経由で openState も clear される */
   close: () => void;
   /** effectScope を破棄して watch を止める。module singleton 利用時の HMR dispose に使う */
@@ -82,6 +89,20 @@ export function usePopover<T>(): UsePopoverResult<T> {
   let suppressNextCloseEmit = false;
 
   function open(anchorEl: HTMLElement, value: T): void {
+    openState.value = { anchorEl, context: value };
+  }
+
+  function toggle(anchorEl: HTMLElement, value: T): void {
+    // 同 anchor の再 click 経路: mousedown で light-dismiss が popover を閉じ、続く click が
+    // この関数を呼ぶが、@toggle "closed" は task-queued のため openState はまだ直前 anchor を
+    // 保持している。ここで openState を undefined に倒すと、後続の queued @toggle "closed" は
+    // 既に undefined を再代入する no-op になり、結果として popover は閉じたまま残る。
+    // hidePopover() は light-dismiss 済みなら no-op、未 dismiss なら冪等に閉じる保険。
+    if (openState.value?.anchorEl === anchorEl) {
+      openState.value = undefined;
+      popoverRef.value?.hidePopover();
+      return;
+    }
     openState.value = { anchorEl, context: value };
   }
 
@@ -138,5 +159,5 @@ export function usePopover<T>(): UsePopoverResult<T> {
     },
   });
 
-  return { Popover, context, open, close, stop };
+  return { Popover, context, open, toggle, close, stop };
 }


### PR DESCRIPTION
## 概要

ターミナル右上のセッションプレビューで吹き出しをクリックすると全文の popover が開くが、開いた状態で同じ吹き出しをもう一度クリックしても閉じない問題を修正する。同じ bubble の再クリックで popover を閉じる(トグル)挙動にした。

## 背景

`TerminalSessionPreview.vue` の各吹き出しは `usePopover` の `open(anchorEl, msg)` を click で呼び、HTML Popover API (`popover="auto"`) の light-dismiss に挙動を任せていた。

`popover="auto"` の light-dismiss は anchor の **mousedown** で popover を閉じるが、続く click イベントで `open()` が再度走り即時 re-open するため、ユーザーから見るとトグル close ができない状態だった。

トグルを成立させるには「同 anchor の click が来た時点で `openState` がまだ前回の anchor を保持している」必要があるが、これは HTML Popover API の `ToggleEvent("closed")` が task-queued である挙動に依存する。`usePopover` 内の既存 race ハンドリング (`onToggle` の `:popover-open` 判定) も同じ前提で書かれており、その前提を活かして同 anchor 判定を click ハンドラに通すことでトグルを成立させた。

`open()` 自体に「同 anchor なら close」を埋め込む案も検討したが、`useFileContextMenu` / `useCommitContextMenu` / `useWorktreeMenu` / `useTaskMenu` の右クリック / ⋮ メニュー系が「同要素の再 open は anchor / 内容を更新する」前提で `open()` を使っており、暗黙挙動変更になるため見送り、新メソッド `toggle()` を追加して `TerminalSessionPreview` だけが opt-in する形にした。

## 変更内容

### `shared/popover/usePopover.ts`

- `toggle(anchorEl, context)` メソッドを追加。`openState.anchorEl === anchorEl` なら `openState` を `undefined` に倒して `hidePopover()` を呼び、それ以外は `open(anchorEl, context)` に委譲する
- `toggle()` の close 経路で `suppressNextCloseEmit` を立てない理由をコメントで明示 (skip フラグを誤って 1 回消費すると本来の next close が誤検出される race モデル)
- `hidePopover()` は light-dismiss 済みなら no-op、未 dismiss なら冪等に閉じる保険として残す
- 既存の `open()` / `close()` / `context` / `Popover` / `stop()` のセマンティクスは変更なし

### `features/terminal/TerminalSessionPreview.vue`

- `usePopover` の分割代入を `open` → `toggle` に切り替え、click ハンドラ `togglePreview` から `togglePreviewPopover(anchor, msg)` を呼ぶ
- `<doc>` ブロックに「同じ bubble を再クリックすると閉じる (トグル)」のユーザー仕様を追記

## 確認事項

- [ ] main / sub overlay それぞれの吹き出しを click → popover が開く
- [ ] 開いている状態で同じ吹き出しを再 click → popover が閉じる(トグル)
- [ ] 開いている状態で別の吹き出しを click → 新しい anchor に flip して開き直す
- [ ] popover の外側を click または ESC → light-dismiss で閉じる
- [ ] subagent の `<details>` を開閉しても sub 吹き出し再 click のトグルが壊れない
