### PR TITLE
ターミナル session preview の popover を広げて 3 段構造に再編

### DIFF
--- a/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
+++ b/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
@@ -42,13 +42,19 @@ DOM 構造は三段:
   位置決めと縦 padding だけを担う透明枠。UA default の `[popover] { overflow: auto }` は
   `overflow-visible` で明示的に打ち消す (打ち消さないと内側 box の `shadow-xl` が外側
   border-box で clip され shadow がほぼ見えなくなる)
-- 中間 wrapper (`max-h-[60vh] overflow-auto rounded-md border border-border-strong shadow-xl`)
-  kind に依らず共通の「スクロール面 + 角丸 + border + shadow」を担う。`overflow-auto` +
-  `border-radius` は CSS Backgrounds Module Level 3 仕様で子の painting を clip するため、
-  内側 box の bg は角丸内に物理的に収まる
-- 内側 box (kind 別)
-  user は `bg-chat-outgoing` + `wrap-break-word whitespace-pre-wrap`、
-  assistant は `bg-chat-incoming` + MarkdownBody 用 CSS var 上書き
+- 中間 wrapper (`max-h-[60vh] overflow-auto rounded-md border border-border-strong shadow-xl`
+  - kind 別 `bg-chat-incoming` / `bg-chat-outgoing`)
+    共通の「スクロール面 + 角丸 + border + shadow」と kind 別の bg を担う。bg を wrapper に
+    持たせるのは `apps/renderer/src/assets/main.css` の `::-webkit-scrollbar-track { background: transparent }`
+    と組み合わせるため。scrollbar gutter は WebKit の content-box 内側に描画されレイアウトを
+    消費するため、内側子要素に bg を持たせると gutter 帯だけ親の bg (透明) が透ける。scroll
+    container 自身に bg を持たせれば gutter ごと kind 色で塗られる。`overflow-auto` +
+    `border-radius` は CSS Backgrounds Module Level 3 §5.3 (Corner Clipping) で子の painting を
+    clip するため、bg は角丸内に収まる
+- 内側 box (kind 別、bg は持たない)
+  user は `wrap-break-word whitespace-pre-wrap text-chat-outgoing-text`、
+  assistant は MarkdownBody + `text-chat-incoming-text` + CSS var 上書き。背景は wrapper
+  から透ける構造
 
 「位置決め (外) / 見た目 + スクロール (中間) / 配色 (内)」と責務を分けることで、外側に
 装飾が混入して bubble overlay と区別できなくなる二重背景や、scroll 面が外側に寄って内側
@@ -318,17 +324,17 @@ const hasSub = computed(() => subMessages.value.length > 0);
     }"
   >
     <template v-if="previewContext">
-      <div class="max-h-[60vh] overflow-auto rounded-md border border-border-strong shadow-xl">
+      <div
+        class="max-h-[60vh] overflow-auto rounded-md border border-border-strong shadow-xl"
+        :class="previewContext.kind === 'assistant' ? 'bg-chat-incoming' : 'bg-chat-outgoing'"
+      >
         <div
           v-if="previewContext.kind === 'assistant'"
-          class="_preview-assistant bg-chat-incoming px-3 py-2 text-chat-incoming-text [--color-foreground-low:var(--color-chat-incoming-text-low)] [--color-foreground:var(--color-chat-incoming-text)] [--md-code-bg:transparent]"
+          class="_preview-assistant px-3 py-2 text-chat-incoming-text [--color-foreground-low:var(--color-chat-incoming-text-low)] [--color-foreground:var(--color-chat-incoming-text)] [--md-code-bg:transparent]"
         >
           <MarkdownBody :content="previewContext.text" />
         </div>
-        <div
-          v-else
-          class="bg-chat-outgoing px-3 py-2 wrap-break-word whitespace-pre-wrap text-chat-outgoing-text"
-        >
+        <div v-else class="px-3 py-2 wrap-break-word whitespace-pre-wrap text-chat-outgoing-text">
           {{ previewContext.text }}
         </div>
       </div>

--- a/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
+++ b/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
@@ -36,12 +36,23 @@ sub overlay の先頭に `subagentTabLabel` 由来の subagent ラベル (Task /
 CSS anchor positioning (`positionArea` + `positionTryFallbacks`) で画面端に押し出された
 ときは反対側へ flip する。同じ bubble を再クリックすると閉じる (トグル)。
 
-DOM 構造は「外側 popover element = 透明な縦 padding 枠」+「内側 box = スクロール面 +
-border + shadow + 角丸」の二段。外側は `bg-transparent border-none px-0 py-3` のみで
-装飾を持たず、内側の user / assistant box が `max-h-[60vh] overflow-auto` で自身を
-スクロール容器化する。外側にも装飾を当てると「グレー枠の中に黒 box が浮く二重背景」に
-なって popover 性が読み取れず、scroll 面も外側に寄って内側 box が伸び続けるため、
-責務を「位置決め (外) / 見た目 + スクロール (内)」で分けている。
+DOM 構造は三段:
+
+- 外側 popover element (`bg-transparent border-none overflow-visible px-0 py-3` のみ)
+  位置決めと縦 padding だけを担う透明枠。UA default の `[popover] { overflow: auto }` は
+  `overflow-visible` で明示的に打ち消す (打ち消さないと内側 box の `shadow-xl` が外側
+  border-box で clip され shadow がほぼ見えなくなる)
+- 中間 wrapper (`max-h-[60vh] overflow-auto rounded-md border border-border-strong shadow-xl`)
+  kind に依らず共通の「スクロール面 + 角丸 + border + shadow」を担う。`overflow-auto` +
+  `border-radius` は CSS Backgrounds Module Level 3 仕様で子の painting を clip するため、
+  内側 box の bg は角丸内に物理的に収まる
+- 内側 box (kind 別)
+  user は `bg-chat-outgoing` + `wrap-break-word whitespace-pre-wrap`、
+  assistant は `bg-chat-incoming` + MarkdownBody 用 CSS var 上書き
+
+「位置決め (外) / 見た目 + スクロール (中間) / 配色 (内)」と責務を分けることで、外側に
+装飾が混入して bubble overlay と区別できなくなる二重背景や、scroll 面が外側に寄って内側
+box が伸び続ける挙動を構造的に排除する。
 </doc>
 
 <script setup lang="ts">
@@ -299,7 +310,7 @@ const hasSub = computed(() => subMessages.value.length > 0);
        assistant 側のみ MarkdownBody で描画 (SessionLogTranscript と同じ規律: user 投稿は
        素のテキストとして書かれる前提で markdown 解釈しない)。 -->
   <PreviewPopover
-    class="m-0 w-3xl max-w-[80vw] border-none bg-transparent px-0 py-3 text-base"
+    class="m-0 w-3xl max-w-[80vw] overflow-visible border-none bg-transparent px-0 py-3 text-base"
     :style="{
       position: 'fixed',
       positionArea: 'block-end span-inline-start',
@@ -307,17 +318,19 @@ const hasSub = computed(() => subMessages.value.length > 0);
     }"
   >
     <template v-if="previewContext">
-      <div
-        v-if="previewContext.kind === 'assistant'"
-        class="_preview-assistant max-h-[60vh] overflow-auto rounded-md border border-border-strong bg-chat-incoming px-3 py-2 text-chat-incoming-text shadow-xl [--color-foreground-low:var(--color-chat-incoming-text-low)] [--color-foreground:var(--color-chat-incoming-text)] [--md-code-bg:transparent]"
-      >
-        <MarkdownBody :content="previewContext.text" />
-      </div>
-      <div
-        v-else
-        class="max-h-[60vh] overflow-auto rounded-md border border-border-strong bg-chat-outgoing px-3 py-2 wrap-break-word whitespace-pre-wrap text-chat-outgoing-text shadow-xl"
-      >
-        {{ previewContext.text }}
+      <div class="max-h-[60vh] overflow-auto rounded-md border border-border-strong shadow-xl">
+        <div
+          v-if="previewContext.kind === 'assistant'"
+          class="_preview-assistant bg-chat-incoming px-3 py-2 text-chat-incoming-text [--color-foreground-low:var(--color-chat-incoming-text-low)] [--color-foreground:var(--color-chat-incoming-text)] [--md-code-bg:transparent]"
+        >
+          <MarkdownBody :content="previewContext.text" />
+        </div>
+        <div
+          v-else
+          class="bg-chat-outgoing px-3 py-2 wrap-break-word whitespace-pre-wrap text-chat-outgoing-text"
+        >
+          {{ previewContext.text }}
+        </div>
       </div>
     </template>
   </PreviewPopover>

--- a/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
+++ b/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
@@ -35,6 +35,13 @@ sub overlay の先頭に `subagentTabLabel` 由来の subagent ラベル (Task /
 `shared/popover` の `usePopover` を per-instance で使い、anchor は被クリック bubble。
 CSS anchor positioning (`positionArea` + `positionTryFallbacks`) で画面端に押し出された
 ときは反対側へ flip する。同じ bubble を再クリックすると閉じる (トグル)。
+
+DOM 構造は「外側 popover element = 透明な縦 padding 枠」+「内側 box = スクロール面 +
+border + shadow + 角丸」の二段。外側は `bg-transparent border-none px-0 py-3` のみで
+装飾を持たず、内側の user / assistant box が `max-h-[60vh] overflow-auto` で自身を
+スクロール容器化する。外側にも装飾を当てると「グレー枠の中に黒 box が浮く二重背景」に
+なって popover 性が読み取れず、scroll 面も外側に寄って内側 box が伸び続けるため、
+責務を「位置決め (外) / 見た目 + スクロール (内)」で分けている。
 </doc>
 
 <script setup lang="ts">
@@ -292,7 +299,7 @@ const hasSub = computed(() => subMessages.value.length > 0);
        assistant 側のみ MarkdownBody で描画 (SessionLogTranscript と同じ規律: user 投稿は
        素のテキストとして書かれる前提で markdown 解釈しない)。 -->
   <PreviewPopover
-    class="m-0 max-h-[60vh] w-lg max-w-[80vw] overflow-auto rounded-lg border border-border bg-background p-3 text-base shadow-lg"
+    class="m-0 w-3xl max-w-[80vw] border-none bg-transparent px-0 py-3 text-base"
     :style="{
       position: 'fixed',
       positionArea: 'block-end span-inline-start',
@@ -302,13 +309,13 @@ const hasSub = computed(() => subMessages.value.length > 0);
     <template v-if="previewContext">
       <div
         v-if="previewContext.kind === 'assistant'"
-        class="_preview-assistant rounded-md bg-chat-incoming px-3 py-2 text-chat-incoming-text [--color-foreground-low:var(--color-chat-incoming-text-low)] [--color-foreground:var(--color-chat-incoming-text)] [--md-code-bg:transparent]"
+        class="_preview-assistant max-h-[60vh] overflow-auto rounded-md border border-border-strong bg-chat-incoming px-3 py-2 text-chat-incoming-text shadow-xl [--color-foreground-low:var(--color-chat-incoming-text-low)] [--color-foreground:var(--color-chat-incoming-text)] [--md-code-bg:transparent]"
       >
         <MarkdownBody :content="previewContext.text" />
       </div>
       <div
         v-else
-        class="rounded-md bg-chat-outgoing px-3 py-2 wrap-break-word whitespace-pre-wrap text-chat-outgoing-text"
+        class="max-h-[60vh] overflow-auto rounded-md border border-border-strong bg-chat-outgoing px-3 py-2 wrap-break-word whitespace-pre-wrap text-chat-outgoing-text shadow-xl"
       >
         {{ previewContext.text }}
       </div>


### PR DESCRIPTION
## 概要

ターミナル右上 / 右下の Claude session preview で吹き出しをクリックして開く全文 popover を、幅を広げた上で「外側 popover element / 中間 scroll wrapper / 内側 box」の三段構造に再編した。

## 背景

- 全文 popover の幅 `w-lg` (32rem) が狭く、長い assistant 応答を読むのに何度もスクロールが必要だった
- 元実装は外側 popover element に `bg-background rounded-lg border shadow-lg overflow-auto max-h-[60vh]` を当て、内側 user / assistant box にも `rounded-md` + chat 配色背景を当てていたため、「グレーの外枠の中に黒い吹き出しが浮く」二重背景になり popover 性が視覚的に読み取れていなかった
- 外側に `overflow-auto` があったため、内側 box (chat 配色の角丸面) はスクロールに追従せず、外側のグレー余白部分がスクロール面になっていて操作意図と動きが噛み合っていなかった
- レビュー過程で次の追加課題が判明
  - 内側 box に `shadow-xl` を当てても外側 popover の UA default `[popover] { overflow: auto }` で構造的に clip され shadow がほぼ見えない
  - assistant / user 内側 box で `max-h / overflow-auto / rounded-md / border / shadow-xl` が完全重複しており SSOT が分裂
  - 実機で popover を開くと、scrollbar が出るケースで内側の黒 box と外側 border の間に scrollbar 幅 (6px) の透明帯が見え popover が破綻して見える ( `apps/renderer/src/assets/main.css` の global `::-webkit-scrollbar-track { background: transparent }` と内側 box bg の組み合わせによる)

## 変更内容

### popover 幅

- 全文 popover の幅を `w-lg` (32rem / 512px) → `w-3xl` (48rem / 768px) に拡張
- `max-w-[80vw]` guard はそのまま維持し、狭い viewport では引き続き 80% に収まる

### DOM 構造を三段に再編

- 外側 popover element: `bg-transparent border-none overflow-visible px-0 py-3` のみ。位置決めと縦 padding だけを担う透明枠。UA default `[popover] { overflow: auto }` は `overflow-visible` で明示的に打ち消す (打ち消さないと内側 shadow が外側 border-box で clip される)
- 中間 wrapper: `max-h-[60vh] overflow-auto rounded-md border border-border-strong shadow-xl` (共通装飾) + kind 別の `bg-chat-incoming` / `bg-chat-outgoing` を `:class` 三項で切り替え。scrollbar gutter (WebKit non-overlay の content-box 内側レイアウト消費) を kind 色で塗るため bg は scroll container 自身に持たせる
- 内側 box: kind 別の `text-chat-*-text` + テキスト処理のみ。bg は持たず wrapper から透ける構造

### `<doc>` ブロック更新

`apps/renderer/src/features/terminal/TerminalSessionPreview.vue` の `<doc>` の「全文 preview」セクションに、三段構造と各段の責務 ( 位置決め (外) / 見た目 + スクロール + bg owner (中間) / 配色 (内)) を追記。`overflow-visible` で UA default を打ち消す理由、`overflow-auto` + `border-radius` の CSS Backgrounds Module Level 3 §5.3 Corner Clipping による角丸内 bg 収まり、scroll container 自身に bg を持たせる理由 (scrollbar gutter 塗り) を理由付きで残した。

## 確認事項

- [ ] terminal の右上 main / 右下 sub の bubble をクリックして popover が開くこと
- [ ] popover が広く (768px / 80vw 上限) 表示されること
- [ ] 内側の chat 配色領域だけが border + shadow を持ち、外側に余分なグレー枠が出ていないこと
- [ ] 長い assistant 応答で内側がスクロールし、外側枠はスクロールしないこと
- [ ] scrollbar が出るケースで内側 bg と border の間に透明帯が出ず、gutter まで kind 色で塗られていること
- [ ] `rounded-md` の corner clipping で kind 色が border 直下まで丸く切れていること
- [ ] 画面端で `positionTryFallbacks` で flip し、新しい幅でも viewport からはみ出さないこと
- [ ] 同じ bubble の再クリックで popover が閉じる (light-dismiss 経路) こと
