### PR TITLE
fix(renderer): タイトルバーとコンテンツの隙間 (WebKit rubber band) を抑止

### DIFF
--- a/apps/renderer/src/assets/main.css
+++ b/apps/renderer/src/assets/main.css
@@ -135,6 +135,15 @@
 }
 
 @layer base {
+  /* macOS WebKit の rubber band (elastic scroll) を抑止する。
+     WebView 内部 NSScrollView の bounce が発火するとタイトルバーとの隙間に
+     SwiftUI 側 .background(Color.black) が透けて見える。SwiftUI WebView (macOS 26)
+     には scroll 制御 API が無いため CSS 側で抑える。 */
+  html,
+  body {
+    overscroll-behavior: none;
+  }
+
   body {
     @apply bg-background text-foreground;
   }


### PR DESCRIPTION
## 概要

renderer の `html` / `body` に `overscroll-behavior: none` を付与し、macOS WebKit の elastic scroll (rubber band) による「タイトルバーとコンテンツの間に黒い隙間が出る」現象を抑止する。

## 背景

トラックパッドでサイドバー / コンテンツを下にスワイプすると、タイトルバーとアプリ本体の間に黒い隙間が一瞬露出する不具合があった。

調査の結果:

- 露出する黒は `apps/native/Sources/Gozd/GozdApp.swift` の `WebView` に敷いている `.background(Color.black)`
- 上に `.webViewContentBackground(.hidden)` を効かせているため、WebKit 内部 `NSScrollView` が bounce すると WebView の透明部分越しに黒が見える
- `apps/renderer/src/features/layout/MainLayout.vue` のルートは `h-screen overflow-hidden` なので DOM 上はスクロール不能だが、WKWebView 内部 scroll view は DOM とは独立に bounce する仕様
- SwiftUI `WebView` (macOS 26 新 API) は内部 `WKScrollView` を制御する公開 modifier を提供しないため、native 側からは止められない

CSS `overscroll-behavior: none` が WebKit でも rubber band 抑止として有効なため、renderer 側で対応する。

## 変更内容

### renderer

- `apps/renderer/src/assets/main.css` の `@layer base` に `html, body { overscroll-behavior: none }` を追記
- 採用理由をコメントで明示 (WebKit / SwiftUI WebView (macOS 26) の制約、native 経路が使えない経緯)

## 確認事項

- [ ] サイドバー / コンテンツをトラックパッドで下にスワイプしても、タイトルバーとの間に黒い隙間が出ないこと
- [ ] 上方向スワイプでも同様に隙間が出ないこと
- [ ] terminal pane (xterm.js scrollback)、filer、preview、session log timeline 等の **内部スクロール** が今まで通り動作すること (端到達時の scroll chain 抑止の副作用が pane の操作性に影響していないこと)
- [ ] dialog (Quick Pick / Session Log 等) を開いた状態でも背後コンテンツの bounce が起きないこと
