### PR TITLE
style(terminal-session-preview): subagent bubble の popover を上向きに開く

### DIFF
--- a/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
+++ b/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
@@ -36,6 +36,13 @@ sub overlay の先頭に `subagentTabLabel` 由来の subagent ラベル (Task /
 CSS anchor positioning (`positionArea` + `positionTryFallbacks`) で画面端に押し出された
 ときは反対側へ flip する。同じ bubble を再クリックすると閉じる (トグル)。
 
+開く向きのデフォルトは由来 overlay によって反転させる。main 由来 (画面上側 bubble) は
+`block-end` で anchor の下に、sub 由来 (画面下側 bubble) は `block-start` で anchor の
+上に開く。下側 bubble の真下は画面端に近く即 flip 前提のレイアウトになるため、初期向きを
+上にしておくことで「open 直後に flip して位置が跳ねる」視覚的なちらつきを構造的に消す。
+flip 規則 (`positionTryFallbacks`) は両 origin で共通のため、開いた後の縁ぶつかり時の
+逆転挙動は維持される。
+
 DOM 構造は三段:
 
 - 外側 popover element (`bg-transparent border-none overflow-visible px-0 py-3` のみ)
@@ -210,20 +217,26 @@ function collectMessages(events: TranscriptEvent[]): PreviewMessage[] {
 const mainMessages = computed<PreviewMessage[]>(() => collectMessages(mainEvents.value));
 const subMessages = computed<PreviewMessage[]>(() => collectMessages(subEvents.value));
 
-// クリックで全文を出す popover。kind は吹き出し色を合わせるための discriminator。
-// PreviewMessage を context にそのまま渡し、popover 側は kind / text しか参照しない
-// (ts は無視される)。型を分けず 1 つにまとめて conversion を消す。
+// クリックで全文を出す popover。kind は吹き出し色を合わせるための discriminator、
+// origin は anchor が main / sub overlay どちらに属するかを popover の開く向きに反映するための
+// discriminator (main は anchor の下に、sub は anchor の上に開く)。
+// PreviewMessage に origin を載せて context として渡し、popover 側は kind / text / origin
+// のみ参照する (ts は無視される)。型を分けず 1 つにまとめて conversion を消す。
 // per-instance: コンポーネント unmount で effect scope が自動破棄されるため stop 不要。
+interface PreviewContext {
+  msg: PreviewMessage;
+  origin: "main" | "sub";
+}
 const {
   Popover: PreviewPopover,
   context: previewContext,
   toggle: togglePreviewPopover,
-} = usePopover<PreviewMessage>();
+} = usePopover<PreviewContext>();
 
-function togglePreview(event: MouseEvent, msg: PreviewMessage) {
+function togglePreview(event: MouseEvent, msg: PreviewMessage, origin: "main" | "sub") {
   const anchor = event.currentTarget;
   if (!(anchor instanceof HTMLElement)) return;
-  togglePreviewPopover(anchor, msg);
+  togglePreviewPopover(anchor, { msg, origin });
 }
 
 // sub overlay の折り畳み状態。`<details>` の `open` 属性を SSOT にすると subagent
@@ -262,7 +275,7 @@ const hasSub = computed(() => subMessages.value.length > 0);
             : 'bg-chat-incoming text-chat-incoming-text'
         "
         :title="msg.text"
-        @click="togglePreview($event, msg)"
+        @click="togglePreview($event, msg, 'main')"
       >
         <span class="line-clamp-2">{{ msg.text }}</span>
       </button>
@@ -302,7 +315,7 @@ const hasSub = computed(() => subMessages.value.length > 0);
                 : 'bg-chat-incoming text-chat-incoming-text'
             "
             :title="msg.text"
-            @click="togglePreview($event, msg)"
+            @click="togglePreview($event, msg, 'sub')"
           >
             <span class="line-clamp-2">{{ msg.text }}</span>
           </button>
@@ -319,23 +332,26 @@ const hasSub = computed(() => subMessages.value.length > 0);
     class="m-0 w-3xl max-w-[80vw] overflow-visible border-none bg-transparent px-0 py-3 text-base"
     :style="{
       position: 'fixed',
-      positionArea: 'block-end span-inline-start',
+      positionArea:
+        previewContext?.origin === 'sub'
+          ? 'block-start span-inline-start'
+          : 'block-end span-inline-start',
       positionTryFallbacks: 'flip-block, flip-inline, flip-block flip-inline',
     }"
   >
     <template v-if="previewContext">
       <div
         class="max-h-[60vh] overflow-auto rounded-md border border-border-strong shadow-xl"
-        :class="previewContext.kind === 'assistant' ? 'bg-chat-incoming' : 'bg-chat-outgoing'"
+        :class="previewContext.msg.kind === 'assistant' ? 'bg-chat-incoming' : 'bg-chat-outgoing'"
       >
         <div
-          v-if="previewContext.kind === 'assistant'"
+          v-if="previewContext.msg.kind === 'assistant'"
           class="_preview-assistant px-3 py-2 text-chat-incoming-text [--color-foreground-low:var(--color-chat-incoming-text-low)] [--color-foreground:var(--color-chat-incoming-text)] [--md-code-bg:transparent]"
         >
-          <MarkdownBody :content="previewContext.text" />
+          <MarkdownBody :content="previewContext.msg.text" />
         </div>
         <div v-else class="px-3 py-2 wrap-break-word whitespace-pre-wrap text-chat-outgoing-text">
-          {{ previewContext.text }}
+          {{ previewContext.msg.text }}
         </div>
       </div>
     </template>


### PR DESCRIPTION
## 概要

ターミナル右下に出る subagent (sub overlay) の bubble をクリックして全文 popover を開くとき、デフォルトの開く向きを下 → 上に反転する。main 由来 (右上 overlay) の bubble は従来通り下向きに開く。

## 背景

`TerminalSessionPreview` は terminal 右上に main session の最新発話、右下に subagent の最新発話を LINE 風 bubble で並べている。bubble クリックで HTML Popover API の全文 popover が開く。

これまで popover は origin によらず `positionArea: 'block-end span-inline-start'` (anchor の下に開く) を初期値にしていた。sub bubble は画面下端に近いため、下開きで配置すると anchor の真下に収まる space が無く、`positionTryFallbacks: 'flip-block, ...'` に頼って毎回上側に flip して着地する状態になっていた。

flip 経路で結果的に上向きに収まるとはいえ、open 直後に位置が跳ねる視覚的なちらつきが残るため、レイアウト前提から「下側 bubble は最初から上向きに開く」を初期値にしたい、というのが今回の起点。

## 変更内容

### `TerminalSessionPreview.vue`

- `usePopover` の context 型を `PreviewMessage` から `{ msg: PreviewMessage; origin: 'main' | 'sub' }` に拡張
- `togglePreview` に第 3 引数 `origin` を追加し、main overlay 側 bubble は `'main'`、sub overlay (subagent) 側 bubble は `'sub'` を渡す
- popover の `positionArea` を `previewContext.origin` で出し分け
  - `main` → `block-end span-inline-start` (anchor の下、従来挙動)
  - `sub` → `block-start span-inline-start` (anchor の上、新規)
- `positionTryFallbacks: 'flip-block, flip-inline, flip-block flip-inline'` は両 origin 共通で維持。開いた後の縁ぶつかり時の逆転挙動は変えない
- template 内の参照を `previewContext.kind` / `.text` → `previewContext.msg.kind` / `.msg.text` に更新
- `<doc>` ブロックに sub 由来 bubble は上開きデフォルトである旨を追記

## 設計判断

### 単一 `usePopover` instance + context 分岐

main / sub で別 `usePopover` instance を立てて positionArea を hard-code する案は採らなかった。`shared/popover` 規律にある「menu kind ごとに独立 singleton を作る」は別 menu 種別 (worktree / task など) を統合しないためのもので、同一 menu の origin 違いを別 instance にするのは過剰分割になる。context に origin メタを 1 つ足すだけで、popover renderer は引き続き「context だけ見ればよい」責務分離を保てる。

### anchor の DOM 属性ではなく context 経由

anchor 要素に `data-origin` を持たせて popover renderer から読みに行く案もあるが、context にメタを乗せた方が SFC 内の DOM ↔ JS の参照経路が片方向 (template → script) に揃う。

## 確認事項

- [ ] 右上 main の bubble をクリック → 従来通り bubble の **下** に popover が開く
- [ ] 右下 sub (subagent) の bubble をクリック → bubble の **上** に popover が開き、open 直後の位置跳ねが発生しない
- [ ] sub overlay が画面上端寄りになる極端な状況 (terminal 縦サイズが極小) で popover が画面外にはみ出そうな場合、`flip-block` で下側へ flip する挙動が維持されている
- [ ] popover の trigger toggle (同じ bubble の再クリックで close)、light-dismiss (popover 外 click) が両 origin で従来通り動く
