### PR TITLE
fix(session-log): SDK 合成 assistant を rewind 分岐 / transcript から除外する

### DIFF
--- a/apps/renderer/src/features/session-log/sessionLog.test.ts
+++ b/apps/renderer/src/features/session-log/sessionLog.test.ts
@@ -531,77 +531,132 @@ describe("parseSessionLog", () => {
   // 同じ会話的親 (u1) に集約されるため放置すると兄弟 branch として浮上する。synthetic を候補から
   // 外したうえで、user "Continue..." 側のチェーンも (synthetic だけしか中身が無いため) 実質的に
   // 空になり、real text 1 本だけが残ることを確認する。
-  test("rewind: 実観測形 (resume mid-AskUserQuestion) で synthetic が branch を生やさない", () => {
-    const log = parseSessionLog(
-      jsonl(
-        {
-          type: "user",
-          uuid: "u1",
-          parentUuid: null,
-          timestamp: TS,
-          message: { role: "user", content: "投稿予定の総評本文をレビュー" },
+  // 実観測形 (studio-front jsonl, 4f073973-… の line 90-109 を縮約) を再現する fixture builder。
+  // AskUserQuestion を投げた直後にセッションが切れ `claude --continue` 相当で resume されたケース。
+  // 木の形:
+  //
+  //   u1 (user 生発話, candidate)
+  //     ├─ a0 (assistant thinking; 最新モデルは signature のみ書き thinking 平文は空 → NOT candidate)
+  //     │   └─ a1 (assistant text "主要箇所…", candidate)
+  //     │       └─ a2 (assistant tool_use:AskUserQuestion, NOT candidate; ここで停止)
+  //     └─ r1 (user "Continue from where you left off.", isMeta:true → NOT candidate)
+  //         └─ r2 (assistant <synthetic> "No response requested.", model:<synthetic>)
+  //
+  // a1 と r2 はいずれも parent が非候補なので `convAncestor` を遡ると共通祖先 u1 で兄弟になる。
+  // synthetic を弾くか弾かないかで convChildren["u1"] の中身が変わり、branch chooser の有無が決まる。
+  // model フィールドを差し替えるだけで「synthetic 弾きあり / なし」を切り替えられる作りにし、両分岐を
+  // 同じ topology で比較できるようにする (= 本 PR の `isBranchCandidate` 早期 return line が test の
+  // 必須カバレッジに入る)。
+  const resumeMidAskFixture = (r2Model: string) =>
+    jsonl(
+      {
+        type: "user",
+        uuid: "u1",
+        parentUuid: null,
+        timestamp: TS,
+        message: { role: "user", content: "投稿予定の総評本文をレビュー" },
+      },
+      // real chain
+      {
+        type: "assistant",
+        uuid: "a0",
+        parentUuid: "u1",
+        timestamp: TS,
+        message: {
+          role: "assistant",
+          model: "claude-opus-4-7",
+          content: [{ type: "thinking", thinking: "", signature: "redacted" }],
         },
-        // real branch: 実 text → tool_use:AskUserQuestion で停止
-        {
-          type: "assistant",
-          uuid: "a1",
-          parentUuid: "u1",
-          timestamp: TS,
-          message: {
-            role: "assistant",
-            model: "claude-opus-4-7",
-            content: [{ type: "text", text: "主要箇所の検証が完了しました。" }],
-          },
+      },
+      {
+        type: "assistant",
+        uuid: "a1",
+        parentUuid: "a0",
+        timestamp: TS,
+        message: {
+          role: "assistant",
+          model: "claude-opus-4-7",
+          content: [{ type: "text", text: "主要箇所の検証が完了しました。" }],
         },
-        {
-          type: "assistant",
-          uuid: "a2",
-          parentUuid: "a1",
-          timestamp: TS,
-          message: {
-            role: "assistant",
-            model: "claude-opus-4-7",
-            content: [{ type: "tool_use", id: "tu1", name: "AskUserQuestion", input: {} }],
-          },
+      },
+      {
+        type: "assistant",
+        uuid: "a2",
+        parentUuid: "a1",
+        timestamp: TS,
+        message: {
+          role: "assistant",
+          model: "claude-opus-4-7",
+          content: [{ type: "tool_use", id: "tu1", name: "AskUserQuestion", input: {} }],
         },
-        // resume branch: bridge-session 等の非候補メタは省略。user resume prompt + synthetic
-        {
-          type: "user",
-          uuid: "r1",
-          parentUuid: "u1",
-          timestamp: TS,
-          message: { role: "user", content: "Continue from where you left off." },
+      },
+      // resume chain: r1 は SDK 注入 (isMeta:true)、r2 が問題の synthetic
+      {
+        type: "user",
+        uuid: "r1",
+        parentUuid: "u1",
+        isMeta: true,
+        timestamp: TS,
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "Continue from where you left off." }],
         },
-        {
-          type: "assistant",
-          uuid: "r2",
-          parentUuid: "r1",
-          timestamp: TS,
-          message: {
-            role: "assistant",
-            model: "<synthetic>",
-            content: [{ type: "text", text: "No response requested." }],
-          },
+      },
+      {
+        type: "assistant",
+        uuid: "r2",
+        parentUuid: "r1",
+        timestamp: TS,
+        message: {
+          role: "assistant",
+          model: r2Model,
+          content: [{ type: "text", text: "No response requested." }],
         },
-      ),
+      },
     );
-    // 期待: synthetic を弾いた結果、resume チェーン (r1 user "Continue...") は branch 候補だが、
-    // real チェーン (a1) と兄弟になり 2 候補で branch chooser が出る。real が #1 (古い)、resume が
-    // #2 (新しい = 最新枝としてデフォルト選択)。lead text が "Continue..." / "主要箇所..." であり、
-    // "No response requested." が選択肢ラベルとして浮上しないことが核心。
+
+  // 本 PR の core invariant: model:"<synthetic>" の r2 は branch 候補から外れ、a1 単独になり branch
+  // chooser は生まれない。a2 (tool_use) は通常通り tool イベントとして並ぶ。
+  test("rewind: 実観測形 (resume mid-AskUserQuestion) で synthetic が branch を生やさない", () => {
+    const log = parseSessionLog(resumeMidAskFixture("<synthetic>"));
+    expect(log.events).toEqual([
+      { kind: "user", text: "投稿予定の総評本文をレビュー", ts: TS },
+      { kind: "assistant", text: "主要箇所の検証が完了しました。", ts: TS },
+      {
+        kind: "tool",
+        name: "AskUserQuestion",
+        input: {},
+        toolUseId: "tu1",
+        ts: TS,
+        result: undefined,
+      },
+    ]);
+    // r1 (isMeta) + r2 (synthetic) が skipped に計上される。a0 の空 thinking は emptyThinking 側。
+    expect(log.skipped).toBe(2);
+    expect(log.emptyThinking).toBe(1);
+    expect(log.models).toEqual(["claude-opus-4-7"]);
+  });
+
+  // contrast test: r2 の model が実モデル (`<synthetic>` 以外) だと同じ topology で a1 と r2 が
+  // u1 兄弟になり、`No response requested.` ラベルの偽 branch chooser が出現する。本 PR が消した
+  // 症状そのもの。`isBranchCandidate` の synthetic 早期 return line を外すと test "rewind: 実観測形…"
+  // の expect 結果がこの contrast 形 (branch chooser が出る) に変わるため、core 変更の退行検出を担保
+  // する pair として機能する。
+  test("rewind: 同じ resume 構造でも model が実モデルなら偽 branch chooser が出る (contrast)", () => {
+    const log = parseSessionLog(resumeMidAskFixture("claude-opus-4-7"));
     expect(log.events).toEqual([
       { kind: "user", text: "投稿予定の総評本文をレビュー", ts: TS },
       {
         kind: "branch",
         ts: TS,
         branchKey: "u1",
-        selectedChildUuid: "r1",
+        selectedChildUuid: "r2",
         options: [
           { childUuid: "a1", index: 1, lead: "主要箇所の検証が完了しました。", ts: TS },
-          { childUuid: "r1", index: 2, lead: "Continue from where you left off.", ts: TS },
+          { childUuid: "r2", index: 2, lead: "No response requested.", ts: TS },
         ],
       },
-      { kind: "user", text: "Continue from where you left off.", ts: TS },
+      { kind: "assistant", text: "No response requested.", ts: TS },
     ]);
   });
 

--- a/apps/renderer/src/features/session-log/sessionLog.test.ts
+++ b/apps/renderer/src/features/session-log/sessionLog.test.ts
@@ -296,6 +296,25 @@ describe("parseSessionLog", () => {
     expect(log.skipped).toBe(2);
   });
 
+  test("SDK 合成 assistant (model:<synthetic>) は transcript に載せず skipped に計上", () => {
+    // 観測形: 実 assistant 応答後に SDK が `model:"<synthetic>"` + `[{type:"text",text:"No response requested."}]`
+    // を同じ親に追記する。これは実応答ではないので skipped に倒す。
+    const log = parseSessionLog(
+      jsonl({
+        type: "assistant",
+        timestamp: TS,
+        message: {
+          role: "assistant",
+          model: "<synthetic>",
+          content: [{ type: "text", text: "No response requested." }],
+        },
+      }),
+    );
+    expect(log.events).toEqual([]);
+    expect(log.skipped).toBe(1);
+    expect(log.models).toEqual([]);
+  });
+
   test("先頭が注入タグでない通常発話は残す (タグが後ろに付くケース)", () => {
     const log = parseSessionLog(
       jsonl({
@@ -453,6 +472,138 @@ describe("parseSessionLog", () => {
         message: { role: "assistant", content: [{ type: "text", text: "昨日は晴れ" }] },
       },
     );
+
+  // 観測症状: 実 assistant 応答 (b1) と SDK 合成 assistant (b2: model:<synthetic>) が同じ親 uuid に
+  // 並ぶ。append-only 木の上では兄弟になるが、合成 assistant は rewind ではないため branch chooser
+  // を出してはいけない (ターミナル上では分岐していないのに UI 上だけ分岐表示される症状)。
+  test("rewind: SDK 合成 assistant は分岐候補から除外する", () => {
+    const log = parseSessionLog(
+      jsonl(
+        {
+          type: "user",
+          uuid: "u1",
+          parentUuid: null,
+          timestamp: TS,
+          message: { role: "user", content: "主要箇所の検証お願い" },
+        },
+        {
+          type: "assistant",
+          uuid: "b1",
+          parentUuid: "u1",
+          timestamp: TS,
+          message: {
+            role: "assistant",
+            model: "claude-opus-4-7",
+            content: [{ type: "text", text: "主要箇所の検証が完了しました。" }],
+          },
+        },
+        {
+          type: "assistant",
+          uuid: "b2",
+          parentUuid: "u1",
+          timestamp: TS,
+          message: {
+            role: "assistant",
+            model: "<synthetic>",
+            content: [{ type: "text", text: "No response requested." }],
+          },
+        },
+      ),
+    );
+    expect(log.events).toEqual([
+      { kind: "user", text: "主要箇所の検証お願い", ts: TS },
+      { kind: "assistant", text: "主要箇所の検証が完了しました。", ts: TS },
+    ]);
+  });
+
+  // 実観測形 (studio-front jsonl): AskUserQuestion 投げた直後にセッションが切れ、`claude --continue`
+  // 相当で resume されたケース。SDK は (a) `Continue from where you left off.` を新規 user prompt
+  // として挿入し、(b) 直前ターンが tool_use 待ちで実応答できないため synthetic assistant
+  // `No response requested.` を 1 件挿入する。append-only 木上では:
+  //
+  //   anchor (u1)
+  //     ├─ assistant(text "主要箇所の検証…")
+  //     │    └─ assistant(tool_use AskUserQuestion)   ← 停止
+  //     └─ user("Continue from where you left off.")
+  //          └─ assistant(<synthetic> "No response requested.")
+  //
+  // text 持ち assistant と synthetic assistant は親 uuid が異なるが、`convAncestor` 経由で
+  // 同じ会話的親 (u1) に集約されるため放置すると兄弟 branch として浮上する。synthetic を候補から
+  // 外したうえで、user "Continue..." 側のチェーンも (synthetic だけしか中身が無いため) 実質的に
+  // 空になり、real text 1 本だけが残ることを確認する。
+  test("rewind: 実観測形 (resume mid-AskUserQuestion) で synthetic が branch を生やさない", () => {
+    const log = parseSessionLog(
+      jsonl(
+        {
+          type: "user",
+          uuid: "u1",
+          parentUuid: null,
+          timestamp: TS,
+          message: { role: "user", content: "投稿予定の総評本文をレビュー" },
+        },
+        // real branch: 実 text → tool_use:AskUserQuestion で停止
+        {
+          type: "assistant",
+          uuid: "a1",
+          parentUuid: "u1",
+          timestamp: TS,
+          message: {
+            role: "assistant",
+            model: "claude-opus-4-7",
+            content: [{ type: "text", text: "主要箇所の検証が完了しました。" }],
+          },
+        },
+        {
+          type: "assistant",
+          uuid: "a2",
+          parentUuid: "a1",
+          timestamp: TS,
+          message: {
+            role: "assistant",
+            model: "claude-opus-4-7",
+            content: [{ type: "tool_use", id: "tu1", name: "AskUserQuestion", input: {} }],
+          },
+        },
+        // resume branch: bridge-session 等の非候補メタは省略。user resume prompt + synthetic
+        {
+          type: "user",
+          uuid: "r1",
+          parentUuid: "u1",
+          timestamp: TS,
+          message: { role: "user", content: "Continue from where you left off." },
+        },
+        {
+          type: "assistant",
+          uuid: "r2",
+          parentUuid: "r1",
+          timestamp: TS,
+          message: {
+            role: "assistant",
+            model: "<synthetic>",
+            content: [{ type: "text", text: "No response requested." }],
+          },
+        },
+      ),
+    );
+    // 期待: synthetic を弾いた結果、resume チェーン (r1 user "Continue...") は branch 候補だが、
+    // real チェーン (a1) と兄弟になり 2 候補で branch chooser が出る。real が #1 (古い)、resume が
+    // #2 (新しい = 最新枝としてデフォルト選択)。lead text が "Continue..." / "主要箇所..." であり、
+    // "No response requested." が選択肢ラベルとして浮上しないことが核心。
+    expect(log.events).toEqual([
+      { kind: "user", text: "投稿予定の総評本文をレビュー", ts: TS },
+      {
+        kind: "branch",
+        ts: TS,
+        branchKey: "u1",
+        selectedChildUuid: "r1",
+        options: [
+          { childUuid: "a1", index: 1, lead: "主要箇所の検証が完了しました。", ts: TS },
+          { childUuid: "r1", index: 2, lead: "Continue from where you left off.", ts: TS },
+        ],
+      },
+      { kind: "user", text: "Continue from where you left off.", ts: TS },
+    ]);
+  });
 
   test("rewind: デフォルトは最新枝を表示し直前に branch セレクタを挿す (捨て枝は出さない)", () => {
     const log = parseSessionLog(rewindLog());

--- a/apps/renderer/src/features/session-log/sessionLog.test.ts
+++ b/apps/renderer/src/features/session-log/sessionLog.test.ts
@@ -516,37 +516,20 @@ describe("parseSessionLog", () => {
     ]);
   });
 
-  // 実観測形 (studio-front jsonl): AskUserQuestion 投げた直後にセッションが切れ、`claude --continue`
-  // 相当で resume されたケース。SDK は (a) `Continue from where you left off.` を新規 user prompt
-  // として挿入し、(b) 直前ターンが tool_use 待ちで実応答できないため synthetic assistant
-  // `No response requested.` を 1 件挿入する。append-only 木上では:
-  //
-  //   anchor (u1)
-  //     ├─ assistant(text "主要箇所の検証…")
-  //     │    └─ assistant(tool_use AskUserQuestion)   ← 停止
-  //     └─ user("Continue from where you left off.")
-  //          └─ assistant(<synthetic> "No response requested.")
-  //
-  // text 持ち assistant と synthetic assistant は親 uuid が異なるが、`convAncestor` 経由で
-  // 同じ会話的親 (u1) に集約されるため放置すると兄弟 branch として浮上する。synthetic を候補から
-  // 外したうえで、user "Continue..." 側のチェーンも (synthetic だけしか中身が無いため) 実質的に
-  // 空になり、real text 1 本だけが残ることを確認する。
-  // 実観測形 (studio-front jsonl, 4f073973-… の line 90-109 を縮約) を再現する fixture builder。
-  // AskUserQuestion を投げた直後にセッションが切れ `claude --continue` 相当で resume されたケース。
-  // 木の形:
+  // 実観測形 (studio-front jsonl) を再現する fixture builder。AskUserQuestion 投げた直後にセッション
+  // が切れ `claude --continue` 相当で resume されたケース。木の形:
   //
   //   u1 (user 生発話, candidate)
-  //     ├─ a0 (assistant thinking; 最新モデルは signature のみ書き thinking 平文は空 → NOT candidate)
+  //     ├─ a0 (assistant thinking; 最新モデルは signature のみで平文は空 → NOT candidate)
   //     │   └─ a1 (assistant text "主要箇所…", candidate)
   //     │       └─ a2 (assistant tool_use:AskUserQuestion, NOT candidate; ここで停止)
   //     └─ r1 (user "Continue from where you left off.", isMeta:true → NOT candidate)
-  //         └─ r2 (assistant <synthetic> "No response requested.", model:<synthetic>)
+  //         └─ r2 (assistant text "No response requested.", model = r2Model)
   //
-  // a1 と r2 はいずれも parent が非候補なので `convAncestor` を遡ると共通祖先 u1 で兄弟になる。
-  // synthetic を弾くか弾かないかで convChildren["u1"] の中身が変わり、branch chooser の有無が決まる。
-  // model フィールドを差し替えるだけで「synthetic 弾きあり / なし」を切り替えられる作りにし、両分岐を
-  // 同じ topology で比較できるようにする (= 本 PR の `isBranchCandidate` 早期 return line が test の
-  // 必須カバレッジに入る)。
+  // 症状の消失は「r1 を弾く isMeta filter (既存) と r2 を弾く synthetic filter (本 PR で追加)」の AND
+  // で初めて成立する。どちらが欠けても a1 と r2 (または r1) が `convAncestor` で u1 兄弟になり偽
+  // branch chooser が浮上する。model フィールドだけ差し替えれば「synthetic filter on/off」を切り替え
+  // られる作りにし、positive / contrast の 2 test で同 topology を比較する。
   const resumeMidAskFixture = (r2Model: string) =>
     jsonl(
       {
@@ -615,49 +598,52 @@ describe("parseSessionLog", () => {
       },
     );
 
-  // 本 PR の core invariant: model:"<synthetic>" の r2 は branch 候補から外れ、a1 単独になり branch
-  // chooser は生まれない。a2 (tool_use) は通常通り tool イベントとして並ぶ。
-  test("rewind: 実観測形 (resume mid-AskUserQuestion) で synthetic が branch を生やさない", () => {
-    const log = parseSessionLog(resumeMidAskFixture("<synthetic>"));
-    expect(log.events).toEqual([
-      { kind: "user", text: "投稿予定の総評本文をレビュー", ts: TS },
-      { kind: "assistant", text: "主要箇所の検証が完了しました。", ts: TS },
-      {
-        kind: "tool",
-        name: "AskUserQuestion",
-        input: {},
-        toolUseId: "tu1",
-        ts: TS,
-        result: undefined,
-      },
-    ]);
-    // r1 (isMeta) + r2 (synthetic) が skipped に計上される。a0 の空 thinking は emptyThinking 側。
-    expect(log.skipped).toBe(2);
-    expect(log.emptyThinking).toBe(1);
-    expect(log.models).toEqual(["claude-opus-4-7"]);
-  });
+  // positive (synthetic) と contrast (実モデル) を pair で並べる。両 test は同じ topology で
+  // model フィールドだけが違う。positive が本 PR の core invariant (偽 chooser 消滅) を assert し、
+  // contrast は `isBranchCandidate` の synthetic 早期 return が外された場合に得られる挙動を
+  // negative control として固定する。contrast の expect 値は「現状の正しい挙動の spec」ではなく
+  // 「本 PR で消したい症状」を退行検出のためにロックしているもので、将来 resume 注入 user prompt
+  // 自体の扱いを変える等 core を深める変更を入れる際は、contrast の expect を更新する前提。
+  describe("rewind: resume mid-AskUserQuestion synthetic exclusion (regression guard pair)", () => {
+    test("positive: model:<synthetic> の r2 は branch 候補から外れ偽 chooser が消える", () => {
+      const log = parseSessionLog(resumeMidAskFixture("<synthetic>"));
+      expect(log.events).toEqual([
+        { kind: "user", text: "投稿予定の総評本文をレビュー", ts: TS },
+        { kind: "assistant", text: "主要箇所の検証が完了しました。", ts: TS },
+        {
+          kind: "tool",
+          name: "AskUserQuestion",
+          input: {},
+          toolUseId: "tu1",
+          ts: TS,
+          result: undefined,
+        },
+      ]);
+      // r1 (isMeta) + r2 (synthetic) が skipped に計上される。a0 の空 thinking は emptyThinking 側。
+      expect(log.skipped).toBe(2);
+      expect(log.emptyThinking).toBe(1);
+      expect(log.models).toEqual(["claude-opus-4-7"]);
+    });
 
-  // contrast test: r2 の model が実モデル (`<synthetic>` 以外) だと同じ topology で a1 と r2 が
-  // u1 兄弟になり、`No response requested.` ラベルの偽 branch chooser が出現する。本 PR が消した
-  // 症状そのもの。`isBranchCandidate` の synthetic 早期 return line を外すと test "rewind: 実観測形…"
-  // の expect 結果がこの contrast 形 (branch chooser が出る) に変わるため、core 変更の退行検出を担保
-  // する pair として機能する。
-  test("rewind: 同じ resume 構造でも model が実モデルなら偽 branch chooser が出る (contrast)", () => {
-    const log = parseSessionLog(resumeMidAskFixture("claude-opus-4-7"));
-    expect(log.events).toEqual([
-      { kind: "user", text: "投稿予定の総評本文をレビュー", ts: TS },
-      {
-        kind: "branch",
-        ts: TS,
-        branchKey: "u1",
-        selectedChildUuid: "r2",
-        options: [
-          { childUuid: "a1", index: 1, lead: "主要箇所の検証が完了しました。", ts: TS },
-          { childUuid: "r2", index: 2, lead: "No response requested.", ts: TS },
-        ],
-      },
-      { kind: "assistant", text: "No response requested.", ts: TS },
-    ]);
+    // negative control: `isBranchCandidate` の synthetic 早期 return line を外すと positive の
+    // expect 結果がこの contrast 形 (偽 branch chooser 出現) に変わる。core 変更の退行検出担保。
+    test("contrast (negative control): r2 が実モデルだと同じ topology で偽 chooser が浮上する", () => {
+      const log = parseSessionLog(resumeMidAskFixture("claude-opus-4-7"));
+      expect(log.events).toEqual([
+        { kind: "user", text: "投稿予定の総評本文をレビュー", ts: TS },
+        {
+          kind: "branch",
+          ts: TS,
+          branchKey: "u1",
+          selectedChildUuid: "r2",
+          options: [
+            { childUuid: "a1", index: 1, lead: "主要箇所の検証が完了しました。", ts: TS },
+            { childUuid: "r2", index: 2, lead: "No response requested.", ts: TS },
+          ],
+        },
+        { kind: "assistant", text: "No response requested.", ts: TS },
+      ]);
+    });
   });
 
   test("rewind: デフォルトは最新枝を表示し直前に branch セレクタを挿す (捨て枝は出さない)", () => {

--- a/apps/renderer/src/features/session-log/sessionLog.test.ts
+++ b/apps/renderer/src/features/session-log/sessionLog.test.ts
@@ -601,9 +601,15 @@ describe("parseSessionLog", () => {
   // positive (synthetic) と contrast (実モデル) を pair で並べる。両 test は同じ topology で
   // model フィールドだけが違う。positive が本 PR の core invariant (偽 chooser 消滅) を assert し、
   // contrast は `isBranchCandidate` の synthetic 早期 return が外された場合に得られる挙動を
-  // negative control として固定する。contrast の expect 値は「現状の正しい挙動の spec」ではなく
-  // 「本 PR で消したい症状」を退行検出のためにロックしているもので、将来 resume 注入 user prompt
-  // 自体の扱いを変える等 core を深める変更を入れる際は、contrast の expect を更新する前提。
+  // ロックして退行検出を担保する。
+  //
+  // contrast の expect 値は「現状の正しい挙動の spec」ではなく「本 PR で消したい症状を退行検出
+  // のためにロックしているもの」。将来 resume 注入 user prompt 自体の扱いを変える等 core を深める
+  // 変更を入れる際は、contrast の expect を更新する前提。
+  //
+  // 両 test は events だけでなく skipped / emptyThinking / models も assert することで、synthetic
+  // 弾きが外れた退行時に「skipped が 2 → 1 に減る」「models[] への重複登録の有無」等の二次的な
+  // 副作用も検出する。
   describe("rewind: resume mid-AskUserQuestion synthetic exclusion (regression guard pair)", () => {
     test("positive: model:<synthetic> の r2 は branch 候補から外れ偽 chooser が消える", () => {
       const log = parseSessionLog(resumeMidAskFixture("<synthetic>"));
@@ -625,9 +631,9 @@ describe("parseSessionLog", () => {
       expect(log.models).toEqual(["claude-opus-4-7"]);
     });
 
-    // negative control: `isBranchCandidate` の synthetic 早期 return line を外すと positive の
-    // expect 結果がこの contrast 形 (偽 branch chooser 出現) に変わる。core 変更の退行検出担保。
-    test("contrast (negative control): r2 が実モデルだと同じ topology で偽 chooser が浮上する", () => {
+    // contrast: `isBranchCandidate` の synthetic 早期 return line を外すと positive の expect
+    // 結果がこの contrast 形 (偽 branch chooser 出現) に変わる。退行検出担保。
+    test("contrast: r2 が実モデルだと同じ topology で偽 chooser が浮上する", () => {
       const log = parseSessionLog(resumeMidAskFixture("claude-opus-4-7"));
       expect(log.events).toEqual([
         { kind: "user", text: "投稿予定の総評本文をレビュー", ts: TS },
@@ -643,6 +649,11 @@ describe("parseSessionLog", () => {
         },
         { kind: "assistant", text: "No response requested.", ts: TS },
       ]);
+      // r1 (isMeta) のみ skipped。r2 は synthetic 弾きが効かないため events に乗り skipped されない。
+      // 分岐確定により a1 / a2 サブツリーは prune される (a0 は分岐より上なので emptyThinking に残る)。
+      expect(log.skipped).toBe(1);
+      expect(log.emptyThinking).toBe(1);
+      expect(log.models).toEqual(["claude-opus-4-7"]);
     });
   });
 

--- a/apps/renderer/src/features/session-log/sessionLog.ts
+++ b/apps/renderer/src/features/session-log/sessionLog.ts
@@ -136,6 +136,17 @@ function isInjectedUserText(text: string): boolean {
   return INJECTED_USER_WRAPPER_RE.test(text);
 }
 
+/**
+ * Claude Code SDK が会話ターン整合のために合成する assistant メッセージか。`model:"<synthetic>"`
+ * が discriminator。例: assistant の実応答後に SDK が `[{type:"text", text:"No response requested."}]`
+ * + `model:"<synthetic>"` の assistant レコードを同じ親に追記する。これは実応答ではないため
+ * transcript / rewind 兄弟検出のどちらにも乗せない。`models` 集計でも同じ discriminator で除外
+ * している (SSOT)。
+ */
+function isSyntheticAssistant(raw: RawLine): boolean {
+  return raw.type === "assistant" && raw.message?.model === "<synthetic>";
+}
+
 // slash command 起動は `type:"user"` の string content として記録され、先頭が
 // `<command-name>/foo</command-name>` か `<command-message>foo</command-message>` で始まる。
 // この先頭判定でだけ command block とみなす。本文中にたまたま <command-name> を含む生発話
@@ -276,6 +287,7 @@ const LEAD_MAX = 80;
  * 外れるため、tool の連鎖は分岐にならない。真の rewind は実発話 / 応答が同一親に複数並ぶ場合のみ。
  */
 function isBranchCandidate(raw: RawLine): boolean {
+  if (isSyntheticAssistant(raw)) return false;
   const content = raw.message?.content;
   if (raw.type === "user") {
     if (raw.isMeta === true) return false;
@@ -500,6 +512,14 @@ export function parseSessionLog(jsonl: string, selection?: BranchSelection): Par
     }
 
     if (raw.type === "assistant") {
+      // SDK 合成 assistant (model:"<synthetic>") は実応答ではなく整合性のための注入。
+      // 例: `[{type:"text", text:"No response requested."}]` が同じ親 uuid に追記される。
+      // transcript に載せると assistant バブルとして描画され、real 応答と兄弟で並ぶと branch
+      // chooser まで生えるため、レコードごと skipped に倒す (block 走査自体を回避)。
+      if (isSyntheticAssistant(raw)) {
+        skipped++;
+        continue;
+      }
       // 実際に使われた model を記録する。content の形 (array / synthetic string) に依らず
       // message.model はレコード単位に付くため、ブロック走査の前にここで採る。null / 空 /
       // システム生成の "<synthetic>" は実モデルではないため除外する。

--- a/apps/renderer/src/features/session-log/sessionLog.ts
+++ b/apps/renderer/src/features/session-log/sessionLog.ts
@@ -140,8 +140,13 @@ function isInjectedUserText(text: string): boolean {
  * Claude Code SDK が会話ターン整合のために合成する assistant メッセージか。`model:"<synthetic>"`
  * が discriminator。例: assistant の実応答後に SDK が `[{type:"text", text:"No response requested."}]`
  * + `model:"<synthetic>"` の assistant レコードを同じ親に追記する。これは実応答ではないため
- * transcript / rewind 兄弟検出のどちらにも乗せない。`models` 集計でも同じ discriminator で除外
- * している (SSOT)。
+ * transcript / rewind 兄弟検出のどちらにも乗せない。
+ *
+ * 既存の `isMeta:true` user filter (`raw.isMeta === true` → `isBranchCandidate` で false 返却 +
+ * 後段の render loop で skipped) と対称な役割を担う。両 filter とも (a) `isBranchCandidate` で
+ * branch 候補から外し、(b) render loop 先頭で transcript への push を skipped に倒す、の 2 役割を
+ * 兼ねる。`isMeta` (既存) は CLI/hook 注入の user レコードを、`isSyntheticAssistant` (本ヘルパー)
+ * は SDK 合成 assistant レコードをそれぞれ受け持つ。
  */
 function isSyntheticAssistant(raw: RawLine): boolean {
   return raw.type === "assistant" && raw.message?.model === "<synthetic>";
@@ -521,15 +526,11 @@ export function parseSessionLog(jsonl: string, selection?: BranchSelection): Par
         continue;
       }
       // 実際に使われた model を記録する。content の形 (array / synthetic string) に依らず
-      // message.model はレコード単位に付くため、ブロック走査の前にここで採る。null / 空 /
-      // システム生成の "<synthetic>" は実モデルではないため除外する。
+      // message.model はレコード単位に付くため、ブロック走査の前にここで採る。null / 空 を
+      // 除外する。`<synthetic>` 除外は上の `isSyntheticAssistant` 早期 return で 1 箇所 SSOT 化
+      // 済みのため、ここではチェックしない (この経路に synthetic は到達しない)。
       const model = raw.message?.model;
-      if (
-        typeof model === "string" &&
-        model !== "" &&
-        model !== "<synthetic>" &&
-        !seenModels.has(model)
-      ) {
+      if (typeof model === "string" && model !== "" && !seenModels.has(model)) {
         seenModels.add(model);
         models.push(model);
       }


### PR DESCRIPTION
## 概要

セッションログダイアログ上で、Claude Agent SDK が会話ターン整合のために挿入する `model:"<synthetic>"` の assistant レコードが偽の rewind 分岐 (#2 `No response requested.`) として branch chooser に浮上していた問題を修正します。

## 背景

別 worktree で AskUserQuestion を使った PR レビュー作業中に、セッションログを開くと #1 が real な assistant 応答、#2 が `No response requested.` という偽分岐が出る症状が観測されました。ターミナル上では分岐していないのに UI 上だけ分岐表示される。

実 jsonl を読んで分かった発生条件は **AskUserQuestion 投げた直後にセッションが中断され、`claude --continue` 相当で resume された** ケースです:

```text
anchor (output_style attachment)
  ├─ assistant text "主要箇所の検証が完了しました…"
  │    └─ assistant tool_use:AskUserQuestion        ← ここで停止
  └─ user "Continue from where you left off." (isMeta:true)  ← resume 注入 prompt
       └─ assistant <synthetic> "No response requested."     ← SDK 合成
```

直前ターンが tool_use 待ちで実応答できないため、SDK が user/assistant alternation invariant を保つために synthetic 埋め草を 1 件追記します。`bridge-session` / `mode` / `permission-mode` の連続注入が resume の指紋。

この 2 本のチェーンは parentUuid 直接一致では兄弟ではないものの、`convAncestor` (非候補ノードを透過して会話的親を遡る) で共通祖先に集約されるため、放置すると兄弟 rewind 候補として branch chooser に出てしまいます。

### 責任分界 (既存 filter と本 PR の追加の関係)

resume 注入 user prompt (`Continue from where you left off.`) は実 jsonl 上 **必ず `isMeta:true` を持って書かれている** ため、既存の `isBranchCandidate` の `if (raw.isMeta === true) return false;` で透過処理される。本 PR で追加するのはこれと対称な assistant 側の synthetic 注入除外: `model:"<synthetic>"` の assistant を `isBranchCandidate` と render loop の両方から弾く。**偽 branch chooser が消える条件は「isMeta filter (既存) と synthetic filter (本 PR で追加) の AND」**。どちらが欠けても a1 (real text) と兄弟になり偽分岐が再発する。

両 filter とも (a) `isBranchCandidate` で branch 候補から外し、(b) render loop 先頭で transcript への push を skipped に倒す、の **同じ 2 役割を兼ねる対称構造** にした。`isMeta` (既存) は CLI/hook 注入の user レコードを、`isSyntheticAssistant` (本 PR で追加) は SDK 合成 assistant レコードをそれぞれ受け持つ。

実観測の補強として `~/.claude/projects/` 配下 485 jsonl を scan した結果、真の SDK 注入 47 件 (resume 15 + synthetic 32) はいずれも上記の discriminator (`isMeta:true` / `model:"<synthetic>"`) を一貫して持っており、前提が崩れているケースは観測されない。

### sentinel 文字列フィルタを巻き戻した経緯

当初は **`No response requested.` 文字列が user role に注入されている** という誤った前提で string sentinel フィルタを書きましたが、実 jsonl 確認で「`No response requested.` 文字列の user-role 出現は無く `type:"assistant"` + `model:"<synthetic>"` だけ」だと判明したため、その実装は巻き戻しています。なお resume の `Continue from where you left off.` 文字列は user role に出現するが、こちらは isMeta:true により既存 filter が透過させるため別途の sentinel フィルタは不要。

## 変更内容

### `sessionLog.ts`

- `isSyntheticAssistant(raw)` ヘルパーを追加。`raw.type === "assistant" && raw.message?.model === "<synthetic>"` を discriminator として 1 箇所 SSOT に閉じ込める。JSDoc で既存 `isMeta:true` user filter と対称な役割 ((a) `isBranchCandidate` で branch 候補除外、(b) render loop 先頭で transcript 除外、の 2 役割を兼ねる) を明示
- `isBranchCandidate` 冒頭で synthetic を弾く → rewind 候補から除外
- assistant の render loop 先頭で synthetic を `skipped++; continue` に倒し、これに合わせて既存 `models[]` 集計内に残っていた `model !== "<synthetic>"` 条件を削除して synthetic 除外を helper 1 箇所に集約する。早期 return が後段の重複条件を構造的に死コード化していたため、重複を残すと将来 helper の振る舞いを変えた際に二重契約として顕在化する罠になる。SSOT 単一源に統一して synthetic を transcript / `kind:"assistant"` event / `models[]` から一括除外する

### `sessionLog.test.ts`

- 単機能テスト: synthetic 単独レコードが skipped に計上され `models[]` にも出ないこと、直接親一致兄弟の synthetic が branch 候補から除外されること (計 2 件)
- 結合テスト pair (regression guard, 計 2 件): 実観測 jsonl 形を縮約した topology (`a0` 空 thinking → `a1` real text → `a2` tool_use AskUserQuestion / `r1` isMeta resume → `r2` synthetic) を `resumeMidAskFixture(r2Model)` builder で表現。positive (`<synthetic>`) と contrast (実モデル) を `describe` で囲い、同 topology で model のみ差し替えることで `isBranchCandidate` の synthetic 早期 return line が test 結果を左右することを構造的に保証。両 test で events に加え skipped / emptyThinking / models も assert し、退行時に「skipped が 2 → 1 に減る」「models[] への重複登録の有無」等の二次的副作用も検出範囲に含める

## 確認事項

- [ ] AskUserQuestion を含む現行セッションが正しく transcript 表示される (既存テスト 100 件 + 新規 単機能 2 件 + pair 2 件 = 計 4 件追加 pass)
- [ ] resume mid-AskUserQuestion で生成された synthetic を含む過去ログを開いて、`No response requested.` バブルおよび偽 branch chooser が消えていること
- [ ] `models[]` 集計に `<synthetic>` が混入しないこと
