### PR TITLE
fix(preview): diff の行番号が桁の途中で折り返される問題を修正

### DIFF
--- a/apps/renderer/src/assets/main.css
+++ b/apps/renderer/src/assets/main.css
@@ -152,6 +152,16 @@
     cursor: pointer;
   }
 
+  /* コードフォントの SSOT (VSCode の editor.fontFamily 相当)。
+     preview.codeFontFamily 設定を PreviewPane / ChangesSummaryView が
+     `--preview-code-font-family` として提供し、未設定 (変数なし) なら --font-mono に fallback する。
+     preflight も pre/code を mono にするが、設定で上書き可能にするため同 layer 後勝ちで差し替える。
+     pre/code を経由しないコード面 (DiffPreview の div 描画) は同じ var 連鎖を scoped CSS で参照する。 */
+  pre,
+  code {
+    font-family: var(--preview-code-font-family, var(--font-mono));
+  }
+
   /* `<dialog>` の UA stylesheet 打ち消し。中身のラッパーで見た目を作る規約。
      Tailwind v4 preflight が margin を消す (tailwindlabs#16372) ため auto 復元 */
   dialog {

--- a/apps/renderer/src/features/preview/ChangesSummaryView.vue
+++ b/apps/renderer/src/features/preview/ChangesSummaryView.vue
@@ -22,6 +22,7 @@ import { onUnmounted, ref } from "vue";
 import { useNotificationStore } from "../../shared/notification";
 import { useChangesStore } from "../changes";
 import ChangesSummaryItem from "./ChangesSummaryItem.vue";
+import { previewCodeFontFamily } from "./previewConfig";
 
 const emit = defineEmits<{
   close: [];
@@ -72,7 +73,12 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="flex h-full flex-col overflow-hidden">
+  <!-- PreviewPane の font wrapper を経由しない兄弟分岐のため、配下の DiffPreview が参照する
+       code font 変数をここでも提供する (未設定時は変数を出さず var() fallback に倒す) -->
+  <div
+    class="flex h-full flex-col overflow-hidden"
+    :style="{ '--preview-code-font-family': previewCodeFontFamily || undefined }"
+  >
     <!-- ヘッダー -->
     <div class="flex items-center gap-2 border-b border-border px-3 py-2">
       <span class="icon-[lucide--file-diff] size-4 shrink-0 text-foreground-low" />

--- a/apps/renderer/src/features/preview/DiffPreview.vue
+++ b/apps/renderer/src/features/preview/DiffPreview.vue
@@ -755,7 +755,7 @@ function blockEdit(event: Event) {
       置くため、Cmd+A は focus が居る section だけに閉じ、hunk-bar / 他 section は scope に入らない。
     -->
     <div
-      class="flex-1 overflow-auto p-4 font-mono text-sm/tight"
+      class="_diff-scroll flex-1 overflow-auto p-4 text-sm/tight"
       :style="{ '--line-no-width': lineNoWidth }"
     >
       <div v-if="state.kind === 'loading'" class="text-foreground-low">Computing diff...</div>
@@ -971,6 +971,13 @@ function blockEdit(event: Event) {
 </template>
 
 <style scoped>
+/* diff 本文は clipboard 制御のため pre/code を使わない div 描画 (下記 `_diff-line` コメント参照) で、
+   main.css @layer base の `pre, code` コードフォント規則が届かない。同じ var 連鎖を
+   ここで参照し、コードフォントの解決 (設定値 → --font-mono fallback) を pre/code 面と揃える。 */
+._diff-scroll {
+  font-family: var(--preview-code-font-family, var(--font-mono));
+}
+
 /* 1 diff 行を 1 block に揃えて clipboard の `\n` を 1 行につき 1 個にする。
    `display: flex` で子要素を blockification すると、contenteditable コピー時に各子の block
    境界でも `\n` が入り、行間に空行が混じる現象になる。block + inline-block + 負 text-indent
@@ -991,10 +998,11 @@ function blockEdit(event: Event) {
   user-select: none;
   /* contenteditable host の UA スタイル `word-wrap: break-word` (継承プロパティ) が
      この box まで届くため、数字が幅 Nch を僅かでも超えると桁の途中で折り返される。
-     scroll コンテナの font-mono で通常は桁 advance = ch だが、fallback font が
-     proportional に解決される環境では桁 glyph が ch ("0" の幅) を超えうる。
-     nowrap で折り返しを構造的に禁止し、tabular-nums で全桁の advance を
-     "0" と同幅に揃えて「N 桁 = Nch」の幅契約をフォント非依存で成立させる。 */
+     コードフォント (`_diff-scroll`) は通常 monospace で桁 advance = ch だが、
+     設定 (preview.codeFontFamily) や fallback font が proportional に解決される環境では
+     桁 glyph が ch ("0" の幅) を超えうる。nowrap で折り返しを構造的に禁止し、
+     tabular-nums で全桁の advance を "0" と同幅に揃えて「N 桁 = Nch」の幅契約を
+     フォント非依存で成立させる。 */
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
 }

--- a/apps/renderer/src/features/preview/DiffPreview.vue
+++ b/apps/renderer/src/features/preview/DiffPreview.vue
@@ -1009,7 +1009,15 @@ function blockEdit(event: Event) {
   padding: 0;
   background: transparent;
   border: none;
-  font: inherit;
+  /* button の UA 既定 font (OS UI font) の打ち消しは shorthand `font: inherit` ではなく
+     longhand で行う。`font` shorthand は reset-only sub-property の `font-variant-numeric`
+     を初期値 normal に戻すため、同 specificity 後勝ちで `_line-no` の tabular-nums
+     (寸法契約の SSOT) を潰してしまう。 */
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  font-style: inherit;
+  line-height: inherit;
   cursor: pointer;
 }
 

--- a/apps/renderer/src/features/preview/DiffPreview.vue
+++ b/apps/renderer/src/features/preview/DiffPreview.vue
@@ -986,6 +986,14 @@ function blockEdit(event: Event) {
   text-align: right;
   color: var(--color-element-hover);
   user-select: none;
+  /* contenteditable host の UA スタイル `word-wrap: break-word` (継承プロパティ) が
+     この box まで届くため、数字が幅 Nch を僅かでも超えると桁の途中で折り返される。
+     diff 本文は monospace 指定なし (preview font 設定に従う) で描画されるので、
+     proportional font では桁 glyph の advance が ch ("0" の幅) を超えうる。
+     nowrap で折り返しを構造的に禁止し、tabular-nums で全桁の advance を
+     "0" と同幅に揃えて「N 桁 = Nch」の幅契約をフォント非依存で成立させる。 */
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
 }
 
 /* 行番号は DOM テキストとして持たず `data-line-no` の値を `::before` で描画する。

--- a/apps/renderer/src/features/preview/DiffPreview.vue
+++ b/apps/renderer/src/features/preview/DiffPreview.vue
@@ -754,7 +754,10 @@ function blockEdit(event: Event) {
       の host で、scroll コンテナ自体は host にしない。hunk-bar は section の **外** に sibling として
       置くため、Cmd+A は focus が居る section だけに閉じ、hunk-bar / 他 section は scope に入らない。
     -->
-    <div class="flex-1 overflow-auto p-4 text-sm/tight" :style="{ '--line-no-width': lineNoWidth }">
+    <div
+      class="flex-1 overflow-auto p-4 font-mono text-sm/tight"
+      :style="{ '--line-no-width': lineNoWidth }"
+    >
       <div v-if="state.kind === 'loading'" class="text-foreground-low">Computing diff...</div>
 
       <div v-else-if="state.kind === 'error'" class="text-destructive-text">
@@ -988,8 +991,8 @@ function blockEdit(event: Event) {
   user-select: none;
   /* contenteditable host の UA スタイル `word-wrap: break-word` (継承プロパティ) が
      この box まで届くため、数字が幅 Nch を僅かでも超えると桁の途中で折り返される。
-     diff 本文は monospace 指定なし (preview font 設定に従う) で描画されるので、
-     proportional font では桁 glyph の advance が ch ("0" の幅) を超えうる。
+     scroll コンテナの font-mono で通常は桁 advance = ch だが、fallback font が
+     proportional に解決される環境では桁 glyph が ch ("0" の幅) を超えうる。
      nowrap で折り返しを構造的に禁止し、tabular-nums で全桁の advance を
      "0" と同幅に揃えて「N 桁 = Nch」の幅契約をフォント非依存で成立させる。 */
   white-space: nowrap;

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -49,7 +49,7 @@ import CodePreview from "./CodePreview.vue";
 import DiffPreview from "./DiffPreview.vue";
 import ImagePreview from "./ImagePreview.vue";
 import MarkdownPreview from "./MarkdownPreview.vue";
-import { previewFontFamily, previewFontSize } from "./previewConfig";
+import { previewCodeFontFamily, previewFontFamily, previewFontSize } from "./previewConfig";
 import { rpcGitShowCommitFile, rpcGitShowFile } from "./rpc";
 import { shouldCloseForMissingFile } from "./shouldCloseForMissingFile";
 import { useBlamePopover } from "./useBlamePopover";
@@ -1018,6 +1018,7 @@ watch(
         :style="{
           fontFamily: previewFontFamily || undefined,
           fontSize: previewFontSize > 0 ? `${previewFontSize}px` : undefined,
+          '--preview-code-font-family': previewCodeFontFamily || undefined,
         }"
       >
         <div v-if="loading" class="p-4 text-sm text-foreground-low">Loading...</div>

--- a/apps/renderer/src/features/preview/index.ts
+++ b/apps/renderer/src/features/preview/index.ts
@@ -1,6 +1,6 @@
 export { default as BlamePopover } from "./BlamePopover.vue";
 export { default as MarkdownBody } from "./MarkdownBody.vue";
 export { default as PreviewPane } from "./PreviewPane.vue";
-export { previewFontFamily, previewFontSize } from "./previewConfig";
+export { previewCodeFontFamily, previewFontFamily, previewFontSize } from "./previewConfig";
 export { registerMarkdownHistoryCommands } from "./registerMarkdownHistoryCommands";
 export { usePreviewStore } from "./usePreviewStore";

--- a/apps/renderer/src/features/preview/previewConfig.ts
+++ b/apps/renderer/src/features/preview/previewConfig.ts
@@ -8,3 +8,5 @@ import { ref } from "vue";
 
 export const previewFontFamily = ref("");
 export const previewFontSize = ref(0);
+/** コード (code preview / diff / markdown コードブロック) 用。空文字列なら monospace スタックに fallback */
+export const previewCodeFontFamily = ref("");

--- a/apps/renderer/src/features/settings/SettingsModal.vue
+++ b/apps/renderer/src/features/settings/SettingsModal.vue
@@ -12,7 +12,7 @@
 import { tryCatch } from "@gozd/shared";
 import { ref, watch } from "vue";
 import { useDialog } from "../palette";
-import { previewFontFamily, previewFontSize } from "../preview";
+import { previewCodeFontFamily, previewFontFamily, previewFontSize } from "../preview";
 import { applyTerminalTheme, terminalFontFamily, terminalFontSize } from "../terminal";
 import { useVoicevoxStore } from "../voicevox";
 import { useWorktreeStore } from "../worktree";
@@ -80,6 +80,9 @@ const REACTIVE_SYNC: Record<string, (value: unknown) => void> = {
   },
   "preview.fontSize": (v) => {
     previewFontSize.value = typeof v === "number" ? v : 0;
+  },
+  "preview.codeFontFamily": (v) => {
+    previewCodeFontFamily.value = typeof v === "string" ? v : "";
   },
 };
 

--- a/apps/renderer/src/features/settings/globalSettingsSchema.ts
+++ b/apps/renderer/src/features/settings/globalSettingsSchema.ts
@@ -41,9 +41,17 @@ export const globalSettingsSections: readonly SettingSection[] = [
       "preview.fontFamily": {
         widget: "string",
         label: "Font Family",
-        description: "Font for prose text (Markdown preview). Code is always monospace",
+        description: "Font for prose text (Markdown preview). Code uses Code Font Family",
         defaultValue: "",
         placeholder: "system-ui, sans-serif",
+      },
+      "preview.codeFontFamily": {
+        widget: "string",
+        label: "Code Font Family",
+        description:
+          "Font for code (code preview, diff, Markdown code blocks). Empty uses the default monospace",
+        defaultValue: "",
+        placeholder: "Menlo, monospace",
       },
       "preview.fontSize": {
         widget: "number",

--- a/apps/renderer/src/features/settings/globalSettingsSchema.ts
+++ b/apps/renderer/src/features/settings/globalSettingsSchema.ts
@@ -41,8 +41,9 @@ export const globalSettingsSections: readonly SettingSection[] = [
       "preview.fontFamily": {
         widget: "string",
         label: "Font Family",
+        description: "Font for prose text (Markdown preview). Code is always monospace",
         defaultValue: "",
-        placeholder: "Menlo, monospace",
+        placeholder: "system-ui, sans-serif",
       },
       "preview.fontSize": {
         widget: "number",

--- a/apps/renderer/src/features/settings/rpc.ts
+++ b/apps/renderer/src/features/settings/rpc.ts
@@ -50,6 +50,7 @@ export function flattenAppConfig(c: AppConfig | undefined): Record<string, unkno
     "terminal.fontSize": c?.terminal?.fontSize ?? 14,
     "preview.fontFamily": c?.preview?.fontFamily ?? "",
     "preview.fontSize": c?.preview?.fontSize ?? 14,
+    "preview.codeFontFamily": c?.preview?.codeFontFamily ?? "",
     "voicevox.enabled": c?.voicevox?.enabled ?? false,
     "voicevox.speedScale": c?.voicevox?.speedScale ?? 1.5,
     "voicevox.volumeScale": c?.voicevox?.volumeScale ?? 1.0,
@@ -60,7 +61,7 @@ export function flattenAppConfig(c: AppConfig | undefined): Record<string, unkno
 /** dot-key の patch を AppConfig に適用する。未知のキーは無視。 */
 function applyDotKey(config: AppConfig, key: string, value: unknown): void {
   const terminal = config.terminal ?? { theme: "", fontFamily: "", fontSize: 0 };
-  const preview = config.preview ?? { fontFamily: "", fontSize: 0 };
+  const preview = config.preview ?? { fontFamily: "", fontSize: 0, codeFontFamily: "" };
   const voicevox = config.voicevox ?? {
     enabled: false,
     speedScale: 0,
@@ -85,6 +86,9 @@ function applyDotKey(config: AppConfig, key: string, value: unknown): void {
       break;
     case "preview.fontSize":
       if (typeof value === "number") preview.fontSize = value;
+      break;
+    case "preview.codeFontFamily":
+      if (typeof value === "string") preview.codeFontFamily = value;
       break;
     case "voicevox.enabled":
       if (typeof value === "boolean") voicevox.enabled = value;

--- a/apps/renderer/src/features/terminal/registerThemeCommand.ts
+++ b/apps/renderer/src/features/terminal/registerThemeCommand.ts
@@ -10,7 +10,7 @@ import { darkThemeNames, lightThemeNames, loadTheme } from "@gozd/themes";
 import { useCommandRegistry } from "../../shared/command";
 import { useQuickPick } from "../palette";
 import type { QuickPickItem } from "../palette";
-import { previewFontFamily, previewFontSize } from "../preview";
+import { previewCodeFontFamily, previewFontFamily, previewFontSize } from "../preview";
 import { rpcLoadAppConfig, rpcSaveAppConfig } from "../settings";
 import {
   currentTheme,
@@ -84,6 +84,9 @@ async function restoreSavedConfig(): Promise<void> {
     }
     if (config.preview.fontSize > 0) {
       previewFontSize.value = config.preview.fontSize;
+    }
+    if (config.preview.codeFontFamily !== "") {
+      previewCodeFontFamily.value = config.preview.codeFontFamily;
     }
   }
 }

--- a/packages/proto/gozd/v1/app_config.proto
+++ b/packages/proto/gozd/v1/app_config.proto
@@ -28,8 +28,12 @@ message TerminalConfig {
 }
 
 message PreviewConfig {
+  // 散文 (markdown 本文等) 用。空文字列なら app デフォルト (sans)
   string font_family = 1;
   uint32 font_size = 2;
+  // コード (code preview / diff / markdown コードブロック) 用。
+  // 空文字列なら monospace スタック (--font-mono) に fallback
+  string code_font_family = 3;
 }
 
 message VoicevoxConfig {


### PR DESCRIPTION
## 概要

preview の diff 表示 (unified / split) で、gutter の行番号が桁の途中で縦に折り返される問題を修正する。あわせてコードフォントの扱いを VSCode と同型に整理し、`preview.codeFontFamily` 設定（未設定 = monospace スタック）を追加する。

## 背景

unified diff で 36 行目の行番号が「3」と「6」に分かれて縦に積まれ、行の高さが崩れる現象が報告された。同じ画面で 37 は折り返されず 36 / 38 だけが折り返されるという挙動だった。

調査の結果、3 つの条件の組み合わせで発生していた:

- diff の各 section は Cmd+A スコープ制御のために `contenteditable=true` だが、WebKit の UA スタイルシートは contenteditable 要素に `word-wrap: break-word` を当てる。これは**継承プロパティ**なので子孫の行番号 box (`_line-no`) まで届く
- `_line-no` は最大行番号の桁数ちょうどの `width: Nch` を持つ inline-block。`ch` は「0」グリフの advance 幅なので、proportional font では 3 / 6 / 8 のような広い数字の組が `Nch` を僅かに超える
- diff 本文は CodePreview と違い `pre` / `code` 要素 (Tailwind preflight で monospace) を経由せず素の `div` / `span` で描画されるため、preview font 設定が未設定だと app の sans font になり、この幅超過が実際に発生する

幅超過した瞬間に break-word が桁の途中で折り返す。「7 が細いフォントでは 37 だけ収まる」という観測パターンとも整合する。selection スコープを section 単位の contenteditable に変えた ( #729 ) 以降の退行。

レビューと対話を通じてさらに以下が確定した:

- blame ボタン経路の問題: `font` shorthand は reset-only sub-property の `font-variant-numeric` を初期値 `normal` に戻すため、`_line-no-btn` の `font: inherit` (button の UA font 打ち消し) が同 specificity 後勝ちで `_line-no` の `tabular-nums` を潰していた
- コード描画面の棚卸しの結果、DiffPreview だけが div/span 描画 (clipboard 制御のため) で preflight の mono が届かず sans になり得る非対称があった。「コードは全て monospace で描画する」方針で統一する
- `preview.fontFamily` 設定は継承で配られるため preflight の要素直接宣言に常に負け、実効範囲は散文のみ。placeholder `"Menlo, monospace"` がコードフォント設定と誤認させる乖離があった
- VSCode のソース (microsoft/vscode) を確認すると、markdown preview は散文 = `markdown.preview.fontFamily`、コード = `editor.fontFamily` (デフォルト mono スタック) と CSS 変数の参照先を分離している。この先例に倣い、`editor.fontFamily` 相当のコードフォント設定を追加する

## 変更内容

### DiffPreview

- `._line-no` に `white-space: nowrap` を追加し、行番号 box 内での折り返しを構造的に禁止する
- `font-variant-numeric: tabular-nums` を追加し、全桁の advance を「0」と同幅に揃えて「N 桁 = Nch」の幅契約をフォント非依存で成立させる
- `._line-no-btn` の `font: inherit` を `font-family` / `font-size` / `font-weight` / `font-style` / `line-height` の longhand に分解し、shorthand による `font-variant-numeric` のリセットを回避する (tabular-nums の所有は `_line-no` 1 箇所に保つ)
- scroll コンテナに `font-family: var(--preview-code-font-family, var(--font-mono))` を当て、コードフォントの解決連鎖に乗せる

### コードフォントの SSOT 化

- proto `PreviewConfig` に `code_font_family` を追加 (空文字列 = monospace fallback のセンチネル)
- `preview.codeFontFamily` 設定を追加 (schema / flatten / applyDotKey / REACTIVE_SYNC / 起動時復元)
- PreviewPane と ChangesSummaryView (font wrapper を経由しない兄弟分岐) が設定値を `--preview-code-font-family` として提供。未設定時は変数を出さず var() fallback に倒す
- main.css の Tier 3 (`@layer base`) に `pre, code { font-family: var(--preview-code-font-family, var(--font-mono)) }` を追加。preflight の mono 固定を「設定で上書き可能な mono デフォルト」に差し替え、CodePreview / markdown コードブロック / diff の全コード面が 1 本の var 連鎖で解決される

### Settings

- `preview.fontFamily` の placeholder を `"system-ui, sans-serif"` に変更し、description「Font for prose text (Markdown preview). Code uses Code Font Family」を追加。散文専用という実効範囲と UI 表示を一致させる
- `preview.codeFontFamily` は placeholder `"Menlo, monospace"` + description「Font for code (code preview, diff, Markdown code blocks). Empty uses the default monospace」

## 確認事項

- [ ] 行番号が 2 桁以上のファイルの diff (unified / split) で行番号が折り返されないこと
- [ ] code font 未設定時に diff / code preview / markdown コードブロックが monospace で描画されること
- [ ] code font に任意のフォントを設定すると 3 つのコード面すべてに反映されること
- [ ] prose font (preview.fontFamily) は markdown 散文に効き、コードには効かないこと
- [ ] Changes summary 配下の diff にも code font 設定が効くこと
- [ ] blame ON でも gutter の縦揃え・桁の水平位置が崩れないこと
- [ ] 設定モーダル Preview セクションに Font Family / Code Font Family の 2 項目が description 付きで表示されること
