### PR TITLE
fix(git-graph): restore HEAD marker hidden by col 2 overflow clip

### DIFF
--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -518,9 +518,9 @@ const ROW_HEIGHT = 24;
 const DOT_RADIUS = 4;
 const GRAPH_PADDING_X = 12;
 /** col 1 (graph 列) の右側に確保する HEAD marker `→` 用余白 (px)。
- * marker は col 2 (description 列) の左外側に absolute 配置されるため、SVG が描く
+ * marker は col 1 内に in-flow 右寄せ配置されるため、SVG が描く
  * lane / dot と marker の x 帯が物理的に重ならない width をここで予約する。
- * 内訳: marker glyph ~14 + col 2 との margin 4 + 安全余白 2 = 20。
+ * 内訳: marker glyph ~14 + col 2 との padding 4 + 安全余白 2 = 20。
  * これを GRAPH_PADDING_X (12) のままにすると `maxLanes === 1` で
  * marker と lane 0 dot の x 帯が衝突する。 */
 const HEAD_MARKER_RIGHT_PADDING = 20;
@@ -1176,28 +1176,20 @@ const isWorkingTreeActive = computed(
               @click="onRowClick(node.commit.hash, $event)"
               @contextmenu="onCommitContextMenu(node.commit.hash, $event)"
             >
-              <!-- col 1 (graph): SVG が absolute で覆うので空セル。
-                   右側に HEAD_MARKER_RIGHT_PADDING ぶんの余白を持ち、marker は col 2 から
-                   この余白領域に飛び出して配置される (= 旧視覚位置: graph 列の右端)。 -->
-              <div />
-
-              <!-- col 2 (description)。
-                   `relative` を持つが background クラスは持たないので、SVG 覆い問題は起きない
-                   (row のように `relative` + 背景の組合せで初めて SVG を覆う)。
-                   HEAD marker は本要素を containing block として left 外側に absolute 配置し、
-                   col 1 右端の予約余白 (HEAD_MARKER_RIGHT_PADDING) に視覚的に乗せる。 -->
-              <div class="relative flex min-w-0 items-center gap-1 truncate pr-2">
-                <!-- HEAD marker: col 2 の左外側に absolute 配置。
-                     `right-full` で marker の右端を col 2 の左端に合わせ、`mr-1` (4px) で
-                     col 2 との隙間を作る。col 1 の右余白 (HEAD_MARKER_RIGHT_PADDING = 20px) 内に
-                     収まるため SVG が描く lane / dot と x 帯が重ならない。 -->
-                <span
-                  v-if="hasHead(node.commit.refs)"
-                  class="absolute right-full mr-1 text-warning-text"
-                  title="HEAD"
-                >
+              <!-- col 1 (graph): SVG が absolute で覆うセル。右端の
+                   HEAD_MARKER_RIGHT_PADDING 余白に HEAD marker を in-flow 右寄せで置く。
+                   col 2 内の absolute 配置 (`right-full`) にすると col 2 の `truncate`
+                   (overflow: hidden) が containing block ごとクリップして marker が消える。
+                   非 positioned content (layer 4) なので row 背景 / SVG の painting order に
+                   影響せず、余白内なので SVG の lane / dot とも x 帯が重ならない。 -->
+              <div class="flex items-center justify-end pr-1">
+                <span v-if="hasHead(node.commit.refs)" class="text-warning-text" title="HEAD">
                   →
                 </span>
+              </div>
+
+              <!-- col 2 (description) -->
+              <div class="flex min-w-0 items-center gap-1 truncate pr-2">
                 <span
                   v-if="isMergeCommit(node.commit)"
                   class="icon-[lucide--git-merge] size-3.5 shrink-0 text-foreground-low"


### PR DESCRIPTION
## 概要

git-graph でコミットタイトルの左に表示される HEAD 矢印 `→` が表示されないデグレを修正する。marker を col 2(description 列)からの absolute 脱出配置ではなく、col 1(graph 列)内の in-flow 右寄せ配置に変更する。

## 背景

a9b22d20「fix(git-graph): keep graph SVG above commit row background via stacking layer split」が、HEAD marker を col 2 の `relative` div を containing block とした `absolute right-full mr-1` 配置に移した。しかし col 2 の div は `truncate`(= `overflow: hidden`)を持つ。

CSS の `overflow: hidden` は in-flow の子だけでなく、**自分が containing block になる absolute 配置の子孫**もクリップする。`right-full` で box の完全に左外側へ出した marker は丸ごとクリップされ、当該コミット以降ずっと不可視になっていた。データ経路(native の `%D` パース → `refs.includes("HEAD")` 判定)には問題がなかった。

旧配置の失敗モードは「サイレントな不可視化」で、テキスト省略のための `truncate` という無関係に見えるクラスが marker を殺すことに気づけない構造だった。

## 変更内容

### HEAD marker の配置方式

- marker を col 1 内の通常フロー右寄せ(`flex items-center justify-end pr-1`)に変更。col 1 の幅には marker 用の `HEAD_MARKER_RIGHT_PADDING`(20px)が既に予約されているため、grid template 変更なしで旧視覚位置(graph 列右端、col 2 との隙間 4px)を再現できる
- overflow への依存が消える: in-flow 要素は自セル内に収まるため、祖先に `overflow: hidden` が付いても消えない
- a9b22d20 の painting order 設計は維持: marker は非 positioned content(layer 4)、overlay SVG は absolute(layer 6)のまま。col 1 セルは background を持たないため「row 背景が SVG を覆う」問題も再発しない

### コメント更新

- `HEAD_MARKER_RIGHT_PADDING` の docstring と col 1 / col 2 のテンプレートコメントを新配置に合わせて更新

## 今回含めない点

### 今回は対応しない

- **marker 専用の grid track 化**: SVG の `width` をレーン領域のみに絞り marker を別トラックに置けば、SVG viewport のクリップにより重なりが構造的に不可能になる。ただし `--graph-cols`(Working Tree 行と共有する SSOT)の 6 トラック化と全行への空セル追加が必要。現状の予約幅は同一 computed 内の算術で完結しており、コスト対効果から in-flow 配置を採る

## 確認事項

- [ ] HEAD コミット行のタイトル左に `→` が表示される
- [ ] hover / selected の row 背景が graph SVG(lane 線・dot)を塗りつぶさない( a9b22d20 の修正が維持されている)
- [ ] `maxLanes === 1` のリポジトリで marker と lane 0 の dot が重ならない
