### PR TITLE
ci: fix 実行後に diff が残ったら fail するチェックを追加

### DIFF
--- a/.github/workflows/code_validation.yml
+++ b/.github/workflows/code_validation.yml
@@ -38,6 +38,13 @@ jobs:
             diff_command: pnpm --filter '...[origin/${{ github.base_ref }}]' --if-present --no-bail --aggregate-output --reporter=append-only lint
             full_command: pnpm run lint:all
 
+          # fix（oxlint --fix / eslint --fix + oxfmt）を実行し、working tree に
+          # 差分が出たら fail する。フォーマット崩れ・自動修正可能な lint 違反が
+          # commit されていないことを保証する
+          - name: fix
+            diff_command: pnpm --filter '...[origin/${{ github.base_ref }}]' --if-present --no-bail --aggregate-output --reporter=append-only fix && git diff --exit-code
+            full_command: pnpm run fix:all && git diff --exit-code
+
           # @gozd/native は SwiftUI / WebKit / FSEvents 等 macOS 専用 API に依存し
           # Linux runner では `swift test` が走らない。別 job（swift-test）で実行する。
           - name: test

--- a/.github/workflows/code_validation.yml
+++ b/.github/workflows/code_validation.yml
@@ -30,19 +30,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # diff_command の --include-workspace-root: pnpm の --filter はルート
+          # ワークスペースプロジェクトをデフォルトで選ばないため、これが無いと
+          # ルート直下ファイル（knip.ts 等）の lint / fix が差分 PR で一切走らない
           - name: typecheck
-            diff_command: pnpm --filter '...[origin/${{ github.base_ref }}]' --if-present --no-bail --aggregate-output --reporter=append-only typecheck
+            diff_command: pnpm --filter '...[origin/${{ github.base_ref }}]' --include-workspace-root --if-present --no-bail --aggregate-output --reporter=append-only typecheck
             full_command: pnpm run typecheck:all
 
           - name: lint
-            diff_command: pnpm --filter '...[origin/${{ github.base_ref }}]' --if-present --no-bail --aggregate-output --reporter=append-only lint
+            diff_command: pnpm --filter '...[origin/${{ github.base_ref }}]' --include-workspace-root --if-present --no-bail --aggregate-output --reporter=append-only lint
             full_command: pnpm run lint:all
 
           # fix（oxlint --fix / eslint --fix + oxfmt）を実行し、working tree に
           # 差分が出たら fail する。フォーマット崩れ・自動修正可能な lint 違反が
           # commit されていないことを保証する
           - name: fix
-            diff_command: pnpm --filter '...[origin/${{ github.base_ref }}]' --if-present --no-bail --aggregate-output --reporter=append-only fix && git diff --exit-code
+            diff_command: pnpm --filter '...[origin/${{ github.base_ref }}]' --include-workspace-root --if-present --no-bail --aggregate-output --reporter=append-only fix && git diff --exit-code
             full_command: pnpm run fix:all && git diff --exit-code
 
           # @gozd/native は SwiftUI / WebKit / FSEvents 等 macOS 専用 API に依存し

--- a/apps/renderer/src/shared/command/defaultKeyBindings.json
+++ b/apps/renderer/src/shared/command/defaultKeyBindings.json
@@ -2,7 +2,11 @@
   { "key": "shift+cmd+p", "command": "commandPalette.show" },
   { "key": "cmd+j", "command": "preview.toggle" },
   { "key": "cmd+[", "command": "markdownPreview.back", "when": "previewVisible && !inputFocused" },
-  { "key": "cmd+]", "command": "markdownPreview.forward", "when": "previewVisible && !inputFocused" },
+  {
+    "key": "cmd+]",
+    "command": "markdownPreview.forward",
+    "when": "previewVisible && !inputFocused"
+  },
   { "key": "cmd+d", "command": "terminal.splitHorizontal", "when": "terminalFocus" },
   { "key": "shift+cmd+d", "command": "terminal.splitVertical", "when": "terminalFocus" },
   { "key": "cmd+w", "command": "terminal.closePane", "when": "terminalFocus" },

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -10,8 +10,8 @@
     "build": "bun src/generateTokens.ts",
     "prepare": "bun src/generateTokens.ts",
     "typecheck": "tsgo --noEmit",
-    "lint": "oxlint --type-aware src/",
-    "fix": "oxlint --type-aware --fix src/ && oxfmt src/"
+    "lint": "oxlint --type-aware",
+    "fix": "oxlint --type-aware --fix && oxfmt ."
   },
   "devDependencies": {
     "@adobe/leonardo-contrast-colors": "1.1.0",

--- a/packages/design-tokens/src/generateTokens.ts
+++ b/packages/design-tokens/src/generateTokens.ts
@@ -148,10 +148,7 @@ const theme = new Theme({
 });
 
 type ContrastGroup = { name: string; values: { value: string }[] };
-const [bgEntry, ...groups] = theme.contrastColors as [
-  { background: string },
-  ...ContrastGroup[],
-];
+const [bgEntry, ...groups] = theme.contrastColors as [{ background: string }, ...ContrastGroup[]];
 
 /* gray scale: step 1 = bg 自身、steps 2..12 = ratios の各点 */
 const grayGroup = groups.find((g) => g.name === "gray");

--- a/packages/eslint-plugin/src/rules/noDefineExpose.test.ts
+++ b/packages/eslint-plugin/src/rules/noDefineExpose.test.ts
@@ -54,10 +54,7 @@ tester.run("no-define-expose", rule, {
 // TypeScript parser 経由で generic 型引数付きの呼び出しを検出することを確認する。
 // Vue SFC では `defineExpose<{ focus(): void }>({ focus })` 形が頻出する。
 tsTester.run("no-define-expose (TypeScript)", rule, {
-  valid: [
-    "const x: number = 1;",
-    "type T = { foo: string }; const x: T = { foo: 'a' };",
-  ],
+  valid: ["const x: number = 1;", "type T = { foo: string }; const x: T = { foo: 'a' };"],
   invalid: [
     {
       code: "defineExpose<{ focus(): void }>({ focus: () => {} });",

--- a/packages/eslint-plugin/src/rules/noIconifyClass.ts
+++ b/packages/eslint-plugin/src/rules/noIconifyClass.ts
@@ -38,7 +38,7 @@ const rule: Rule.RuleModule = {
     },
     messages: {
       iconifyClass:
-        "Iconify Tailwind class `{{match}}` is forbidden. Import the icon component instead: `import IconLucideX from \"~icons/lucide/x\"` and render `<IconLucideX class=\"...\" />`.",
+        'Iconify Tailwind class `{{match}}` is forbidden. Import the icon component instead: `import IconLucideX from "~icons/lucide/x"` and render `<IconLucideX class="..." />`.',
     },
     schema: [],
   },

--- a/packages/eslint-plugin/src/rules/noRawTailwindPalette.ts
+++ b/packages/eslint-plugin/src/rules/noRawTailwindPalette.ts
@@ -25,7 +25,10 @@ import type { Rule } from "eslint";
 import type { AST as VueAST } from "vue-eslint-parser";
 
 type Literal = Rule.Node & { type: "Literal" };
-type TemplateElement = Rule.Node & { type: "TemplateElement"; value: { cooked?: string | null; raw: string } };
+type TemplateElement = Rule.Node & {
+  type: "TemplateElement";
+  value: { cooked?: string | null; raw: string };
+};
 
 /* Tailwind 標準 color utility prefix (color を取る utility のみ)。
  * margin / padding 等の non-color utility は対象外 */

--- a/packages/shiki-lang-map/package.json
+++ b/packages/shiki-lang-map/package.json
@@ -9,12 +9,9 @@
   "scripts": {
     "prepare": "bun src/generateExtensionLangMap.ts",
     "typecheck": "tsgo --noEmit",
-    "lint": "oxlint --type-aware src/",
-    "fix": "oxlint --type-aware --fix src/ && oxfmt src/",
+    "lint": "oxlint --type-aware",
+    "fix": "oxlint --type-aware --fix && oxfmt .",
     "test": "bun test"
-  },
-  "peerDependencies": {
-    "shiki": "^4.0.0"
   },
   "devDependencies": {
     "@types/bun": "catalog:",
@@ -25,5 +22,8 @@
     "oxlint": "catalog:",
     "oxlint-tsgolint": "catalog:",
     "shiki": "4.2.0"
+  },
+  "peerDependencies": {
+    "shiki": "^4.0.0"
   }
 }

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "prepare": "bun scripts/generateThemeLoaders.ts",
     "typecheck": "tsgo --noEmit",
-    "lint": "oxlint --type-aware src/",
-    "fix": "oxlint --type-aware --fix src/ && oxfmt src/"
+    "lint": "oxlint --type-aware",
+    "fix": "oxlint --type-aware --fix && oxfmt '!vendor/**'"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/themes/scripts/generateThemeLoaders.ts
+++ b/packages/themes/scripts/generateThemeLoaders.ts
@@ -27,7 +27,10 @@ interface ThemeEntry {
 
 const LUMINANCE_THRESHOLD = 0.5;
 
-const files = fs.readdirSync(VENDOR_DIR).filter((f) => f.endsWith(".json")).sort();
+const files = fs
+  .readdirSync(VENDOR_DIR)
+  .filter((f) => f.endsWith(".json"))
+  .sort();
 
 const themes: ThemeEntry[] = files.map((file) => {
   const json = JSON.parse(fs.readFileSync(path.join(VENDOR_DIR, file), "utf-8")) as {


### PR DESCRIPTION
## 概要

CI の validation matrix に `fix` エントリを追加する。差分パッケージ + ワークスペースルート（ルート設定変更時は全体）の `fix` script を実行し、working tree に diff が残ったら `git diff --exit-code` で fail する。あわせて、ゲートのカバレッジ穴（diff 経路のルート欠落、`src/` 限定の fix script）を塞ぎ、実行で発覚した既存コードの整形 drift を修正する。

## 背景

これまで CI には typecheck / lint / test しかなく、フォーマットを検証するジョブが存在しなかった。フォーマットは lefthook の pre-commit（staged files への oxfmt / oxlint --fix / eslint --fix）だけが担っていた。

しかし lefthook 方式には構造的な漏れがある:

- glob の網羅性に依存する。実際に renderer の oxfmt ジョブには `.json` が含まれず、`packages/eslint-plugin` / `packages/design-tokens` には oxfmt ジョブ自体がなかった
- local hook を通らない経路が存在する。Renovate の bot PR、GitHub web 上の編集、`git commit -n`

この漏れの実証として、本 PR の作業中に `pnpm run fix:all` を実行したところ main に整形 drift が見つかった（5 ファイル + fix スコープ拡大後に `themes/scripts/generateThemeLoaders.ts` の 1 件、いずれも本 PR で修正済み）。

drift の実害は「存在」ではなく顕在化のタイミングにある。誰かが fix を実行した瞬間、過去の drift が無関係な整形 hunk としてその PR に混入する。gozd は並列エージェント開発が前提で、エージェントが fix を自律的に高頻度で実行するため、このノイズは毎回「自分の変更か? 拾うか捨てるか?」という判断を強制する。

CI ゲートの本質は美観ではなく、**「fix 後の diff = 100% 自分の変更」という不変条件の保証**にある。main がクリーン保証されていれば、エージェントは fix 結果の diff を無条件に自分の変更として扱える。

チェック方式は「fix 実行 + `git diff --exit-code`」とした。formatter ごとに `--check` モードの有無・挙動が異なる（oxfmt / oxlint --fix / eslint --fix）のを吸収でき、SSOT は各 package の `fix` script のままになる。lefthook の formatter は速い自動修正（DX）として維持し、CI が強制ゲートを担う役割分担とする。

レビューループで、ゲートが lefthook より狭いカバレッジを持つ領域が 2 つ特定された。「CI ゲートが lefthook を包含する」前提が成立するよう、いずれも本 PR 内で修正した:

- pnpm の `--filter` はルートワークスペースをデフォルトで選ばないため、`diff_command` ではルート直下ファイル（`knip.ts` 等）の lint / fix が一切走らない。既存の typecheck / lint も同じ穴を持っていた
- `design-tokens` / `shiki-lang-map` / `themes` の `fix` が `src/` 限定で、lefthook がカバーする `themes/scripts/` 等がゲート対象外だった（実際に drift が実在した）

## 変更内容

### CI

- `code_validation.yml` の matrix に `fix` エントリを追加。差分パッケージのみ（ルート設定ファイル変更時は `fix:all` で全体）を対象とし、実行後の `git diff --exit-code` で差分検出時に fail する
- `typecheck` / `lint` / `fix` の `diff_command` に `--include-workspace-root` を付与し、ルート直下ファイルを差分 PR でもゲートする

### fix script のスコープ拡大

- `design-tokens` / `shiki-lang-map` / `themes` の `lint` / `fix` を `src/` 限定から package 全体に拡大
- `themes` の oxfmt は `'!vendor/**'` で vendor（上流 iTerm2-Color-Schemes の tracked JSON、整形すると上流との同一性が壊れる）を除外。oxfmt の負パターン単独指定は「cwd 全体を walk して除外のみ適用」する挙動
- oxfmt は `package.json` を sort-package-json でキーソートするため、新たに対象へ入った `shiki-lang-map/package.json` の `peerDependencies` が正規位置へ移動している

### 整形 drift の修正

- `apps/renderer/src/shared/command/defaultKeyBindings.json` — 行幅超過の折り返し
- `packages/design-tokens/src/generateTokens.ts`、`packages/eslint-plugin` 配下 3 ファイル — oxfmt の整形（1 行化・クォートスタイル統一）
- `packages/themes/scripts/generateThemeLoaders.ts` — メソッドチェーンの折り返し（fix スコープ拡大で顕在化）

## 今回含めない点

### 今回は対応しない

- lefthook の glob 漏れ（renderer の `.json`、eslint-plugin / design-tokens の oxfmt ジョブ欠如）の修正。CI ゲートのカバレッジが lefthook を包含するようになったため、hook 側の漏れは DX の問題（CI で初めて気づく）に格下げされる。必要になったら別 PR で対応する

## 確認事項

- [ ] `fix:all && git diff --exit-code` が exit 0（冪等性 + ルート含む全 package.json が正規形）であることはローカル検証済み
- [ ] 本 PR 自体の CI で新しい `fix` ジョブが green になること
