### PR TITLE
feat(terminal): session preview overlay に折りたたみと高さ上限スクロールを追加する

### DIFF
--- a/apps/renderer/CLAUDE.md
+++ b/apps/renderer/CLAUDE.md
@@ -5,7 +5,7 @@
   - Tier 1 (primitives): `@gozd/design-tokens` package が Adobe Leonardo で生成 → `dist/tokens.generated.css` を `main.css` が `@import`
   - Tier 1 brand-fixed (例外): theme 追従しない固定 brand 色 (LINE 配色等) は `main.css` の `:root` に手書きで定義し、命名規約 `--<scope>-<role>-primitive` で識別する
   - Tier 2 (semantic aliases): `main.css` の `@theme inline` で role 名定義
-  - Tier 3 (element defaults): `main.css` の `@layer base` で UA 上書き / scrollbar
+  - Tier 3 (element defaults): `main.css` の `@layer base` で UA 上書き
 - Tier 1 primitives は **手書き禁止**。brand を変えるときは [`packages/design-tokens/src/generateTokens.ts`](../../packages/design-tokens/src/generateTokens.ts) の `BRAND` を編集し `pnpm install` (prepare で自動再生成)
 - Tier 1 brand-fixed primitives (`--<scope>-<role>-primitive`) は **例外的に `main.css` の `:root` への手書きを許可** する。theme 追従しない固定色は Adobe Leonardo 生成パイプラインに乗らないため。例: chat-\* (LINE ダークモード配色)
 - UI を書く / 直すときの規律一覧は project-local skill [`/.claude/skills/gozd-ui/SKILL.md`](../../.claude/skills/gozd-ui/SKILL.md) を参照 (Claude Code 自動適用)

--- a/apps/renderer/src/assets/main.css
+++ b/apps/renderer/src/assets/main.css
@@ -33,7 +33,7 @@
  * Tier 1 (primitives, :root) は `@gozd/design-tokens` package で生成し、上の
  * @import で取り込む。本 file は consumer 側として:
  *   - Tier 2 (semantic aliases, @theme inline): role 名 utility を生成
- *   - Tier 3 (element defaults, @layer base): UA stylesheet 打ち消し / scrollbar
+ *   - Tier 3 (element defaults, @layer base): UA stylesheet 打ち消し
  *
  * @theme inline modifier は utility 値に var(--primitive) を直接展開するため、
  * 将来 light theme で primitive 側を override したとき自動 propagate する。
@@ -119,10 +119,6 @@
   /* intent: info (text-only、solid なし。primary と同 hue の text step を借用) */
   --color-info: var(--blue-11);
 
-  /* scrollbar (UA pseudo-element 専用、utility 化対象なし) */
-  --color-scrollbar-thumb: var(--gray-a6);
-  --color-scrollbar-thumb-hover: var(--gray-a8);
-
   /* chat (Tier 2 semantic alias): brand 固定 primitive (`:root` 配下) を `var()` で
      参照する。値の直書きは Tier 1 に集約し、Tier 2 は role 名のマッピングだけ持つ。 */
   --color-chat-incoming: var(--chat-incoming-primitive);
@@ -143,9 +139,8 @@
     overscroll-behavior: none;
   }
 
-  /* gozd は dark 固定 UI。UA に dark を宣言し、native scrollbar (scrollbar-width 指定で
-     ::-webkit-scrollbar が無効になる要素) や form control を dark バリアントで描画させる。
-     未宣言だと UA はライトページ扱いで暗背景に黒 thumb を出す */
+  /* gozd は dark 固定 UI。UA に dark を宣言し、native scrollbar や form control を
+     dark バリアントで描画させる。未宣言だと UA はライトページ扱いで暗背景に黒 thumb を出す */
   html {
     color-scheme: dark;
   }
@@ -175,22 +170,5 @@
     padding: 0;
     border: none;
     background: transparent;
-  }
-
-  /* overlay scrollbar (全要素適用、SessionLogTimeline の操作 bar と区別する
-     ため低 chroma + 白 alpha で固定) */
-  ::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
-  }
-  ::-webkit-scrollbar-track {
-    background: transparent;
-  }
-  ::-webkit-scrollbar-thumb {
-    background: var(--color-scrollbar-thumb);
-    border-radius: 3px;
-  }
-  ::-webkit-scrollbar-thumb:hover {
-    background: var(--color-scrollbar-thumb-hover);
   }
 }

--- a/apps/renderer/src/assets/main.css
+++ b/apps/renderer/src/assets/main.css
@@ -143,6 +143,13 @@
     overscroll-behavior: none;
   }
 
+  /* gozd は dark 固定 UI。UA に dark を宣言し、native scrollbar (scrollbar-width 指定で
+     ::-webkit-scrollbar が無効になる要素) や form control を dark バリアントで描画させる。
+     未宣言だと UA はライトページ扱いで暗背景に黒 thumb を出す */
+  html {
+    color-scheme: dark;
+  }
+
   body {
     @apply bg-background text-foreground;
   }

--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -3,7 +3,7 @@ Git commit graph showing the current worktree branch and the default branch.
 
 ## Structure
 
-- Working Tree row: sticky header **inside** the scroll area (`position: sticky; top: 0`). Placed inside the scroll container so its row width matches commit rows after the scrollbar gutter — placing it outside would shift columns by the scrollbar width and break vertical alignment with commit rows
+- Working Tree row: sticky header **inside** the scroll area (`position: sticky; top: 0`). Placed inside the scroll container so it shares the same effective width as commit rows regardless of scrollbar presence, keeping columns vertically aligned
 - Connector line: dashed SVG path straight down lane 0 from the top to the HEAD row (HEAD is always on lane 0, so no curve is needed)
 - Scrollable commit list: HTML rows for commit data + SVG overlay for graph lines and dots
 - Column alignment: Working Tree row and commit rows share `grid-template-columns: var(--graph-cols)` defined once at the graph list root. Empty cells in the Working Tree row (author / hash) are left as empty grid tracks — no spacer divs. The Date cell on the Working Tree row shows the max mtime of changed files (`workingTreeMtime` computed from `useGitStatusStore`); blank when clean / not yet loaded
@@ -1064,8 +1064,9 @@ const isWorkingTreeActive = computed(
         tabindex="0"
         @keydown="onKeydown"
       >
-        <!-- スクロール可能なコミットリスト。Working Tree 行はこの中に sticky で置く
-             (scroll container の外に置くと scrollbar 幅ぶん commit 行と column がズレるため)。 -->
+        <!-- スクロール可能なコミットリスト。Working Tree 行はこの中に sticky で置き、
+             commit 行と同じ effective 幅を共有させて column を揃える (scrollbar の
+             有無・幅に依存しない)。 -->
         <div ref="scrollContainer" class="min-h-0 flex-1 overflow-auto">
           <!-- Working Tree 固定行: scroll container 内で sticky 配置。
                commit 行と同じ親 = 同じ effective 幅になり、grid template が構造的に揃う。 -->

--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -254,7 +254,7 @@ const activeRootWorktree = computed(() => {
       </div>
     </div>
 
-    <div class="_sidebar-scroll flex flex-1 scrollbar-none flex-col overflow-y-auto py-4">
+    <div class="flex flex-1 flex-col overflow-y-auto py-4">
       <DragDropProvider @drag-end="onDragEnd">
         <RepoSection
           v-for="(rootDir, i) in repoStore.dirOrder"
@@ -328,10 +328,3 @@ const activeRootWorktree = computed(() => {
     <VoicevoxPanel />
   </div>
 </template>
-
-<style scoped>
-/* scrollbar 自体を非表示 (macOS の overlay も hover で content に被るため使わない)。スクロール操作はトラックパッド / ホイールのみ */
-._sidebar-scroll::-webkit-scrollbar {
-  display: none;
-}
-</style>

--- a/apps/renderer/src/features/terminal/TerminalLeaf.vue
+++ b/apps/renderer/src/features/terminal/TerminalLeaf.vue
@@ -95,8 +95,11 @@ function handleTerminalBlur() {
 
 <template>
   <div class="min-h-0 min-w-0" :data-leaf-id="leafId">
+    <!-- container-type: size は TerminalSessionPreview のスクロール面 (max-h-[40cqh]) が
+         leaf 高さを参照するための query container 指定。size-full で寸法が親から確定して
+         いるため size containment による高さ collapse は起きない -->
     <div
-      class="relative size-full rounded-lg p-1 outline"
+      class="@container-size relative size-full rounded-lg p-1 outline"
       :style="{ backgroundColor: currentTheme.background }"
       :class="
         isFocused

--- a/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
+++ b/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
@@ -42,12 +42,12 @@ agent。空文字フォールバックは "Subagent")。開閉状態は Vue 側 
 
 スクロール面は summary の外に出さず、details 内の wrapper div に閉じる (summary は
 スクロールせず、bubble と被らない)。details 自体にはスタイルを当てず、native の
-open/close と summary 表示制御だけに使う。wrapper の高さ上限は `max-h-[40cqh]`
-(leaf 高さの 40%)。% は details (block / auto 高) を跨いで伝播しないため、TerminalLeaf
-の relative コンテナを `container-type: size` にして cqh で leaf 高さを直接参照する。
-main + sub 同時表示時は合算 80cqh + summary / padding の固定分のため、縦分割で leaf が
-低いとき (概算 440px 未満) は両 overlay が重なりうる (視覚的な被りのみで、両者とも
-操作は可能)。wrapper の `flex-col-reverse` は
+open/close と summary 表示制御だけに使う。wrapper の高さ上限は `max-h-[calc(50cqh-2rem)]`。
+% は details (block / auto 高) を跨いで伝播しないため、TerminalLeaf の relative コンテナを
+`container-type: size` にして cqh で leaf 高さを直接参照する。50cqh から 2rem を引くのは
+summary 高 (約 1.5rem) + 上下 inset 分の予算で、各 overlay 全体 (summary + wrapper) が
+leaf の 50% に収まる。main + sub が両方最大高でも合算が leaf を超えず、重ならない。
+wrapper の `flex-col-reverse` は
 単一子 (bubble 列) の並びには影響せず、scroll の初期位置と anchor を末尾 (最新発言)
 側に倒すための指定。wrapper は `pointer-events-auto` の通常の scroll container として
 振る舞い、bubble の隙間でも wheel は overlay のスクロールになる (`pointer-events-none`
@@ -252,7 +252,9 @@ const hasSub = computed(() => subMessages.value.length > 0);
            anchor を末尾 (最新発言) に倒すための指定。wrapper は pointer-events-auto の
            通常の scroll container (bubble の隙間でも wheel が overlay のスクロールに
            なる)。root の余白だけが pointer-events-none でターミナルへ透過する -->
-      <div class="pointer-events-auto flex max-h-[40cqh] flex-col-reverse overflow-y-auto p-2">
+      <div
+        class="pointer-events-auto flex max-h-[calc(50cqh-2rem)] flex-col-reverse overflow-y-auto p-2"
+      >
         <div class="flex flex-col gap-1">
           <div
             v-for="(msg, i) in mainMessages"
@@ -297,7 +299,9 @@ const hasSub = computed(() => subMessages.value.length > 0);
            generated content の gap 計算が崩れる挙動があるため、details はネイティブの
            open/close と summary 表示制御だけに使い、レイアウト / スクロールは中の div に
            閉じる。wrapper の構造は main と同じ。 -->
-      <div class="pointer-events-auto flex max-h-[40cqh] flex-col-reverse overflow-y-auto p-2">
+      <div
+        class="pointer-events-auto flex max-h-[calc(50cqh-2rem)] flex-col-reverse overflow-y-auto p-2"
+      >
         <div class="flex flex-col gap-1">
           <div
             v-for="(msg, i) in subMessages"

--- a/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
+++ b/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
@@ -44,8 +44,10 @@ agent。空文字フォールバックは "Subagent")。開閉状態は Vue 側 
 スクロールせず、bubble と被らない)。details 自体にはスタイルを当てず、native の
 open/close と summary 表示制御だけに使う。wrapper の高さ上限は `max-h-[40cqh]`
 (leaf 高さの 40%)。% は details (block / auto 高) を跨いで伝播しないため、TerminalLeaf
-の relative コンテナを `container-type: size` にして cqh で leaf 高さを直接参照する
-(main + sub 同時表示でも summary 込みで重ならない)。wrapper の `flex-col-reverse` は
+の relative コンテナを `container-type: size` にして cqh で leaf 高さを直接参照する。
+main + sub 同時表示時は合算 80cqh + summary / padding の固定分のため、縦分割で leaf が
+低いとき (概算 440px 未満) は両 overlay が重なりうる (視覚的な被りのみで、両者とも
+操作は可能)。wrapper の `flex-col-reverse` は
 単一子 (bubble 列) の並びには影響せず、scroll の初期位置と anchor を末尾 (最新発言)
 側に倒すための指定。wrapper は `pointer-events-auto` の通常の scroll container として
 振る舞い、bubble の隙間でも wheel は overlay のスクロールになる (`pointer-events-none`
@@ -75,11 +77,7 @@ DOM 構造は三段:
   border-box で clip され shadow がほぼ見えなくなる)
 - 中間 wrapper (`max-h-[60vh] overflow-auto rounded-md border border-border-strong shadow-xl`
   - kind 別 `bg-chat-incoming` / `bg-chat-outgoing`)
-    共通の「スクロール面 + 角丸 + border + shadow」と kind 別の bg を担う。bg を wrapper に
-    持たせるのは `apps/renderer/src/assets/main.css` の `::-webkit-scrollbar-track { background: transparent }`
-    と組み合わせるため。scrollbar gutter は WebKit の content-box 内側に描画されレイアウトを
-    消費するため、内側子要素に bg を持たせると gutter 帯だけ親の bg (透明) が透ける。scroll
-    container 自身に bg を持たせれば gutter ごと kind 色で塗られる。`overflow-auto` +
+    共通の「スクロール面 + 角丸 + border + shadow」と kind 別の bg を担う。`overflow-auto` +
     `border-radius` は CSS Backgrounds Module Level 3 §5.3 (Corner Clipping) で子の painting を
     clip するため、bg は角丸内に収まる
 - 内側 box (kind 別、bg は持たない)
@@ -254,15 +252,7 @@ const hasSub = computed(() => subMessages.value.length > 0);
            anchor を末尾 (最新発言) に倒すための指定。wrapper は pointer-events-auto の
            通常の scroll container (bubble の隙間でも wheel が overlay のスクロールに
            なる)。root の余白だけが pointer-events-none でターミナルへ透過する -->
-      <!-- scrollbar-width (CSS Scrollbars Level 1) はグローバルの ::-webkit-scrollbar
-           スタイルをこの要素だけ無効化する標準 override。legacy カスタムスクロールバーは
-           要素を classic scrollbar (レイアウト幅を消費) に強制するため、外して macOS
-           ネイティブの overlay scrollbar (幅消費ゼロ) に戻すことで出現時のガタつきを
-           構造的に消す。scrollbar-gutter は OS 設定「スクロールバーを常に表示」(classic
-           強制) のユーザー向けの幅予約 -->
-      <div
-        class="pointer-events-auto flex max-h-[40cqh] scrollbar-thin scrollbar-gutter-stable flex-col-reverse overflow-y-auto p-2"
-      >
+      <div class="pointer-events-auto flex max-h-[40cqh] flex-col-reverse overflow-y-auto p-2">
         <div class="flex flex-col gap-1">
           <div
             v-for="(msg, i) in mainMessages"
@@ -307,9 +297,7 @@ const hasSub = computed(() => subMessages.value.length > 0);
            generated content の gap 計算が崩れる挙動があるため、details はネイティブの
            open/close と summary 表示制御だけに使い、レイアウト / スクロールは中の div に
            閉じる。wrapper の構造は main と同じ。 -->
-      <div
-        class="pointer-events-auto flex max-h-[40cqh] scrollbar-thin scrollbar-gutter-stable flex-col-reverse overflow-y-auto p-2"
-      >
+      <div class="pointer-events-auto flex max-h-[40cqh] flex-col-reverse overflow-y-auto p-2">
         <div class="flex flex-col gap-1">
           <div
             v-for="(msg, i) in subMessages"

--- a/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
+++ b/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
@@ -12,8 +12,9 @@ main / sub を独立した 2 つの overlay に分け、terminal の右上に ma
 
 各 overlay の内側は「応答 (run)」単位で表示する。連続する同 kind の発言を 1 つの run と
 して束ね、user / assistant それぞれ最新 3 run を表示対象にする。各 run は最後の発言
-1 件で代表させ、最新の assistant run だけ末尾 3 件まで展開する (進行中の連続応答の流れを
-見せるため)。AskUserQuestion (`kind:"ask"` イベント) は `expandAskMessages` で
+1 件で代表させ、assistant が応答中 (ログ末尾の run が assistant) のときだけ、その run を
+末尾 3 件まで展開する (進行中の連続応答の流れを見せるため。user が最新なら応答は完結して
+いるので全 run を畳む)。AskUserQuestion (`kind:"ask"` イベント) は `expandAskMessages` で
 「質問 = assistant 発言」「回答 = user 発言」に inline 展開してから user / assistant のみを
 filter で残す (preview は会話テキストだけ見せたいので thinking / tool / image / branch
 ごと捨てる)。選択肢は parser 側で本来落とさないため、ここでは ask 展開の副作用ではなく
@@ -30,12 +31,27 @@ run 単位で kind ごとに件数を確保するため、assistant が連続応
 中間 span に逃がしている)。bubble が 0 件の overlay は非表示にし、両 overlay とも空なら
 何も描画しない。
 
-## sub の subagent ラベル
+## 折りたたみと高さ上限
 
-sub overlay の先頭に `subagentTabLabel` 由来の subagent ラベル (Task / workflow agent)
-を出し、どの subagent の発話なのかを明示する。ラベルは `<details><summary>` で
-括られており、native の open/close で bubble 群を折りたためる。状態は Vue 側に持たず
-`<details>` の `open` 属性が SSOT。
+main / sub とも `<details><summary>` で bubble 群を折りたためる。summary は main が
+固定ラベル "Main"、sub が `subagentTabLabel` 由来の subagent ラベル (Task / workflow
+agent。空文字フォールバックは "Subagent")。開閉状態は Vue 側 ref
+(`mainOpen` / `subOpen`) が SSOT。`open` 属性そのものを SSOT にすると v-if / subagent
+切替の unmount → mount で静的 `open` に戻ってしまうため、`:open` バインド + `@toggle`
+同期にしている。
+
+スクロール面は summary の外に出さず、details 内の wrapper div に閉じる (summary は
+スクロールせず、bubble と被らない)。details 自体にはスタイルを当てず、native の
+open/close と summary 表示制御だけに使う。wrapper の高さ上限は `max-h-[40cqh]`
+(leaf 高さの 40%)。% は details (block / auto 高) を跨いで伝播しないため、TerminalLeaf
+の relative コンテナを `container-type: size` にして cqh で leaf 高さを直接参照する
+(main + sub 同時表示でも summary 込みで重ならない)。wrapper の `flex-col-reverse` は
+単一子 (bubble 列) の並びには影響せず、scroll の初期位置と anchor を末尾 (最新発言)
+側に倒すための指定。wrapper は `pointer-events-auto` の通常の scroll container として
+振る舞い、bubble の隙間でも wheel は overlay のスクロールになる (`pointer-events-none`
+でヒットテストだけ透過させると、wheel の標準動作「target から最も近い scrollable
+ancestor をスクロール」がターミナルに向いてしまう)。root の余白 (padding) だけは
+従来どおり `pointer-events-none` でターミナルへ透過する。
 
 ## 全文 preview
 
@@ -197,9 +213,15 @@ function togglePreview(event: MouseEvent, msg: PreviewMessage, origin: "main" | 
   togglePreviewPopover(anchor, { msg, origin });
 }
 
-// sub overlay の折り畳み状態。`<details>` の `open` 属性を SSOT にすると subagent
-// 切替で <details> が unmount → mount される度に静的 `open` で展開状態に戻ってしまうため、
-// Vue 側 ref を SSOT にして `<details :open="subOpen">` でバインドし、`@toggle` で同期する。
+// 各 overlay の折り畳み状態。`<details>` の `open` 属性を SSOT にすると v-if /
+// subagent 切替で <details> が unmount → mount される度に静的 `open` で展開状態に
+// 戻ってしまうため、Vue 側 ref を SSOT にして `<details :open>` でバインドし、
+// `@toggle` で同期する。
+const mainOpen = ref(true);
+function onMainToggle(event: Event) {
+  if (!(event.target instanceof HTMLDetailsElement)) return;
+  mainOpen.value = event.target.open;
+}
 const subOpen = ref(true);
 function onSubToggle(event: Event) {
   if (!(event.target instanceof HTMLDetailsElement)) return;
@@ -217,67 +239,98 @@ const hasSub = computed(() => subMessages.value.length > 0);
        key に index を含めるのは、最新 assistant run の連続発言が同一 ts を持ち得るため -->
   <div
     v-if="hasMain"
-    class="pointer-events-none absolute top-1 right-3 z-10 flex w-56 max-w-[35%] flex-col gap-1 rounded-md bg-background/70 p-2 text-xs/tight"
+    class="pointer-events-none absolute top-1 right-3 z-10 w-56 max-w-[35%] overflow-hidden rounded-md bg-background/70 text-xs/tight"
   >
-    <div
-      v-for="(msg, i) in mainMessages"
-      :key="`${i}-${msg.kind}-${msg.ts}`"
-      class="flex min-w-0"
-      :class="msg.kind === 'user' ? 'justify-end' : ''"
-    >
-      <button
-        type="button"
-        class="pointer-events-auto block max-w-[85%] cursor-pointer rounded-lg px-2 py-1 text-left hover:brightness-110"
-        :class="
-          msg.kind === 'user'
-            ? 'bg-chat-outgoing text-chat-outgoing-text'
-            : 'bg-chat-incoming text-chat-incoming-text'
-        "
-        :title="msg.text"
-        @click="togglePreview($event, msg, 'main')"
+    <details :open="mainOpen" @toggle="onMainToggle">
+      <summary
+        class="pointer-events-auto cursor-pointer truncate bg-element-hover px-2 py-1 text-xs font-semibold text-foreground-low hover:bg-element-active [&::-webkit-details-marker]:hidden [&::marker]:hidden"
       >
-        <span class="line-clamp-2">{{ msg.text }}</span>
-      </button>
-    </div>
+        Main
+      </summary>
+      <!-- スクロール面は summary の外に出さず details 内の wrapper に閉じる (summary と
+           被らない)。高さ上限は % が details (block / auto 高) を跨いで伝播しないため、
+           leaf (TerminalLeaf の container-type: size) を参照する cqh で直接指定する。
+           flex-col-reverse は単一子 (bubble 列) の並びには影響せず、scroll 初期位置 /
+           anchor を末尾 (最新発言) に倒すための指定。wrapper は pointer-events-auto の
+           通常の scroll container (bubble の隙間でも wheel が overlay のスクロールに
+           なる)。root の余白だけが pointer-events-none でターミナルへ透過する -->
+      <!-- scrollbar-width (CSS Scrollbars Level 1) はグローバルの ::-webkit-scrollbar
+           スタイルをこの要素だけ無効化する標準 override。legacy カスタムスクロールバーは
+           要素を classic scrollbar (レイアウト幅を消費) に強制するため、外して macOS
+           ネイティブの overlay scrollbar (幅消費ゼロ) に戻すことで出現時のガタつきを
+           構造的に消す。scrollbar-gutter は OS 設定「スクロールバーを常に表示」(classic
+           強制) のユーザー向けの幅予約 -->
+      <div
+        class="pointer-events-auto flex max-h-[40cqh] scrollbar-thin scrollbar-gutter-stable flex-col-reverse overflow-y-auto p-2"
+      >
+        <div class="flex flex-col gap-1">
+          <div
+            v-for="(msg, i) in mainMessages"
+            :key="`${i}-${msg.kind}-${msg.ts}`"
+            class="flex min-w-0"
+            :class="msg.kind === 'user' ? 'justify-end' : ''"
+          >
+            <button
+              type="button"
+              class="block max-w-[85%] cursor-pointer rounded-lg px-2 py-1 text-left hover:brightness-110"
+              :class="
+                msg.kind === 'user'
+                  ? 'bg-chat-outgoing text-chat-outgoing-text'
+                  : 'bg-chat-incoming text-chat-incoming-text'
+              "
+              :title="msg.text"
+              @click="togglePreview($event, msg, 'main')"
+            >
+              <span class="line-clamp-2">{{ msg.text }}</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </details>
   </div>
 
-  <!-- sub: 右下。main と同じ LINE 風シーケンス。物理的距離で main との混在を回避する。
-       最上段に subagent ラベル (subagentTabLabel が組み立てた agent 名 / workflow 見出し)
-       を出し、どの subagent の発話なのかを明示する。 -->
+  <!-- sub: 右下。main と同じ LINE 風シーケンス + 同じ max-h スクロール / 折りたたみ構造。
+       物理的距離で main との混在を回避する。summary は subagentTabLabel が組み立てた
+       agent 名 / workflow 見出しで、どの subagent の発話なのかを明示する。 -->
   <div
     v-if="hasSub"
-    class="pointer-events-none absolute right-3 bottom-1 z-10 flex w-56 max-w-[35%] flex-col gap-1 rounded-md bg-background/70 p-2 text-xs/tight"
+    class="pointer-events-none absolute right-3 bottom-1 z-10 w-56 max-w-[35%] overflow-hidden rounded-md bg-background/70 text-xs/tight"
   >
     <details :open="subOpen" @toggle="onSubToggle">
       <summary
-        class="pointer-events-auto cursor-pointer truncate px-1 text-xs font-semibold text-foreground-low hover:text-foreground [&::-webkit-details-marker]:hidden [&::marker]:hidden"
+        class="pointer-events-auto cursor-pointer truncate bg-element-hover px-2 py-1 text-xs font-semibold text-foreground-low hover:bg-element-active [&::-webkit-details-marker]:hidden [&::marker]:hidden"
         :title="subLabel"
       >
         {{ subLabel }}
       </summary>
       <!-- bubble 用の内側コンテナ。details に直接 flex / gap を当てると WebKit で
            generated content の gap 計算が崩れる挙動があるため、details はネイティブの
-           open/close と summary 表示制御だけに使い、レイアウトは中の div に閉じる。 -->
-      <div class="flex flex-col gap-1 pt-1">
-        <div
-          v-for="(msg, i) in subMessages"
-          :key="`${i}-${msg.kind}-${msg.ts}`"
-          class="flex min-w-0"
-          :class="msg.kind === 'user' ? 'justify-end' : ''"
-        >
-          <button
-            type="button"
-            class="pointer-events-auto block max-w-[85%] cursor-pointer rounded-lg px-2 py-1 text-left hover:brightness-110"
-            :class="
-              msg.kind === 'user'
-                ? 'bg-chat-outgoing text-chat-outgoing-text'
-                : 'bg-chat-incoming text-chat-incoming-text'
-            "
-            :title="msg.text"
-            @click="togglePreview($event, msg, 'sub')"
+           open/close と summary 表示制御だけに使い、レイアウト / スクロールは中の div に
+           閉じる。wrapper の構造は main と同じ。 -->
+      <div
+        class="pointer-events-auto flex max-h-[40cqh] scrollbar-thin scrollbar-gutter-stable flex-col-reverse overflow-y-auto p-2"
+      >
+        <div class="flex flex-col gap-1">
+          <div
+            v-for="(msg, i) in subMessages"
+            :key="`${i}-${msg.kind}-${msg.ts}`"
+            class="flex min-w-0"
+            :class="msg.kind === 'user' ? 'justify-end' : ''"
           >
-            <span class="line-clamp-2">{{ msg.text }}</span>
-          </button>
+            <button
+              type="button"
+              class="block max-w-[85%] cursor-pointer rounded-lg px-2 py-1 text-left hover:brightness-110"
+              :class="
+                msg.kind === 'user'
+                  ? 'bg-chat-outgoing text-chat-outgoing-text'
+                  : 'bg-chat-incoming text-chat-incoming-text'
+              "
+              :title="msg.text"
+              @click="togglePreview($event, msg, 'sub')"
+            >
+              <span class="line-clamp-2">{{ msg.text }}</span>
+            </button>
+          </div>
         </div>
       </div>
     </details>

--- a/apps/renderer/src/features/terminal/terminalSessionPreviewMessages.test.ts
+++ b/apps/renderer/src/features/terminal/terminalSessionPreviewMessages.test.ts
@@ -21,7 +21,7 @@ function texts(input: PreviewEvent[]): string[] {
 }
 
 describe("collectMessages", () => {
-  test("代表例: 各 run は最終発言で代表し、最新 assistant run だけ末尾 3 件展開する", () => {
+  test("代表例: 各 run は最終発言で代表し、応答中の assistant run だけ末尾 3 件展開する", () => {
     const input = events(
       "u1",
       "a",
@@ -45,9 +45,14 @@ describe("collectMessages", () => {
     expect(texts([])).toEqual([]);
   });
 
-  test("最後が user run でも、途中にある最新 assistant run が展開される", () => {
+  test("最後が user run のとき、assistant run は展開せず 1 件代表に畳む", () => {
     const input = events("u1", "a", "a1-1", "a1-2", "u2");
-    expect(texts(input)).toEqual(["u1", "a", "a1-1", "a1-2", "u2"]);
+    expect(texts(input)).toEqual(["u1", "a1-2", "u2"]);
+  });
+
+  test("user が最新なら、直前の連続 assistant 応答も代表 1 件になる", () => {
+    const input = events("u1", "a1", "u2", "a2-1", "a2-2", "a2-3", "u3");
+    expect(texts(input)).toEqual(["u1", "a1", "u2", "a2-3", "u3"]);
   });
 
   test("空文字 event を挟んだ同 kind 連続は 1 run に束ねられる (run 分断しない)", () => {

--- a/apps/renderer/src/features/terminal/terminalSessionPreviewMessages.ts
+++ b/apps/renderer/src/features/terminal/terminalSessionPreviewMessages.ts
@@ -25,8 +25,9 @@ interface PreviewRun {
 
 // 各 kind とも最新 3 run (= 3 応答分) を表示対象にする
 const RUNS_PER_KIND = 3;
-// 最新の assistant run だけ末尾 3 件まで展開する (進行中の連続応答の流れを見せる)。
-// それ以外の run は最後の 1 件で代表させる
+// assistant が応答中 (= ログ末尾の run が assistant) のときだけ、その run を末尾 3 件まで
+// 展開する (進行中の連続応答の流れを見せる)。user が最新なら応答は完結しているので
+// 全 run を最後の 1 件で代表させる
 const LATEST_ASSISTANT_RUN_MESSAGES = 3;
 
 export function collectMessages(events: PreviewEvent[]): PreviewMessage[] {
@@ -52,11 +53,12 @@ export function collectMessages(events: PreviewEvent[]): PreviewMessage[] {
 
   // runs は events 出現順なので、選んだ message をそのまま flatten すれば表示順になる。
   // ts="" / parse 不能 ts の event が混ざっても順序が崩れない (ts での sort はしない)
-  const lastAssistantRun = runs.findLast((r) => r.kind === "assistant");
+  const latestRun = runs[runs.length - 1];
+  const expandedRun = latestRun?.kind === "assistant" ? latestRun : undefined;
   const out: PreviewMessage[] = [];
   for (const run of runs) {
     if (!kept.has(run)) continue;
-    const take = run === lastAssistantRun ? LATEST_ASSISTANT_RUN_MESSAGES : 1;
+    const take = run === expandedRun ? LATEST_ASSISTANT_RUN_MESSAGES : 1;
     for (const m of run.messages.slice(-take)) {
       out.push({ kind: m.kind, text: m.text, ts: m.ts });
     }


### PR DESCRIPTION
## 概要

ターミナルの Claude セッション preview overlay (`TerminalSessionPreview.vue`) に以下を加える。

- main overlay も sub と同様に `<details><summary>` で折りたたみ可能にする (summary は固定ラベル "Main")
- bubble 群に高さ上限 (leaf 高さの 40%) を付け、溢れたらスクロールする。スクロール初期位置は最新発言側
- user 発言が最新のとき、assistant の連続応答 run が 1 件代表に畳まれないバグを修正する

さらに、スクロールバー出現時の幅ガタつきの調査でグローバル `::-webkit-scrollbar` カスタムスタイルが根本原因と判明したため、**カスタム scrollbar スタイルを全廃し、macOS native overlay scrollbar をアプリ全体のデフォルトにする**。

## 背景

PR #764 で preview を run 単位表示にしたが、2 つの問題が残っていた。

- 展開対象を「ログ内最新の assistant run」(`findLast`) で選んでいたため、user が最後に発言して応答が完結した後も直前の assistant run が末尾 3 件展開されたままになっていた。「進行中の応答だけ展開する」が意図なので、展開条件は kind 検索ではなくログ末尾の run の位置で判定すべきだった
- bubble の表示件数が増えた (最大 8 件) ことで、overlay がターミナル本体を覆い隠すようになった

実装過程で判明した問題と判断:

- summary を sticky にして root 全体をスクロールさせる案は、スクロール内容がタイトルの下を貫通するため却下。スクロール面は details 内の wrapper div に閉じ、summary (タイトル) と物理的に分離した
- details には flex を当てられず (WebKit の gap 計算崩れ)、% max-height も auto 高 block を跨いで伝播しない。leaf 高さ比の上限は `TerminalLeaf` の relative コンテナを `container-type: size` にし、wrapper が `max-h-[40cqh]` で直接参照する方式にした
- overlay は従来「root が `pointer-events-none`、bubble だけ auto」の透過 HUD 設計だったが、scroll container とは両立しない (wheel の標準動作は「ヒットテストの target から最も近い scrollable ancestor をスクロール」のため、bubble の隙間ではターミナルがスクロールされる)。スクロール wrapper は `pointer-events-auto` の通常 scroll container にした

### scrollbar デフォルトの全廃に至る経緯

スクロールバー出現時に content 幅がガタつく問題を調査した結果:

- 根本原因は `main.css` のグローバル `::-webkit-scrollbar` (6px カスタム)。これを持つ要素は **常に classic scrollbar (レイアウト幅を消費) に強制される**。macOS のネイティブデフォルトは overlay scrollbar (幅消費ゼロ) なので、本来ガタつきは構造的に発生しない
- このグローバルスタイルは PR #31 (Electron から Electrobun への移行) に説明なしで混入したもので、設計判断の記録がない
- サイドバーの「scrollbar 完全非表示」( `scrollbar-width: none` + `display: none` ) も「幅が常時予約される」前提への回避策であり、その前提自体がこのグローバルスタイルの産物だった

そこで個別対応 (要素単位の `scrollbar-width` opt-out) ではなくデフォルト自体を直す方針とし、グローバル `::-webkit-scrollbar` / 専用 token / サイドバーの非表示指定をすべて削除した。native overlay scrollbar は幅を消費しないため、幅ガタつきは全領域で構造的に消える。

- native scrollbar を dark バリアントで描画させるため `html { color-scheme: dark }` を宣言する (未宣言だと UA がライトページ扱いし、暗背景に黒 thumb を出す)。dark 固定 UI として本来あるべき宣言

## 変更内容

### run 展開ロジック (`terminalSessionPreviewMessages.ts`)

- 展開対象を `findLast(assistant)` から「ログ末尾の run が assistant のときのみその run」に変更。user が最新なら全 run を最後の 1 件で代表させる
- テストを新仕様に書き換え、連続 assistant 応答直後に user 発言があるケースの回帰テストを追加

### 折りたたみ (`TerminalSessionPreview.vue`)

- main も sub と同じ `<details><summary>` 構造に統一。開閉状態は Vue ref (`mainOpen` / `subOpen`) が SSOT
- summary は solid `bg-element-hover` + `hover:bg-element-active` のヘッダー帯。スクロール面の外で常時固定
- root の padding を撤去し、summary とスクロール wrapper にそれぞれ padding を持たせる (root は `overflow-hidden` で角丸クリップ)

### スクロール (`TerminalSessionPreview.vue` / `TerminalLeaf.vue`)

- スクロール面は details 内の wrapper div に閉じ、`max-h-[40cqh]` + `overflow-y-auto`。`TerminalLeaf` の relative コンテナに `container-type: size` を追加して cqh の参照先にする
- wrapper の `flex-col-reverse` (単一子) でスクロール初期位置と anchor を最新発言側に倒す
- wrapper は `pointer-events-auto`。root の余白だけが従来どおりターミナルへ透過する
- main + sub 同時表示時は合算 80cqh + 固定分のため、縦分割で leaf が低いとき (概算 440px 未満) は overlay が重なりうる。視覚的な被りのみで機能は破壊されないため許容し、条件を doc に明記

### scrollbar デフォルト (`main.css` / `SidebarPane.vue`)

- グローバル `::-webkit-scrollbar` ブロックと専用 token (`--color-scrollbar-thumb` / `-hover`) を削除
- サイドバーの `scrollbar-none` + scoped `::-webkit-scrollbar { display: none }` を削除
- `html { color-scheme: dark }` を宣言
- `GitGraphPane` の doc / コメントに残っていた classic scrollbar 前提の文言 (「scrollbar 幅ぶん column がズレる」) を、scrollbar 幅非依存の現行仕様の宣言に更新

## 確認事項

- [x] user 発言が最新のとき、assistant の応答が 1 bubble に畳まれること
- [x] assistant 応答中は最新 run だけ末尾 3 件展開されること
- [x] main / sub とも summary クリックで折りたためること
- [x] bubble が多いとき leaf 高さの 40% で止まり、最新発言が見える位置から上スクロールできること
- [x] スクロールバー出現で bubble の折り返しがガタつかないこと
- [x] スクロールバーが暗背景で視認できること (黒 thumb でない)
- [x] サイドバー含む全領域が macOS native overlay scrollbar で表示されること

