### PR TITLE
feat(theme): scrollbar-width thin と scrollbar-gutter stable をデフォルト化する

### DIFF
--- a/apps/renderer/CLAUDE.md
+++ b/apps/renderer/CLAUDE.md
@@ -5,7 +5,7 @@
   - Tier 1 (primitives): `@gozd/design-tokens` package が Adobe Leonardo で生成 → `dist/tokens.generated.css` を `main.css` が `@import`
   - Tier 1 brand-fixed (例外): theme 追従しない固定 brand 色 (LINE 配色等) は `main.css` の `:root` に手書きで定義し、命名規約 `--<scope>-<role>-primitive` で識別する
   - Tier 2 (semantic aliases): `main.css` の `@theme inline` で role 名定義
-  - Tier 3 (element defaults): `main.css` の `@layer base` で UA 上書き
+  - Tier 3 (element defaults): `main.css` の `@layer base` で UA 上書き / scrollbar
 - Tier 1 primitives は **手書き禁止**。brand を変えるときは [`packages/design-tokens/src/generateTokens.ts`](../../packages/design-tokens/src/generateTokens.ts) の `BRAND` を編集し `pnpm install` (prepare で自動再生成)
 - Tier 1 brand-fixed primitives (`--<scope>-<role>-primitive`) は **例外的に `main.css` の `:root` への手書きを許可** する。theme 追従しない固定色は Adobe Leonardo 生成パイプラインに乗らないため。例: chat-\* (LINE ダークモード配色)
 - UI を書く / 直すときの規律一覧は project-local skill [`/.claude/skills/gozd-ui/SKILL.md`](../../.claude/skills/gozd-ui/SKILL.md) を参照 (Claude Code 自動適用)

--- a/apps/renderer/src/assets/main.css
+++ b/apps/renderer/src/assets/main.css
@@ -33,7 +33,7 @@
  * Tier 1 (primitives, :root) は `@gozd/design-tokens` package で生成し、上の
  * @import で取り込む。本 file は consumer 側として:
  *   - Tier 2 (semantic aliases, @theme inline): role 名 utility を生成
- *   - Tier 3 (element defaults, @layer base): UA stylesheet 打ち消し
+ *   - Tier 3 (element defaults, @layer base): UA stylesheet 打ち消し / scrollbar
  *
  * @theme inline modifier は utility 値に var(--primitive) を直接展開するため、
  * 将来 light theme で primitive 側を override したとき自動 propagate する。
@@ -170,5 +170,23 @@
     padding: 0;
     border: none;
     background: transparent;
+  }
+
+  /* scrollbar デフォルト (CSS Scrollbars Level 1 / Overflow Level 3 標準プロパティのみ。
+     ::-webkit-scrollbar は要素を classic scrollbar に強制するため使わない)。
+     overlay scrollbar (macOS 既定) では thin は細い overlay、gutter は no-op。
+     classic scrollbar (OS 設定「常に表示」/「自動」+ 非タッチマウス) では thin が
+     消費幅を抑え、stable が幅を常時予約してスクロールバー出現時のガタつきを防ぐ */
+  * {
+    scrollbar-width: thin;
+  }
+
+  /* stable は classic 環境で overflow: hidden の box にも gutter を予約する仕様のため、
+     `*` 一括にせず縦スクロール utility に限定する (角丸クリップ用 overflow-hidden に
+     空の縦帯が出るのを防ぐ)。scrollbar-gutter は縦 scrollbar の inline-end gutter に
+     のみ作用するため横スクロール utility は対象外。:where() で詳細度ゼロに保ち、
+     要素側の個別指定で上書き可能にする */
+  :where(.overflow-auto, .overflow-y-auto, .overflow-scroll, .overflow-y-scroll) {
+    scrollbar-gutter: stable;
   }
 }


### PR DESCRIPTION
## 概要

CSS Scrollbars Level 1 / Overflow Level 3 の標準プロパティで scrollbar のアプリ全体デフォルトを定める。

- `scrollbar-width: thin` — `*` で全要素に適用
- `scrollbar-gutter: stable` — 縦スクロール utility (`overflow-auto` / `overflow-y-auto` / `overflow-scroll` / `overflow-y-scroll`) に限定して適用

## 背景

PR ( #766 ) でカスタム `::-webkit-scrollbar` を全廃し macOS native overlay scrollbar をデフォルト化したが、overlay になるのは OS 設定に依存する。「スクロールバーを表示 = 自動」(デフォルト) でもタッチ面のないマウスが接続されていると classic scrollbar (常時表示・レイアウト幅を消費) に解決されるため、そうした環境では PR #766 の「幅ガタつきは構造的に消える」という前提が成立しない (実機で確認)。

`scrollbar-gutter: stable` はまさにこのケースのための標準メカニズムで、overlay 環境では no-op、classic 環境では幅を常時予約してスクロールバー出現時のガタつきを防ぐ。PR #766 の実装過程では `scrollbar-gutter-stable` が付いていたが最終 commit で削除されており、本 PR で「OS 設定を尊重しつつ classic 環境でも壊れない」形に倒し直す。

なお `thin` 未満の幅指定は標準では不可能 ( `scrollbar-width` は `auto` / `thin` / `none` のみ。length 値の提案は CSSWG が Wontfix で却下: w3c/csswg-drafts issue6263 )。`::-webkit-scrollbar` での幅指定は要素を classic に強制するため native overlay 方針と両立せず採らない。

## 変更内容

### scrollbar デフォルト (`main.css` @layer base)

- `* { scrollbar-width: thin }` を追加。overlay 環境では細い overlay、classic 環境では消費幅を抑える
- `:where(.overflow-auto, .overflow-y-auto, .overflow-scroll, .overflow-y-scroll) { scrollbar-gutter: stable }` を追加。`:where()` で詳細度ゼロに保ち、要素側の個別指定で上書き可能にする
- `*` 一括にしない理由: `stable` は classic 環境で `overflow: hidden` の box にも gutter を予約する仕様 (MDN) のため、角丸クリップ用 `overflow-hidden` (27 箇所) に空の縦帯が出る。横スクロール utility を含めない理由: `scrollbar-gutter` は縦 scrollbar の inline-end gutter にのみ作用し、横バーの高さ予約は仕様の射程外

### ドキュメント

- `main.css` ヘッダーと `apps/renderer/CLAUDE.md` の Tier 3 (element defaults) 記述に scrollbar を復元

## 確認事項

- [ ] classic 環境 (システム設定 > 外観 > スクロールバーを表示 = 常に、または「自動」+ 非タッチマウス) で、サイドバー / preview overlay のスクロールバーが細く、内容の増減で幅がガタつかないこと
- [ ] overlay 環境 (トラックパッドのみ等) で従来どおり overlay 表示され、gutter の空帯が出ないこと
- [ ] `overflow-hidden` の角丸クリップ要素 (dialog / preview overlay root 等) に空の縦帯が出ないこと
