### PR TITLE
fix(lefthook): renderer の .ts も eslint で fix し CI とのギャップを解消

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -58,11 +58,15 @@ pre-commit:
             run: pnpm exec oxlint --type-aware --fix {staged_files} && pnpm exec oxfmt {staged_files}
             stage_fixed: true
 
-          # apps/renderer: .ts は oxlint、.vue は eslint。oxfmt は全ファイルに適用
+          # apps/renderer: .ts / .vue とも eslint で fix する。renderer の lint/fix SSOT は
+          # eslint (package.json: lint=`eslint .` / fix=`eslint . -c eslint.config.fix.ts`)。
+          # .ts を oxlint に回すと eslint 専用ルール (import-x/order 等) が .ts で抜け、
+          # CI の fix:all (eslint 全ファイル) でのみ差分が出て「ローカルは通るが CI が落ちる」
+          # ギャップになるため、CI と同じ eslint に揃える。oxfmt は全対象拡張子に適用。
           # 同一ファイルへの競合を避けるため piped で直列実行。
           # 親 group には glob を置かない: lefthook の group は親 glob と子 glob を
           # OR（和集合）で連結するため、親 glob は子を絞り込めず追加にしかならない。
-          # 親 glob があると .md/.css 単独 commit でも oxlint(.ts)/eslint(.vue) が
+          # 親 glob があると .md/.css 単独 commit でも eslint(.ts/.vue) が
           # 対象外ファイルを受け取り「No files found to lint」で落ちる。
           # 子ごとに glob を持たせて振り分けを完結させる。
           - name: renderer
@@ -70,12 +74,8 @@ pre-commit:
             group:
               piped: true
               jobs:
-                - name: oxlint
-                  glob: "**/*.ts"
-                  run: pnpm exec oxlint --type-aware --fix {staged_files}
-                  stage_fixed: true
                 - name: eslint
-                  glob: "**/*.vue"
+                  glob: "**/*.{ts,vue}"
                   run: pnpm exec eslint -c eslint.config.fix.ts --no-warn-ignored --cache --fix {staged_files}
                   stage_fixed: true
                 # oxfmt は対象拡張子を明示。glob 無しだと .json/.svg/.png まで


### PR DESCRIPTION
## 概要

lefthook (pre-commit) の renderer グループを、`.ts` / `.vue` とも eslint で fix するように統一する。これまで `.ts` を oxlint、`.vue` を eslint に振り分けていたのを、CI と同じ eslint に揃える。

## 背景

別 PR ( #785 ) で renderer の `.ts` ファイルのみを変更したところ、ローカルの pre-commit は通ったのに CI の `fix` ジョブだけが import 並び替えの差分で fail した。

原因を追ったところ、renderer の lint/fix の SSOT は eslint であるのに、lefthook だけが `.ts` を oxlint に回していたことが判明した。

- renderer `package.json`: `lint` = `eslint .` / `fix` = `eslint . --fix -c eslint.config.fix.ts && oxfmt .` — `.ts` も `.vue` も eslint
- CI の `fix` ジョブ ( `fix:all` ) はこの renderer `fix` スクリプトを呼ぶため、eslint が全ファイルに適用される
- 一方 lefthook の renderer group は `.ts` → oxlint、`.vue` → eslint に分けていた

`import-x/order` ( import 並び替え ) は `eslint.config.fix.ts` でのみ有効な eslint 専用ルールで、oxlint には相当ルールがない。このため `.ts` 単独の変更では pre-commit の eslint 専用ルールが効かず、CI の `fix:all` で初めて差分が出る「ローカルは通るが CI が落ちる」ギャップになっていた。

root / packages ( shared / themes 等 ) は各自の lint/fix が oxlint なので、lefthook が `.ts` に oxlint を使うのは正しい。SSOT がずれていたのは renderer group だけ。

## 変更内容

### lefthook renderer group の lint を eslint に一本化

- `.ts` → oxlint のジョブを削除
- eslint ジョブの glob を `**/*.vue` から `**/*.{ts,vue}` に拡張
- 結果として renderer の `fix` スクリプト ( eslint 全ファイル → oxfmt ) と挙動が一致する

root / packages 側の oxlint ジョブは変更しない ( それぞれ oxlint が SSOT のため ) 。

## 今回は対応しない

### pre-commit の速度

oxlint より eslint の方が遅いため、renderer の `.ts` を含む commit の pre-commit は多少遅くなる。ただし「ローカルで通ったのに CI で落ちる」を解消する正しさを優先する。速度が問題になれば oxlint への import 並び替えルール移植を別途検討する。

## 確認事項

- [ ] renderer の `.ts` のみを変更した commit で、pre-commit が eslint の `import-x/order` を適用すること ( ローカルと CI の挙動が一致すること )
- [ ] `lefthook validate` が通ること ( 確認済み: All good )
