### PR TITLE
feat(sidebar): worktree とその task 群を境界カードでグルーピング

### DIFF
--- a/apps/renderer/src/assets/main.css
+++ b/apps/renderer/src/assets/main.css
@@ -314,7 +314,7 @@
 /* Claude 状態オーラ (worktree カード)。
    box-shadow を ::after 擬似要素に逃がし、選択中表現 (_fx-quest-active 本体の
    box-shadow) と同一プロパティを奪い合わないようにする。これで「選択中 かつ
-   working/asking/done」のカードでも、選択枠のブルーム + inset 縁取りと状態オーラが
+   working/asking/done」のカードでも、選択枠のブルームと状態オーラが
    別レイヤーとして両立する (単一要素の box-shadow に両者を載せると後勝ちで一方が消える)。 */
 ._fx-aura-working,
 ._fx-aura-asking,

--- a/apps/renderer/src/assets/main.css
+++ b/apps/renderer/src/assets/main.css
@@ -302,38 +302,13 @@
   left: 125%;
 }
 
-/* 選択中カード: 左エッジの発光バー + 薄い primary 縁取り + ブルーム。
-   モダンゲームの「選択中スロット」表現 (回転枠のような装飾過多は避ける) */
+/* 選択中カード: アウトライン表現 (border-primary は utility 側で付与) + 外周ブルーム。
+   カード内部は塗らない。塗り (青 fill) は focus 行の capsule (bg-primary-subtle) だけが持ち、
+   「カードが選択中」と「どの行に focus があるか」を fill ｘ outline で階層分離する。
+   カード自体を青く塗ると focus 行の青 capsule と青ｘ青で潰れるため塗りは持たせない。 */
 ._fx-quest-active {
   position: relative;
-  background: color-mix(in srgb, var(--color-primary) 14%, transparent);
-  box-shadow:
-    0 0 22px color-mix(in oklch, var(--color-primary) 30%, transparent),
-    inset 0 0 0 1px color-mix(in oklch, var(--color-primary) 35%, transparent);
-}
-
-._fx-quest-active::before {
-  content: "";
-  position: absolute;
-  left: -1px;
-  top: 14%;
-  bottom: 14%;
-  width: 3px;
-  border-radius: 2px;
-  background: linear-gradient(to bottom, transparent, var(--color-primary), transparent);
-  box-shadow: 0 0 10px var(--color-primary);
-  animation: fx-edge-pulse 2.4s ease-in-out infinite;
-  pointer-events: none;
-}
-
-@keyframes fx-edge-pulse {
-  0%,
-  100% {
-    opacity: 0.65;
-  }
-  50% {
-    opacity: 1;
-  }
+  box-shadow: 0 0 16px color-mix(in oklch, var(--color-primary) 22%, transparent);
 }
 
 /* Claude 状態オーラ (worktree カード)。

--- a/apps/renderer/src/features/sidebar/features/repo/RepoSection.vue
+++ b/apps/renderer/src/features/sidebar/features/repo/RepoSection.vue
@@ -126,7 +126,7 @@ function onHeaderClick() {
       </button>
     </header>
 
-    <div v-if="isGitRepo && !visiblyCollapsed" class="flex flex-col">
+    <div v-if="isGitRepo && !visiblyCollapsed" class="flex flex-col gap-2">
       <WtCard
         v-for="wt in orderedWorktrees"
         :key="wt.path"
@@ -141,7 +141,7 @@ function onHeaderClick() {
       />
       <button
         type="button"
-        class="_fx-shine flex w-full items-center justify-center gap-1.5 rounded-md border border-dashed border-border px-2 py-1.5 text-xs tracking-widest text-foreground-low uppercase transition-colors hover:border-primary hover:bg-primary-subtle hover:text-primary-text disabled:cursor-not-allowed disabled:text-foreground-muted disabled:hover:border-border disabled:hover:bg-transparent disabled:hover:text-foreground-muted"
+        class="_fx-shine flex w-full items-center justify-center gap-1.5 rounded-md px-2 py-1 text-xs text-foreground-low transition-colors hover:bg-element-hover hover:text-foreground disabled:cursor-not-allowed disabled:text-foreground-muted disabled:hover:bg-transparent disabled:hover:text-foreground-muted"
         :disabled="isCreating"
         @click="emit('addWorktree', rootDir)"
       >

--- a/apps/renderer/src/features/sidebar/features/worktree/TaskRow.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/TaskRow.vue
@@ -149,12 +149,12 @@ function onMenuClick(event: MouseEvent) {
     <button
       type="button"
       :data-active="active"
-      class="flex w-full items-center gap-2 rounded-lg p-2 text-left transition-colors hover:bg-element-hover focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden focus-visible:ring-inset data-[active=true]:bg-primary-subtle"
+      class="flex w-full items-center gap-2 rounded-md px-2 py-1 text-left transition-colors hover:bg-element-hover focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden focus-visible:ring-inset data-[active=true]:bg-primary-subtle data-[active=true]:hover:bg-primary-subtle-hover"
       @click="emit('select', task)"
     >
       <component
         :is="visual.icon"
-        class="size-5 shrink-0"
+        class="size-4 shrink-0"
         :class="[visual.color, visual.animate]"
         role="img"
         :aria-label="visual.ariaLabel"

--- a/apps/renderer/src/features/sidebar/features/worktree/WtCard.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/WtCard.vue
@@ -8,11 +8,11 @@ upstream ahead-behind / ⋮) と、Task 行 (TaskRow) を縦に並べる。task 
 (border + 内パディング) を持ち、task がある場合はヘッダとボディを divider で区切る。
 ヘッダ = worktree identity ゾーン、ボディ = その worktree に属する task 群ゾーンとして
 構造で分離する。これにより branch/home icon (identity) と claude state icon (task の状態)
-が別ゾーンに分かれ、同一 glutter に並列して見分けづらくなる問題を解消する。
+が別ゾーンに分かれ、同一 gutter に並列して見分けづらくなる問題を解消する。
 
-カード境界は `overflow-hidden` を使わない。`_fx-quest-active` の選択エッジ glow
-(`::before`、left:-1px に張り出す) がクリップされて消えるため。内パディング `p-1` で
-内部 row を角丸にし、row の hover 背景がカードの角丸境界とぶつからないようにする。
+カード境界は `overflow-hidden` を使わない。active カードの `_fx-quest-active` が持つ
+外周ブルーム (`box-shadow`) がクリップされて消えるため。内パディング `p-0.5` で内部 row
+を角丸にし、row の hover 背景がカードの角丸境界とぶつからないようにする。
 
 server port バッジは、その worktree の端末で LISTEN 中の dev server の port を表示する
 (issue #768、live のみ)。詳細は [docs/server.md](../../../../../../../docs/server.md)。

--- a/apps/renderer/src/features/sidebar/features/worktree/WtCard.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/WtCard.vue
@@ -2,6 +2,18 @@
 1 worktree のカード。ヘッダ (branch icon / branch / server port バッジ / git status /
 upstream ahead-behind / ⋮) と、Task 行 (TaskRow) を縦に並べる。task が無い wt はヘッダのみ。
 
+## グルーピング
+
+「worktree とそれに属する task 群」を 1 つの単位として明示するため、カードは境界
+(border + 内パディング) を持ち、task がある場合はヘッダとボディを divider で区切る。
+ヘッダ = worktree identity ゾーン、ボディ = その worktree に属する task 群ゾーンとして
+構造で分離する。これにより branch/home icon (identity) と claude state icon (task の状態)
+が別ゾーンに分かれ、同一 glutter に並列して見分けづらくなる問題を解消する。
+
+カード境界は `overflow-hidden` を使わない。`_fx-quest-active` の選択エッジ glow
+(`::before`、left:-1px に張り出す) がクリップされて消えるため。内パディング `p-1` で
+内部 row を角丸にし、row の hover 背景がカードの角丸境界とぶつからないようにする。
+
 server port バッジは、その worktree の端末で LISTEN 中の dev server の port を表示する
 (issue #768、live のみ)。詳細は [docs/server.md](../../../../../../../docs/server.md)。
 
@@ -11,9 +23,15 @@ Task は PR/issue picker や手動操作で永続的に作られ、Claude sessio
 
 ## ハイライト
 
-active wt の場合、wt ヘッダには常に capsule fill。さらに focused PTY が task に
-紐づいているなら該当 task 行にも capsule。wt と task の両方が同時にハイライト
-されることで「どの wt のどの task に focus があるか」が一目で識別できる。
+選択表現を 2 レベルで階層分離する。fill (青 capsule) は常にカード内 1 行だけ。
+
+- **カード = アウトライン**: active worktree は border-primary + 外周グロー
+  (`_fx-quest-active`) で示す。内部は塗らない。
+- **行 = fill**: focus がある 1 行だけ `bg-primary-subtle` の capsule。focused PTY が
+  task なら該当 task 行、task に focus が無い (wt の素のターミナル) なら header。
+
+カード自体を青く塗ると focus 行の青 capsule と青ｘ青で潰れて「どの行か」が読めなく
+なるため、塗りは行だけが持つ。所属 (active worktree であること) は card の outline が担う。
 
 ## 並び順
 
@@ -124,8 +142,14 @@ const focusedTaskId = computed(() => {
   return found?.task.id;
 });
 
-/** focus が wt 内にあるなら header に capsule (task focus 時も同時にハイライト) */
-const headerActive = computed(() => props.active);
+/**
+ * header の capsule (青 fill) は「wt が active かつ task に focus が無い」ときだけ。
+ * task に focus があるときは該当 task 行を fill するので、header まで fill すると
+ * 同一カード内に青 fill が 2 つ並んで「どの行が focus か」が潰れる。fill は常に
+ * 1 行だけ、という不変条件を保つ。active worktree であること自体は card の
+ * border-primary + glow が示すため、header fill が消えても所属は分かる。
+ */
+const headerActive = computed(() => props.active && focusedTaskId.value === undefined);
 
 /** main worktree (= リポジトリ root) は git worktree remove 不可。現状メニュー項目は Remove のみ。 */
 const canRemove = computed(() => !props.wt.isMain);
@@ -144,20 +168,17 @@ function onHeaderClick() {
 <template>
   <article
     :data-active="active"
-    class="rounded-lg transition-colors data-[active=true]:bg-primary-subtle"
-    :class="[active && '_fx-quest-active', auraClass]"
+    class="rounded-lg border p-0.5 transition-colors"
+    :class="[active ? '_fx-quest-active border-primary' : 'border-border-subtle', auraClass]"
   >
     <div class="group/wt relative">
-      <div
-        role="button"
-        tabindex="0"
+      <button
+        type="button"
         :data-active="headerActive"
-        class="_fx-shine flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 py-1 text-foreground-low transition-colors hover:bg-element-hover focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden focus-visible:ring-inset"
+        class="_fx-shine flex w-full items-center gap-2 rounded-md px-2 py-0.5 text-left text-foreground-low transition-colors hover:bg-element-hover focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden focus-visible:ring-inset data-[active=true]:bg-primary-subtle data-[active=true]:hover:bg-primary-subtle-hover"
         @click="onHeaderClick"
-        @keydown.enter.prevent="onHeaderClick"
-        @keydown.space.prevent="onHeaderClick"
       >
-        <span class="grid size-5 shrink-0 place-items-center" aria-hidden="true">
+        <span class="grid size-4 shrink-0 place-items-center" aria-hidden="true">
           <component :is="branchIcon" class="size-3.5" />
         </span>
         <span class="flex-1 truncate text-left text-xs font-medium">{{ branchLabel }}</span>
@@ -193,7 +214,7 @@ function onHeaderClick() {
             <span>{{ wt.upstream.behind }}</span>
           </span>
         </span>
-      </div>
+      </button>
       <button
         v-if="canRemove"
         type="button"
@@ -205,7 +226,7 @@ function onHeaderClick() {
       </button>
     </div>
 
-    <div v-if="tasksWithStatus.length > 0">
+    <div v-if="tasksWithStatus.length > 0" class="mt-0.5 border-t border-border-subtle pt-0.5">
       <TaskRow
         v-for="entry in tasksWithStatus"
         :key="entry.task.id"

--- a/apps/renderer/src/features/sidebar/features/worktree/WtCard.vue
+++ b/apps/renderer/src/features/sidebar/features/worktree/WtCard.vue
@@ -1,5 +1,5 @@
 <doc lang="md">
-1 worktree のカード。ヘッダ (branch icon / branch / server port バッジ / git status /
+1 worktree のカード。ヘッダ (branch 名 / server port バッジ / git status /
 upstream ahead-behind / ⋮) と、Task 行 (TaskRow) を縦に並べる。task が無い wt はヘッダのみ。
 
 ## グルーピング
@@ -7,8 +7,11 @@ upstream ahead-behind / ⋮) と、Task 行 (TaskRow) を縦に並べる。task 
 「worktree とそれに属する task 群」を 1 つの単位として明示するため、カードは境界
 (border + 内パディング) を持ち、task がある場合はヘッダとボディを divider で区切る。
 ヘッダ = worktree identity ゾーン、ボディ = その worktree に属する task 群ゾーンとして
-構造で分離する。これにより branch/home icon (identity) と claude state icon (task の状態)
-が別ゾーンに分かれ、同一 gutter に並列して見分けづらくなる問題を解消する。
+構造で分離する。
+
+ヘッダには icon を置かず branch 名のみで identity を示す。gutter に出る icon を task 行の
+claude state icon だけに限定することで、worktree identity (branch 名) と task の状態 (icon)
+が別レイヤーに分かれ、複数種の icon が同一 gutter に並列して見分けづらくなる問題を解消する。
 
 カード境界は `overflow-hidden` を使わない。active カードの `_fx-quest-active` が持つ
 外周ブルーム (`box-shadow`) がクリップされて消えるため。内パディング `p-0.5` で内部 row
@@ -54,8 +57,6 @@ import TaskRow from "./TaskRow.vue";
 import IconLucideArrowDown from "~icons/lucide/arrow-down";
 import IconLucideArrowUp from "~icons/lucide/arrow-up";
 import IconLucideEllipsisVertical from "~icons/lucide/ellipsis-vertical";
-import IconLucideGitBranch from "~icons/lucide/git-branch";
-import IconLucideHouse from "~icons/lucide/house";
 import IconLucideServer from "~icons/lucide/server";
 
 const props = defineProps<{
@@ -95,7 +96,6 @@ const auraClass = computed<string | undefined>(() => {
   return top === undefined ? undefined : AURA_CLASS[top];
 });
 
-const branchIcon = computed(() => (props.wt.isMain ? IconLucideHouse : IconLucideGitBranch));
 const branchLabel = computed(() => resolveBranchLabel(props.wt.branch));
 
 const statusIcons = computed(() => {
@@ -178,9 +178,6 @@ function onHeaderClick() {
         class="_fx-shine flex w-full items-center gap-2 rounded-md px-2 py-0.5 text-left text-foreground-low transition-colors hover:bg-element-hover focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-hidden focus-visible:ring-inset data-[active=true]:bg-primary-subtle data-[active=true]:hover:bg-primary-subtle-hover"
         @click="onHeaderClick"
       >
-        <span class="grid size-4 shrink-0 place-items-center" aria-hidden="true">
-          <component :is="branchIcon" class="size-3.5" />
-        </span>
         <span class="flex-1 truncate text-left text-xs font-medium">{{ branchLabel }}</span>
         <span
           v-if="livePorts.length > 0"


### PR DESCRIPTION
## 概要

サイドバーの worktree 表示を刷新し、worktree とそれに属する task 群を境界カードで明示的にグルーピングする。worktree ヘッダのアイコンを廃止して gutter に出るアイコンを task の claude status だけに絞り、選択 / hover の配色を階層整理し、行の高さをスリム化する。

## 背景

サイドバーで、worktree ヘッダ行（home / branch アイコン）と task 行（claude status アイコン）が境界なくフラットに縦積みされており、「どこからどこまでが 1 つの worktree の塊か」が読めなかった。さらに home / branch / claude-status の各アイコンが同一 gutter にほぼ同サイズで並列し、identity（どの worktree か）と state（Claude の状態）という別レイヤーの情報が等価に見えて見分けづらかった。

検討の過程で、当初の「左アクセントバーで worktree identity を示す」案は 2026 時点で AI slop の典型でありアンチパターンのため却下した。grouping は border + divider の構造だけで表す方針に切り替えた。

また選択中 worktree をカード全体の青 fill で示す旧挙動は、focus 行の青 capsule と青ｘ青で潰れて「カード内のどの行に focus があるか」が読めない配色破綻があったため、fill x outline で階層分離する方式に変更した。

worktree ヘッダのアイコンは、当初は main を home / それ以外を branch アイコンで示していたが、gutter に identity アイコンと status アイコンが混在してごちゃつく。最終的にヘッダのアイコンを廃止し、worktree の identity は branch 名のテキストだけで示すことで、gutter に出るアイコンを task の claude status だけに限定した。main の home アイコン復活・branch 名 bold での区別も試したが、インデントずれや弱い強調で識別効果が乏しく、フラットに揃える方を採用した。

## 変更内容

### worktree のカードグルーピング

- worktree ごとに border + 内パディングの境界カードにし、task がある場合は divider で header（identity ゾーン）と body（task 群ゾーン）を分離
- カード境界に `overflow-hidden` は使わない。`_fx-quest-active` の外周ブルーム（`box-shadow`）がクリップされて消えるため、内パディングで内部 row を角丸にする方式で回避
- カード間に gap を入れ、グループ内は密・グループ間は疎にして塊の境界を強調

### worktree ヘッダの簡素化

- ヘッダの home / branch アイコンを廃止し、worktree identity は branch 名のテキストだけで示す。gutter に出るアイコンを task の claude status だけに限定し、複数種のアイコンが同一 gutter に並列する状態を解消

### 選択 / hover の配色階層

- 選択表現を fill x outline で分離。active worktree カードは border-primary + 外周グローのアウトラインのみ（内部は塗らない）、塗り（`bg-primary-subtle` capsule）は focus 行 1 つだけが持つ
- header capsule は task に focus が無いとき（`focusedTaskId === undefined`）だけ点灯。task focus 時は該当 task 行のみ塗ることで、カード内の青 fill を常に 1 行に保つ
- hover はグレー（`bg-element-hover`）、青（primary）は選択 / focus 専用に役割分離。active 行の hover は複合 variant `data-[active=true]:hover:bg-primary-subtle-hover` で specificity を勝たせて確実に効かせる

### スリム化

- worktree ヘッダ / task 行の縦パディングとアイコン枠を縮小
- New worktree ボタンの dashed border と all-caps を撤去、青 hover をグレーに統一

## 確認事項

- [ ] worktree とその task 群が 1 つのカードとして括られて見えるか
- [ ] gutter に出るアイコンが task の claude status だけになり、ごちゃつきが解消しているか
- [ ] active worktree が outline、focus 行のみ青 fill で、青ｘ青の潰れが解消しているか
- [ ] active task / active header の hover が一段濃い青で効くか
- [ ] task ゼロの worktree がヘッダのみのカードとして自然に見えるか
