### PR TITLE
fix(fs): worktree 削除後の readDir で出る outsideDir を path containment 標準化で解消

### DIFF
--- a/apps/native/Sources/Gozd/BundleAssetSchemeHandler.swift
+++ b/apps/native/Sources/Gozd/BundleAssetSchemeHandler.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GozdCore
 import UniformTypeIdentifiers
 import WebKit
 
@@ -8,9 +9,9 @@ import WebKit
 // 直ロードでは subresource (`/assets/*.js` 等) が WKWebView sandbox に弾かれる。
 // WWDC25「Meet WebKit for SwiftUI」公式パターンに従い custom scheme で serve する。
 //
-// path traversal 防止: `..` を含むパスを `standardized` で正規化し、symlink を解決した
-// 実体パスが `bundledRoot` 配下にあることを必ず確認する。`gozd-app://` は renderer から
-// fetch 可能なため、XSS 経由で bundle 外を読まれないよう構造的に防ぐ。
+// path traversal 防止: `resolveContained` (FilePath.lexicallyResolving) で relPath を
+// `bundledRoot` 配下へ閉じ込める。`gozd-app://` は renderer から fetch 可能なため、
+// XSS 経由で bundle 外を読まれないよう構造的に防ぐ (containment の SSOT は PathContainment.swift)。
 
 struct BundleAssetSchemeHandler: URLSchemeHandler {
   /// `.app` 内 renderer 配置ルート。Bundle が無い (swift run 直叩き等) と nil。
@@ -31,19 +32,13 @@ struct BundleAssetSchemeHandler: URLSchemeHandler {
         }
         let relPath = url.path.hasPrefix("/") ? String(url.path.dropFirst()) : url.path
         let normalized = relPath.isEmpty ? "index.html" : relPath
-        // path traversal 防止: `..` を含むパスを standardized で正規化し、symlink を
-        // 解決した実体パスが bundledRoot 配下にあることを確認する。`gozd-app://` は
-        // renderer から fetch 可能なため、XSS 経由で bundle 外を読まれないようにする。
-        let candidate = root.appendingPathComponent(normalized).standardized
-        let resolvedFile = candidate.resolvingSymlinksInPath()
-        let resolvedRoot = root.resolvingSymlinksInPath()
-        let rootPath = resolvedRoot.path
-        let prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
-        guard resolvedFile.path == rootPath || resolvedFile.path.hasPrefix(prefix) else {
+        // path traversal 防止: relPath を bundledRoot 配下へ閉じ込める。bundle 外へ
+        // 抜ける (`..` / 絶対パス) なら nil → fileDoesNotExist。
+        guard let containedPath = resolveContained(base: root.path, subpath: normalized) else {
           continuation.finish(throwing: URLError(.fileDoesNotExist))
           return
         }
-        let fileURL = candidate
+        let fileURL = URL(fileURLWithPath: containedPath)
         do {
           let data = try Data(contentsOf: fileURL)
           let mime =

--- a/apps/native/Sources/GozdCore/Fs/FSOps.swift
+++ b/apps/native/Sources/GozdCore/Fs/FSOps.swift
@@ -7,10 +7,9 @@ import Foundation
 // 1. **path は dir からの相対パス**として扱う。絶対パスや `..` を経由した
 //    dir 範囲外アクセスは拒否する（path traversal 対策）。
 //
-// 2. **判定は realpath ベース**: `URL.resolvingSymlinksInPath()` で symlink を
-//    解決した実パスで `dir` 配下にあるかを判定する。文字列 prefix 判定だけだと
-//    `/foo/bar` が `/foo/barbaz` の prefix になる罠を踏むので
-//    `targetPath == dirPath || targetPath.hasPrefix(dirPath + "/")` で照合。
+// 2. **判定は `resolveContained` (FilePath.lexicallyResolving) に委譲**: path
+//    containment の SSOT は `PathContainment.swift`。Apple 公式 API で絶対パス注入 /
+//    `..` 脱出 / prefix 罠を構造的に防ぐ。FS 非依存なので削除済み dir でも決定的に動く。
 //
 // 3. **戻り値は素の Swift 型**（`Data` / `[FSEntry]`）。proto 型変換は RPC 境界
 //    （URLSchemeHandler）に閉じ込める。GitOps と同じ流儀。
@@ -193,13 +192,8 @@ public enum FSError: Error, Equatable {
 // MARK: - private helpers
 
 private func resolveSafe(dir: String, path: String) throws -> String {
-  let dirURL = URL(fileURLWithPath: dir).resolvingSymlinksInPath()
-  let targetURL = URL(fileURLWithPath: path, relativeTo: dirURL).resolvingSymlinksInPath()
-  let dirPath = dirURL.path
-  let targetPath = targetURL.path
-  // /foo が /foobar の prefix になる罠を避けるため separator まで照合する。
-  if targetPath == dirPath || targetPath.hasPrefix(dirPath + "/") {
-    return targetPath
+  guard let resolved = resolveContained(base: dir, subpath: path) else {
+    throw FSError.outsideDir(requestedPath: path)
   }
-  throw FSError.outsideDir(requestedPath: path)
+  return resolved
 }

--- a/apps/native/Sources/GozdCore/Fs/PathContainment.swift
+++ b/apps/native/Sources/GozdCore/Fs/PathContainment.swift
@@ -1,0 +1,26 @@
+import System
+
+// untrusted な subpath を base ディレクトリ配下へ安全に解決する path containment の SSOT。
+//
+// Apple 公式 `swift-system` の `FilePath.lexicallyResolving` を使う。これは「untrusted な
+// subpath からの path traversal を防ぎ、結果が base 配下に lexically 収まることを保証する」
+// 専用 API (ドキュメント記載の用途そのもの)。手書きの `URL.resolvingSymlinksInPath()` +
+// 文字列 prefix 照合を置き換える:
+//
+// - **絶対パス注入を無害化**: subpath の root (`/etc/passwd` の `/`) を除去して base 配下に閉じる
+// - **`..` 脱出を拒否**: 正規化後に先頭が `..` になる (base を抜ける) なら nil
+// - **prefix 罠が無い**: component 単位で照合するため `/foo` が `/foobar` を誤許可しない
+// - **FS 非依存**: symlink 解決も existence check もしないため、base が存在しなくても
+//   (削除済み worktree root 等) 決定的に動作する。`URL(fileURLWithPath:)` の存在依存な
+//   dir/file 判定に起因する「削除直後だけ containment が誤って外れる」バグが構造的に消える
+//
+// symlink に関する契約: lexical 解決なので base 配下に実在する escaping symlink は辿れてしまう
+// (Apple ドキュメント明記の trade-off)。gozd の脅威モデルは renderer XSS による path 文字列
+// 注入であり、攻撃者は worktree / bundle 内に symlink を仕込めない (これらの経路に write 権限が
+// 無い)。したがって lexical containment がこのレイヤの正しい防壁。
+public func resolveContained(base: String, subpath: String) -> String? {
+  guard let resolved = FilePath(base).lexicallyResolving(FilePath(subpath)) else {
+    return nil
+  }
+  return resolved.string
+}

--- a/apps/native/Sources/GozdCore/Fs/PathContainment.swift
+++ b/apps/native/Sources/GozdCore/Fs/PathContainment.swift
@@ -15,9 +15,14 @@ import System
 //   dir/file 判定に起因する「削除直後だけ containment が誤って外れる」バグが構造的に消える
 //
 // symlink に関する契約: lexical 解決なので base 配下に実在する escaping symlink は辿れてしまう
-// (Apple ドキュメント明記の trade-off)。gozd の脅威モデルは renderer XSS による path 文字列
-// 注入であり、攻撃者は worktree / bundle 内に symlink を仕込めない (これらの経路に write 権限が
-// 無い)。したがって lexical containment がこのレイヤの正しい防壁。
+// (Apple ドキュメント明記の trade-off)。これで防御レベルは下がらない:
+//   - bundle (`gozd-app://` の `.app` 内) は読み取り専用で symlink を仕込めない
+//   - worktree (`gozd-rpc://` / `gozd-file://`) は user / Claude が自由に書ける作業ディレクトリ
+//     で symlink を仕込めるが、機密ファイル読み取りの主防壁はここの containment ではない。
+//     dir 制約なしで任意絶対パスを読む `/fs/readFileAbsolute` (preview が worktree 外ファイルを
+//     表示する正規経路) が既に存在し、XSS 経由の bytes 回収を止めるのは `gozd-rpc://` の
+//     CORS Origin allowlist (RpcSchemeHandler)。よって resolveSafe の symlink follow の有無は
+//     防御の主軸でなく、lexical containment は「base 配下に閉じる」役割として必要十分。
 public func resolveContained(base: String, subpath: String) -> String? {
   guard let resolved = FilePath(base).lexicallyResolving(FilePath(subpath)) else {
     return nil

--- a/apps/native/Tests/GozdCoreTests/FSOpsTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSOpsTests.swift
@@ -91,6 +91,19 @@ struct FSOpsReadDirTests {
     #expect(result.entries.isEmpty)
   }
 
+  @Test("dir (worktree root) 自体が削除済みでも path=\".\" は outsideDir でなく notFound")
+  func notFoundForDeletedRootDir() async throws {
+    // worktree 削除後、その root を dir に readDir(path: ".") する経路の回帰。
+    // 不在 dir に対し `URL(fileURLWithPath:)` の 2 引数版は「ファイル」扱いになり、相対 path "."
+    // が親へ解決されて outsideDir を誤発火していた (isDirectory: true で修正)。
+    let dir = try makeTempDir()
+    try FileManager.default.removeItem(at: URL(fileURLWithPath: dir))
+
+    let result = try await FSOps.readDir(dir: dir, path: ".")
+    #expect(result.notFound == true)
+    #expect(result.entries.isEmpty)
+  }
+
   @Test("ディレクトリが同名ファイルに置換された場合も notFound を返す")
   func notFoundForDirReplacedByFile() async throws {
     let dir = try makeTempDir()

--- a/apps/native/Tests/GozdCoreTests/FSOpsTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSOpsTests.swift
@@ -94,8 +94,9 @@ struct FSOpsReadDirTests {
   @Test("dir (worktree root) 自体が削除済みでも path=\".\" は outsideDir でなく notFound")
   func notFoundForDeletedRootDir() async throws {
     // worktree 削除後、その root を dir に readDir(path: ".") する経路の回帰。
-    // 不在 dir に対し `URL(fileURLWithPath:)` の 2 引数版は「ファイル」扱いになり、相対 path "."
-    // が親へ解決されて outsideDir を誤発火していた (isDirectory: true で修正)。
+    // 旧実装 (`URL(fileURLWithPath:path, relativeTo:)`) は不在 dir で相対 path "." を親へ
+    // 解決して outsideDir を誤発火していた。`resolveContained` (FS 非依存の lexical 解決) が
+    // これを構造的に防ぐ。
     let dir = try makeTempDir()
     try FileManager.default.removeItem(at: URL(fileURLWithPath: dir))
 

--- a/apps/native/Tests/GozdCoreTests/PathContainmentTests.swift
+++ b/apps/native/Tests/GozdCoreTests/PathContainmentTests.swift
@@ -1,0 +1,36 @@
+import Testing
+
+@testable import GozdCore
+
+@Suite("resolveContained (path containment SSOT)")
+struct PathContainmentTests {
+  // FS 非依存を保証するため、存在しない base を使う (削除済み worktree root 相当)。
+  let base = "/Users/x/.local/share/gozd/worktrees/deleted-wt/branch"
+
+  @Test("空 / \".\" は base 自身に解決する")
+  func rootResolvesToBase() {
+    #expect(resolveContained(base: base, subpath: "") == base)
+    #expect(resolveContained(base: base, subpath: ".") == base)
+  }
+
+  @Test("通常の相対 path は base 配下に join する")
+  func joinsRelative() {
+    #expect(resolveContained(base: base, subpath: "sub/a.txt") == base + "/sub/a.txt")
+  }
+
+  @Test("内部の \"..\" は base を抜けなければ正規化して許可する")
+  func normalizesInnerDotDot() {
+    #expect(resolveContained(base: base, subpath: "a/../b") == base + "/b")
+  }
+
+  @Test("base を抜ける \"..\" traversal は nil")
+  func rejectsEscapingDotDot() {
+    #expect(resolveContained(base: base, subpath: "../escape") == nil)
+    #expect(resolveContained(base: base, subpath: "a/../../b") == nil)
+  }
+
+  @Test("絶対パス注入は root を除去して base 配下へ閉じ込める")
+  func neutralizesAbsoluteInjection() {
+    #expect(resolveContained(base: base, subpath: "/etc/passwd") == base + "/etc/passwd")
+  }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,7 +77,7 @@ Gozd.app/Contents/
 `pnpm dev` は `apps/native/scripts/build-dev-app.sh` で **dev 専用 `.app`**（dock icon が dev カラー、タイトルが `gozd (dev)`）を生成し、renderer は Vite dev server (`http://localhost:<port>`、port は root `package.json` の `dev` script で `GOZD_DEV_VITE_PORT` env として設定し Vite / Swift 両方が SSOT として受け取る) から読み込む。Vite default の 5173 ではなく gozd 固有ポートを使い、かつ `vite.config.ts` で `strictPort: true` を指定する。理由は別 worktree からの二重 `pnpm dev` / 別 Vite アプリと衝突したときに fallback で別ポートを掴むと、Swift `.app` は env から受け取った port 固定なので先発の Vite に繋がって「別 worktree のはずなのに先発の内容が表示される」サイレント事故になるため。`pnpm build` は `build-app.sh` で stable 版 `.app` を生成し、renderer はバンドル内 `views/main/index.html` を `gozd-app://` URLSchemeHandler 経由でロードする。
 
 > [!NOTE]
-> `WebPage` には `loadFileURL(_:allowingReadAccessTo:)` 相当が無いため、ローカル HTML / asset は `gozd-app://localhost/...` URLSchemeHandler で配信する（WWDC25「Meet WebKit for SwiftUI」公式パターン）。`gozd-app://` の resolver は `.standardized` + `resolvingSymlinksInPath` した実体パスが bundle root 配下にあることを検証して path traversal を防ぐ。
+> `WebPage` には `loadFileURL(_:allowingReadAccessTo:)` 相当が無いため、ローカル HTML / asset は `gozd-app://localhost/...` URLSchemeHandler で配信する（WWDC25「Meet WebKit for SwiftUI」公式パターン）。`gozd-app://` の resolver は `resolveContained`（`FilePath.lexicallyResolving`）で relPath を bundle root 配下へ閉じ込めて path traversal を防ぐ。path containment の SSOT は `GozdCore/Fs/PathContainment.swift`（`gozd-rpc://` の `FSOps.resolveSafe` も同じ helper を使う）。
 
 ### `bin/gozd` シェルラッパーの動作
 


### PR DESCRIPTION
## 概要

new worktree 実行後に worktree を削除すると、filer が `RPC /fs/readDir failed: 500 outsideDir(requestedPath: ".")` を表示して "Failed to read directory" になる不具合を修正する。

原因は path containment（path traversal guard）の手書き実装が、ファイルシステムの存在状態に依存していたこと。これを Apple 公式の `FilePath.lexicallyResolving`（`import System`、macOS SDK 同梱）に全面置換し、containment ロジックを `PathContainment.swift` の `resolveContained` に SSOT 化した。

## 背景

filer が削除済み worktree root を `readDir(path: ".")` で読みに行く経路で 500 が出ていた。調査の結果、`FSOps.resolveSafe` の `URL(fileURLWithPath:)`（2 引数版）が **stat でディレクトリ性を判定**しており、dir が存在するときは `.` が自身に、削除済みのときは「ファイル」扱いとなって `.` が**親ディレクトリ**に解決され、containment check を誤って外れて `outsideDir` を投げていた。renderer はルート読みを `path: "."` で送る設計（`filerUtils.ts` の `pathForNativeRpc`）のため、worktree 削除直後にこの経路が必ず踏まれる。

修正手段を検討する中で、業界標準・OSS 実装を調査した:

- `URL(fileURLWithPath:isDirectory:true)` で existence 依存だけ潰す案は、バグは消えるが手書きの文字列 prefix 照合（絶対パス注入の暗黙処理・区切り境界の罠）が残る
- `realpath(3)` ベースは非存在パスで NULL を返し削除済み worktree root を扱えない（deepest-existing-ancestor パターンで回避は可能だが TOCTOU は解決せず複雑性に見合わない）
- TOCTOU・symlink follow まで構造的に潰す `openat2`/`RESOLVE_BENEATH`（Go `os.Root` / Rust `cap-std`）は **macOS に相当機構が無い**

結論として、untrusted な path 文字列注入（renderer XSS）に対する正しい防壁レイヤは lexical containment であり、その専用 API である `FilePath.lexicallyResolving` が過不足なく要件を満たす。これは FS 非依存で決定的に動くため、存在依存バグが構造的に発生しない。

## 変更内容

### path containment の標準化（独自実装の撤去）

- `GozdCore/Fs/PathContainment.swift` を新設し、`resolveContained(base:subpath:)` を SSOT として公開（`FilePath.lexicallyResolving` の薄いラッパ）
- `FSOps.resolveSafe`（`gozd-rpc://` のファイル読み）を `resolveContained` 経由に変更
- `BundleAssetSchemeHandler`（`gozd-app://` の asset 配信）の手書き `standardized` + `resolvingSymlinksInPath` + 文字列 prefix 照合を `resolveContained` に置換
- 真の traversal guard はこの 2 箇所のみと特定。`ShellCommandOps`（symlink 等価比較）/ `WorktreeOps`（worktree 同定）/ `ProjectKey`（キー導出）/ `FSWatchRegistry`（FSEvents 帰属）の `resolvingSymlinksInPath`・`hasPrefix` は責務が異なるため対象外とした

### テスト

- `PathContainmentTests` を新設。空 / `.` の base 自身解決、相対 join、内部 `..` の正規化、脱出 `..` の拒否、絶対パス注入の無害化を FS 非依存で検証
- `FSOpsTests` に「dir（worktree root）自体が削除済みでも `path: "."` は `outsideDir` でなく `notFound`」の回帰テストを追加

### ドキュメント

- `docs/architecture.md` の `gozd-app://` resolver の記述を実装（`resolveContained` / `FilePath.lexicallyResolving`）に同期し、containment SSOT の所在を明記

## 確認事項

- [ ] worktree を新規作成 → 削除した直後に filer がエラーを出さず空表示に倒れること
- [ ] 既存ファイルの読み込み・ディレクトリ表示・preview の画像/SVG（`gozd-app://` / `gozd-rpc://`）が従来どおり動くこと
- [ ] `swift test --filter "PathContainmentTests|FSOps"` が通ること（ローカルでは 18 件 pass を確認済み）
