### PR TITLE
fix(sidebar): 左端のネオンフレームグロー除去とサイドバー scrollbar の細幅化

### DIFF
--- a/apps/renderer/src/assets/main.css
+++ b/apps/renderer/src/assets/main.css
@@ -193,6 +193,29 @@
     scrollbar-width: thin;
   }
 
+  /* サイドバー専用のカスタム細幅 scrollbar。標準の thin より細い固定 6px を出すため
+     scrollbar-width を auto に戻して ::-webkit-scrollbar を再有効化する
+     (thin/none 指定時は webkit 擬似要素が無視される)。占有幅は overflow-y: scroll の
+     実トラックが常時担い、gutter は要素側で auto に倒す (_thin-scrollbar utility) */
+  ._thin-scrollbar {
+    scrollbar-width: auto;
+    scrollbar-gutter: auto;
+  }
+
+  ._thin-scrollbar::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+
+  ._thin-scrollbar::-webkit-scrollbar-thumb {
+    border-radius: 9999px;
+    background: color-mix(in oklch, var(--color-foreground) 25%, transparent);
+  }
+
+  ._thin-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
   /* stable は classic 環境で overflow: hidden の box にも gutter を予約する仕様のため、
      `*` 一括にせず縦スクロール utility に限定する (角丸クリップ用 overflow-hidden に
      空の縦帯が出るのを防ぐ)。scrollbar-gutter は縦 scrollbar の inline-end gutter に

--- a/apps/renderer/src/features/arcade/ArcadeLayer.vue
+++ b/apps/renderer/src/features/arcade/ArcadeLayer.vue
@@ -1,6 +1,6 @@
 <doc lang="md">
 ゲームジュース層の全画面オーバーレイ。UI 最前面 (pointer-events: none) に
-パーティクル canvas / ビネット / オーロラ / ネオンフレーム / イベントフラッシュを重ねる。
+パーティクル canvas / ビネット / オーロラ / イベントフラッシュを重ねる。
 
 ## 重ね順と操作透過
 
@@ -20,7 +20,7 @@
 ## パフォーマンス
 
 - canvas パーティクルはイベント発火時のみ rAF を回し、空になれば停止する (idle 時の rAF ゼロ)
-- 一方 aurora / ネオンフレーム / 各種グローは CSS 合成による**常時演出**。GPU レイヤーは
+- 一方 aurora / 各種グローは CSS 合成による**常時演出**。GPU レイヤーは
   保持され続けるため、canvas のような完全停止はせず idle 時も合成負荷が残る。
   aurora は `will-change: transform` で常時 drift するため、無負荷ではない点に注意
 </doc>
@@ -125,8 +125,6 @@ onUnmounted(() => {
     <div class="_fx-aurora absolute inset-0"></div>
     <!-- 周辺減光で中央に視線を集める -->
     <div class="_fx-vignette absolute inset-0"></div>
-    <!-- 常時表示のネオンフレーム (ウィンドウ全体を HUD で縁取る) -->
-    <div class="_fx-frame absolute inset-0"></div>
     <!-- パーティクル -->
     <canvas ref="fxCanvas" class="absolute inset-0 size-full"></canvas>
     <!-- イベントフラッシュ (画面端の発光) -->
@@ -137,12 +135,6 @@ onUnmounted(() => {
 <style>
 ._fx-vignette {
   background: radial-gradient(ellipse 120% 100% at 50% 45%, transparent 60%, oklch(0 0 0 / 0.3));
-}
-
-._fx-frame {
-  box-shadow:
-    inset 0 0 70px color-mix(in oklch, var(--color-primary) 9%, transparent),
-    inset 0 0 3px color-mix(in oklch, var(--color-primary) 40%, transparent);
 }
 
 ._fx-aurora {

--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -306,7 +306,7 @@ const activeRootWorktree = computed(() => {
       </div>
     </div>
 
-    <div ref="scrollContainer" class="flex flex-1 flex-col overflow-y-auto py-4">
+    <div ref="scrollContainer" class="_thin-scrollbar flex flex-1 flex-col overflow-y-scroll py-4">
       <DragDropProvider @drag-end="onDragEnd">
         <RepoSection
           v-for="(rootDir, i) in repoStore.dirOrder"


### PR DESCRIPTION
## 概要

UI の見た目に関する 2 つの修正をまとめる。

- 画面左端に出ていた primary 色のグロー（全画面オーバーレイの常時ネオンフレーム）を除去
- サイドバーのスクロールバーを固定 6px に細くし、出現/消失時のガタつきを防ぎつつ予約幅を狭くする

## 背景

### 左端のグロー

サイドバー左端に primary 色のグローが縦帯として乗って見えるという指摘から調査した。原因は `ArcadeLayer` の `_fx-frame`（`fixed inset-0` の全画面装飾レイヤーに `box-shadow: inset 0 0 70px ... primary` を載せ、ウィンドウ全周を縁取るネオンフレーム）。inset box-shadow は四辺に均等にかかるが、暗い無地のサイドバー背景上でだけコントラストが立ち、「左端だけ光っている」ように見えていた。常時演出として必須ではないため除去する。

### サイドバー scrollbar の幅

マウス接続環境（classic scrollbar）でサイドバーのスクロールバーが予約する空き幅が広いという指摘から調査した。判明した制約は以下:

- `scrollbar-style: overlay` は提案中のドラフトで未実装、`overflow: overlay` は廃止済みのため、OS 設定に依存しないオーバーレイ表示を純 CSS で強制する手段は存在しない
- `scrollbar-gutter: stable` は **UA デフォルトのスクロールバー幅** を予約する仕様で、`::-webkit-scrollbar { width }` のカスタム幅には追従しない。そのため stable のままでは 6px 予約にできない
- `scrollbar-width: thin` / `none` を指定した要素では `::-webkit-scrollbar` 擬似要素が無視される

これらを踏まえ、カスタム幅 + 予約あり + ガタつき無しをネイティブで両立する手段として、対象要素だけ `overflow-y: scroll` の実トラックで占有幅を常時確保し、その幅を `::-webkit-scrollbar` で 6px に固定する方式を採用した。

## 変更内容

### arcade

- `ArcadeLayer` から `_fx-frame`（ネオンフレーム）の要素・CSS・`<doc>` 記述を削除。`_fx-aurora` / `_fx-vignette` 等の他の演出は維持

### sidebar / scrollbar

- `_thin-scrollbar` utility を追加。対象要素だけ `scrollbar-width: auto` に戻して `::-webkit-scrollbar` を再有効化し、`width: 6px` のサム（角丸・半透明）+ 透明トラックを定義
- サイドバーのスクロールコンテナを `overflow-y: auto` → `overflow-y: scroll` + `_thin-scrollbar` に変更。実トラックが常時 6px を占有するため出現/消失のガタつきが出ない
- グローバルは従来どおり `scrollbar-width: thin` + `scrollbar-gutter: stable` の標準動作を維持し、カスタム 6px はサイドバーにスコープ

## 確認事項

- [ ] サイドバーのスクロールバーが 6px で表示され、スクロール有無でレイアウトがガタつかないこと
- [ ] サイドバー以外の scroll 領域（filer / preview 等）が従来の thin + stable のままであること
- [ ] 画面左端のグローが消えていること（aurora / vignette は残ること）
