### PR TITLE
feat(ui): UI テキストをデフォルト選択不可にし、コンテンツだけ選択可にする

### DIFF
--- a/.claude/skills/gozd-ui/SKILL.md
+++ b/.claude/skills/gozd-ui/SKILL.md
@@ -209,6 +209,19 @@ container は `focus-visible:` を使うと「キーボード focus のみ visua
 
 gozd は dark 固定。`dark:bg-X` のような手動上書きは禁止。token が light/dark を CSS variable 経由で内部解決する (将来 light theme 追加時は primitive を `.light` scope に再宣言)。
 
+## テキスト選択 (`user-select`) は default-deny + opt-in
+
+native アプリ志向の UI なので、chrome (ボタン / ラベル / ツリー / タブ等) のテキストはドラッグ選択させない。`main.css` の `@layer base` が `body { user-select: none }` をデフォルトにしているため、**新規 chrome 要素に `select-none` を貼る必要はない** (貼っても冗長)。
+
+コピー対象のコンテンツだけが `select-text` で opt-in する:
+
+- コード / diff / markdown preview は `contenteditable="true"` host なので base 層の `[contenteditable="true"]` 規則で自動的に選択可。個別注釈は不要
+- contenteditable でも markdown でもない plain text コンテンツ (会話本文 / ターミナル全文 popover / エラートースト本文等) はコンテンツコンテナに `select-text` を当てる
+- 選択可コンテンツの中にある操作専用要素 (fold の `summary`、行番号等) は内側で `select-none` を保ち、操作と選択を分離する
+
+> [!CAUTION]
+> WebKit (WKWebView) は `-webkit-` プレフィックス無しの `user-select` を**無視する**。Tailwind の `select-none` / `select-text` は両方出力するので utility を使う限り問題ない。`main.css` 等の生 CSS で `user-select` を書くときは `-webkit-user-select` を必ず併記する (無いと default-none 自体が効かない)。
+
 ## 条件付き class は `:class` バインディングで書く
 
 ```vue

--- a/apps/renderer/src/assets/main.css
+++ b/apps/renderer/src/assets/main.css
@@ -161,6 +161,32 @@
     @apply bg-background text-foreground;
   }
 
+  /* native アプリ志向の UI 規律: chrome (ボタン / ラベル / ツリー / タブ等) のテキストは
+     ドラッグ選択させないのをデフォルトにし、コピー対象のコンテンツ (コード / diff /
+     markdown / 会話本文 / コミットメッセージ等) だけが user-select: text で opt-in する。
+     要素ごとに select-none を貼る denylist は、新規 chrome を足すたびに貼り忘れて選択可能
+     テキストが混入する構造欠陥を持つため、default-deny + allowlist に倒す (SSOT)。
+     WebKit (WKWebView) は子の明示 user-select: text で祖先の none を上書きできる。
+     selectAll(Cmd+A) は user-select: none と仕様保証が無いため、contenteditable host 側は
+     下の規則で明示 text にし、contenteditable の暗黙の選択可挙動には依存しない。
+     WebKit は -webkit- プレフィックス無しの user-select を無視する。Tailwind の select-* は
+     両方出すが、ここは生 CSS なので -webkit-user-select を必ず併記する (これが無いと
+     default-none 自体が効かない)。 */
+  body {
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  /* form control と編集 host は入力 / 選択が前提。preview の contenteditable host
+     (CodePreview / DiffPreview の各 section / MarkdownPreview) もこの属性 marker で
+     一括 opt-in する (個別注釈不要、SSOT)。 */
+  input,
+  textarea,
+  [contenteditable="true"] {
+    -webkit-user-select: text;
+    user-select: text;
+  }
+
   button {
     cursor: pointer;
   }

--- a/apps/renderer/src/features/changes/ChangesTreeItem.vue
+++ b/apps/renderer/src/features/changes/ChangesTreeItem.vue
@@ -108,7 +108,7 @@ function onContextMenu(event: MouseEvent) {
   <div>
     <button
       type="button"
-      class="flex w-full cursor-pointer items-center gap-1 px-1 py-0.5 text-left text-xs select-none hover:bg-element-hover"
+      class="flex w-full cursor-pointer items-center gap-1 px-1 py-0.5 text-left text-xs hover:bg-element-hover"
       :style="{ paddingLeft: `${depth * 12 + 8}px` }"
       @click="onClick"
       @contextmenu="onContextMenu"

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -431,7 +431,7 @@ function onContextMenu(event: MouseEvent) {
     <button
       v-if="!isRoot"
       ref="button"
-      class="flex w-full items-center gap-1 rounded-sm px-1 py-0.5 text-left text-sm select-none hover:bg-element"
+      class="flex w-full items-center gap-1 rounded-sm px-1 py-0.5 text-left text-sm hover:bg-element"
       :class="[
         selectedRelPath === path ? 'bg-element' : '',
         textColorClass,

--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -976,10 +976,7 @@ const isWorkingTreeActive = computed(
 </script>
 
 <template>
-  <div
-    ref="root"
-    class="flex size-full flex-col overflow-hidden bg-background text-foreground select-none"
-  >
+  <div ref="root" class="flex size-full flex-col overflow-hidden bg-background text-foreground">
     <div class="flex shrink-0 items-center gap-1.5 border-b border-border px-3 py-1.5">
       <IconLucideGitCommitHorizontal class="size-4 text-foreground-low" />
       <span class="text-xs font-semibold text-foreground-low">Git Graph</span>

--- a/apps/renderer/src/features/layout/NotificationToastItem.vue
+++ b/apps/renderer/src/features/layout/NotificationToastItem.vue
@@ -108,9 +108,12 @@ async function copyDetail() {
         @click="toggle"
       >
         <span class="flex items-center gap-1">
-          <!-- エラー本文はコピー対象。cause が無い通知は Copy ボタンが出ないため、
-               本文がコピー不能にならないよう select-text で選択可にする。 -->
-          <span class="select-text">{{ message }}</span>
+          <!-- エラー本文はコピー対象。cause がある通知は本 button が toggle するため
+               select-text を同居させず、Copy ボタン (message + detail) をコピー導線にする。
+               cause が無い通知は button が disabled で click しないので、Copy ボタンも出ない
+               本文を select-text で選択可にしても toggle が暴発しない (select-text と click を
+               同一要素に同居させない)。 -->
+          <span :class="hasCause ? '' : 'select-text'">{{ message }}</span>
           <IconLucideChevronDown
             v-if="hasCause"
             class="size-3 shrink-0 text-foreground-low transition-transform"

--- a/apps/renderer/src/features/layout/NotificationToastItem.vue
+++ b/apps/renderer/src/features/layout/NotificationToastItem.vue
@@ -108,7 +108,9 @@ async function copyDetail() {
         @click="toggle"
       >
         <span class="flex items-center gap-1">
-          <span>{{ message }}</span>
+          <!-- エラー本文はコピー対象。cause が無い通知は Copy ボタンが出ないため、
+               本文がコピー不能にならないよう select-text で選択可にする。 -->
+          <span class="select-text">{{ message }}</span>
           <IconLucideChevronDown
             v-if="hasCause"
             class="size-3 shrink-0 text-foreground-low transition-transform"
@@ -137,7 +139,7 @@ async function copyDetail() {
         </button>
       </div>
       <pre
-        class="max-h-64 overflow-auto font-mono text-xs break-all whitespace-pre-wrap text-foreground"
+        class="max-h-64 overflow-auto font-mono text-xs break-all whitespace-pre-wrap text-foreground select-text"
         >{{ detail }}</pre
       >
     </div>

--- a/apps/renderer/src/features/palette/features/issue-picker/IssuePickerDialog.vue
+++ b/apps/renderer/src/features/palette/features/issue-picker/IssuePickerDialog.vue
@@ -157,7 +157,7 @@ useEventListener(dialogRef, "click", (e: MouseEvent) => {
         />
         <label
           v-if="viewer !== ''"
-          class="shrink-0 cursor-pointer rounded-sm px-2 py-0.5 text-xs select-none has-focus-visible:ring-2 has-focus-visible:ring-ring"
+          class="shrink-0 cursor-pointer rounded-sm px-2 py-0.5 text-xs has-focus-visible:ring-2 has-focus-visible:ring-ring"
           :class="
             filterAssignee
               ? 'bg-primary text-foreground'

--- a/apps/renderer/src/features/palette/features/pr-picker/PrPickerDialog.vue
+++ b/apps/renderer/src/features/palette/features/pr-picker/PrPickerDialog.vue
@@ -164,7 +164,7 @@ useEventListener(dialogRef, "click", (e: MouseEvent) => {
         />
         <label
           v-if="viewer !== ''"
-          class="shrink-0 cursor-pointer rounded-sm px-2 py-0.5 text-xs select-none has-focus-visible:ring-2 has-focus-visible:ring-ring"
+          class="shrink-0 cursor-pointer rounded-sm px-2 py-0.5 text-xs has-focus-visible:ring-2 has-focus-visible:ring-ring"
           :class="
             filterAssignee
               ? 'bg-primary text-foreground'
@@ -176,7 +176,7 @@ useEventListener(dialogRef, "click", (e: MouseEvent) => {
         </label>
         <label
           v-if="viewer !== ''"
-          class="shrink-0 cursor-pointer rounded-sm px-2 py-0.5 text-xs select-none has-focus-visible:ring-2 has-focus-visible:ring-ring"
+          class="shrink-0 cursor-pointer rounded-sm px-2 py-0.5 text-xs has-focus-visible:ring-2 has-focus-visible:ring-ring"
           :class="
             filterReviewer
               ? 'bg-primary text-foreground'

--- a/apps/renderer/src/features/preview/MarkdownBody.vue
+++ b/apps/renderer/src/features/preview/MarkdownBody.vue
@@ -73,6 +73,12 @@ watch(
  */
 ._markdown-body {
   overflow-wrap: anywhere;
+  /* markdown 本文はコピー対象コンテンツ。MarkdownPreview では contenteditable host として
+     base 層の [contenteditable] 規則でも text になるが、session-log / terminal preview では
+     contenteditable 無しで使われるため、host 自身に明示して全経路で選択可を担保する。
+     WebKit (WKWebView) は -webkit- プレフィックス無しの user-select を無視するため両方書く。 */
+  -webkit-user-select: text;
+  user-select: text;
 }
 
 /* contenteditable host として focus を取る経路 (MarkdownPreview 経由) で、keyboard focus

--- a/apps/renderer/src/features/session-log/SessionLogTimeline.vue
+++ b/apps/renderer/src/features/session-log/SessionLogTimeline.vue
@@ -299,7 +299,7 @@ useEventListener(window, "pointerup", () => {
           <!-- 軸ヘッダ (時刻表示 + シーク領域)。クリックでその位置へ、左右ドラッグで連続シークする。
                sticky で縦スクロールから外し、固定する (agent 行だけがスクロールする)。 -->
           <div
-            class="sticky top-0 z-10 flex h-6 cursor-ew-resize touch-none items-center justify-between bg-background text-[10px] text-foreground-low tabular-nums select-none"
+            class="sticky top-0 z-10 flex h-6 cursor-ew-resize touch-none items-center justify-between bg-background text-[10px] text-foreground-low tabular-nums"
             @pointerdown="onScrubDown"
           >
             <span class="pointer-events-none">{{ startLabel }}</span>

--- a/apps/renderer/src/features/session-log/SessionLogTranscript.vue
+++ b/apps/renderer/src/features/session-log/SessionLogTranscript.vue
@@ -504,8 +504,15 @@ onBeforeUnmount(teardownObserver);
       Session log has no conversation events.
     </p>
 
-    <!-- トランスクリプト本文 (LINE 風チャット)。現在地は横断タイムラインの playhead が示す -->
-    <div v-else ref="contentRef" class="min-h-0 flex-1 space-y-3 overflow-y-auto px-4 py-3">
+    <!-- トランスクリプト本文 (LINE 風チャット)。現在地は横断タイムラインの playhead が示す。
+         会話本文はコピー対象コンテンツなので select-text で選択可にする (assistant の markdown は
+         MarkdownBody 側で text、user / ask / tool I/O の plain text はここで担保)。
+         折りたたみ操作の summary だけは内側で select-none を保ち、操作と選択を分離する。 -->
+    <div
+      v-else
+      ref="contentRef"
+      class="min-h-0 flex-1 space-y-3 overflow-y-auto px-4 py-3 select-text"
+    >
       <template v-for="(ev, i) in parsed.events" :key="`${sessionKey}:${i}`">
         <!-- rewind 分岐セレクタ: ここで会話が枝分かれした。番号は古い順 (最新が最大)。
                選択中の枝をハイライトし、他をクリックでその枝へ切り替える。捨て枝が

--- a/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
+++ b/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
@@ -348,8 +348,10 @@ const hasSub = computed(() => subMessages.value.length > 0);
     }"
   >
     <template v-if="previewContext">
+      <!-- 全文 popover はメッセージを読む / コピーする面なので select-text で選択可にする
+           (compact な吹き出しプレビューは click-to-expand の chrome なのでデフォルト none のまま)。 -->
       <div
-        class="max-h-[60vh] overflow-auto rounded-md border border-border-strong shadow-xl"
+        class="max-h-[60vh] overflow-auto rounded-md border border-border-strong shadow-xl select-text"
         :class="previewContext.msg.kind === 'assistant' ? 'bg-chat-incoming' : 'bg-chat-outgoing'"
       >
         <div


### PR DESCRIPTION
## 概要

UI のテキスト選択ポリシーを「デフォルト選択不可 ( default-deny ) + コンテンツだけ opt-in ( allowlist )」に統一する。`@layer base` で `body { user-select: none }` をデフォルトに置き、コピー対象のコンテンツ ( コード / diff / markdown / 会話本文 / コミット詳細 / エラートースト本文 ) だけが `select-text` で選択可になる。

これにより、サイドバーの repo 名・git graph の commit 行・ファイルツリー・タブ・各種フィルタ toggle といった chrome のテキストは native アプリのようにドラッグ選択できなくなり、コピーすべき本文だけが選択できる。

## 背景

「UI のテキストは全て `user-select: none` であるべき」という要件が出発点。実装方針として allowlist ( デフォルト none + コンテンツ opt-in ) と denylist ( 要素ごとに `select-none` ) を比較した。

現状は denylist で、`select-none` を要素ごとに手で貼っていた ( tree item / picker / graph / timeline 等 )。これは「新規 chrome 要素を足すたびに `select-none` を貼り忘れると、その瞬間に選択可能テキストが混入する」構造欠陥を持つ。要件 ( chrome は選択不可 ) を人間の貼り忘れない努力に肩代わりさせており、同じ意図が N 箇所に散る SSOT 違反でもある。

allowlist にするとデフォルトが要件と一致 ( correct-by-construction ) し、選択可にすべきコンテンツは有限・少数なので opt-in で管理できる。default-deny はセキュリティの allowlist と同じく「漏れたら選択できない」安全側に倒れる。

### WebKit プレフィックスの罠

初回実装で `body { user-select: none }` を生 CSS でプレフィックス無しに書いたところ、WKWebView ではデフォルト none が一切効かなかった。WebKit は `-webkit-` プレフィックス無しの `user-select` を無視する。Tailwind の `select-none` / `select-text` は `-webkit-user-select` と `user-select` を両方出力するため utility 経由なら問題ないが、`main.css` 等の生 CSS では `-webkit-user-select` の併記が必須。これが無いと default-none 自体が効かず、効いていた Tailwind `select-none` を削除した分だけ chrome がかえって選択可能になる。生 CSS の `user-select` には `-webkit-` を併記して解消した。

## 変更内容

### デフォルト ( SSOT を 1 箇所に )

- `main.css` の `@layer base` に `body { user-select: none }` を追加 ( `-webkit-` 併記 )
- `input` / `textarea` / `[contenteditable="true"]` を `user-select: text` に。preview の contenteditable host ( CodePreview / DiffPreview の各 section / MarkdownPreview ) は属性 marker で一括 opt-in され、個別注釈は不要

### コンテンツの opt-in

- `MarkdownBody` の `._markdown-body` に `user-select: text` を直接付与。MarkdownPreview ( contenteditable ) だけでなく、session-log アシスタント発話 / terminal preview アシスタント発話 ( contenteditable 無し ) も全経路で選択可になる
- `SessionLogTranscript` の本文コンテナに `select-text` ( user 吹き出し / ask Q&A / tool I/O の plain text )。fold 操作の `summary` は内側で `select-none` を保ち操作と選択を分離
- `TerminalSessionPreview` の全文 popover に `select-text` ( compact プレビューは click-to-expand の chrome なので none のまま )
- `NotificationToastItem` のエラー本文 span と detail pre に `select-text` ( cause が無い通知は Copy ボタンが出ないため、本文がコピー不能になる回帰を防止 )

### 冗長な `select-none` の撤去

base デフォルトに回収し、`ChangesTreeItem` / `FileTreeItem` / `GitGraphPane` / `IssuePickerDialog` / `PrPickerDialog` / `SessionLogTimeline` の `select-none` を削除。chrome の見た目・挙動は不変。

### ドキュメント

- `gozd-ui` skill に「テキスト選択 ( `user-select` ) は default-deny + opt-in」節を追加。WebKit プレフィックス必須も CAUTION で明記

## 確認事項

- [ ] chrome ( サイドバー repo 名 / git graph 行 / ファイルツリー / タブ / フィルタ toggle ) がドラッグ選択不可になっている
- [ ] コンテンツ ( コード / diff / markdown / 会話本文 / コミット詳細 / エラートースト本文 ) は選択・コピー可能
- [ ] ターミナル ( xterm.js ) のコピーが従来どおり動作する
- [ ] 入力欄 ( command palette / 各種 input ) でテキスト選択・編集が動作する
