### PR TITLE
サイドバー起動時の layout shift を解消（worktree state キャッシュ + git 非依存 task ロード）

### DIFF
--- a/apps/native/Sources/Gozd/AppRuntime.swift
+++ b/apps/native/Sources/Gozd/AppRuntime.swift
@@ -237,6 +237,7 @@ final class AppRuntime {
 
     let createdDispatcher = RpcDispatcher(
       configDir: AppRuntime.defaultConfigDir(),
+      stateDir: AppRuntime.defaultStateDir(),
       onPtyText: onPtyText,
       onPtyExit: onPtyExit,
       onHook: onHook,
@@ -321,6 +322,14 @@ final class AppRuntime {
   private static func defaultConfigDir() -> String {
     let home = FileManager.default.homeDirectoryForCurrentUser
     return home.appendingPathComponent(".config/\(bundlePrefix)").path
+  }
+
+  /// `~/.local/state/gozd`。dev/stable で同じパスを使う（config と同じ共有方針）。
+  /// app state は「前回の続き」を表す state であり、ユーザー設定 (config) ではない
+  /// ため XDG state ディレクトリに置く。`~/.config/gozd` (config) とは別管理。
+  private static func defaultStateDir() -> String {
+    let home = FileManager.default.homeDirectoryForCurrentUser
+    return home.appendingPathComponent(".local/state/\(bundlePrefix)").path
   }
 
   /// socket / settings / launch dir / Bundle ID で共有する prefix。

--- a/apps/native/Sources/Gozd/AppRuntime.swift
+++ b/apps/native/Sources/Gozd/AppRuntime.swift
@@ -321,7 +321,7 @@ final class AppRuntime {
   /// app state / config / Task / ProjectConfig も同じものを共有する。
   private static func defaultConfigDir() -> String {
     let home = FileManager.default.homeDirectoryForCurrentUser
-    return home.appendingPathComponent(".config/\(bundlePrefix)").path
+    return home.appendingPathComponent(".config").appendingPathComponent(bundlePrefix).path
   }
 
   /// `~/.local/state/gozd`。dev/stable で同じパスを使う（config と同じ共有方針）。
@@ -329,7 +329,8 @@ final class AppRuntime {
   /// ため XDG state ディレクトリに置く。`~/.config/gozd` (config) とは別管理。
   private static func defaultStateDir() -> String {
     let home = FileManager.default.homeDirectoryForCurrentUser
-    return home.appendingPathComponent(".local/state/\(bundlePrefix)").path
+    return home.appendingPathComponent(".local").appendingPathComponent("state")
+      .appendingPathComponent(bundlePrefix).path
   }
 
   /// socket / settings / launch dir / Bundle ID で共有する prefix。

--- a/apps/native/Sources/GozdCore/Rpc/RpcDispatcher+Task.swift
+++ b/apps/native/Sources/GozdCore/Rpc/RpcDispatcher+Task.swift
@@ -8,6 +8,16 @@ import GozdProto
 // `handleClaudeSessionRemoveByPty`) が担当する。
 
 extension RpcDispatcher {
+  // git 非依存で tasks.json だけを読む高速経路。renderer が起動直後、worktree キャッシュから
+  // 描画したカードに task 行を即埋めるために使う (rpcGitWorktreeList の git 部分を待たない)。
+  func handleTaskList(_ body: Data) async throws -> Data {
+    let req = try Gozd_V1_TaskListRequest(jsonUTF8Data: body)
+    let list = try await tasks.list(dir: req.dir)
+    var resp = Gozd_V1_TaskListResponse()
+    resp.tasks = list
+    return try resp.jsonUTF8Data()
+  }
+
   func handleTaskAdd(_ body: Data) async throws -> Data {
     let req = try Gozd_V1_TaskAddRequest(jsonUTF8Data: body)
     let task = try await tasks.add(

--- a/apps/native/Sources/GozdCore/Rpc/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/Rpc/RpcDispatcher.swift
@@ -52,6 +52,7 @@ public actor RpcDispatcher {
 
   public init(
     configDir: String,
+    stateDir: String,
     onPtyText: @escaping @Sendable (UInt32, String) -> Void,
     onPtyExit: @escaping @Sendable (UInt32, PTYExitReason) -> Void,
     onHook: @escaping HookHandler = { _ in },
@@ -77,7 +78,7 @@ public actor RpcDispatcher {
       onRemoteRefsChange: onRemoteRefsChange,
       onWorktreeChange: onWorktreeChange
     )
-    self.appState = AppStateStore(configDir: configDir)
+    self.appState = AppStateStore(stateDir: stateDir)
     self.appConfig = AppConfigStore(configDir: configDir)
     self.projectConfig = ProjectConfigStore(configDir: configDir)
     self.tasks = TaskStore(configDir: configDir)
@@ -190,6 +191,7 @@ public actor RpcDispatcher {
     case "/git/createWorktree": return try await handleCreateWorktree(body)
     case "/git/worktreeRemove": return try await handleWorktreeRemove(body)
     // task
+    case "/task/list": return try await handleTaskList(body)
     case "/task/add": return try await handleTaskAdd(body)
     case "/task/setTerminalTitle": return try await handleTaskSetTerminalTitle(body)
     case "/task/setUserTitle": return try await handleTaskSetUserTitle(body)

--- a/apps/native/Sources/GozdCore/Store/AppStateStore.swift
+++ b/apps/native/Sources/GozdCore/Store/AppStateStore.swift
@@ -2,7 +2,7 @@ import Foundation
 import GozdProto
 import SwiftProtobuf
 
-// アプリ状態の永続化（`~/.config/gozd/app-state.json`）。
+// アプリ状態の永続化（`~/.local/state/gozd/app-state.json`）。
 //
 // 設計判断:
 //
@@ -10,9 +10,9 @@ import SwiftProtobuf
 //    `init(jsonString:)` を使う。ワイヤーフォーマットと storage 形式を同じ
 //    proto 型で揃え、Codable との二重管理を避ける。
 //
-// 2. **configDir は init で固定**。`~/.config/gozd` はサーバーワイドな初期化
-//    時パラメータでリクエスト毎に変わらないため、issue #310 のステートレス化
-//    （worktree dir 必須）の対象外。
+// 2. **stateDir は init で固定**。app state は「前回の続き」を表す state であり
+//    ユーザー設定 (config) ではないため XDG state ディレクトリ (`~/.local/state/gozd`)
+//    に置く。サーバーワイドな初期化時パラメータでリクエスト毎に変わらない。
 //
 // 3. **load 時にファイル不在ならデフォルト値**を返す（初回起動）。
 //    SwiftProtobuf の JSON parse は `ignoreUnknownFields = true` を渡し、
@@ -32,13 +32,11 @@ public final class AppStateStore {
   /// AppState の既知 top-level field 名（proto3 JSON の lower-camel 表記）。
   /// proto schema が変わったらこの set も同期して更新する。
   private static let knownTopLevelKeys: Set<String> = [
-    "windowFrame",
-    "lastOpenedDir",
     "sidebarRepos",
   ]
 
-  public init(configDir: String) {
-    self.filePath = (configDir as NSString).appendingPathComponent("app-state.json")
+  public init(stateDir: String) {
+    self.filePath = (stateDir as NSString).appendingPathComponent("app-state.json")
   }
 
   public func load() throws -> Gozd_V1_AppState {

--- a/apps/native/Tests/GozdCoreTests/AppStateStoreTests.swift
+++ b/apps/native/Tests/GozdCoreTests/AppStateStoreTests.swift
@@ -11,25 +11,34 @@ struct AppStateStoreTests {
     let dir = try makeTempDir()
     defer { try? FileManager.default.removeItem(at: URL(fileURLWithPath: dir)) }
 
-    let store = AppStateStore(configDir: dir)
+    let store = AppStateStore(stateDir: dir)
 
     var state = Gozd_V1_AppState()
-    state.lastOpenedDir = "/Users/test/projects/foo"
-    var frame = Gozd_V1_WindowFrame()
-    frame.x = 100
-    frame.y = 200
-    frame.width = 1280
-    frame.height = 800
-    state.windowFrame = frame
+    var repo = Gozd_V1_SidebarRepo()
+    repo.rootDir = "/Users/test/projects/foo"
+    repo.repoName = "foo"
+    repo.isGitRepo = true
+    repo.collapsed = true
+    var wt = Gozd_V1_WorktreeCacheEntry()
+    wt.path = "/Users/test/projects/foo/wt1"
+    wt.branch = "feature/x"
+    wt.isMain = false
+    repo.worktrees = [wt]
+    state.sidebarRepos = [repo]
 
     try store.save(state)
     let loaded = try store.load()
 
-    #expect(loaded.lastOpenedDir == "/Users/test/projects/foo")
-    #expect(loaded.windowFrame.x == 100)
-    #expect(loaded.windowFrame.y == 200)
-    #expect(loaded.windowFrame.width == 1280)
-    #expect(loaded.windowFrame.height == 800)
+    #expect(loaded.sidebarRepos.count == 1)
+    let r = loaded.sidebarRepos[0]
+    #expect(r.rootDir == "/Users/test/projects/foo")
+    #expect(r.repoName == "foo")
+    #expect(r.isGitRepo == true)
+    #expect(r.collapsed == true)
+    #expect(r.worktrees.count == 1)
+    #expect(r.worktrees[0].path == "/Users/test/projects/foo/wt1")
+    #expect(r.worktrees[0].branch == "feature/x")
+    #expect(r.worktrees[0].isMain == false)
   }
 
   @Test("ファイル不在時の load は default proto を返す")
@@ -37,26 +46,27 @@ struct AppStateStoreTests {
     let dir = try makeTempDir()
     defer { try? FileManager.default.removeItem(at: URL(fileURLWithPath: dir)) }
 
-    let store = AppStateStore(configDir: dir)
+    let store = AppStateStore(stateDir: dir)
     let loaded = try store.load()
-    #expect(loaded.lastOpenedDir == "")
-    #expect(loaded.windowFrame.width == 0)
+    #expect(loaded.sidebarRepos.isEmpty)
   }
 
-  @Test("configDir が存在しなくても save が中間ディレクトリを作る")
+  @Test("stateDir が存在しなくても save が中間ディレクトリを作る")
   func savesNestedDir() throws {
     let dir = try makeTempDir()
     defer { try? FileManager.default.removeItem(at: URL(fileURLWithPath: dir)) }
 
     let nestedDir = (dir as NSString).appendingPathComponent("a/b/c")
-    let store = AppStateStore(configDir: nestedDir)
+    let store = AppStateStore(stateDir: nestedDir)
 
     var state = Gozd_V1_AppState()
-    state.lastOpenedDir = "/x"
+    var repo = Gozd_V1_SidebarRepo()
+    repo.rootDir = "/x"
+    state.sidebarRepos = [repo]
     try store.save(state)
 
     let loaded = try store.load()
-    #expect(loaded.lastOpenedDir == "/x")
+    #expect(loaded.sidebarRepos.first?.rootDir == "/x")
   }
 
   @Test("save は既存ファイルの未知 top-level field を保持する")
@@ -68,15 +78,17 @@ struct AppStateStoreTests {
     let filePath = (dir as NSString).appendingPathComponent("app-state.json")
     let initialJson = """
       {
-        "lastOpenedDir": "/old",
+        "sidebarRepos": [{"rootDir": "/old"}],
         "futureField": {"version": 2, "extras": ["a", "b"]}
       }
       """
     try initialJson.write(toFile: filePath, atomically: true, encoding: .utf8)
 
-    let store = AppStateStore(configDir: dir)
+    let store = AppStateStore(stateDir: dir)
     var state = try store.load()
-    state.lastOpenedDir = "/new"
+    var repo = Gozd_V1_SidebarRepo()
+    repo.rootDir = "/new"
+    state.sidebarRepos = [repo]
     try store.save(state)
 
     // 保存後のファイルに futureField が残っていることを確認
@@ -87,7 +99,8 @@ struct AppStateStoreTests {
       Issue.record("saved file is not a JSON object")
       return
     }
-    #expect(savedDict["lastOpenedDir"] as? String == "/new")
+    let savedRepos = savedDict["sidebarRepos"] as? [[String: Any]]
+    #expect(savedRepos?.first?["rootDir"] as? String == "/new")
     #expect(savedDict["futureField"] != nil)
     if let future = savedDict["futureField"] as? [String: Any] {
       #expect(future["version"] as? Int == 2)
@@ -102,11 +115,10 @@ struct AppStateStoreTests {
     let dir = try makeTempDir()
     defer { try? FileManager.default.removeItem(at: URL(fileURLWithPath: dir)) }
 
-    let store = AppStateStore(configDir: dir)
+    let store = AppStateStore(stateDir: dir)
 
-    // 初回 save: sidebar repos と lastOpenedDir を埋める
+    // 初回 save: sidebar repos を埋める
     var first = Gozd_V1_AppState()
-    first.lastOpenedDir = "/old"
     var repo = Gozd_V1_SidebarRepo()
     repo.rootDir = "/repo/a"
     repo.repoName = "a"
@@ -118,7 +130,6 @@ struct AppStateStoreTests {
     try store.save(cleared)
 
     let loaded = try store.load()
-    #expect(loaded.lastOpenedDir == "")
     #expect(loaded.sidebarRepos.isEmpty)
   }
 
@@ -130,15 +141,15 @@ struct AppStateStoreTests {
     let filePath = (dir as NSString).appendingPathComponent("app-state.json")
     let json = """
       {
-        "lastOpenedDir": "/x",
+        "sidebarRepos": [{"rootDir": "/x"}],
         "totallyUnknownField": "should not break parse"
       }
       """
     try json.write(toFile: filePath, atomically: true, encoding: .utf8)
 
-    let store = AppStateStore(configDir: dir)
+    let store = AppStateStore(stateDir: dir)
     let loaded = try store.load()
-    #expect(loaded.lastOpenedDir == "/x")
+    #expect(loaded.sidebarRepos.first?.rootDir == "/x")
   }
 }
 

--- a/apps/native/Tests/GozdCoreTests/RpcDispatcherTests.swift
+++ b/apps/native/Tests/GozdCoreTests/RpcDispatcherTests.swift
@@ -21,6 +21,7 @@ struct RpcDispatcherTests {
 
     let dispatcher = RpcDispatcher(
       configDir: dir,
+      stateDir: dir,
       onPtyText: { _, _ in },
       onPtyExit: { _, _ in }
     )
@@ -41,13 +42,17 @@ struct RpcDispatcherTests {
 
     let dispatcher = RpcDispatcher(
       configDir: dir,
+      stateDir: dir,
       onPtyText: { _, _ in },
       onPtyExit: { _, _ in }
     )
 
     var saveReq = Gozd_V1_SaveAppStateRequest()
     var state = Gozd_V1_AppState()
-    state.lastOpenedDir = "/foo/bar"
+    var repo = Gozd_V1_SidebarRepo()
+    repo.rootDir = "/foo/bar"
+    repo.repoName = "bar"
+    state.sidebarRepos = [repo]
     saveReq.state = state
     _ = try await dispatcher.dispatch(path: "/appState/save", body: saveReq.jsonUTF8Data())
 
@@ -55,7 +60,7 @@ struct RpcDispatcherTests {
     let loadResp = try await dispatcher.dispatch(
       path: "/appState/load", body: loadReq.jsonUTF8Data())
     let parsed = try Gozd_V1_LoadAppStateResponse(jsonUTF8Data: loadResp)
-    #expect(parsed.state.lastOpenedDir == "/foo/bar")
+    #expect(parsed.state.sidebarRepos.first?.rootDir == "/foo/bar")
   }
 
   @Test("/fs/readFile は dir / path から bytes を返す")
@@ -68,6 +73,7 @@ struct RpcDispatcherTests {
 
     let dispatcher = RpcDispatcher(
       configDir: dir,
+      stateDir: dir,
       onPtyText: { _, _ in },
       onPtyExit: { _, _ in }
     )
@@ -96,6 +102,7 @@ struct RpcDispatcherTests {
     let (exitEvents, exitContinuation) = AsyncStream<(UInt32, PTYExitReason)>.makeStream()
     let dispatcher = RpcDispatcher(
       configDir: dir,
+      stateDir: dir,
       onPtyText: { _, _ in },
       onPtyExit: { id, reason in
         exitContinuation.yield((id, reason))
@@ -139,6 +146,7 @@ struct RpcDispatcherTests {
 
     let dispatcher = RpcDispatcher(
       configDir: configDir,
+      stateDir: configDir,
       onPtyText: { _, _ in },
       onPtyExit: { _, _ in }
     )
@@ -193,6 +201,7 @@ struct RpcDispatcherTests {
 
     let dispatcher = RpcDispatcher(
       configDir: configDir,
+      stateDir: configDir,
       onPtyText: { _, _ in },
       onPtyExit: { _, _ in }
     )
@@ -273,6 +282,7 @@ struct RpcDispatcherTests {
 
     let dispatcher = RpcDispatcher(
       configDir: configDir,
+      stateDir: configDir,
       onPtyText: { _, _ in },
       onPtyExit: { _, _ in }
     )
@@ -333,6 +343,7 @@ struct RpcDispatcherTests {
 
     let dispatcher = RpcDispatcher(
       configDir: configDir,
+      stateDir: configDir,
       onPtyText: { _, _ in },
       onPtyExit: { _, _ in }
     )
@@ -411,6 +422,7 @@ struct RpcDispatcherTests {
 
     let dispatcher = RpcDispatcher(
       configDir: dir,
+      stateDir: dir,
       onPtyText: { _, _ in },
       onPtyExit: { _, _ in }
     )
@@ -441,6 +453,7 @@ struct RpcDispatcherTests {
 
     let dispatcher = RpcDispatcher(
       configDir: dir,
+      stateDir: dir,
       onPtyText: { _, _ in },
       onPtyExit: { _, _ in }
     )
@@ -460,6 +473,7 @@ struct RpcDispatcherTests {
 
     let dispatcher = RpcDispatcher(
       configDir: dir,
+      stateDir: dir,
       onPtyText: { _, _ in },
       onPtyExit: { _, _ in }
     )
@@ -483,6 +497,7 @@ struct RpcDispatcherTests {
 
     let dispatcher = RpcDispatcher(
       configDir: dir,
+      stateDir: dir,
       onPtyText: { _, _ in },
       onPtyExit: { _, _ in }
     )
@@ -522,6 +537,7 @@ struct RpcDispatcherTests {
 
     let dispatcher = RpcDispatcher(
       configDir: dir,
+      stateDir: dir,
       onPtyText: { _, _ in },
       onPtyExit: { _, _ in }
     )
@@ -544,6 +560,7 @@ struct RpcDispatcherTests {
     let (hookStream, hookContinuation) = AsyncStream<Gozd_V1_HookMessage>.makeStream()
     let dispatcher = RpcDispatcher(
       configDir: dir,
+      stateDir: dir,
       onPtyText: { _, _ in },
       onPtyExit: { _, _ in },
       onHook: { hook in
@@ -570,6 +587,7 @@ struct RpcDispatcherTests {
     let (openStream, openContinuation) = AsyncStream<String>.makeStream()
     let dispatcher = RpcDispatcher(
       configDir: dir,
+      stateDir: dir,
       onPtyText: { _, _ in },
       onPtyExit: { _, _ in },
       onHook: { _ in },
@@ -594,6 +612,7 @@ struct RpcDispatcherTests {
 
     let dispatcher = RpcDispatcher(
       configDir: dir,
+      stateDir: dir,
       onPtyText: { _, _ in },
       onPtyExit: { _, _ in }
     )
@@ -705,6 +724,7 @@ private func dispatchShowCommitFile(
 ) async throws -> Gozd_V1_GitShowCommitFileResponse {
   let dispatcher = RpcDispatcher(
     configDir: configDir,
+    stateDir: configDir,
     onPtyText: { _, _ in },
     onPtyExit: { _, _ in }
   )

--- a/apps/renderer/src/features/sidebar/rpc.ts
+++ b/apps/renderer/src/features/sidebar/rpc.ts
@@ -14,6 +14,8 @@ import {
   SaveAppStateResponse,
   TaskAddRequest,
   TaskAddResponse,
+  TaskListRequest,
+  TaskListResponse,
   TaskRemoveRequest,
   TaskRemoveResponse,
   TaskSetTerminalTitleRequest,
@@ -39,6 +41,11 @@ export const rpcGitWorktreeRemove = (req: GitWorktreeRemoveRequest) =>
   rpc("/git/worktreeRemove", req, GitWorktreeRemoveRequest, GitWorktreeRemoveResponse);
 
 // --- task ---
+
+// git 非依存で tasks.json だけを読む高速経路。起動直後、worktree キャッシュから描画した
+// カードに task 行を即埋めるために使う（重い rpcGitWorktreeList の git 部分を待たない）。
+export const rpcTaskList = (req: TaskListRequest) =>
+  rpc("/task/list", req, TaskListRequest, TaskListResponse);
 
 // task ≠ session 設計: task は PR/issue picker や手動操作で生まれる永続オブジェクト。
 // Claude session は task に attach する短命属性として server 側で扱う。

--- a/apps/renderer/src/features/sidebar/useSidebarData.ts
+++ b/apps/renderer/src/features/sidebar/useSidebarData.ts
@@ -11,6 +11,7 @@ import {
   rpcAppStateLoad,
   rpcAppStateSave,
   rpcGitWorktreeList,
+  rpcTaskList,
   rpcTaskSetTerminalTitle,
 } from "./rpc";
 import type { BranchChangePayload, FsWatchReadyPayload, WorktreeChangePayload } from "./rpc";
@@ -72,13 +73,32 @@ export function useSidebarData() {
     for (const dir of stalePaths) terminalStore.remove(dir);
   }
 
-  // 新規 repo が追加されたら即 fetch
+  /**
+   * git 非依存で tasks.json を読み、起動直後に worktree キャッシュから描画したカードへ
+   * task 行を即埋める高速経路。`fetchRepo`（git worktree list + 各 wt の git status を
+   * 含む重い真値取得）と並走させ、task の SSOT (tasks.json) を git の往復を待たずに反映する。
+   * 失敗時は fetchRepo の真値が task を届けるため silent に諦める（補助経路。fetchRepo 側が
+   * 失敗を notify する）。
+   */
+  async function prefetchTasks(rootDir: string) {
+    const repo = repoStore.repos[rootDir];
+    if (repo === undefined || !repo.isGitRepo) return;
+    const result = await tryCatch(rpcTaskList({ dir: rootDir }));
+    if (!result.ok) return;
+    repoStore.applyRepoTasks(rootDir, result.value.tasks);
+  }
+
+  // 新規 repo が追加されたら即 fetch。git の往復が重いので、task だけ git 非依存の
+  // prefetch を並走させて起動直後のカード内 layout shift（task 行の遅延挿入）を抑える。
   watch(
     () => [...repoStore.dirOrder],
     (next, prev) => {
       const prevSet = new Set(prev);
       for (const dir of next) {
-        if (!prevSet.has(dir)) void fetchRepo(dir);
+        if (!prevSet.has(dir)) {
+          void prefetchTasks(dir);
+          void fetchRepo(dir);
+        }
       }
     },
     { immediate: true },

--- a/apps/renderer/src/shared/repo/useRepoStore.test.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.test.ts
@@ -129,4 +129,30 @@ describe("applyRepoTasks", () => {
 
     expect(store.repos["/r1"]?.worktrees[0]?.tasks.map((t) => t.id)).toEqual(["t-new"]);
   });
+
+  test("removeRepo → 同 rootDir 再追加で applyRepoTasks が再び効く（git 真値フラグの掃除）", () => {
+    setActivePinia(createPinia());
+    const store = useRepoStore();
+    store.addRepo({
+      rootDir: "/r1",
+      repoName: "r1",
+      isGitRepo: true,
+      worktrees: [wt("/r1/wt-1", "feat")],
+    });
+    // 1 回目: git 真値到達でフラグが立つ
+    store.updateRepoData("/r1", [wt("/r1/wt-1", "feat")]);
+
+    store.removeRepo("/r1");
+    // 再追加（キャッシュから楽観カードを復元した状態）
+    store.addRepo({
+      rootDir: "/r1",
+      repoName: "r1",
+      isGitRepo: true,
+      worktrees: [wt("/r1/wt-1", "feat")],
+    });
+
+    // フラグが残っていれば no-op になり task が出ない。掃除済みなら prefetch が再び効く。
+    store.applyRepoTasks("/r1", [task("t1", "/r1/wt-1")]);
+    expect(store.repos["/r1"]?.worktrees[0]?.tasks.map((t) => t.id)).toEqual(["t1"]);
+  });
 });

--- a/apps/renderer/src/shared/repo/useRepoStore.test.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.test.ts
@@ -1,6 +1,7 @@
-import type { WorktreeEntry } from "@gozd/proto";
+import { Task, type WorktreeEntry } from "@gozd/proto";
 import { describe, expect, test } from "bun:test";
-import { collectFsWatchTargetDirs, type RepoState } from "./useRepoStore";
+import { createPinia, setActivePinia } from "pinia";
+import { collectFsWatchTargetDirs, type RepoState, useRepoStore } from "./useRepoStore";
 
 function wt(path: string, branch: string, isMain = false): WorktreeEntry {
   return {
@@ -14,6 +15,10 @@ function wt(path: string, branch: string, isMain = false): WorktreeEntry {
     upstream: undefined,
     latestMtime: 0,
   };
+}
+
+function task(id: string, worktreeDir: string): Task {
+  return Task.fromPartial({ id, worktreeDir });
 }
 
 describe("collectFsWatchTargetDirs", () => {
@@ -79,5 +84,49 @@ describe("collectFsWatchTargetDirs", () => {
       },
     };
     expect(collectFsWatchTargetDirs(["/ghost", "/alive"], repos)).toEqual(new Set(["/alive"]));
+  });
+});
+
+describe("applyRepoTasks", () => {
+  test("worktreeDir で task を各 wt に割り当て、gitStatuses 等は保持する", () => {
+    setActivePinia(createPinia());
+    const store = useRepoStore();
+    store.addRepo({
+      rootDir: "/r1",
+      repoName: "r1",
+      isGitRepo: true,
+      worktrees: [
+        { ...wt("/r1", "main", true), gitStatuses: { "a.txt": ".M" } },
+        wt("/r1/wt-1", "feat"),
+      ],
+    });
+
+    store.applyRepoTasks("/r1", [task("t2", "/r1"), task("t1", "/r1/wt-1")]);
+
+    const repo = store.repos["/r1"];
+    expect(repo?.worktrees[0]?.tasks.map((t) => t.id)).toEqual(["t2"]);
+    expect(repo?.worktrees[1]?.tasks.map((t) => t.id)).toEqual(["t1"]);
+    // tasks のみ差し替え。git status 等の他フィールドは保持する。
+    expect(repo?.worktrees[0]?.gitStatuses).toEqual({ "a.txt": ".M" });
+  });
+
+  test("git 真値（updateRepoData）到達後の applyRepoTasks は no-op（prefetch race ガード）", () => {
+    setActivePinia(createPinia());
+    const store = useRepoStore();
+    store.addRepo({
+      rootDir: "/r1",
+      repoName: "r1",
+      isGitRepo: true,
+      worktrees: [wt("/r1/wt-1", "feat")],
+    });
+
+    // git 真値が先に到達（往復中に増えた t-new を含む最新 task）
+    store.updateRepoData("/r1", [
+      { ...wt("/r1/wt-1", "feat"), tasks: [task("t-new", "/r1/wt-1")] },
+    ]);
+    // 古い prefetch スナップショット（t-new を含まない）が後着しても真値を消さない
+    store.applyRepoTasks("/r1", []);
+
+    expect(store.repos["/r1"]?.worktrees[0]?.tasks.map((t) => t.id)).toEqual(["t-new"]);
   });
 });

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -318,6 +318,10 @@ export const useRepoStore = defineStore("repo", () => {
       gitStatusGenByDir.delete(removed.rootDir);
       for (const wt of removed.worktrees) gitStatusGenByDir.delete(wt.path);
     }
+    // git 真値到達フラグも掃除する。残すと同 rootDir を再追加したとき applyRepoTasks が
+    // 永久 no-op になり、起動時 task 高速ロード（prefetch）の便益が失われて layout shift が
+    // 一段戻る。gitStatusGenByDir と同じ per-root 補助状態として同じライフサイクルで掃除する。
+    gitTruthAppliedRoots.delete(rootDir);
     if (selectedDir.value !== undefined) {
       const stillOwned = findRepoOwning(selectedDir.value);
       if (stillOwned === undefined) {

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -102,6 +102,15 @@ export const useRepoStore = defineStore("repo", () => {
     return gitStatusGenByDir.get(dir) ?? 0;
   }
 
+  /**
+   * `updateRepoData`（= `rpcGitWorktreeList` の git 真値の唯一の書き込み口）が一度でも
+   * 走った rootDir の集合。`applyRepoTasks`（git 非依存の prefetch 適用）が、git 真値
+   * 到達後に古い tasks.json スナップショットで上書きするのを防ぐガードに使う。
+   * git 真値は tasks.json を JOIN した最新 task を含むため、真値到達後は prefetch の
+   * 出番が無いという不変条件を表す。reactivity 不要なため素の Set で持つ。
+   */
+  const gitTruthAppliedRoots = new Set<string>();
+
   /** selectedDir を含む repo を逆引き。最初に dir を含む repo */
   const selectedRepo = computed(() => {
     const dir = selectedDir.value;
@@ -224,6 +233,9 @@ export const useRepoStore = defineStore("repo", () => {
       current.worktrees.some((w) => w.path === selectedDir.value) &&
       !merged.some((w) => w.path === selectedDir.value);
     repos.value[rootDir] = { ...current, worktrees: merged };
+    // git 真値が書かれた印。以降 applyRepoTasks（prefetch）は古い task スナップショットで
+    // 上書きしない（真値は tasks.json を JOIN した最新 task を含むため出番が無い）。
+    gitTruthAppliedRoots.add(rootDir);
     if (orphanedActiveDir) {
       // 外部 git worktree remove 経由だとユーザー操作なしに active dir が切り替わる。
       // feature 層が DI した notifier 経由でユーザーに通知する。未注入なら console.info。
@@ -412,10 +424,14 @@ export const useRepoStore = defineStore("repo", () => {
    * git 非依存で読んだ task 一覧（`rpcTaskList`）を、既存 worktrees に worktreeDir で
    * 割り当てる。起動直後、worktree キャッシュから描画したカードに task 行を即埋める高速
    * 経路。各 wt は spread で gitStatuses / upstream 等を保持し、tasks のみ差し替える。
-   * その後 `fetchRepo` → `updateRepoData` の git 真値（同じ tasks.json 由来の task を含む）
-   * が来たら全体が上書きされるため整合は壊れない。task の SSOT は tasks.json。
+   * `updateRepoData` で git 真値が既に書かれた repo は no-op にする。prefetch と fetchRepo
+   * は並走起動され完了順序は保証されない。fetchRepo が先に完了したケースで、prefetch の
+   * 古い tasks.json スナップショット（往復中に session hook 等で task が増えた場合、真値
+   * より古い）が後着して真値の task を消す race を構造的に塞ぐ。git 真値到達後は prefetch
+   * の出番が無い（真値が tasks.json を JOIN した最新 task を含む）。task の SSOT は tasks.json。
    */
   function applyRepoTasks(rootDir: string, tasks: Task[]) {
+    if (gitTruthAppliedRoots.has(rootDir)) return;
     const current = repos.value[rootDir];
     if (current === undefined) return;
     repos.value[rootDir] = {

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -1,4 +1,4 @@
-import { AppState, type UpstreamStatus, type WorktreeEntry } from "@gozd/proto";
+import { type AppState, type Task, type UpstreamStatus, WorktreeEntry } from "@gozd/proto";
 import { acceptHMRUpdate, defineStore } from "pinia";
 import { computed, ref } from "vue";
 
@@ -342,20 +342,12 @@ export const useRepoStore = defineStore("repo", () => {
   // --- 永続化サポート（I/O は feature 側で実施） ---
 
   /**
-   * load した state のうち sidebar 以外のフィールド（windowFrame 等）を保持し、
-   * save 時に同じ値を書き戻すための pass-through buffer。
-   */
-  let cachedBaseState: AppState = AppState.fromJSON({});
-
-  /**
    * AppState の sidebar 関連フィールドを現在の store の状態で組み立てて返す。
    * shared スコープの制約により RPC 呼び出しは feature 側で行うので、
    * snapshot 構築だけここで提供する。
    */
   function buildAppStateSnapshot(): AppState {
     return {
-      ...cachedBaseState,
-      lastOpenedDir: selectedDir.value ?? cachedBaseState.lastOpenedDir,
       sidebarRepos: dirOrder.value.map((rootDir) => {
         const r = repos.value[rootDir];
         return {
@@ -363,6 +355,15 @@ export const useRepoStore = defineStore("repo", () => {
           repoName: r?.repoName ?? "",
           isGitRepo: r?.isGitRepo ?? false,
           collapsed: collapsedRoots.value.has(rootDir),
+          // worktree キャッシュ: 起動直後の楽観カード描画に必要な最小サブセットだけ
+          // 射影する。git status / tasks / upstream を含めないことで、gitStatusChange
+          // push のたびに snapshot が変化して save watch が回るのを防ぐ
+          // （既存 debounce 相乗り + 射影限定）。SSOT は git。
+          worktrees: (r?.worktrees ?? []).map((wt) => ({
+            path: wt.path,
+            branch: wt.branch,
+            isMain: wt.isMain,
+          })),
         };
       }),
     };
@@ -372,9 +373,13 @@ export const useRepoStore = defineStore("repo", () => {
    * 起動時に 1 回呼ぶ。`app-state.json` から読んだ AppState を渡すと、
    * sidebar repos / order / collapsed を復元する。既に gozdOpen で追加済みの
    * repo は新規エントリとして末尾に保持する（先勝ち merge）。
+   *
+   * worktrees はキャッシュ（path/branch/isMain のみ）から実カードとして復元し、
+   * 起動直後の layout shift を消す。git status / tasks / upstream は欠けた状態で
+   * 描画され、`fetchRepo` → `updateRepoData` の真値が来たら同一 path のカードが
+   * key 維持で in-place 更新される（楽観描画）。SSOT は git。
    */
   function hydrateFromAppState(state: AppState) {
-    cachedBaseState = state;
     const nextRepos: Record<string, RepoState> = {};
     const nextOrder: string[] = [];
     const nextCollapsed = new Set<string>();
@@ -384,7 +389,9 @@ export const useRepoStore = defineStore("repo", () => {
         rootDir: r.rootDir,
         repoName: r.repoName,
         isGitRepo: r.isGitRepo,
-        worktrees: [],
+        worktrees: r.worktrees.map((wt) =>
+          WorktreeEntry.fromPartial({ path: wt.path, branch: wt.branch, isMain: wt.isMain }),
+        ),
       };
       nextOrder.push(r.rootDir);
       if (r.collapsed) nextCollapsed.add(r.rootDir);
@@ -401,6 +408,25 @@ export const useRepoStore = defineStore("repo", () => {
     collapsedRoots.value = nextCollapsed;
   }
 
+  /**
+   * git 非依存で読んだ task 一覧（`rpcTaskList`）を、既存 worktrees に worktreeDir で
+   * 割り当てる。起動直後、worktree キャッシュから描画したカードに task 行を即埋める高速
+   * 経路。各 wt は spread で gitStatuses / upstream 等を保持し、tasks のみ差し替える。
+   * その後 `fetchRepo` → `updateRepoData` の git 真値（同じ tasks.json 由来の task を含む）
+   * が来たら全体が上書きされるため整合は壊れない。task の SSOT は tasks.json。
+   */
+  function applyRepoTasks(rootDir: string, tasks: Task[]) {
+    const current = repos.value[rootDir];
+    if (current === undefined) return;
+    repos.value[rootDir] = {
+      ...current,
+      worktrees: current.worktrees.map((wt) => ({
+        ...wt,
+        tasks: tasks.filter((t) => t.worktreeDir === wt.path),
+      })),
+    };
+  }
+
   return {
     repos,
     dirOrder,
@@ -414,6 +440,7 @@ export const useRepoStore = defineStore("repo", () => {
     isSameRepoAsActive,
     addRepo,
     updateRepoData,
+    applyRepoTasks,
     setWorktreeGitStatuses,
     getGitStatusGen,
     appendWorktree,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -264,14 +264,16 @@ zsh 起動
 
 ## データ永続化
 
-アプリの状態と設定は `~/.config/gozd/` に proto3 JSON で保存する。dev / stable で永続ディレクトリは共有する。channel で分離するのは衝突回避が必要な実行時リソース（socket / TMPDIR / Vite URL / CLI ソース参照先）のみ。ファイル I/O は常に native（Swift）側で行い、renderer からは RPC request 経由でアクセスする。
+アプリのデータは XDG の役割で 2 ディレクトリに分ける。ユーザー設定 (config) / プロジェクトデータは `~/.config/gozd/`、「前回の続き」を表す state（ウィンドウ状態 / sidebar 並び順・折りたたみ / worktree 一覧キャッシュ）は `~/.local/state/gozd/` に proto3 JSON で保存する。どちらも dev / stable で永続ディレクトリは共有する。channel で分離するのは衝突回避が必要な実行時リソース（socket / TMPDIR / Vite URL / CLI ソース参照先）のみ。ファイル I/O は常に native（Swift）側で行い、renderer からは RPC request 経由でアクセスする。
 
 > [!WARNING]
 > 永続ファイルへの cross-process ロックは未実装。dev / stable を同時起動した場合、各ストア（`AppStateStore` / `AppConfigStore` / `TaskStore` / `ProjectConfigStore`）の `load → mutate → save` が並走すると、最後に save したプロセスが他方の変更を上書きする可能性がある。
 
 ```text
+~/.local/state/gozd/
+└── app-state.json                        # state: sidebar repo 並び順 / 折りたたみ / worktree 一覧キャッシュ
+
 ~/.config/gozd/
-├── app-state.json                        # グローバル: ウィンドウ状態 / repo 並び順 / 折りたたみ状態
 ├── config.json                           # グローバル: ユーザー設定（VOICEVOX 等）
 └── projects/
     └── <projectKey>/                     # <repoName>-<hash>（realpath の SHA-256 先頭12文字）

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -264,7 +264,7 @@ zsh 起動
 
 ## データ永続化
 
-アプリのデータは XDG の役割で 2 ディレクトリに分ける。ユーザー設定 (config) / プロジェクトデータは `~/.config/gozd/`、「前回の続き」を表す state（ウィンドウ状態 / sidebar 並び順・折りたたみ / worktree 一覧キャッシュ）は `~/.local/state/gozd/` に proto3 JSON で保存する。どちらも dev / stable で永続ディレクトリは共有する。channel で分離するのは衝突回避が必要な実行時リソース（socket / TMPDIR / Vite URL / CLI ソース参照先）のみ。ファイル I/O は常に native（Swift）側で行い、renderer からは RPC request 経由でアクセスする。
+アプリのデータは XDG の役割で 2 ディレクトリに分ける。ユーザー設定 (config) / プロジェクトデータは `~/.config/gozd/`、「前回の続き」を表す state（sidebar 並び順・折りたたみ / worktree 一覧キャッシュ）は `~/.local/state/gozd/` に proto3 JSON で保存する。どちらも dev / stable で永続ディレクトリは共有する。channel で分離するのは衝突回避が必要な実行時リソース（socket / TMPDIR / Vite URL / CLI ソース参照先）のみ。ファイル I/O は常に native（Swift）側で行い、renderer からは RPC request 経由でアクセスする。
 
 > [!WARNING]
 > 永続ファイルへの cross-process ロックは未実装。dev / stable を同時起動した場合、各ストア（`AppStateStore` / `AppConfigStore` / `TaskStore` / `ProjectConfigStore`）の `load → mutate → save` が並走すると、最後に save したプロセスが他方の変更を上書きする可能性がある。

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -30,18 +30,17 @@
 
 ## アプリ状態の復元
 
-`~/.config/gozd/app-state.json` に最後のウィンドウ状態を保存し、次回起動時に sidebar として hydrate する。dev / stable で同じファイルを共有する。
+`~/.local/state/gozd/app-state.json`（XDG state ディレクトリ）に最後の sidebar 状態を保存し、次回起動時に sidebar として hydrate する。dev / stable で同じファイルを共有する。
 
 save の発火条件は `buildAppStateSnapshot()` のシリアライズ結果が前回と変化した時のみ。`worktrees` / `gitStatuses` / `task` などサイドバー描画用のデータは snapshot に含まれないため、git status push / `fetchRepo` / Task title 同期では save が走らない。発火するのは `dirOrder` / `collapsedRoots` / `selectedDir` / 各 repo の `repoName` / `isGitRepo` が実際に変化した時のみ。
 
 > [!WARNING]
 > dev / stable を同時起動して両方の sidebar を編集した場合、最後に save したプロセスが他方の sidebar 状態を上書きする。プロセス間ロックは未実装。詳細は [architecture.md](./architecture.md#データ永続化) を参照。
 
-保存する情報:
+保存する情報（`~/.local/state/gozd/app-state.json`、XDG state ディレクトリ）:
 
-- sidebar に表示中の repo 一覧（`sidebarRepos`: rootDir / repoName / collapsed）
-- 最後にアクティブだった worktree ディレクトリ（`lastOpenedDir`）
-- ウィンドウフレーム（位置・サイズ）
+- sidebar に表示中の repo 一覧（`sidebarRepos`: rootDir / repoName / isGitRepo / collapsed）
+- 各 repo の worktree 一覧キャッシュ（`sidebarRepos[].worktrees`: path / branch / isMain）。起動直後の layout shift を消すための楽観描画用。SSOT は git で、`rpcGitWorktreeList` の真値が来たら上書きされる
 
 起動時の挙動:
 
@@ -65,11 +64,11 @@ save の発火条件は `buildAppStateSnapshot()` のシリアライズ結果が
 
 ### 永続化
 
-`app-state.json` の `sidebarRepos` で同居中の repo 一覧（rootDir / repoName / collapsed 状態）を永続化済み。
+`app-state.json` の `sidebarRepos` で同居中の repo 一覧（rootDir / repoName / collapsed 状態）+ 各 repo の worktree 一覧キャッシュを永続化済み。
 
 未実装:
 
-- 起動時の active worktree 自動復元（`lastOpenedDir` は保存されているが hydrate 時に `selectedDir` へ反映していない）
+- 起動時の active worktree 自動復元（最後に選択していた worktree の記憶・復元は未実装）
 - worktree ごとの setup / teardown スクリプト（`pnpm install` 等の初期化自動化）
 
 将来的に永続化対象が大きく増えた場合は SQLite への移行を検討する。

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -32,7 +32,7 @@
 
 `~/.local/state/gozd/app-state.json`（XDG state ディレクトリ）に最後の sidebar 状態を保存し、次回起動時に sidebar として hydrate する。dev / stable で同じファイルを共有する。
 
-save の発火条件は `buildAppStateSnapshot()` のシリアライズ結果が前回と変化した時のみ。`worktrees` / `gitStatuses` / `task` などサイドバー描画用のデータは snapshot に含まれないため、git status push / `fetchRepo` / Task title 同期では save が走らない。発火するのは `dirOrder` / `collapsedRoots` / `selectedDir` / 各 repo の `repoName` / `isGitRepo` が実際に変化した時のみ。
+save の発火条件は `buildAppStateSnapshot()` のシリアライズ結果が前回と変化した時のみ。snapshot に含めるのは `dirOrder` / `collapsedRoots` / 各 repo の `repoName` / `isGitRepo` と、各 worktree の `path` / `branch` / `isMain`（worktree 一覧キャッシュ）。`gitStatuses` / `task` は snapshot に含めないため、git status push / Task title 同期では save が走らない（`selectedDir` も snapshot 非対象）。発火するのは上記フィールドが実際に変化した時のみ。
 
 > [!WARNING]
 > dev / stable を同時起動して両方の sidebar を編集した場合、最後に save したプロセスが他方の sidebar 状態を上書きする。プロセス間ロックは未実装。詳細は [architecture.md](./architecture.md#データ永続化) を参照。

--- a/packages/proto-ts/src/index.ts
+++ b/packages/proto-ts/src/index.ts
@@ -22,7 +22,6 @@ export {
   LoadAppStateResponse,
   SaveAppStateRequest,
   SaveAppStateResponse,
-  WindowFrame,
 } from "./generated/gozd/v1/app_state";
 export {
   ClaudeSessionLogEntry,
@@ -166,6 +165,8 @@ export {
   TaskAddRequest,
   TaskAddResponse,
   TaskList,
+  TaskListRequest,
+  TaskListResponse,
   TaskRemoveRequest,
   TaskRemoveResponse,
   TaskSetTerminalTitleRequest,

--- a/packages/proto/gozd/v1/app_state.proto
+++ b/packages/proto/gozd/v1/app_state.proto
@@ -2,33 +2,37 @@ syntax = "proto3";
 
 package gozd.v1;
 
-// アプリ全体の状態。`~/.config/gozd/app-state.json` に永続化される。
+// アプリのウィンドウ状態。`~/.local/state/gozd/app-state.json` に永続化される。
+// 「前回の続き」を表す state であり、ユーザー設定 (config) ではないため XDG state
+// ディレクトリ (~/.local/state) に置く。
 //
 // 永続化形式は proto3 JSON mapping。SwiftProtobuf の jsonString() で
 // 直接ファイルに書き、jsonString() で復元する。RPC ワイヤーフォーマットと
 // 永続化形式を同一 proto 型で揃え、Codable との二重管理を避ける。
 message AppState {
-  WindowFrame window_frame = 1;
-  // 最後に開いていた worktree の絶対パス（再起動時の復元用）
-  string last_opened_dir = 2;
   // window 内に同居するサイドバー repo リスト。順序は dirOrder と一致する
   repeated SidebarRepo sidebar_repos = 3;
 }
 
-// サイドバー上の 1 repo の永続化エントリ。worktrees は
-// 起動時に再 fetch するため永続化しない（一次情報は git に問い合わせる）。
+// サイドバー上の 1 repo の永続化エントリ。
 message SidebarRepo {
   string root_dir = 1;
   string repo_name = 2;
   bool is_git_repo = 3;
   bool collapsed = 4;
+  // worktree 一覧の起動時キャッシュ。SSOT は git。起動直後はこのキャッシュから
+  // 実カードを描画して layout shift を消し、rpcGitWorktreeList の真値で上書きする。
+  // path/branch/is_main のみ持つ。git status / tasks は SSOT が別 (git / tasks.json)
+  // なのでキャッシュしない (二重保持回避)。
+  repeated WorktreeCacheEntry worktrees = 5;
 }
 
-message WindowFrame {
-  double x = 1;
-  double y = 2;
-  double width = 3;
-  double height = 4;
+// worktree 一覧の最小キャッシュ要素。WorktreeEntry (common.proto) のうち、起動直後の
+// カード描画に必要な最小サブセット。
+message WorktreeCacheEntry {
+  string path = 1;
+  string branch = 2;
+  bool is_main = 3;
 }
 
 message LoadAppStateRequest {}

--- a/packages/proto/gozd/v1/app_state.proto
+++ b/packages/proto/gozd/v1/app_state.proto
@@ -10,6 +10,9 @@ package gozd.v1;
 // 直接ファイルに書き、jsonString() で復元する。RPC ワイヤーフォーマットと
 // 永続化形式を同一 proto 型で揃え、Codable との二重管理を避ける。
 message AppState {
+  // 1, 2 は削除済みの window_frame / last_opened_dir（produce/consume 経路が無い dead
+  // field だった）。番号の誤再利用を防ぐため reserved にする。
+  reserved 1, 2;
   // window 内に同居するサイドバー repo リスト。順序は dirOrder と一致する
   repeated SidebarRepo sidebar_repos = 3;
 }

--- a/packages/proto/gozd/v1/task.proto
+++ b/packages/proto/gozd/v1/task.proto
@@ -18,6 +18,16 @@ message TaskList {
   repeated Task tasks = 1;
 }
 
+// git 非依存で tasks.json だけを読む高速経路。起動直後、worktree キャッシュから描画した
+// カードに task 行を即埋めるために使う（重い rpcGitWorktreeList の git 部分を待たずに
+// task を出す）。projectKey は dir から server 側で算出する。
+message TaskListRequest {
+  string dir = 1;
+}
+message TaskListResponse {
+  repeated Task tasks = 1;
+}
+
 message TaskAddRequest {
   string dir = 1;
   string worktree_dir = 3;


### PR DESCRIPTION
## 概要

アプリ起動時にサイドバーで起きていた layout shift を解消する。worktree カードと task 行を起動直後に即描画し、git status 等の重い情報だけを後追いで反映する構成にした。あわせて永続化レイヤを XDG の役割に沿って整理し、`app-state` を state ディレクトリへ移設、未使用フィールドを削除した。

## 背景

起動時、サイドバーは repo ヘッダが即表示された後、各 repo の worktree カードが遅れて挿入され、さらにその中の task 行がもう一段遅れて現れ、その都度セクション高さが飛んでいた。

原因は永続化境界にあった。repo メタ（rootDir / repoName / collapsed / 並び順）は `app-state.json` に永続化され即描画されるが、worktree 一覧と task は永続化されておらず、毎起動 `rpcGitWorktreeList`（`git worktree list` + 各 worktree の `git status` を並列実行し tasks.json を JOIN）で取得していた。`RpcDispatcher` は actor だが各 git 実行は `await` で suspend するため repo 間は並行だが、git プロセス起動コスト分の遅延は残り、これが「config は即・実体値は遅延」の速度差として layout shift になっていた。

worktree 実体の SSOT は git、task の SSOT は tasks.json であり、どちらもユーザー設定ではない。一方で `app-state` は「前回の続き」を表す state で、XDG 上は `~/.config`（config）ではなく `~/.local/state` が適切な置き場所である。この整理に沿って、worktree は起動描画用の state キャッシュとして持ち、task は専用 SSOT を git の往復を待たずに読む経路を足した。

## 変更内容

### worktree のキャッシュと楽観描画

- `SidebarRepo` に `worktrees`（`WorktreeCacheEntry { path, branch, is_main }`）を追加し、起動描画に必要な最小サブセットだけを永続化する
- hydrate でキャッシュから実カードを描画し、`rpcGitWorktreeList` の真値が来たら同一 path のカードを in-place 更新する（楽観描画）。skeleton は使わない
- save スナップショットは path/branch/is_main だけを射影し、`gitStatusChange` push のたびに save が走らないようにする

### git 非依存の task 高速ロード

- `/task/list`（`TaskListRequest` / `TaskListResponse`）を新設。`tasks.list(dir:)` で tasks.json だけを読み、git に依存しない
- hydrate 経路で `prefetchTasks` を `fetchRepo` と並走させ、worktree キャッシュから描画したカードに task 行を即埋める
- task は app-state にキャッシュしない（tasks.json という専用 SSOT を持つため二重永続を避ける）

### prefetch と git 真値の整合ガード

- `prefetchTasks` と `fetchRepo` は並走起動され完了順序の保証が無い。`updateRepoData`（git 真値の唯一の書き込み口）が走った rootDir を `gitTruthAppliedRoots` に記録し、`applyRepoTasks`（prefetch 適用）は記録済みなら no-op にする。git 真値到達後は prefetch の出番が無い（真値が tasks.json を JOIN した最新 task を含む）という不変条件で、古い task スナップショットが真値の task を消す race を構造的に塞ぐ
- `removeRepo` で `gitTruthAppliedRoots` を `gitStatusGenByDir` と同じライフサイクルで掃除する。残すと同 rootDir 再追加時に prefetch が永久 no-op になり layout shift が一段戻る + Set がリークするため

### 永続化レイヤの整理

- `AppStateStore` の永続化先を `~/.config/gozd` から `~/.local/state/gozd`（XDG state）へ移設
- produce / consume 経路がコードに存在しない dead field（`window_frame` / `last_opened_dir` / `WindowFrame` message）を proto / Swift / renderer / test から削除し、削除した field 番号を `reserved 1, 2;` 化

### ドキュメント

- `docs/architecture.md` / `docs/workspace.md` を state ディレクトリ分離・worktree キャッシュ・dead field 削除に合わせて更新

## 今回含めない点

### 別 PR で対応

- `~/.config/gozd/app-state.json`（旧ロケーションの実機データ）は稼働中の stable が読み書きしており、git 管理外のため本 PR の対象外。新ロケーション新設のみ行い、旧ファイルへの移行コードはアプリに入れない（後方互換を作らない方針）。新ビルドのリリース後に旧ファイルは自然に未使用になる

## 確認事項

- [ ] 起動直後に worktree カードと task 行が一緒に並び、git status バッジだけ後追いで付く（カード高さは不変）こと
- [ ] worktree 一覧が外部で変化した場合、初回 fetch 後に正しく reconcile されること
- [ ] 新規 / キャッシュ無しの repo は従来どおり fetch 後に worktree が出ること
- [ ] repo を window から削除→再追加したとき、起動時に task 行が即出る（git 往復ぶん遅延しない）こと
