### PR TITLE
feat(preview): worktree 外の絶対パス画像 / SVG を preview で開けるようにする

### DIFF
--- a/apps/native/Sources/Gozd/FileServerSchemeHandler.swift
+++ b/apps/native/Sources/Gozd/FileServerSchemeHandler.swift
@@ -13,12 +13,15 @@ import WebKit
 // 経路:
 //   - `/fs` : 作業ツリーの実ファイル（`FSOps.readFileBytes`、`resolveSafe` で path traversal 防止）
 //   - `/git`: `git show HEAD:<path>` の出力（`GitOps.showFile`）
+//   - `/abs`: worktree 外の絶対パス（`FSOps.readFileBytesAbsolute`、dir 制約なし）。terminal link 等で
+//             worktree 外を開いた画像 / SVG 用。テキスト preview の `readFileAbsolute` RPC と同じ
+//             「dir 外参照を許す」契約を `<img>` 経路に揃えるためのもの
 //
 // dir は **絶対パスをクエリで運ぶ**。worktree dir 集合を native 側にミラーすると watch race の
 // 温床になるため、handler は呼び出し側責任契約 (= renderer の `<img>` 経路が組み立てる dir) を
 // 採用する。`/fs` 側は `FSOps.resolveSafe` が dir 配下に閉じることを保証するため、外部から
 // 任意 path を渡されても dir 配下のみが配信される。`/git` 側は dir が git repo でなければ
-// `runGit` が失敗する。
+// `runGit` が失敗する。`/abs` は dir を取らず path 単独（絶対パス）で受ける。
 //
 // MIME は path の拡張子から `UTType` で sniff する。判定不能は `application/octet-stream` で
 // 出すと WebKit が broken-image にしてくれる (silent drop 防止の観点で response は必ず返す)。
@@ -32,6 +35,10 @@ import WebKit
 //     `GitValidate.swift` の「新規 op を生やす時の checklist」契約に整合させる
 //   - `/fs` 経路は `FSOps.readFileBytes` 内の `resolveSafe` が dir 配下に閉じる traversal guard
 //     を担い、追加で `validateRelPath` を safety net として呼ぶ
+//   - `/abs` 経路は意図的に containment を持たない (worktree 外参照が目的)。テキストの
+//     `readFileAbsolute` RPC と同じく任意の絶対パスを読むが、CORS 規律 (Allow-Origin を返さない)
+//     により `<img>` 表示のみ可能で `fetch()` / canvas での bytes 回収は構造的に塞がれる。
+//     git に渡さないため option 注入 guard (`validateRelPath`) は適用しない (絶対パスを reject するため)
 
 struct FileServerSchemeHandler: URLSchemeHandler {
   func reply(for request: URLRequest) -> AsyncThrowingStream<URLSchemeTaskResult, any Error> {
@@ -42,11 +49,11 @@ struct FileServerSchemeHandler: URLSchemeHandler {
           return
         }
         do {
-          let (dir, relPath) = try parseQuery(url: url)
           let kind = (url.path.hasPrefix("/") ? String(url.path.dropFirst()) : url.path)
-          let data = try await fetchBytes(kind: kind, dir: dir, relPath: relPath)
+          let path = try parsePath(url: url)
+          let data = try await fetchBytes(kind: kind, url: url, path: path)
           let mime =
-            UTType(filenameExtension: (relPath as NSString).pathExtension)?.preferredMIMEType
+            UTType(filenameExtension: (path as NSString).pathExtension)?.preferredMIMEType
             ?? "application/octet-stream"
           let resp = HTTPURLResponse(
             url: url,
@@ -72,29 +79,46 @@ struct FileServerSchemeHandler: URLSchemeHandler {
 
   // MARK: - private
 
-  private func parseQuery(url: URL) throws -> (dir: String, relPath: String) {
-    guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-      throw FileServerError.invalidURL
-    }
-    let items = components.queryItems ?? []
-    let dir = items.first(where: { $0.name == "dir" })?.value ?? ""
-    let path = items.first(where: { $0.name == "path" })?.value ?? ""
-    if dir.isEmpty || path.isEmpty {
+  /// 全 kind 共通の `path` クエリ。`/fs` `/git` では worktree 相対パス、`/abs` では絶対パス。
+  private func parsePath(url: URL) throws -> String {
+    let path = queryValue(url: url, name: "path") ?? ""
+    if path.isEmpty {
       throw FileServerError.missingQuery
     }
-    return (dir, path)
+    return path
   }
 
-  private func fetchBytes(kind: String, dir: String, relPath: String) async throws -> Data {
-    // safety net: option 注入 / NUL / 改行 / .. traversal を入口で reject する。
-    // `/fs` は FSOps.resolveSafe が traversal を直接 reject するが、option 注入経路 (`-` 始まり) は
-    // `/fs` でも実害は無いものの、checklist 契約として両経路で同じ guard を通す。
-    try validateRelPath(relPath)
+  /// `/fs` `/git` 専用の `dir` クエリ（絶対パス）。`/abs` は dir を取らない。
+  private func parseDir(url: URL) throws -> String {
+    let dir = queryValue(url: url, name: "dir") ?? ""
+    if dir.isEmpty {
+      throw FileServerError.missingQuery
+    }
+    return dir
+  }
+
+  private func queryValue(url: URL, name: String) -> String? {
+    guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+      return nil
+    }
+    return components.queryItems?.first(where: { $0.name == name })?.value
+  }
+
+  private func fetchBytes(kind: String, url: URL, path: String) async throws -> Data {
     switch kind {
     case "fs":
-      return try FSOps.readFileBytes(dir: dir, path: relPath)
+      let dir = try parseDir(url: url)
+      // safety net: option 注入 / NUL / 改行 / .. traversal を入口で reject する。
+      // FSOps.resolveSafe が traversal を直接 reject するが、checklist 契約として guard を通す。
+      try validateRelPath(path)
+      return try FSOps.readFileBytes(dir: dir, path: path)
     case "git":
-      return try await GitOps.showFile(dir: dir, relPath: relPath)
+      let dir = try parseDir(url: url)
+      try validateRelPath(path)
+      return try await GitOps.showFile(dir: dir, relPath: path)
+    case "abs":
+      // 絶対パスを dir 制約なしで読む。git に渡さないため validateRelPath (絶対パスを reject) は通さない。
+      return try FSOps.readFileBytesAbsolute(absolutePath: path)
     default:
       throw FileServerError.unknownKind(kind)
     }
@@ -110,7 +134,7 @@ enum FileServerError: Error, CustomStringConvertible {
     switch self {
     case .invalidURL: return "invalid URL components"
     case .missingQuery: return "missing dir or path query parameter"
-    case .unknownKind(let kind): return "unknown kind: \(kind) (expected /fs or /git)"
+    case .unknownKind(let kind): return "unknown kind: \(kind) (expected /fs, /git or /abs)"
     }
   }
 }

--- a/apps/native/Sources/Gozd/FileServerSchemeHandler.swift
+++ b/apps/native/Sources/Gozd/FileServerSchemeHandler.swift
@@ -83,7 +83,7 @@ struct FileServerSchemeHandler: URLSchemeHandler {
   private func parsePath(url: URL) throws -> String {
     let path = queryValue(url: url, name: "path") ?? ""
     if path.isEmpty {
-      throw FileServerError.missingQuery
+      throw FileServerError.missingQuery("path")
     }
     return path
   }
@@ -92,7 +92,7 @@ struct FileServerSchemeHandler: URLSchemeHandler {
   private func parseDir(url: URL) throws -> String {
     let dir = queryValue(url: url, name: "dir") ?? ""
     if dir.isEmpty {
-      throw FileServerError.missingQuery
+      throw FileServerError.missingQuery("dir")
     }
     return dir
   }
@@ -126,14 +126,12 @@ struct FileServerSchemeHandler: URLSchemeHandler {
 }
 
 enum FileServerError: Error, CustomStringConvertible {
-  case invalidURL
-  case missingQuery
+  case missingQuery(String)
   case unknownKind(String)
 
   var description: String {
     switch self {
-    case .invalidURL: return "invalid URL components"
-    case .missingQuery: return "missing dir or path query parameter"
+    case .missingQuery(let name): return "missing required query parameter: \(name)"
     case .unknownKind(let kind): return "unknown kind: \(kind) (expected /fs, /git or /abs)"
     }
   }

--- a/apps/native/Sources/GozdCore/Fs/FSOps.swift
+++ b/apps/native/Sources/GozdCore/Fs/FSOps.swift
@@ -50,7 +50,9 @@ public enum FSOps {
   }
 
   /// 絶対パスで raw bytes を読み取る（dir 制約なし）。preview の worktree 外画像 / SVG 用。
-  /// テキスト経路の `readFileAbsolute` と同じ「dir 外参照を許す」契約を bytes 版で持つ。
+  /// テキスト経路の `readFileAbsolute` と揃えているのは「dir 外参照を許す」参照範囲の契約のみ。
+  /// 戻り方は別で、不在 / ディレクトリは throw し handler が 500 → `<img>` error に倒す
+  /// （notFound / directory の正常応答への畳み込みはテキスト経路 `readFileAt` が担う）。
   public static func readFileBytesAbsolute(absolutePath: String) throws -> Data {
     return try Data(contentsOf: URL(fileURLWithPath: absolutePath))
   }

--- a/apps/native/Sources/GozdCore/Fs/FSOps.swift
+++ b/apps/native/Sources/GozdCore/Fs/FSOps.swift
@@ -49,6 +49,12 @@ public enum FSOps {
     return try Data(contentsOf: URL(fileURLWithPath: target))
   }
 
+  /// 絶対パスで raw bytes を読み取る（dir 制約なし）。preview の worktree 外画像 / SVG 用。
+  /// テキスト経路の `readFileAbsolute` と同じ「dir 外参照を許す」契約を bytes 版で持つ。
+  public static func readFileBytesAbsolute(absolutePath: String) throws -> Data {
+    return try Data(contentsOf: URL(fileURLWithPath: absolutePath))
+  }
+
   public static func writeFile(dir: String, path: String, data: Data) throws {
     let target = try resolveSafe(dir: dir, path: path)
     let parentDir = (target as NSString).deletingLastPathComponent

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -160,9 +160,6 @@ const fileType = computed<FileType>(() => {
   return detectFileType(path);
 });
 
-/** 選択中パスが worktree 外の絶対パスか（terminal link から worktree 外を開いた場合） */
-const isExternalPath = computed(() => selection.value?.kind === "absolute");
-
 /** 画像プレビュー表示中か（diff 不可のため モード制限に使用） */
 const isImagePreview = computed(() => {
   const ft = fileType.value;
@@ -735,6 +732,18 @@ function buildFileServerUrl(
 }
 
 /**
+ * worktree 外の絶対パス画像 / SVG 用の `gozd-file://localhost/abs?path=<absPath>&v=<version>` を構築。
+ * `/abs` は dir 制約を持たず、テキスト preview の `fsReadFileAbsolute` と同じ「worktree 外参照」
+ * 契約を `<img>` 経路に揃える。git 履歴を持たないため Original タブ (gitOriginal) は無い。
+ */
+function buildAbsFileServerUrl(absPath: string, version: number): string {
+  const url = new URL("abs", FILE_SERVER_BASE_URL);
+  url.searchParams.set("path", absPath);
+  url.searchParams.set("v", String(version));
+  return url.href;
+}
+
+/**
  * commit mode (single 単体 or 範囲) かを集約判定。
  * `orderedRange` の null 経路の分岐と、uncommitted 専用データ (`renameOldPaths`) の適用 gate に使う。
  */
@@ -747,8 +756,13 @@ const imageUrl = computed(() => {
   if (!previewEnabled.value) return undefined;
   const ft = fileType.value;
   if (ft !== "image" && ft !== "svg") return undefined;
-  // 絶対パス（worktree 外）は file server 経路で扱えない。画像/SVG は
-  // fsReadFileAbsolute 経由の binary 表示にフォールバックする。
+  const sel = selection.value;
+  if (sel === undefined) return undefined;
+  // 絶対パス（worktree 外）は dir 制約のない `/abs` 経路で配信する。git 履歴を持たないため
+  // Original タブは無く、常に working tree の実ファイルを指す。
+  if (sel.kind === "absolute") {
+    return buildAbsFileServerUrl(sel.absPath, fetchVersionRef.value);
+  }
   const relPath = selectedRelPath.value;
   const dir = worktreeStore.dir;
   if (relPath === undefined || dir === undefined) return undefined;
@@ -766,11 +780,6 @@ const imageUrl = computed(() => {
 /** preview チェックボックスを表示するか（diff モードでは非表示） */
 const showPreviewCheckbox = computed(() => {
   if (activeMode.value === "diff") return false;
-  // 絶対パス（worktree 外）の image / svg は file server 経由で読めないため Preview トグルを出さない。
-  // markdown はテキスト経路で読めるためトグル対象を維持する。
-  if (isExternalPath.value && (fileType.value === "image" || fileType.value === "svg")) {
-    return false;
-  }
   return hasRenderedView(fileType.value);
 });
 
@@ -1051,20 +1060,12 @@ watch(
           @line-number-click="onDiffLineClick"
         />
 
-        <!-- 画像プレビュー（バイナリ画像 + SVG preview モード） -->
+        <!-- 画像プレビュー（バイナリ画像 + SVG preview モード）。worktree 外の絶対パスも /abs 経路で配信 -->
         <ImagePreview
           v-else-if="imageUrl"
           :src="imageUrl"
           @error="error = 'Failed to load image'"
         />
-
-        <!-- worktree 外の絶対パス image / svg は file server 経由で読めないため未対応を明示する -->
-        <div
-          v-else-if="(fileType === 'image' || fileType === 'svg') && isExternalPath"
-          class="p-4 text-sm text-foreground-low"
-        >
-          Image preview is not available for paths outside the worktree
-        </div>
 
         <!-- バイナリ（画像以外） -->
         <div v-else-if="displayIsBinary" class="p-4 text-sm text-foreground-low">

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,16 +161,17 @@ renderer の origin は dev (`http://localhost:$GOZD_DEV_VITE_PORT`) / build (`g
 採用している防御規律:
 
 - **`gozd-rpc://`**: request の `Origin` が allowlist (`gozd-app://localhost` + dev 時のみ `http://localhost:$GOZD_DEV_VITE_PORT`) に含まれるときのみ `Access-Control-Allow-Origin: <origin>` を echo back + `Vary: Origin` を併送する。それ以外 (空文字 / 攻撃 origin) はヘッダを返さない → WebKit が CORS reject。renderer 内 XSS が `fetch("gozd-rpc://localhost/fs/readFileAbsolute", ...)` で機密ファイル bytes を回収する経路を構造的に塞ぐ
-- **`gozd-file://`**: `Allow-Origin` ヘッダを一切返さない方針。`<img>` は passive content として CORS check 対象外で表示可能、一方 `fetch()` / `canvas.getImageData()` は CORS reject される。「画像は見える、bytes は機械的に取れない」を両立する規律
+- **`gozd-file://`**: `Allow-Origin` ヘッダを一切返さない方針。`<img>` は passive content として CORS check 対象外で表示可能、一方 `fetch()` / `canvas.getImageData()` は CORS reject される。「画像は見える、bytes は機械的に取れない」を両立する規律。`/abs` 経路は worktree 外の任意絶対パスを読むが、この規律により `<img>` 表示のみ可能で bytes の機械的回収は塞がれる
 
 両方とも `Allow-Origin: *` (全 origin 許可) は禁止。`*` は WebKit に「許可」を伝える正当なヘッダだが、XSS 経路で任意 origin からの bytes 回収を構造的に許してしまう。
 
 ### gozd-file:// URLSchemeHandler（preview の `<img>` 配信）
 
-preview ペインの image / SVG 表示専用。`<img src="gozd-file://localhost/{fs|git}?dir=<absDir>&path=<relPath>&v=<n>">` の URL を `FileServerSchemeHandler`（`apps/native/Sources/Gozd/FileServerSchemeHandler.swift`）が raw bytes で返す。
+preview ペインの image / SVG 表示専用。`<img src="gozd-file://localhost/{fs|git|abs}?...">` の URL を `FileServerSchemeHandler`（`apps/native/Sources/Gozd/FileServerSchemeHandler.swift`）が raw bytes で返す。`/fs` `/git` は `dir` + `path`（worktree 相対）、`/abs` は `path`（絶対パス）単独で受ける。
 
-- `/fs` : `FSOps.readFileBytes`（`resolveSafe` で path traversal 防止）
+- `/fs` : `FSOps.readFileBytes`（`resolveSafe` で dir 配下に path traversal 防止）
 - `/git`: `GitOps.showFile`（= `git show HEAD:<path>`）
+- `/abs`: `FSOps.readFileBytesAbsolute`（dir 制約なし）。worktree 外の画像 / SVG 用。テキスト preview の `fsReadFileAbsolute` RPC と同じ「dir 外参照を許す」契約を `<img>` 経路に揃える。git に渡さないため `validateRelPath`（絶対パスを reject）は通さず、CORS 規律で bytes 回収を塞ぐことを防御境界とする
 
 テキスト系のファイル読みは従来通り `gozd-rpc://` 経由で `FileReadResult.content: string` を使う。proto3 `string` がバイナリを保持できない問題は画像 / SVG 経路だけ別 scheme に分けることで回避する（proto 全体への破壊変更を避ける判断）。詳細は [preview.md](preview.md) を参照。
 

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -126,9 +126,10 @@ git 変更ファイルには Original / Diff / Current の3タブを表示する
 - 画像 / SVG: WKWebView が `file://` をブロックするため、native の `gozd-file://` URLSchemeHandler 経由で raw bytes を配信
   - `gozd-file://localhost/fs?dir=<absDir>&path=<relPath>&v=<n>` — 作業ツリーの実ファイル (`FSOps.readFileBytes`、`resolveSafe` で path traversal 防止)
   - `gozd-file://localhost/git?dir=<absDir>&path=<relPath>&v=<n>` — `git show HEAD:<path>` の出力 (Original タブ)
+  - `gozd-file://localhost/abs?path=<absPath>&v=<n>` — worktree 外の絶対パス (`FSOps.readFileBytesAbsolute`、dir 制約なし)。terminal link 等で worktree 外を開いた画像 / SVG 用。テキスト preview の `fsReadFileAbsolute` と同じ「worktree 外参照を許す」契約を `<img>` 経路に揃えたもの。git 履歴を持たないため Original タブ (`/git`) は無い
   - `?v=<n>` パラメータは `fsChange` 等の再 fetch トリガーで同一 URL を再読み込みさせるためのキャッシュバスト
   - proto を bytes 化せずに `<img>` 直配信に倒した理由: テキスト系は従来通り `gozd-rpc://` + UTF-8 string で扱い、画像 / SVG だけ別 scheme に分ける方が proto 全体への破壊変更を避けられる
-- 絶対パスの場合は git 操作（`gitShowFile`）を呼ばない
+- worktree 外の絶対パスは git 操作（`gitShowFile`）を呼ばず、画像 / SVG は `/abs` 経路で配信する
 - rename (move) されたファイルの Original / Diff: `gitStatuses` のキーは新パスのみ持つため、status と同一 snapshot で届く `renameOldPaths`（新パス → 旧パス、`useGitStatusStore` が SSOT）で HEAD 側のパスを解決してから `gitShowFile` / `gozd-file://localhost/git` を引く。旧パス解決を欠くと HEAD 側が notFound になり「全行追加」の diff に倒れる。uncommitted モードの HEAD 側 blame（`rev === "HEAD"`）も同じ map で旧パスに揃える
 - バイナリ判定: NUL バイト（`0x00`）の有無で判定（git と同じ方式）
 - 最大サイズ: 1MB を超えるファイルはバイナリ扱い


### PR DESCRIPTION
## 概要

terminal link 等から worktree 外の絶対パスを開いたとき、画像 / SVG を preview で表示できなかった制限を撤廃する。`gozd-file://` に dir 制約なしの `/abs` 経路を追加し、テキスト preview と同じ「worktree 外参照を許す」契約を `<img>` 経路に対称化した。

## 背景

preview の画像 / SVG は `gozd-file://localhost/fs?dir=<absDir>&path=<relPath>` で配信され、native の `FSOps.readFileBytes` → `resolveSafe` が **dir 配下に containment** していた。これが worktree 外の絶対パスを構造的に弾いていた。

一方テキスト preview は `FSOps.readFileAbsolute`（dir 制約なし）で worktree 外も読めており、画像だけが開けないという非対称が生じていた。

`PreviewPane.vue` の `imageUrl` には「絶対パスは fsReadFileAbsolute 経由の binary 表示にフォールバックする」とコメントされていたが、**そのフォールバックは未実装**で、代わりに "Image preview is not available for paths outside the worktree" という諦めメッセージを出す専用分岐があった。本 PR はこの非対称を解消する。

## 変更内容

### native（file server）

- `FSOps.readFileBytesAbsolute(absolutePath:)` を追加（dir 制約なしの bytes 読み）
- `FileServerSchemeHandler` に `/abs?path=<absPath>` kind を追加。`/fs`・`/git` は `dir` + `path`（worktree 相対）、`/abs` は `path`（絶対パス）単独で受けるよう解析を分離
- `validateRelPath` は `/abs` では通さない（絶対パスを reject するため、かつ git に渡さないため不要）

### renderer（preview）

- `buildAbsFileServerUrl()` を追加、`imageUrl` を `selection.kind === "absolute"` のとき `/abs` URL を返すよう対応
- 諦めメッセージの分岐を削除
- `showPreviewCheckbox` の外部パス除外を撤廃（Preview トグルを worktree 外でも表示）
- 未使用化した `isExternalPath` computed を削除

### docs

- `docs/preview.md` / `docs/architecture.md` の file server URL 一覧に `/abs` を追記

## セキュリティ

`/abs` は dir containment を持たないが、`gozd-file://` は `Access-Control-Allow-Origin` を一切返さない既存規律により、`<img>` 表示（passive content）のみ可能で `fetch()` / `canvas.getImageData()` での bytes 回収は CORS で構造的に塞がれる。テキストの `fsReadFileAbsolute` RPC が既に dir 制約なしで任意絶対パスを読める capability を持っており、それと対称な拡張に留めている。

## 確認事項

- [ ] worktree 外の絶対パス画像 / SVG が preview で表示される（dev で確認済み）
- [ ] worktree 内の画像 / SVG が従来通り `/fs`・`/git` で表示される
- [ ] `<img>` は表示できるが `fetch("gozd-file://localhost/abs?...")` は CORS reject される
