### PR TITLE
fix(fswatch): ref 検知と working-tree status を経路分離し branch label の遅延を解消

### DIFF
--- a/apps/native/Sources/GozdCore/Fs/FSWatchRegistry.swift
+++ b/apps/native/Sources/GozdCore/Fs/FSWatchRegistry.swift
@@ -50,8 +50,20 @@ import Foundation
 //    そこで `git rev-parse --git-dir --git-common-dir` で 2 つの git dir を解決し、
 //    FSWatcher の paths に追加する。通常 clone では両者が一致するので dedupe する。
 //
-// 3. **debounce**。FSEvents は数十 ms 以内に同一バッチを連続 dispatch する。
-//    1 バッチを 1 つの push にまとめるため、Task の実行内でフラグ管理する。
+// 3. **event class による経路分離**（issue #809）。`git switch` は性質の異なる 2 種の event を
+//    生む: working tree のファイル書き換え（大量・差分依存・全体 snapshot で十分・低優先）と、
+//    ref store（`.git/HEAD` / 共有 `reftable/`）の書き換え（1 個・確定的・branch label を即駆動・
+//    高優先）。両者を 1 本の直列ループで FIFO 処理し各 working-tree バッチで full `git status`
+//    （数十 ms）を await すると、checkout 終盤の HEAD バッチがこの backlog の後ろに並び、branch
+//    検知が working-tree 書き換え量に従属して数秒遅れる。これを防ぐため処理を 2 経路に分ける:
+//    - **直列イベントループ**は `classify` + `fsChange` + ref 系 dispatch（`refDigest` 経由の
+//      `branchChange` / `remoteRefsChange` / head 由来 `worktreeChange`）のみを担う。ref 系は
+//      `refDigest` が安価（≒ 0 秒）なので working-tree status を待たず即処理され、branch label の
+//      latency が working tree 書き換え量から切り離される。
+//    - **working-tree 由来の `gitStatusFull`** は直列ループから外し、dir ごとの trailing-debounce
+//      タスク（`scheduleStatusRefresh`）に集約する。checkout flood の N バッチ → status 実行は
+//      最新 1 回に畳む（誤り 1: status の consumer は全員が working tree 全体 snapshot を読み、
+//      個別ファイル event を誰も使わないため、N 回取り直す必要が無い）。
 //
 // 4. **push の重複は許容**。renderer 側は冪等な再 fetch（onMessage の handler）
 //    で受け止めるので、`fsChange` と `gitStatusChange` を両方出しても問題ない。
@@ -158,9 +170,28 @@ public actor FSWatchRegistry {
   /// `fsWatchReady` 経由で renderer が再 fetch して baseline を張り直すため、最初の status を
   /// 無条件 push して native の cache と renderer を再同期させる。
   private var lastPushedStatusByDir: [String: GitOps.StatusFull] = [:]
+  /// dir ごとの working-tree status trailing-debounce タスク。新しい working-tree event の
+  /// 到着で先行タスクをキャンセルし、最新リクエストだけを `gitStatusFull` まで進める
+  /// (checkout flood の N バッチを最新 1 回に畳む。issue #809)。entry の lifecycle に揃え、
+  /// `_unwatch` でキャンセル + 破棄する。
+  private var statusDebounceTasks: [String: Task<Void, Never>] = [:]
+  /// dir ごとの status リクエスト世代。`scheduleStatusRefresh` で increment し、
+  /// `gitStatusFull` の await 前後で「自分が最新リクエストか」を再 check する。Task.cancel は
+  /// 協調的かつ非同期で、`gitStatusFull` (Process) のキャンセルは SIGTERM 中断として効くが、
+  /// SIGTERM が届く前に git status が正常完了した in-flight Task は cancel では止まらず結果を
+  /// 持って await 後コードへ進む (`runProcessCollectingOutput` の onCancel でも continuation は
+  /// returning で resume される)。debounce 窓を抜けた後に新リクエストが来た、この「cancel が間に
+  /// 合わなかった」古い in-flight が新しい結果を上書きするのを世代比較で弾く (watch generation とは
+  /// 独立。同一 watch 内での request 順序を守る軸)。
+  private var statusRequestGenerationByDir: [String: UInt64] = [:]
   /// watch ごとに増える世代番号。unwatch 後に積まれていた stale event の dispatch を
   /// 抑止するため、event 配送前後に entries[dir]?.generation と一致するか check する。
   private var nextGeneration: UInt64 = 0
+  /// working-tree status の trailing-debounce 待機 (ms)。FSWatcher の latency=0.1s で複数
+  /// バッチに分割される checkout flood を 1 回の `gitStatusFull` に畳むための窓。branch label は
+  /// ref 系経路 (`worktreeChange`) が即時駆動するため、この遅延は status バッジ系 (changes /
+  /// filer) にのみ効く (issue #809 の CAUTION)。
+  private static let statusDebounceMs = 150
 
   public init(
     onFsChange: @escaping FsChangeHandler,
@@ -311,6 +342,12 @@ public actor FSWatchRegistry {
     // dedup キャッシュも掃除する。再 watch 後の最初の status を無条件 push させ、
     // dir 削除後の別 repo 再配置などで stale 値が次の push を握り潰すのを防ぐ。
     lastPushedStatusByDir.removeValue(forKey: dir)
+    // 進行中の status debounce タスクをキャンセルして破棄する。unwatch を跨いだ stale な
+    // gitStatusFull の発火を止める (タスク内の isActive 再 check でも弾かれるが、無駄な
+    // git fork を残さないためここでキャンセルする)。request 世代も破棄し、再 watch 時は
+    // 世代 0 起点に戻す。
+    statusDebounceTasks.removeValue(forKey: dir)?.cancel()
+    statusRequestGenerationByDir.removeValue(forKey: dir)
     // 同一 resolved dir を指していた他の userDir 逆引きも掃除する。
     // 同一 resolved に複数 userDir（symlink パスと非 symlink パスなど）で watch が
     // 重ねられた状態で、片方しか unwatch されないと逆引きエントリが leak するため。
@@ -480,33 +517,74 @@ public actor FSWatchRegistry {
     }
 
     if result.hasGitStatusChange {
-      // 同一 dir の handleEvents は driving Task の serial for-await で直列化される
-      // (1 dir = 1 Task = 1 ループ、`await handleEvents` の return まで次の events を取らない)。
-      // よって gitStatusFull の await 中に同一 dir の別 batch が割り込み、古い実体を読んだ
-      // batch が後着して新しい push を上書きする reorder は構造的に起きない。actor reentrancy
-      // で割り込めるのは別 dir(別 Task)の処理のみ。再 watch を跨ぐ古い batch は下の
-      // isActive(generation) が弾く。この不変条件が成立するため status 読み取りの後着破棄
-      // guard は不要 (将来 handleEvents を並行起動する設計にしない限り再導入しない)。
-      let status: GitOps.StatusFull
+      // working-tree 由来の status 再取得は直列ループから外し、dir ごとの trailing-debounce
+      // タスクに集約する。直列ループ内で gitStatusFull を await すると、checkout 終盤の HEAD
+      // バッチがこの backlog の後ろに並んで branch 検知が遅延する (issue #809 誤り 2)。ここでは
+      // スケジュールするだけで await せず、ref 系 dispatch (上の worktreeChange / branchChange) が
+      // working tree 書き換え量に従属しないようにする。
+      scheduleStatusRefresh(dir: dir, watchGeneration: generation, originalDir: originalDir)
+    }
+  }
+
+  /// working-tree 由来の `gitStatusFull` を trailing-debounce タスクに集約する。新しい
+  /// working-tree event ごとに先行タスクをキャンセルし request 世代を進めるため、checkout flood
+  /// の N バッチは最新 1 回の status 取得に畳まれる (issue #809)。直列ループからは await せず
+  /// fire-and-forget で呼ぶ。
+  private func scheduleStatusRefresh(dir: String, watchGeneration: UInt64, originalDir: String) {
+    let requestGeneration = (statusRequestGenerationByDir[dir] ?? 0) + 1
+    statusRequestGenerationByDir[dir] = requestGeneration
+    statusDebounceTasks[dir]?.cancel()
+    statusDebounceTasks[dir] = Task { [weak self] in
+      // trailing-debounce: 窓の間に新 event が来れば先行タスクが cancel され、この sleep が
+      // CancellationError で抜ける。最新リクエストだけが窓を生き延びて status を取る。
       do {
-        status = try await GitOps.gitStatusFull(dir: dir)
+        try await Task.sleep(for: .milliseconds(FSWatchRegistry.statusDebounceMs))
       } catch {
-        // 観察可能性のためログを残す。renderer は次の FSEvents バッチで再 fetch するため
-        // 致命的ではないが、繰り返し発生していれば一時障害として診断したい。
-        StderrLog.write(
-          tag: "FSWatchRegistry", "gitStatusFull failed for \(dir): \(error)")
         return
       }
-      // gitStatusFull の await 中に unwatch されている可能性があるため再 check
-      guard isActive(dir: dir, generation: generation) else { return }
-      // 内容が直近 push と同一なら push しない。gitignore 対象（ビルド成果物 /
-      // node_modules 等）の書き込みは作業ツリー event として gitStatusChange を立てるが
-      // git status 出力には現れず StatusFull は不変になる。typecheck / ビルド中の連射を
-      // ここで止める（理由は lastPushedStatusByDir の docstring 参照）。
-      if lastPushedStatusByDir[dir] == status { return }
-      lastPushedStatusByDir[dir] = status
-      onGitStatusChange(originalDir, status)
+      await self?.runStatusRefresh(
+        dir: dir, watchGeneration: watchGeneration,
+        requestGeneration: requestGeneration, originalDir: originalDir)
     }
+  }
+
+  /// debounce 窓を生き延びたリクエストの `gitStatusFull` を実行し、最新であれば push する。
+  /// await 前後で watch 世代 (unwatch / 再 watch) と request 世代 (後続 event による新リクエスト)
+  /// の両方を再 check し、古い in-flight status が新しい結果を上書きするのを防ぐ
+  /// (issue #809 の CAUTION)。
+  private func runStatusRefresh(
+    dir: String, watchGeneration: UInt64, requestGeneration: UInt64, originalDir: String
+  ) async {
+    // await 前: watch 世代 + request 世代がどちらも最新か。
+    guard isActive(dir: dir, generation: watchGeneration) else { return }
+    guard statusRequestGenerationByDir[dir] == requestGeneration else { return }
+    let status: GitOps.StatusFull
+    do {
+      status = try await GitOps.gitStatusFull(dir: dir)
+    } catch {
+      // debounce タスクが後続 event / unwatch でキャンセルされると、in-flight の git status は
+      // SIGTERM で中断され `commandFailed` として throw される (CancellationError ではない)。
+      // これは正常な畳み込みであって障害ではないため silent return し、本物の git 障害だけを
+      // stderr に残す。cancel の粒度を scheduleStatusRefresh の sleep catch と揃え、issue #809 の
+      // 「git status 連打ログ」抑止の検証ノイズにしない。
+      if Task.isCancelled { return }
+      // 観察可能性のためログを残す。renderer は次の FSEvents バッチで再 fetch するため
+      // 致命的ではないが、繰り返し発生していれば一時障害として診断したい。
+      StderrLog.write(tag: "FSWatchRegistry", "gitStatusFull failed for \(dir): \(error)")
+      return
+    }
+    // await 後: unwatch / 再 watch (watch 世代) と、後続 event の新リクエスト (request 世代) を
+    // 両方再 check。cancel が SIGTERM 到達前に正常完了した古い in-flight (statusRequestGenerationByDir
+    // docstring 参照) が新しい結果を上書きしないようここで弾く。
+    guard isActive(dir: dir, generation: watchGeneration) else { return }
+    guard statusRequestGenerationByDir[dir] == requestGeneration else { return }
+    // 内容が直近 push と同一なら push しない。gitignore 対象（ビルド成果物 / node_modules 等）の
+    // 書き込みは作業ツリー event として gitStatusChange を立てるが git status 出力には現れず
+    // StatusFull は不変になる。typecheck / ビルド中の連射をここで止める（理由は
+    // lastPushedStatusByDir の docstring 参照）。
+    if lastPushedStatusByDir[dir] == status { return }
+    lastPushedStatusByDir[dir] = status
+    onGitStatusChange(originalDir, status)
   }
 
   public func isWatching(dir userDir: String) -> Bool {

--- a/apps/native/Sources/GozdCore/Fs/FSWatchRegistry.swift
+++ b/apps/native/Sources/GozdCore/Fs/FSWatchRegistry.swift
@@ -187,24 +187,41 @@ public actor FSWatchRegistry {
   /// watch ごとに増える世代番号。unwatch 後に積まれていた stale event の dispatch を
   /// 抑止するため、event 配送前後に entries[dir]?.generation と一致するか check する。
   private var nextGeneration: UInt64 = 0
-  /// working-tree status の trailing-debounce 待機 (ms)。FSWatcher の latency=0.1s で複数
-  /// バッチに分割される checkout flood を 1 回の `gitStatusFull` に畳むための窓。branch label は
-  /// ref 系経路 (`worktreeChange`) が即時駆動するため、この遅延は status バッジ系 (changes /
-  /// filer) にのみ効く (issue #809 の CAUTION)。
-  private static let statusDebounceMs = 150
+  /// working-tree status の trailing-debounce 待機。FSWatcher の latency=0.1s で複数バッチに
+  /// 分割される checkout flood を 1 回の status 取得に畳むための窓。branch label は ref 系経路
+  /// (`worktreeChange`) が即時駆動するため、この遅延は status バッジ系 (changes / filer) にのみ
+  /// 効く (issue #809 の CAUTION)。
+  ///
+  /// pure trailing-debounce のため、窓幅未満の間隔でファイルが鳴り続ける病的な継続 churn では
+  /// status 発火が窓ごとに先送りされ続ける starvation edge を持つ (旧設計の毎バッチ実行には無い
+  /// トレードオフ)。現実のファイル変更は必ず gap が空くため実害は薄く、ignore 対象の churn は
+  /// 仮に発火しても `lastPushedStatusByDir` の dedup で潰れる。max-wait cap で緩和できるが、それは
+  /// issue #809 が消したい「sustained churn 中の定期 git status」を再導入するため意図的に入れない。
+  /// starvation が実機で観測されたら cap を検討する。
+  /// 注入可能にしているのはテストで debounce 窓を制御するため (production は default の 150ms)。
+  private let statusDebounce: Duration
+  /// working-tree status の取得関数。production は `GitOps.gitStatusFull`。テストでは status の
+  /// 完了タイミングを制御できる fetcher を注入し、gen 二重 check の race (古い in-flight が新しい
+  /// 結果を上書きしないこと) を決定的に検証する seam として使う。
+  private let statusFetcher: @Sendable (_ dir: String) async throws -> GitOps.StatusFull
 
   public init(
     onFsChange: @escaping FsChangeHandler,
     onGitStatusChange: @escaping GitStatusChangeHandler,
     onBranchChange: @escaping BranchChangeHandler,
     onRemoteRefsChange: @escaping RemoteRefsChangeHandler,
-    onWorktreeChange: @escaping WorktreeChangeHandler
+    onWorktreeChange: @escaping WorktreeChangeHandler,
+    statusDebounce: Duration = .milliseconds(150),
+    statusFetcher: @escaping @Sendable (_ dir: String) async throws -> GitOps.StatusFull =
+      GitOps.gitStatusFull
   ) {
     self.onFsChange = onFsChange
     self.onGitStatusChange = onGitStatusChange
     self.onBranchChange = onBranchChange
     self.onRemoteRefsChange = onRemoteRefsChange
     self.onWorktreeChange = onWorktreeChange
+    self.statusDebounce = statusDebounce
+    self.statusFetcher = statusFetcher
   }
 
   /// dir の監視を開始する。同一 resolved dir に対する `watch` 呼び出しは冪等で
@@ -534,11 +551,14 @@ public actor FSWatchRegistry {
     let requestGeneration = (statusRequestGenerationByDir[dir] ?? 0) + 1
     statusRequestGenerationByDir[dir] = requestGeneration
     statusDebounceTasks[dir]?.cancel()
+    // `[weak self]` クロージャからは actor プロパティへ self 経由でしか触れないため、
+    // Sendable な debounce 値を Task 生成前にローカルへ退避してキャプチャする。
+    let debounce = statusDebounce
     statusDebounceTasks[dir] = Task { [weak self] in
       // trailing-debounce: 窓の間に新 event が来れば先行タスクが cancel され、この sleep が
       // CancellationError で抜ける。最新リクエストだけが窓を生き延びて status を取る。
       do {
-        try await Task.sleep(for: .milliseconds(FSWatchRegistry.statusDebounceMs))
+        try await Task.sleep(for: debounce)
       } catch {
         return
       }
@@ -560,7 +580,7 @@ public actor FSWatchRegistry {
     guard statusRequestGenerationByDir[dir] == requestGeneration else { return }
     let status: GitOps.StatusFull
     do {
-      status = try await GitOps.gitStatusFull(dir: dir)
+      status = try await statusFetcher(dir)
     } catch {
       // debounce タスクが後続 event / unwatch でキャンセルされると、in-flight の git status は
       // SIGTERM で中断され `commandFailed` として throw される (CancellationError ではない)。

--- a/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
@@ -674,6 +674,114 @@ struct FSWatchRegistryTests {
     await sleepThreaded(.milliseconds(500))
     #expect(collector.snapshot().isEmpty)
   }
+
+  @Test("await 後の request 世代 re-check が、後続リクエストに抜かれた古い in-flight status の push を弾く")
+  func staleInFlightStatusDroppedByRequestGeneration() async throws {
+    // 本 PR (issue #809) の正しさの要である「gitStatusFull の await 後 request 世代 re-check」を
+    // 決定的に踏む。実 git では status の完了タイミングを制御できないため、status fetcher を注入し
+    // 完了を gate する。SIGTERM 到達前に正常完了した古い in-flight (cancel では止まらない) が
+    // 新しい結果を上書きしないことを固定する。fetcher を注入する以上、debounce 窓は短く (20ms) して
+    // event ごとに別 fetch を踏ませる (production の 150ms 畳み込みとは別の検証軸)。
+    let repo = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: repo) }
+    try await initGitRepo(at: repo)
+
+    // call#0 = statusA (in-flight に保持して後で stale 化)、call#1 = statusB (最新として push)。
+    // statuses のキーで A/B を識別する。
+    let statusA = GitOps.StatusFull(
+      statuses: ["a.txt": "??"], renameOldPaths: [:], head: "", branchHead: "main",
+      hasUpstream: false, ahead: 0, behind: 0, latestMtime: 0)
+    let statusB = GitOps.StatusFull(
+      statuses: ["b.txt": "??"], renameOldPaths: [:], head: "", branchHead: "main",
+      hasUpstream: false, ahead: 0, behind: 0, latestMtime: 0)
+    let fetcher = GatedStatusFetcher(statuses: [statusA, statusB])
+
+    let collector = EventNameCollector()
+    let registry = FSWatchRegistry(
+      onFsChange: { _, _ in },
+      onGitStatusChange: { _, status in
+        collector.append("status:\(status.statuses.keys.sorted().joined(separator: ","))")
+      },
+      onBranchChange: { _ in },
+      onRemoteRefsChange: { _ in },
+      onWorktreeChange: { _ in },
+      statusDebounce: .milliseconds(20),
+      statusFetcher: { _ in await fetcher.fetch() }
+    )
+
+    try await registry.watch(dir: repo.path)
+    await sleepThreaded(.milliseconds(300))
+
+    // 1 回目の working-tree 変更 → debounce 後 fetcher#0 が呼ばれ statusA を抱えてブロック (in-flight)。
+    // fetcher.callsMade は NSLock 同期読みなので waitUntil の同期 predicate で踏める (FSEvents
+    // propagation 待ち — WaitUntil.swift の用途規律「OS event 到達待ち」に該当)。
+    try "a".write(to: repo.appendingPathComponent("a.txt"), atomically: false, encoding: .utf8)
+    await waitUntil(
+      timeout: .seconds(2), description: "fetcher call #0 in-flight",
+      lastObserved: { "calls=\(fetcher.callsMade)" }
+    ) { fetcher.callsMade >= 1 }
+
+    // 2 回目の working-tree 変更 → request 世代が進む。fetcher#1 (statusB) は先に release しておき、
+    // 最新リクエストとして push される。
+    fetcher.release(call: 1)
+    try "b".write(to: repo.appendingPathComponent("b.txt"), atomically: false, encoding: .utf8)
+    await waitForEvent(collector, matching: { $0 == "status:b.txt" })
+
+    // in-flight だった fetcher#0 を今 release する。古い request 世代 (call#0) なので await 後の
+    // re-check で弾かれ、statusA は push されない。settle 窓で不在を確定する。
+    fetcher.release(call: 0)
+    await sleepThreaded(.milliseconds(300))
+
+    let events = collector.snapshot()
+    #expect(events.contains("status:b.txt"))
+    #expect(!events.contains("status:a.txt"))
+  }
+
+  @Test("await 後の watch 世代 re-check が、unwatch を跨いだ古い in-flight status の push を弾く")
+  func staleInFlightStatusDroppedByWatchGenerationOnUnwatch() async throws {
+    // request 世代版と対の regression guard。in-flight の gitStatusFull の await 中に unwatch される
+    // ケースで、entry 消滅 (watch 世代の無効化) を await 後の isActive re-check が捕まえ、stale な
+    // status を push しないことを固定する。
+    let repo = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: repo) }
+    try await initGitRepo(at: repo)
+
+    let statusA = GitOps.StatusFull(
+      statuses: ["a.txt": "??"], renameOldPaths: [:], head: "", branchHead: "main",
+      hasUpstream: false, ahead: 0, behind: 0, latestMtime: 0)
+    let fetcher = GatedStatusFetcher(statuses: [statusA])
+
+    let collector = EventNameCollector()
+    let registry = FSWatchRegistry(
+      onFsChange: { _, _ in },
+      onGitStatusChange: { _, _ in collector.append("gitStatusChange") },
+      onBranchChange: { _ in },
+      onRemoteRefsChange: { _ in },
+      onWorktreeChange: { _ in },
+      statusDebounce: .milliseconds(20),
+      statusFetcher: { _ in await fetcher.fetch() }
+    )
+
+    try await registry.watch(dir: repo.path)
+    await sleepThreaded(.milliseconds(300))
+
+    // working-tree 変更 → debounce 後 fetcher#0 が statusA を抱えてブロック (in-flight)。
+    try "a".write(to: repo.appendingPathComponent("a.txt"), atomically: false, encoding: .utf8)
+    await waitUntil(
+      timeout: .seconds(2), description: "fetcher call #0 in-flight",
+      lastObserved: { "calls=\(fetcher.callsMade)" }
+    ) { fetcher.callsMade >= 1 }
+
+    // in-flight のまま unwatch。entry が消え watch 世代が無効化される。
+    await registry.unwatch(dir: repo.path)
+
+    // in-flight だった fetcher#0 を release。unwatch 済みなので await 後の isActive(watch 世代)
+    // re-check で弾かれ、statusA は push されない。
+    fetcher.release(call: 0)
+    await sleepThreaded(.milliseconds(300))
+
+    #expect(collector.snapshot().isEmpty)
+  }
 }
 
 // MARK: - classify pure unit tests
@@ -1119,6 +1227,68 @@ private final class EventCounter: @unchecked Sendable {
     defer { lock.unlock() }
     return count
   }
+}
+
+/// FSWatchRegistry に注入する status fetcher の test double。呼ばれた順に index を振り、
+/// `release(call:)` されるまでブロックして `statuses[index]` を返す。`gitStatusFull` の完了
+/// タイミングを test 側で制御し、await 後の世代 re-check (古い in-flight が新しい結果を上書き
+/// しないこと) を決定的に踏むための seam。cancel には応答しない (SIGTERM 到達前に正常完了する
+/// in-flight を模す)。`callsMade` は NSLock 同期読みで `waitUntil` の同期 predicate から踏める。
+private final class GatedStatusFetcher: @unchecked Sendable {
+  private let lock = NSLock()
+  private let statuses: [GitOps.StatusFull]
+  private var callCount = 0
+  private var gates: [Int: CheckedContinuation<Void, Never>] = [:]
+  private var released: Set<Int> = []
+
+  init(statuses: [GitOps.StatusFull]) {
+    self.statuses = statuses
+  }
+
+  func fetch() async -> GitOps.StatusFull {
+    let index: Int = {
+      lock.lock()
+      defer { lock.unlock() }
+      let i = callCount
+      callCount += 1
+      return i
+    }()
+    await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+      lock.lock()
+      // continuation 登録前に release が来ていれば即 resume (lock 区間での race を閉じる)。
+      if released.contains(index) {
+        lock.unlock()
+        cont.resume()
+      } else {
+        gates[index] = cont
+        lock.unlock()
+      }
+    }
+    return statusAt(index)
+  }
+
+  func release(call index: Int) {
+    lock.lock()
+    released.insert(index)
+    let cont = gates.removeValue(forKey: index)
+    lock.unlock()
+    cont?.resume()
+  }
+
+  var callsMade: Int {
+    lock.lock()
+    defer { lock.unlock() }
+    return callCount
+  }
+
+  private func statusAt(_ index: Int) -> GitOps.StatusFull {
+    if index < statuses.count { return statuses[index] }
+    return statuses.last ?? GatedStatusFetcher.emptyStatus
+  }
+
+  static let emptyStatus = GitOps.StatusFull(
+    statuses: [:], renameOldPaths: [:], head: "", branchHead: "",
+    hasUpstream: false, ahead: 0, behind: 0, latestMtime: 0)
 }
 
 private final class EventNameCollector: @unchecked Sendable {

--- a/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
+++ b/apps/native/Tests/GozdCoreTests/FSWatchRegistryTests.swift
@@ -156,17 +156,20 @@ struct FSWatchRegistryTests {
     await waitForEvent(collector, matching: { $0 == "git:clean" })
 
     // 2 回目: ignore 対象なので status は clean のまま = 内容一致で dedup され push されない。
-    // b.log の batch が dispatch されたことを relDir == "dir-b" の fsChange で待ち、次の c.txt を
-    // b.log とは別 batch に確実に分離する（同一 batch に coalesce すると b.log の clean status が
-    // 単独で評価されず dedup を検証できない）。
+    // b.log の batch が dispatch されたことを relDir == "dir-b" の fsChange で待つ。さらに
+    // status の trailing-debounce 窓 (statusDebounceMs=150ms) + gitStatusFull の実行時間を超える
+    // settle を挟み、b.log の status 評価 (clean → dedup) を c.txt より前に確実に発火させる
+    // (issue #809 で gitStatusFull は直列 await から debounce タスクへ移行。settle を挟まないと
+    // b.log の debounce タスクが c.txt の schedule にキャンセルされ、同一窓に畳まれて b.log 単独の
+    // dedup を検証できない)。
     try "b".write(
       to: dirB.appendingPathComponent("b.log"), atomically: false, encoding: .utf8)
     await waitForEvent(collector, matching: { $0 == "fs:dir-b" })
+    await sleepThreaded(.milliseconds(400))
 
     // 3 回目: ignore されない c.txt を作る。status が dirty（?? c.txt）に変わるので dedup されず
-    // git:dirty が push される。serial for-await により c.txt の handleEvents は b.log の
-    // handleEvents が gitStatusFull の await 込みで完全に return した後に走る。よって git:dirty
-    // 到達時点で b.log の dedup 判定は確定済みで、settle 無しに観測できる。
+    // git:dirty が push される。b.log の status 評価は上の settle で確定済みのため、git:dirty
+    // 到達時点で b.log の dedup 判定は観測可能。
     try "c".write(
       to: repo.appendingPathComponent("c.txt"), atomically: false, encoding: .utf8)
     await waitForEvent(collector, matching: { $0 == "git:dirty" })

--- a/docs/filer.md
+++ b/docs/filer.md
@@ -28,14 +28,16 @@ flowchart LR
 
 ファイル監視の実体は Swift 側の watch registry（FSEvents をラップ）。renderer は repo store の派生 computed として「開いている全 repo / 全 worktree の dir 集合」を計算し、watch 同期 layer がその集合を観測して差分を `rpcFsWatch` / `rpcFsUnwatch` で発射する。詳細は [architecture.md](architecture.md#fswatch-の対象スコープ)。
 
-| push event        | 発火条件                                                                                                                              | ルートペインの挙動                                                                                                |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `fsChange`        | watch 対象 dir 配下のファイル変化                                                                                                     | active dir 一致時のみ反応。ルート配下の変更はルート再 load、サブディレクトリ配下の変更は event bus 経由で子に通知 |
-| `gitStatusChange` | per-wt の `.git/index` / HEAD、common の `refs/remotes/*` / `packed-refs`、作業ツリー側のファイル変更（`fsChange` と同 burst で発火） | active dir 一致時のみ反応。`gitStatusStore` の再 load + ルート再構築 + event bus で全ツリー子ノードに通知         |
-| `fsWatchReady`    | watch 登録成功直後の再同期シグナル                                                                                                    | サイドバー / GitGraphPane 側で消費（ルートペインは購読しない）                                                    |
+| push event        | 発火条件                                                                                                                                                                 | ルートペインの挙動                                                                                                |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `fsChange`        | watch 対象 dir 配下のファイル変化                                                                                                                                        | active dir 一致時のみ反応。ルート配下の変更はルート再 load、サブディレクトリ配下の変更は event bus 経由で子に通知 |
+| `gitStatusChange` | per-wt の `.git/index` / HEAD、common の `refs/remotes/*` / `packed-refs`、作業ツリー側のファイル変更（working-tree 由来は trailing-debounce 経由で遅延発火。下記 NOTE） | active dir 一致時のみ反応。`gitStatusStore` の再 load + ルート再構築 + event bus で全ツリー子ノードに通知         |
+| `fsWatchReady`    | watch 登録成功直後の再同期シグナル                                                                                                                                       | サイドバー / GitGraphPane 側で消費（ルートペインは購読しない）                                                    |
 
 > [!NOTE]
 > `gitStatusChange` の native 側 debounce は watch registry 内部で行う。`.git/` 配下を Node.js API の `fs.watchFile` で 500ms ポーリングする旧設計は持たない。
+>
+> working-tree 由来の `gitStatusChange`（`git status` 全体 snapshot）は dir ごとの trailing-debounce タスクに集約し、`git switch` 等の checkout flood で出る複数 FSEvents バッチを最新 1 回の `git status` に畳む。ref 系（branch / HEAD / worktree 検知）は debounce を通さず即時 dispatch するため、branch label の反映は working tree の書き換え量に従属しない（[architecture.md](architecture.md#ssot-push-の-dir-filter-規律) / `FSWatchRegistry` 冒頭コメント参照）。
 
 ## 並走 race の防御
 


### PR DESCRIPTION
## 概要

`FSWatchRegistry` のファイル監視処理を event class で 2 経路に分離する。直列イベントループには `classify` + `fsChange` + ref 系 dispatch（`refDigest` 経由の `branchChange` / `remoteRefsChange` / head 由来 `worktreeChange`）のみを残し、working-tree 由来の `gitStatusFull` を dir ごとの trailing-debounce タスクに外出しする。これにより branch label の反映 latency が working tree の書き換え量から切り離され、大 repo でも `git switch` のサイドバー反映が即時になる。

## 背景

ターミナルで `git switch` すると prompt は即座に変わるのに、サイドバーの worktree branch label が反映されるまで 5 秒以上かかる症状があった。worktree が多くワーキングツリーの大きい repo で顕著で、小さい repo では即時に反映される。加えて `git switch` 後しばらく native が `git status` を回し続け CPU / ログが大量に出続けていた。

調査の結果、2 つの根本設計誤りが判明した。

### ref event と working-tree event が同じ直列経路に混載されている（症状の真因）

`git switch` は性質の異なる 2 種の event を生む。working tree のファイル書き換え（大量・差分依存・全体 snapshot で十分・低優先）と、`.git/HEAD`（reftable backend なら共有テーブル）の書き換え（1 個・確定的・branch label を即駆動すべき・高優先）。

`FSWatchRegistry` は dir ごとに 1 本の直列 Task で両者を FIFO 処理し、各 working-tree 変更バッチで full `git status`（数十 ms）を直列に await していた。checkout 終盤に来る `.git/HEAD` バッチがこの backlog の後ろに並ぶため、branch 検知（`refDigest` → `worktreeChange`）が working-tree status の掃けるのを待たされ数秒遅れていた。git において branch 切替は「ref 1 個の確定操作」であり working tree の物理書き換え量とは無関係なのに、現設計は branch 検知の latency を working-tree 書き換え量に従属させていた。これが「大 repo で遅く・小 repo で速い」の正体。

### working-tree 変更ごとに full status を回すのは監視粒度と消費粒度のミスマッチ

`gitStatusFull` の出力（statuses map / branchHead / upstream / latestMtime）の consumer は全員が「working tree 全体の status snapshot」を読み、個別ファイルイベントを誰も使っていない。FSEvents が運ぶ「ファイル X が変わった」という粒度は `classify` で `hasGitStatusChange` という単一 bool に潰され捨てられる。必要なのは「working tree が動いた事実 1 つ → 最新の full status を 1 回取る」だけなのに、N 個の working-tree 変更イベントに対し N 回 full status を取り直していた。

`git/git` v2.54 のソースで grounding 済み: checkout の working tree 書き込み（= FSEvents）はアルファベット順で、branch を大きく跨ぐ切替では大量の FSEvents が出る。`git status` 自体は `GIT_OPTIONAL_LOCKS=0` 設定済みのため index 書き戻しを抑止し自己ループは無く、flood 源は純粋に checkout。`refDigest`（`for-each-ref` + `symbolic-ref`）は `gitStatusFull` と桁違いに安価で、ref 系を分離して即処理できる。

## 変更内容

### ref 系 dispatch と working-tree status の経路分離

- `handleEvents` の `gitStatusFull` 直列 await を撤去し、`scheduleStatusRefresh` の呼び出しに置換。ref 系 dispatch（`refDigest` 経由）は直列ループ内に残す
- working-tree 由来の `gitStatusFull` を dir ごとの trailing-debounce タスク（既定 150ms）に集約。checkout flood の複数 FSEvents バッチを最新 1 回の `git status` に畳む

### 不変条件の維持（直列 await 撤去で崩れる「後着 reorder 防止」の再構築）

- 新しい working-tree event ごとに先行 debounce タスクを `cancel` し、最新リクエストだけが debounce 窓を生き延びて status を取る
- `statusRequestGenerationByDir` を導入し、`gitStatusFull` の await 前後で「自分が最新リクエストか」を再 check。`Task.cancel` は協調的・非同期で、`gitStatusFull` の cancel は SIGTERM 中断として効くが、SIGTERM 到達前に正常完了した in-flight Task は結果を持って await 後コードへ進む（`runProcessCollectingOutput` の onCancel でも continuation は returning で resume される）。この「cancel が間に合わなかった」古い in-flight が新しい結果を上書きするのを世代比較で弾く
- 既存の watch generation guard（`isActive(dir:generation:)`）も await 後に再 check し、unwatch / 再 watch を跨いだ stale 抑止を維持
- `_unwatch` で debounce タスクのキャンセルと request 世代の破棄を行い、entry の lifecycle に揃える

### cancel 由来 SIGTERM ログの抑止

- debounce タスクが後続 event / unwatch でキャンセルされると、in-flight の `git status` は SIGTERM 中断で `commandFailed`（`CancellationError` ではない）を throw する。これは正常な畳み込みであって障害ではないため、`runStatusRefresh` の catch で `Task.isCancelled` を見て silent return し、本物の git 障害だけを stderr に残す。`scheduleStatusRefresh` の sleep catch（cancel silent return）と粒度を揃え、issue が消したい「git status 連打ログ」の検証ノイズにしない

### テスト・ドキュメント

- `FSWatchRegistry` に `statusFetcher` / `statusDebounce` を既定値つきで注入可能にし（production は `GitOps.gitStatusFull` / 150ms）、status の完了タイミングを gate できる fetcher で gen 二重 check の race を決定的にテストする seam を追加。本変更の正しさの要である「await 後の request 世代 / watch 世代 re-check」を 2 ケースで固定（後続リクエストに抜かれた古い in-flight / unwatch を跨いだ古い in-flight が、いずれも push されない）
- dedup テストの「直列 await により b.log の status 評価が c.txt より前に完了する」前提を、debounce 窓を超える settle で b.log の status 評価を先に発火させる前提へ更新
- `docs/filer.md` の `gitStatusChange` 発火条件と NOTE を、working-tree 由来が trailing-debounce で遅延発火し ref 系は即時 dispatch される旨に更新

## 今回含めない点

### 今回は対応しない

- **多バッチ flood の畳み込み / starvation / SIGTERM cancel ログ抑止の自動テスト**は追加しない。FSEvents 自身が latency=0.1s 窓で高速バーストを 1 バッチに畳むため、unit テストで高速に N ファイルを書くと旧設計でも 1 バッチ = 1 status になり旧新を区別できない。多バッチ flood の再現は「100ms 超（別バッチ化）かつ debounce 窓未満」の細い帯で間隔制御する必要があり本質的に flaky。SIGTERM cancel 経路の決定的再現も同様に困難なため、これらは静的読み + 実機確認に委ねる（正しさの要である gen 二重 check は上記 seam テストで決定的にカバー済み）

### 既知のトレードオフ（コードにコメント済み）

- pure trailing-debounce のため、窓幅未満の間隔でファイルが鳴り続ける病的な継続 churn では status 発火が窓ごとに先送りされる starvation edge を持つ（旧設計の毎バッチ実行には無い）。現実のファイル変更は必ず gap が空くため実害は薄く、ignore 対象 churn は dedup で潰れる。max-wait cap で緩和できるが、それは issue が消したい「sustained churn 中の定期 git status」を再導入するため意図的に入れない。実機で starvation 観測時に cap を再検討する

## 確認事項

- [ ] `swift build` 成功、`swift test`（363 tests / 52 suites）全通過
- [ ] **実機確認が必須**（型チェック・テストでは症状の解消を検証できない）。worktree 多数・大 working tree の repo で次を確認: `git switch` の prompt 変化と同時にサイドバーの branch label が変わるか / checkout 中に changes / filer ビューが固まらないか / 切替後に `git status` 連打のログ洪水が止まっているか
