### PR TITLE
fix(claude-status): pending done の効果抑止を claudeFx 正規化ストリームに一元化

### DIFF
--- a/apps/renderer/src/features/arcade/ArcadeLayer.vue
+++ b/apps/renderer/src/features/arcade/ArcadeLayer.vue
@@ -12,9 +12,10 @@
 
 - pointerdown (capture): クリック位置に火花 + ボタン系 target ならクリック音。
   同時に AudioContext を unlock する (autoplay policy 対応)
-- hook push: done → 花火 + ファンファーレ / needs-input → アラート音 + アンバーフラッシュ /
-  running → エンゲージ音 / tool-done → チック音 / session-start → 起動音 /
-  stop-failure → エラー音 + レッドフラッシュ
+- claudeFx (terminal が hook を解釈して再発行する正規化イベント): done → 花火 + ファンファーレ /
+  needs-input → アラート音 + アンバーフラッシュ / running → エンゲージ音 / tool-done → チック音 /
+  session-start → 起動音 / stop-failure → エラー音 + レッドフラッシュ。pending done（裏で作業
+  継続中 = 真の完了ではない）は terminal 側で除去されるため、ここには届かず演出も出ない
 - 通知 store: error の発生 (lastEvent) でエラー音 + レッドフラッシュ
 
 ## パフォーマンス
@@ -33,8 +34,9 @@ import { onMessage } from "../../shared/rpc";
 import { createParticleEngine, type ParticleEngine } from "./particleEngine";
 import { sfx, unlockAudio } from "./sfx";
 
-/** hook push payload のうち arcade が使う部分 (payload 型は feature 定義の規約) */
-interface ArcadeHookPayload {
+/** 正規化済み claudeFx のうち arcade が使う部分。完了扱いしない hook (pending done 等) は
+ *  terminal 側で除去済みなので、arcade は受け取った event に素直に反応すればよい。 */
+interface ArcadeFxPayload {
   event: string;
 }
 
@@ -93,8 +95,8 @@ const HOOK_REACTIONS: Record<string, () => void> = {
   },
 };
 
-const disposeHook = onMessage<ArcadeHookPayload>("hook", (payload) => {
-  HOOK_REACTIONS[payload.event]?.();
+const disposeHook = onMessage<ArcadeFxPayload>("claudeFx", (fx) => {
+  HOOK_REACTIONS[fx.event]?.();
 });
 onUnmounted(disposeHook);
 

--- a/apps/renderer/src/features/arcade/ArcadeLayer.vue
+++ b/apps/renderer/src/features/arcade/ArcadeLayer.vue
@@ -31,14 +31,9 @@ import { useEventListener } from "@vueuse/core";
 import { onMounted, onUnmounted, ref, useTemplateRef, watch } from "vue";
 import { useNotificationStore } from "../../shared/notification";
 import { onMessage } from "../../shared/rpc";
+import type { ClaudeFxEvent, HookEvent } from "../terminal";
 import { createParticleEngine, type ParticleEngine } from "./particleEngine";
 import { sfx, unlockAudio } from "./sfx";
-
-/** 正規化済み claudeFx のうち arcade が使う部分。完了扱いしない hook (pending done 等) は
- *  terminal 側で除去済みなので、arcade は受け取った event に素直に反応すればよい。 */
-interface ArcadeFxPayload {
-  event: string;
-}
 
 /** フラッシュ演出の表示時間 (ms)。CSS の _fx-flash アニメーション長と揃える */
 const FLASH_DURATION_MS = 700;
@@ -75,7 +70,9 @@ useEventListener(
   { capture: true },
 );
 
-const HOOK_REACTIONS: Record<string, () => void> = {
+// Partial<Record<HookEvent, ...>> で keying することで、event 名のタイポと未対応 event を
+// 型で検出する（claudeFx の event は HookEvent union）。
+const HOOK_REACTIONS: Partial<Record<HookEvent, () => void>> = {
   "session-start": () => sfx.boot(),
   running: () => sfx.engage(),
   "tool-done": () => sfx.tick(),
@@ -95,7 +92,7 @@ const HOOK_REACTIONS: Record<string, () => void> = {
   },
 };
 
-const disposeHook = onMessage<ArcadeFxPayload>("claudeFx", (fx) => {
+const disposeHook = onMessage<ClaudeFxEvent>("claudeFx", (fx) => {
   HOOK_REACTIONS[fx.event]?.();
 });
 onUnmounted(disposeHook);

--- a/apps/renderer/src/features/terminal/claudeStatus.test.ts
+++ b/apps/renderer/src/features/terminal/claudeStatus.test.ts
@@ -16,20 +16,22 @@ function setup() {
 }
 
 describe("handleHookEvent done", () => {
-  test("pending work が無ければ done になり displayClaudeState も done", () => {
+  test("pending work が無ければ done になり displayClaudeState も done。fx も発行される", () => {
     const { claudeStatusByPtyId, manager } = setup();
-    manager.handleHookEvent(1, "done", {
+    const fx = manager.handleHookEvent(1, "done", {
       last_assistant_message: "完了しました。",
       pending_work: false,
     });
     const status = claudeStatusByPtyId.value[1];
     expect(status?.state).toBe("done");
     expect(displayClaudeState(status)).toBe("done");
+    // 真の done は効果ストリームに流す（音・演出・読み上げが出る）
+    expect(fx).toEqual({ ptyId: 1, event: "done", message: "完了しました。" });
   });
 
-  test("pending work があっても state は done に倒し、displayClaudeState だけ working にする", () => {
+  test("pending work があっても state は done に倒し、displayClaudeState だけ working。fx は発行しない", () => {
     const { claudeStatusByPtyId, manager } = setup();
-    manager.handleHookEvent(1, "done", {
+    const fx = manager.handleHookEvent(1, "done", {
       last_assistant_message: "サブエージェントに投げました。",
       pending_work: true,
     });
@@ -37,8 +39,10 @@ describe("handleHookEvent done", () => {
     // 状態機械は done を経由する（clearDoneStates で消化可能・固着しない）
     expect(status?.state).toBe("done");
     expect(status?.state === "done" && status.pendingWork).toBe(true);
-    // 表示だけ working に倒し、緑バッジ・通知を抑止する
+    // 表示だけ working に倒し、緑バッジを抑止する
     expect(displayClaudeState(status)).toBe("working");
+    // 効果の抑止はここ 1 箇所。fx を発行しないので音・演出・読み上げは購読側に届かない
+    expect(fx).toBeUndefined();
   });
 
   test("pending な done のあと pending なし done が来たら displayClaudeState が working → done に回復する", () => {
@@ -66,5 +70,41 @@ describe("handleHookEvent done", () => {
     expect(claudeStatusByPtyId.value[1]?.state).toBe("done");
     manager.clearDoneStates("/wt");
     expect(claudeStatusByPtyId.value[1]?.state).toBe("idle");
+  });
+});
+
+describe("handleHookEvent fx 発行（効果ストリームの単一発行点）", () => {
+  test("running / tool-done / needs-input / stop-failure は fx を発行する", () => {
+    const { manager } = setup();
+    expect(manager.handleHookEvent(1, "running", {})).toEqual({ ptyId: 1, event: "running" });
+    // tool-done は working 中のみ（done 中の遅延は無視）
+    expect(manager.handleHookEvent(1, "tool-done", {})).toEqual({ ptyId: 1, event: "tool-done" });
+    expect(
+      manager.handleHookEvent(1, "needs-input", {
+        tool_name: "Bash",
+        tool_input: { command: "ls" },
+      }),
+    ).toEqual({ ptyId: 1, event: "needs-input", toolName: "Bash", toolInput: { command: "ls" } });
+    expect(
+      manager.handleHookEvent(1, "stop-failure", { last_assistant_message: "API error" }),
+    ).toEqual({ ptyId: 1, event: "stop-failure", message: "API error" });
+  });
+
+  test("dead PTY への hook は fx を発行しない", () => {
+    const claudeStatusByPtyId = ref<Record<number, ClaudeStatus>>({});
+    const manager = createClaudeStatusManager({
+      claudeStatusByPtyId,
+      panes: { getSessionPtyId: () => undefined, iteratePanes: () => [] },
+      isPtyAlive: () => false,
+    });
+    expect(manager.handleHookEvent(1, "done", { pending_work: false })).toBeUndefined();
+  });
+
+  test("done 後の遅延 tool-done は state も fx も変えない", () => {
+    const { claudeStatusByPtyId, manager } = setup();
+    manager.handleHookEvent(1, "done", { pending_work: false });
+    const lateFx = manager.handleHookEvent(1, "tool-done", {});
+    expect(lateFx).toBeUndefined();
+    expect(claudeStatusByPtyId.value[1]?.state).toBe("done");
   });
 });

--- a/apps/renderer/src/features/terminal/claudeStatus.test.ts
+++ b/apps/renderer/src/features/terminal/claudeStatus.test.ts
@@ -79,15 +79,26 @@ describe("handleHookEvent fx 発行（効果ストリームの単一発行点）
     expect(manager.handleHookEvent(1, "running", {})).toEqual({ ptyId: 1, event: "running" });
     // tool-done は working 中のみ（done 中の遅延は無視）
     expect(manager.handleHookEvent(1, "tool-done", {})).toEqual({ ptyId: 1, event: "tool-done" });
+    // 本番では tool_input は JSON 文字列で届く（proto3 string）。boundary で 1 度 parse して
+    // 構造化オブジェクトとして fx に載ることを検証する。
     expect(
       manager.handleHookEvent(1, "needs-input", {
         tool_name: "Bash",
-        tool_input: { command: "ls" },
+        tool_input: '{"command":"ls"}',
       }),
     ).toEqual({ ptyId: 1, event: "needs-input", toolName: "Bash", toolInput: { command: "ls" } });
     expect(
       manager.handleHookEvent(1, "stop-failure", { last_assistant_message: "API error" }),
     ).toEqual({ ptyId: 1, event: "stop-failure", message: "API error" });
+  });
+
+  test("needs-input の tool_input が壊れた JSON 文字列でも throw せず toolInput は undefined", () => {
+    const { manager } = setup();
+    const fx = manager.handleHookEvent(1, "needs-input", {
+      tool_name: "Bash",
+      tool_input: "{not json",
+    });
+    expect(fx).toEqual({ ptyId: 1, event: "needs-input", toolName: "Bash", toolInput: undefined });
   });
 
   test("dead PTY への hook は fx を発行しない", () => {

--- a/apps/renderer/src/features/terminal/claudeStatus.ts
+++ b/apps/renderer/src/features/terminal/claudeStatus.ts
@@ -133,6 +133,23 @@ export function isHookEvent(value: string): value is HookEvent {
   return (HOOK_EVENTS as readonly string[]).includes(value);
 }
 
+/**
+ * 音・演出・読み上げの「効果」を駆動する正規化イベント。terminal が hook を 1 度だけ解釈した
+ * 結果として発行する (`dispatchMessage("claudeFx", ...)`)。効果を出すべきでない hook
+ * (pending work が残る done = 裏で作業継続中 / dead PTY 等) はここで `undefined` に潰されるので、
+ * このストリームを購読する側 (voicevox / arcade) は pending を意識せず受け取るだけでよい。
+ * 「done を完了扱いするか」の判断を購読者ごとに散らさず、解釈点 1 箇所に集約するための型。
+ */
+export interface ClaudeFxEvent {
+  ptyId: number;
+  event: HookEvent;
+  /** done / stop-failure の last_assistant_message */
+  message?: string;
+  /** needs-input の tool 情報 */
+  toolName?: string;
+  toolInput?: unknown;
+}
+
 /** PermissionRequest の debounce 時間（ms）。この間に tool-done が来たら asking にしない */
 const ASK_DEBOUNCE_MS = 150;
 
@@ -192,9 +209,13 @@ export function createClaudeStatusManager(deps: ClaudeStatusManagerDeps) {
    * PermissionRequest は debounce し、一瞬で通過するケース（自動承認）を除外する。
    * done 後の遅延 tool-done（イベント順序逆転）は無視する。
    */
-  function handleHookEvent(ptyId: number, event: HookEvent, payload: Record<string, unknown>) {
-    // kill/exit 済みの PTY への遅延イベントを無視
-    if (!isPtyAlive(ptyId)) return;
+  function handleHookEvent(
+    ptyId: number,
+    event: HookEvent,
+    payload: Record<string, unknown>,
+  ): ClaudeFxEvent | undefined {
+    // kill/exit 済みの PTY への遅延イベントを無視（効果も出さない）
+    if (!isPtyAlive(ptyId)) return undefined;
 
     const current = claudeStatusByPtyId.value[ptyId];
 
@@ -215,7 +236,7 @@ export function createClaudeStatusManager(deps: ClaudeStatusManagerDeps) {
           onSessionAttached?.(ptyId, sessionId);
         }
         claudeStatusByPtyId.value[ptyId] = { state: "idle", lastActivityAt: Date.now() };
-        break;
+        return { ptyId, event };
       }
       case "session-end": {
         cancelAskTimer(ptyId);
@@ -234,19 +255,21 @@ export function createClaudeStatusManager(deps: ClaudeStatusManagerDeps) {
           );
         } else if (endingSessionId !== currentSessionId) {
           delete ptyIdBySessionId.value[endingSessionId];
-          break;
+          // 旧 session の stale な session-end。効果は出さない。
+          return undefined;
         }
         if (currentSessionId !== undefined) {
           delete ptyIdBySessionId.value[currentSessionId];
           delete sessionIdByPtyId.value[ptyId];
         }
         delete claudeStatusByPtyId.value[ptyId];
-        break;
+        // session-end に反応する効果は無いが、解釈結果として発行する
+        return { ptyId, event };
       }
       case "running": {
         cancelAskTimer(ptyId);
         claudeStatusByPtyId.value[ptyId] = { state: "working", lastActivityAt: Date.now() };
-        break;
+        return { ptyId, event };
       }
       case "needs-input": {
         const toolName = typeof payload.tool_name === "string" ? payload.tool_name : undefined;
@@ -273,7 +296,8 @@ export function createClaudeStatusManager(deps: ClaudeStatusManagerDeps) {
             };
           }, ASK_DEBOUNCE_MS),
         );
-        break;
+        // 効果（アラート音・読み上げ）は従来どおり debounce せず即時発火させる
+        return { ptyId, event, toolName, toolInput };
       }
       case "tool-failure": {
         cancelAskTimer(ptyId);
@@ -281,25 +305,25 @@ export function createClaudeStatusManager(deps: ClaudeStatusManagerDeps) {
           // ユーザーが Ctrl+C でツール実行を中断 → プロンプト待ちに戻る。
           // session-start 後にしか発火しないため current は存在する。
           // current が undefined なら session-start 未到達の仕様外イベントなので無視。
-          if (current === undefined) return;
+          if (current === undefined) return undefined;
           // lastActivityAt は維持（中断はユーザー操作で、Claude の活動ではない）
           claudeStatusByPtyId.value[ptyId] = {
             state: "idle",
             lastActivityAt: current.lastActivityAt,
           };
-          break;
+          return undefined;
         }
         // interrupt でないツール失敗は tool-done と同じ扱い（working 継続）
-        if (current?.state === "done") break;
+        if (current?.state === "done") return undefined;
         claudeStatusByPtyId.value[ptyId] = { state: "working", lastActivityAt: Date.now() };
-        break;
+        return undefined;
       }
       case "tool-done": {
         cancelAskTimer(ptyId);
         // done 後の遅延 tool-done を無視（イベント順序逆転対策）
-        if (current?.state === "done") break;
+        if (current?.state === "done") return undefined;
         claudeStatusByPtyId.value[ptyId] = { state: "working", lastActivityAt: Date.now() };
-        break;
+        return { ptyId, event };
       }
       case "done": {
         cancelAskTimer(ptyId);
@@ -309,16 +333,20 @@ export function createClaudeStatusManager(deps: ClaudeStatusManagerDeps) {
             : undefined;
         // Stop は常に done へ倒す。pending_work（background_tasks / session_crons が残る =
         // 裏で作業継続中）は done バリアントの flag として保持し、表示層 (displayClaudeState) で
-        // working として描画して緑バッジ・通知を抑止する。working を直接維持すると、Claude が
+        // working として描画して緑バッジを抑止する。working を直接維持すると、Claude が
         // 再起動しないケース（background 完了通知の欠落）で状態が固着し、done 経由でしか効かない
         // clearDoneStates での消化経路を失う。done を必ず経由させることで固着を防ぐ。
+        const pendingWork = payload.pending_work === true;
         claudeStatusByPtyId.value[ptyId] = {
           state: "done",
           lastActivityAt: Date.now(),
           message,
-          pendingWork: payload.pending_work === true,
+          pendingWork,
         };
-        break;
+        // 効果（音・演出・読み上げ）の抑止はここ 1 箇所で行う。pending done は真の完了では
+        // ないため fx を発行しない → 購読側は pending を一切意識しない。
+        if (pendingWork) return undefined;
+        return { ptyId, event, message };
       }
       case "stop-failure": {
         // API エラーによる停止。done と同様に人間への通知が必要
@@ -332,7 +360,7 @@ export function createClaudeStatusManager(deps: ClaudeStatusManagerDeps) {
           lastActivityAt: Date.now(),
           message,
         };
-        break;
+        return { ptyId, event, message };
       }
     }
   }

--- a/apps/renderer/src/features/terminal/claudeStatus.ts
+++ b/apps/renderer/src/features/terminal/claudeStatus.ts
@@ -1,3 +1,4 @@
+import { tryCatch } from "@gozd/shared";
 import { ref, type FunctionalComponent, type Ref, type SVGAttributes } from "vue";
 import IconLucideCircleCheck from "~icons/lucide/circle-check";
 import IconLucideCircleEllipsis from "~icons/lucide/circle-ellipsis";
@@ -108,7 +109,7 @@ export function displayClaudeState(status: ClaudeStatus | undefined): ClaudeStat
  * - tool-failure: PostToolUseFailure（ツール実行失敗。is_interrupt で中断判定）
  * - stop-failure: StopFailure（API エラーによる停止）
  */
-type HookEvent =
+export type HookEvent =
   | "session-start"
   | "session-end"
   | "running"
@@ -131,6 +132,23 @@ const HOOK_EVENTS: readonly HookEvent[] = [
 
 export function isHookEvent(value: string): value is HookEvent {
   return (HOOK_EVENTS as readonly string[]).includes(value);
+}
+
+/**
+ * Claude hook の `tool_input` を構造化オブジェクトにする。proto3 の string 制約により
+ * boundary までは JSON 文字列で運ばれる（CLI が object → JSON 文字列にシリアライズする）。
+ * ここで 1 度だけ parse することで、`extractAskingText` 等の object 判定が初めて成立する。
+ * 既に object のケース（テスト等）はそのまま通し、parse 失敗・非 object は undefined にする。
+ */
+function parseToolInput(raw: unknown): Record<string, unknown> | undefined {
+  if (typeof raw === "object" && raw !== null) return raw as Record<string, unknown>;
+  if (typeof raw !== "string" || raw === "") return undefined;
+  const result = tryCatch(() => JSON.parse(raw) as unknown);
+  if (!result.ok) return undefined;
+  const parsed = result.value;
+  return typeof parsed === "object" && parsed !== null
+    ? (parsed as Record<string, unknown>)
+    : undefined;
 }
 
 /**
@@ -273,10 +291,8 @@ export function createClaudeStatusManager(deps: ClaudeStatusManagerDeps) {
       }
       case "needs-input": {
         const toolName = typeof payload.tool_name === "string" ? payload.tool_name : undefined;
-        const toolInput =
-          typeof payload.tool_input === "object" && payload.tool_input !== null
-            ? (payload.tool_input as Record<string, unknown>)
-            : undefined;
+        // tool_input は boundary まで JSON 文字列で運ばれるため 1 度だけ構造化する
+        const toolInput = parseToolInput(payload.tool_input);
         // debounce: タイマー満了まで asking にしない
         cancelAskTimer(ptyId);
         askTimers.set(
@@ -363,6 +379,10 @@ export function createClaudeStatusManager(deps: ClaudeStatusManagerDeps) {
         return { ptyId, event, message };
       }
     }
+    // 全 HookEvent を case で処理済み。新しい event を追加して case を書き忘れると、ここで
+    // `event` が never に絞られず compile error になる（hook event 種別を増やす方向の取りこぼし防止）。
+    event satisfies never;
+    return undefined;
   }
 
   /**

--- a/apps/renderer/src/features/terminal/index.ts
+++ b/apps/renderer/src/features/terminal/index.ts
@@ -3,5 +3,5 @@ export { useTerminalStore } from "./useTerminalStore";
 export { applyTerminalTheme, registerThemeCommand } from "./registerThemeCommand";
 export { terminalFontFamily, terminalFontSize } from "./terminalConfig";
 export { CLAUDE_STATE_VISUAL, displayClaudeState } from "./claudeStatus";
-export type { ClaudeState, ClaudeStatus, ClaudeFxEvent } from "./claudeStatus";
+export type { ClaudeState, ClaudeStatus, ClaudeFxEvent, HookEvent } from "./claudeStatus";
 export type { HookPayload } from "./rpc";

--- a/apps/renderer/src/features/terminal/index.ts
+++ b/apps/renderer/src/features/terminal/index.ts
@@ -3,5 +3,5 @@ export { useTerminalStore } from "./useTerminalStore";
 export { applyTerminalTheme, registerThemeCommand } from "./registerThemeCommand";
 export { terminalFontFamily, terminalFontSize } from "./terminalConfig";
 export { CLAUDE_STATE_VISUAL, displayClaudeState } from "./claudeStatus";
-export type { ClaudeState, ClaudeStatus } from "./claudeStatus";
+export type { ClaudeState, ClaudeStatus, ClaudeFxEvent } from "./claudeStatus";
 export type { HookPayload } from "./rpc";

--- a/apps/renderer/src/features/terminal/useTerminalStore.ts
+++ b/apps/renderer/src/features/terminal/useTerminalStore.ts
@@ -3,7 +3,7 @@ import { acceptHMRUpdate, defineStore } from "pinia";
 import { computed, ref, shallowRef } from "vue";
 import { useContextKeys } from "../../shared/command";
 import { useNotificationStore } from "../../shared/notification";
-import { onMessage } from "../../shared/rpc";
+import { dispatchMessage, onMessage } from "../../shared/rpc";
 import type { ClaudeStatus } from "./claudeStatus";
 import { isHookEvent, createClaudeStatusManager } from "./claudeStatus";
 import { createPtySessionManager } from "./ptySession";
@@ -362,7 +362,7 @@ export const useTerminalStore = defineStore("terminal", () => {
       const { event, ptyId } = payload;
       if (!isHookEvent(event)) return;
       // claudeStatus.ts は snake_case の payload を期待するので boundary で変換する
-      claude.handleHookEvent(ptyId, event, {
+      const fx = claude.handleHookEvent(ptyId, event, {
         session_id: payload.sessionId,
         last_assistant_message: payload.lastAssistantMessage,
         tool_name: payload.toolName,
@@ -370,6 +370,10 @@ export const useTerminalStore = defineStore("terminal", () => {
         is_interrupt: payload.isInterrupt,
         pending_work: payload.pendingWork,
       });
+      // 効果（音・演出・読み上げ）は正規化済みの claudeFx ストリームに流す。pending done 等の
+      // 「完了扱いしない hook」は handleHookEvent が undefined を返して落とすので、購読側は
+      // pending を意識せず受け取れる（判断は handleHookEvent 1 箇所に集約）。
+      if (fx !== undefined) dispatchMessage("claudeFx", fx);
     });
   }
 

--- a/apps/renderer/src/features/voicevox/speechText.test.ts
+++ b/apps/renderer/src/features/voicevox/speechText.test.ts
@@ -48,15 +48,6 @@ describe("extractSpeechText", () => {
     expect(extractSpeechText("done", {})).toBeUndefined();
   });
 
-  test("done イベントで pending_work が true なら読み上げを抑止する", () => {
-    expect(
-      extractSpeechText("done", {
-        last_assistant_message: "サブエージェントに投げました。",
-        pending_work: true,
-      }),
-    ).toBeUndefined();
-  });
-
   test("needs-input イベントで AskUserQuestion の question を返す", () => {
     expect(
       extractSpeechText("needs-input", {

--- a/apps/renderer/src/features/voicevox/speechText.ts
+++ b/apps/renderer/src/features/voicevox/speechText.ts
@@ -42,9 +42,6 @@ export function extractSpeechText(
   payload: Record<string, unknown>,
 ): string | undefined {
   if (event === "done") {
-    // background_tasks / session_crons が残る Stop は真の done ではない（裏で作業継続中）。
-    // 早期の読み上げを抑止し、pending が無い本物の Stop でのみ読み上げる。
-    if (payload.pending_work === true) return undefined;
     const message =
       typeof payload.last_assistant_message === "string"
         ? payload.last_assistant_message

--- a/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
+++ b/apps/renderer/src/features/voicevox/useVoicevoxStore.ts
@@ -5,7 +5,7 @@ import { computed, readonly, ref, shallowRef, watch } from "vue";
 import { useNotificationStore } from "../../shared/notification";
 import { onMessage } from "../../shared/rpc";
 import { rpcLoadAppConfig, updateAppConfig } from "../settings";
-import type { HookPayload } from "../terminal";
+import type { ClaudeFxEvent } from "../terminal";
 import {
   rpcVoicevoxCheckEngine,
   rpcVoicevoxLaunch,
@@ -349,19 +349,18 @@ export const useVoicevoxStore = defineStore("voicevox", () => {
 
   function initHookSubscription() {
     disposeHookListener?.();
-    disposeHookListener = onMessage<HookPayload>("hook", (payload) => {
+    // 正規化済み claudeFx を購読する。pending done など「完了扱いしない」hook は terminal 側で
+    // 既に除去されているので、ここでは pending を判定しない（判断は handleHookEvent に集約）。
+    disposeHookListener = onMessage<ClaudeFxEvent>("claudeFx", (fx) => {
       if (!enabled.value) return;
-      if (!SPEAK_EVENTS.has(payload.event)) return;
-      // extractSpeechText は旧 snake_case payload を期待するため境界で変換する
+      if (!SPEAK_EVENTS.has(fx.event)) return;
+      // extractSpeechText は snake_case payload を期待するため境界で変換する
       const legacyPayload: Record<string, unknown> = {
-        ptyId: payload.ptyId,
-        last_assistant_message: payload.lastAssistantMessage,
-        tool_name: payload.toolName,
-        tool_input: payload.toolInput,
-        is_interrupt: payload.isInterrupt,
-        pending_work: payload.pendingWork,
+        last_assistant_message: fx.message,
+        tool_name: fx.toolName,
+        tool_input: fx.toolInput,
       };
-      const text = extractSpeechText(payload.event, legacyPayload);
+      const text = extractSpeechText(fx.event, legacyPayload);
       if (text) {
         void speak(text, speedScale.value, volumeScale.value);
       }

--- a/docs/claude-status.md
+++ b/docs/claude-status.md
@@ -98,11 +98,19 @@ foreground subagent（Task tool の同期実行）はサブエージェント完
 
 CLI が 2 配列の length を OR で畳んで `pending_work` 信号を立て、状態判定に渡す。
 
-`pending_work` が立っていても **状態は常に `done` に倒す**。`pending_work` は `ClaudeStatus` の `done` バリアントに flag として保持し、表示層が `displayClaudeState()` 経由で `done + pendingWork` を `working` として描画して緑バッジ・吹き出し・音声を抑止する。pending が空になった本物の `Stop`（次のターン終了）で `pendingWork` が落ち、表示が `working` → `done` に切り替わる。
+`pending_work` が立っていても **状態は常に `done` に倒す**。`pending_work` は `ClaudeStatus` の `done` バリアントに flag として保持し、バッジは `displayClaudeState()` 経由で `done + pendingWork` を `working` として描画する。pending が空になった本物の `Stop`（次のターン終了）で `pendingWork` が落ち、表示が `working` → `done` に切り替わる。
 
 `working` を直接維持せず必ず `done` を経由させる理由は **状態固着の回避**。`Stop` 後に Claude が再起動しないケース（background 完了通知の欠落 / 予約再起動の不発）では「次の `Stop`」が永久に来ない。`working` を維持するとその状態に張り付き、`done` でしか効かない `clearDoneStates`（フォーカス時の既読消化）での消化経路も失う。`done` を経由させることで、再起動が来なくてもフォーカスで `idle` に消化でき、完了通知が永久に出ない事故を防ぐ。
 
-判定（`done + pendingWork` を完了扱いしない）は表示の `displayClaudeState()` と音声の `speechText.ts` の 2 経路に出るが、いずれも SSOT である proto の `pending_work` フィールド 1 つを参照する。
+### 効果（音・演出・読み上げ）の抑止は claudeFx に一元化する
+
+「`done + pendingWork` を完了扱いするか」の判断を購読者ごとに散らすと、効果購読者を増やすたび取りこぼす（実際に arcade 演出の取りこぼしが起きた）。これを防ぐため、効果は **`hook` を解釈する terminal が再発行する正規化イベント `claudeFx` 1 本** に集約する。
+
+- `handleHookEvent` が hook を解釈した結果として `ClaudeFxEvent` を返し、`useTerminalStore` が `dispatchMessage("claudeFx", fx)` で再発行する
+- pending done / dead PTY など「完了扱いしない hook」は `handleHookEvent` が `undefined` を返して落とす（**抑止判断はこの 1 箇所のみ**）
+- 効果側（VOICEVOX 読み上げ・arcade の演出/効果音）は `claudeFx` を購読するだけで、`pending_work` を一切見ない。pending done は構造的に届かないため、新しい効果購読者を足しても取りこぼせない
+
+バッジ（`displayClaudeState()`）と効果（`claudeFx`）は別経路だが、どちらも判断の起点は `handleHookEvent` 内の `pending_work` 評価 1 箇所（SSOT は proto の `pending_work` フィールド）。
 
 > [!NOTE]
 > 旧バージョン（v2.1.145 未満）の Claude Code は両キーを stdin に乗せないが、CLI は欠落を count 0（= pending なし）として扱うため、その場合は従来どおり `pendingWork` なしの `done` になる（欠落 == 空で正しい挙動）。

--- a/docs/claude-status.md
+++ b/docs/claude-status.md
@@ -110,7 +110,7 @@ CLI が 2 配列の length を OR で畳んで `pending_work` 信号を立て、
 - pending done / dead PTY など「完了扱いしない hook」は `handleHookEvent` が `undefined` を返して落とす（**抑止判断はこの 1 箇所のみ**）
 - 効果側（VOICEVOX 読み上げ・arcade の演出/効果音）は `claudeFx` を購読するだけで、`pending_work` を一切見ない。pending done は構造的に届かないため、新しい効果購読者を足しても取りこぼせない
 
-バッジ（`displayClaudeState()`）と効果（`claudeFx`）は別経路だが、どちらも判断の起点は `handleHookEvent` 内の `pending_work` 評価 1 箇所（SSOT は proto の `pending_work` フィールド）。
+`pendingWork` flag の **算出は `handleHookEvent` の done 分岐 1 箇所**（SSOT は proto の `pending_work` フィールド）。この flag を読む**判断点はバッジ側（`displayClaudeState()`）と効果側（fx 発行可否）の 2 経路**だが、いずれも同じ flag を参照する。バッジは表示 state、効果はイベント駆動で出力先が異なるため、責務として分離している。
 
 > [!NOTE]
 > 旧バージョン（v2.1.145 未満）の Claude Code は両キーを stdin に乗せないが、CLI は欠落を count 0（= pending なし）として扱うため、その場合は従来どおり `pendingWork` なしの `done` になる（欠落 == 空で正しい挙動）。


### PR DESCRIPTION
## 概要

pending done（background 実行や予約再起動が残っている `Stop`）に対する「完了扱いしない」抑止を、購読者ごとの個別判定から、`hook` を解釈する terminal が再発行する正規化イベント `claudeFx` 1 本に一元化する。効果（VOICEVOX 読み上げ・arcade の演出/効果音）は pending を一切意識せず、pending done を構造的に受け取れなくする。あわせて「hook event 種別を増やす方向」の取りこぼしも型で塞ぎ、needs-input の `tool_input` を本番データ形（JSON 文字列）に合わせて構造化する。

## 背景

PR ( #811 ) で「pending done を真の done と区別してバッジ・通知を抑止する」仕組みを入れたが、判断（`pending_work === true` なら完了扱いしない）が購読者ごとに散在していた:

- `claudeStatus.ts`（バッジ用 `displayClaudeState`）
- `speechText.ts`（VOICEVOX 読み上げ）
- arcade（演出/効果音）は **そもそも gate していなかった**

その結果、main にマージ後、background Explore agent を待っている（バッジは `working`）状態で arcade の done 演出と効果音だけが鳴る取りこぼしが発生した。「バッジは working なのに done の音が鳴る」という観察は、`pending_work=true` が renderer まで正しく届いていた（＝検出は機能）一方で、gate していない arcade 経路だけがすり抜けたことを示す。

調査で確定した事実:

- `Stop` フック stdin の `background_tasks` は実測で `type: "shell"`（`run_in_background` の Bash）を確認。Claude Code バイナリの解析で、`local_agent` / `local_workflow`（= 非同期 Agent / Workflow）も `running`/`pending` かつ backgrounded なら同配列に含まれる（filter 関数で確認）。よって background Agent も `pending_work=true` になる
- 根本問題は検出ではなく、抑止判断が購読者ごとに散らばっていて新しい効果購読者を取りこぼす設計だったこと

## 変更内容

### 効果ストリームの一元化（claudeFx）

- `handleHookEvent` が hook を解釈した結果として `ClaudeFxEvent` を返すよう変更。pending done / dead PTY など「完了扱いしない hook」は `undefined` を返して落とす（**抑止判断はこの 1 箇所のみ**）
- `useTerminalStore` が戻り値を `dispatchMessage("claudeFx", fx)` で再発行する
- VOICEVOX（`useVoicevoxStore`）と arcade（`ArcadeLayer`）は `hook` ではなく `claudeFx` を購読するように変更。各所の `pending_work` 個別判定を撤去（`speechText.ts` の done 抑止分岐も削除）

### event 種別を増やす方向の取りこぼし防止

- `handleHookEvent` の switch 末尾に `event satisfies never` を置き、`HookEvent` を追加して case を書き忘れると compile error になるようにした（効果の silent ドロップ防止）。「購読者を増やす方向」と「event 種別を増やす方向」の双方を構造で塞ぐ

### tool_input の構造化（AskUserQuestion 読み上げ/吹き出しの修復）

- `tool_input` は proto3 string 制約により boundary まで JSON 文字列で運ばれる（CLI が object → JSON 文字列にシリアライズ）。従来は `typeof === "object"` 判定のため renderer 側で常に undefined になり、AskUserQuestion の質問が読み上げ・吹き出しに乗らない既存バグがあった
- `parseToolInput`（`tryCatch` で `JSON.parse` をラップ）を新設し、needs-input 分岐で 1 度だけ構造化。読み上げ（`extractAskingText`）と asking 吹き出し（`TaskRow`）の両経路で質問本文が出るようになる

### arcade の型統一

- 独自縮小型 `ArcadeFxPayload` を撤去し共有 `ClaudeFxEvent` を購読。`HOOK_REACTIONS` を `Partial<Record<HookEvent, () => void>>` 型にして、event 名のタイポ・未対応 event を型検出できるようにした

### バッジ（据え置き）

- バッジは従来どおり `displayClaudeState()` が `done + pendingWork` を `working` として描画する。状態は常に `done` を経由するため `clearDoneStates`（フォーカス時の既読消化）で消化でき固着しない

### ドキュメント / テスト

- `docs/claude-status.md` に「効果の抑止は claudeFx に一元化する」節を追加し、「`pendingWork` の算出 1 箇所・判断 2 経路（バッジ / 効果）」を明示
- `ArcadeLayer.vue` の `<doc>` を `claudeFx` 購読に更新
- `claudeStatus.test.ts` に fx 発行の単一発行点テスト（pending done → fx 発行しない / 真の done・running・tool-done・needs-input・stop-failure → fx 発行 / dead PTY → 発行しない / done 後の遅延 tool-done → 発行しない）と、`tool_input` を本番データ形（JSON 文字列）で渡すテスト・壊れた JSON でも throw しないテストを追加

## 確認事項

- [ ] background Agent / `run_in_background` Bash を起動したまま主エージェントのターンが終わった際、arcade の done 演出・効果音と VOICEVOX 読み上げが出ず、バッジは `working` のままであること（実機確認。今回の取りこぼしは構文・unit では検出できず実機でのみ発覚したため）
- [ ] 裏の作業が完了して本物の `Stop`（pending なし）が来たとき、バッジが `done` に切り替わり、演出・音・読み上げが出ること
- [ ] AskUserQuestion 発生時に、質問本文が VOICEVOX で読み上げられ、サイドバーの吹き出しにも表示されること（tool_input 構造化の修復確認）
