### PR TITLE
fix(session-log): queued_command の画像付き prompt で base64 が生露出する問題を修正

### DIFF
--- a/packages/claude-session-log/src/sessionLog.test.ts
+++ b/packages/claude-session-log/src/sessionLog.test.ts
@@ -570,6 +570,31 @@ describe("parseSessionLog", () => {
     expect(log.skipped).toBe(0);
   });
 
+  // 画像添付つきで queue に積むと prompt は string でなく ContentBlock[] (text + image) になる。
+  // string と決め打ちして配列を text に push すると base64 が生露出する。message.content と同じく
+  // text → user / image → image に分離する。
+  test("queued_command の prompt が配列なら text/image を分離する", () => {
+    const log = parseSessionLog(
+      jsonl({
+        type: "attachment",
+        timestamp: TS,
+        attachment: {
+          type: "queued_command",
+          commandMode: "prompt",
+          prompt: [
+            { type: "text", text: "これ見て\n[Image #1]" },
+            { type: "image", source: { type: "base64", media_type: "image/png", data: "AAAA" } },
+          ],
+        },
+      }),
+    );
+    expect(log.events).toEqual([
+      { kind: "user", text: "これ見て\n[Image #1]", ts: TS },
+      { kind: "image", ts: TS, source: { mediaType: "image/png", base64: "AAAA" } },
+    ]);
+    expect(log.skipped).toBe(0);
+  });
+
   test("parse 失敗行は malformed に計上し他行は継続処理", () => {
     const valid = JSON.stringify({
       type: "user",

--- a/packages/claude-session-log/src/sessionLog.test.ts
+++ b/packages/claude-session-log/src/sessionLog.test.ts
@@ -595,6 +595,28 @@ describe("parseSessionLog", () => {
     expect(log.skipped).toBe(0);
   });
 
+  // 配列 prompt 内の未知 block は無言で落とさず skipped に計上する。この skipped 計上は
+  // userArrayBlockEvent (helper) ではなく queued_command 配列ループ側の固有コードなので、
+  // 通常 user 経路の既存テストでは踏まれず独立に検証する必要がある。
+  test("queued_command の配列 prompt 内の未知 block は skipped に計上", () => {
+    const log = parseSessionLog(
+      jsonl({
+        type: "attachment",
+        timestamp: TS,
+        attachment: {
+          type: "queued_command",
+          commandMode: "prompt",
+          prompt: [
+            { type: "text", text: "ここだけ拾う" },
+            { type: "future_block_type", foo: 1 },
+          ],
+        },
+      }),
+    );
+    expect(log.events).toEqual([{ kind: "user", text: "ここだけ拾う", ts: TS }]);
+    expect(log.skipped).toBe(1);
+  });
+
   test("parse 失敗行は malformed に計上し他行は継続処理", () => {
     const valid = JSON.stringify({
       type: "user",

--- a/packages/claude-session-log/src/sessionLog.ts
+++ b/packages/claude-session-log/src/sessionLog.ts
@@ -110,8 +110,10 @@ interface RawMessage {
 // `type:"attachment"` レコードの中身。queued_command のみ会話に載せるため prompt を読む。
 interface RawAttachment {
   type?: string;
-  // queued_command が積んだ発話本文。信頼境界外の入力なので optional。
-  prompt?: string;
+  // queued_command が積んだ発話本文。`message.content` と同じ shape を取り、テキストのみなら
+  // string、画像添付があると ContentBlock[] (text + image) になる。信頼境界外の入力なので
+  // optional。string と決め打ちすると画像添付時に配列が text に流れ込み base64 が生露出する。
+  prompt?: string | ContentBlock[];
   // queue 種別の SSOT。"prompt" = ユーザーの生発話 / "task-notification" = 注入通知。
   // 上流 (Claude Code) が分類済みのため本文パターンで再導出せずこのフィールドで採否を決める。
   commandMode?: string;
@@ -450,6 +452,23 @@ function toolResultText(content: string | ContentBlock[]): string {
     .join("\n");
 }
 
+/**
+ * user content 配列の 1 ブロックを transcript イベントにする。content 配列は通常の
+ * `message.content` と queued_command の `attachment.prompt` の 2 経路に現れ、どちらでも
+ * text → user / image → image の対応は同一。ここに一元化し「一方だけ image 分離を欠く」
+ * 非対称バグ (base64 が text に生露出する類) を構造的に防ぐ。
+ *
+ * tool_result は実 user メッセージにしか現れず ask / tool 充填という別ロジック (askById /
+ * toolById への副作用) なのでこの helper の責務外。呼び出し側が先に処理する。text / image
+ * 以外は undefined を返し、呼び出し側が skipped 計上する (silent drop 禁止の観察可能性は
+ * 呼び出し側に残す)。
+ */
+function userArrayBlockEvent(block: ContentBlock, ts: string): TranscriptEvent | undefined {
+  if (block.type === "text") return { kind: "user", text: block.text, ts };
+  if (block.type === "image") return { kind: "image", ts, source: imageSource(block) };
+  return undefined;
+}
+
 /** branchKey (分岐点 = 候補が共有する親 uuid) → 選択した childUuid。未指定の分岐点は最新枝を採る。 */
 export type BranchSelection = Map<string, string>;
 
@@ -724,9 +743,7 @@ export function parseSessionLog(jsonl: string, selection?: BranchSelection): Par
       }
       if (Array.isArray(content)) {
         for (const block of content) {
-          if (block.type === "text") {
-            events.push({ kind: "user", text: block.text, ts });
-          } else if (block.type === "tool_result") {
+          if (block.type === "tool_result") {
             // AskUserQuestion の応答なら ask イベントの answer を充填する。引き当ては
             // askById 優先 → toolById fallback の順 (同 tool_use_id が両方に居ることは無いが、
             // ask 経路を先に試すことで「ask に登録されているのに tool として処理する」誤りを防ぐ)。
@@ -763,12 +780,16 @@ export function parseSessionLog(jsonl: string, selection?: BranchSelection): Par
               text: toolResultText(block.content),
               isError: block.is_error === true,
             };
-          } else if (block.type === "image") {
-            events.push({ kind: "image", ts, source: imageSource(block) });
-          } else {
-            // 未知 block type は無言で落とさず skipped に計上する (footer 観察可能性)。
-            skipped++;
+            continue;
           }
+          // text / image は両 content 経路 (message.content / queued_command.prompt) で同一
+          // 処理。helper に一元化済み。undefined (未知 block) は無言で落とさず skipped に計上する。
+          const ev = userArrayBlockEvent(block, ts);
+          if (ev === undefined) {
+            skipped++;
+            continue;
+          }
+          events.push(ev);
         }
         continue;
       }
@@ -861,13 +882,31 @@ export function parseSessionLog(jsonl: string, selection?: BranchSelection): Par
     // 上流が分類済みの commandMode を SSOT にし、生発話 ("prompt") のみ拾う。注入通知
     // ("task-notification" 等) は除外する。prompt は生発話なので本文を加工せずそのまま出す
     // (本文が <span> や <command-name> 始まりの正当な発話を切り詰めない)。
+    //
+    // prompt は message.content と同じ shape: テキストのみなら string、画像添付があると
+    // ContentBlock[] (text + image)。array の場合は通常の user content 配列と同じく text →
+    // user / image → image に分離する。string と決め打ちして配列を text に push すると base64
+    // が生露出するため、shape で分岐する。
     if (raw.type === "attachment" && raw.attachment?.type === "queued_command") {
       const { commandMode, prompt } = raw.attachment;
-      if (commandMode === "prompt" && prompt !== undefined && prompt !== "") {
-        events.push({ kind: "user", text: prompt, ts });
+      if (commandMode !== "prompt" || prompt === undefined) {
+        skipped++;
         continue;
       }
-      skipped++;
+      if (typeof prompt === "string") {
+        if (prompt === "") skipped++;
+        else events.push({ kind: "user", text: prompt, ts });
+        continue;
+      }
+      // 配列 prompt は通常の message.content と同じ text / image 処理を共有する。
+      for (const block of prompt) {
+        const ev = userArrayBlockEvent(block, ts);
+        if (ev === undefined) {
+          skipped++;
+          continue;
+        }
+        events.push(ev);
+      }
       continue;
     }
 


### PR DESCRIPTION
## 概要

Claude Code セッションログのログビューアーで、ユーザーが画像を添付して queue に積んだ発話（`queued_command`）の base64 データが、構造化された画像ではなく JSON 配列のテキストとして生露出していた問題を修正する。

`packages/claude-session-log` の parser を修正し、queued_command の `prompt` が配列（text + image）のとき通常の `message.content` と同じく text → user / image → image に分離する。あわせて両経路で重複していた text/image マッピングを helper に一元化した。

## 背景

ログビューアーで添付画像の parse が崩れ、`{"type":"image","source":{"type":"base64",...,"data":"iVBORw0KGgo..."}}` のような巨大な base64 を含む JSON がテキストとして画面に露出していた。

実ログ（`studio-front` セッション）を調査したところ、原因は parser の queued_command 処理にあった。

- `queued_command` の `attachment.prompt` フィールドは、テキストのみなら `string` だが、ユーザーが画像を添付して queue に積むと `message.content` と同じ `ContentBlock[]` 配列（`[{type:"text"}, {type:"image", source:{base64}}]`）になる
- ところが parser は型を `string` と誤宣言しており、`events.push({ kind: "user", text: prompt })` で配列をそのまま `text`（string 型のフィールド）に push していた
- 型宣言が誤っていたため TypeScript もコンパイル時に検出できず、view 層が配列を文字列化して base64 を露出させていた

通常の `type:"user"` content 配列経路は text/image を正しく分離していたのに、queued_command 経路だけがこの分離を欠いていた（同じ「user content blocks の処理」が 2 箇所に重複し、片方だけ image 分離を欠く非対称欠陥）。

## 変更内容

### parser 修正

- `RawAttachment.prompt` の型を `string` から `string | ContentBlock[]` に修正。信頼境界外データの実際に取りうる shape を正確に宣言する
- queued_command 処理を shape で分岐し、配列の場合は text → user イベント / image → image イベントに分離（base64 は `ImageSource.base64` に隔離され text には流れない）

### 重複処理の一元化

- user content 配列の text/image マッピングを `userArrayBlockEvent(block, ts)` helper に抽出し、通常 user 経路と queued_command 経路の両方が共有する
- これにより「一方の経路だけ image 分離を欠く」非対称バグが構造的に再発不能になる
- `tool_result`（実 user メッセージ専用、ask/tool 充填の副作用あり）と文字列 prompt 処理（生発話 verbatim で意味が異なる）は意図的に分けたまま。helper は両経路で同一な text/image マッピングだけを担う

### テスト追加

- queued_command の prompt が配列（text + image）のとき text/image を正しく分離するテストを追加

## 確認事項

- [x] `packages/claude-session-log` の全テスト（66 件）が通過
- [x] 型チェック通過
- [x] dev 環境のログビューアーで base64 が露出せず画像として表示されることを確認

https://claude.ai/code/session_01UAvWsCnZrBqrsoe1PBs9YM
