### PR TITLE
chore(renovate): 共有 preset github>miyaoka/renovate-config を導入

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:best-practices",
-    ":pinDependencies",
-    "github>miyaoka/renovate-config"
-  ],
+  "extends": ["config:best-practices", ":pinDependencies", "github>miyaoka/renovate-config"],
   "labels": ["dependencies"],
   "assignees": ["miyaoka"],
   "reviewers": ["miyaoka"]

--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices", ":pinDependencies"],
+  "extends": [
+    "config:best-practices",
+    ":pinDependencies",
+    "github>miyaoka/renovate-config"
+  ],
   "labels": ["dependencies"],
   "assignees": ["miyaoka"],
-  "reviewers": ["miyaoka"],
-  "packageRules": [
-    {
-      "description": "auto-merge tsgo dev preview daily releases",
-      "matchPackageNames": ["@typescript/native-preview"],
-      "automerge": true
-    }
-  ]
+  "reviewers": ["miyaoka"]
 }


### PR DESCRIPTION
## 概要

`renovate.json` を共有 preset `github>miyaoka/renovate-config` を `extends` する構成に変更する。これまでローカルに直書きしていた tsgo（`@typescript/native-preview`）の auto-merge ルールを削除し、共有 preset 側のルールに委譲する。

## 背景

複数 repo にまたがる Renovate の運用ルール（auto-merge やランタイムのグルーピング）が各 repo にコピーされると、ルール変更のたびに全 repo を直す必要があり SSOT が崩れる。共有 preset `miyaoka/renovate-config` に一本化することで、ルールの管理点を 1 箇所に集約する。

ローカルの `packageRules`（tsgo の auto-merge）を削除しても機能が失われないことを、共有 preset の `default.json` を実際に取得して確認した。共有 preset には同一の tsgo auto-merge ルールに加え、以下も含まれている:

- `@typescript/native-preview` の auto-merge（ローカルと同一）
- oxlint / oxlint-tsgolint のグルーピング
- node / @types/node のグルーピング（24.x 制約）
- bun / @types/bun のグルーピング
- pnpm（mise + packageManager + Dockerfile）のグルーピング
- `lockFileMaintenance` の auto-merge

## 変更内容

### renovate.json

- `extends` に `github>miyaoka/renovate-config` を追加
- ローカルの `packageRules`（tsgo auto-merge）を削除し共有 preset に委譲
- `labels` / `assignees` / `reviewers` は維持

## 確認事項

- [ ] 共有 preset 導入後も tsgo の auto-merge が引き続き機能すること（Renovate の dependency dashboard / PR で確認）
- [ ] oxlint / node / bun / pnpm のグルーピングが期待どおり効くこと
