### PR TITLE
chore(knip): unplugin-icons の virtual import を unresolved 検査から除外

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -21,6 +21,10 @@ const config: KnipConfig = {
         // ため、knip からは unused に見える
         "@iconify-json/lucide",
       ],
+      // unplugin-icons の `~icons/lucide/*` は Vite が build 時に生成する virtual module で
+      // ディスク上に実体がない。静的解析する knip は恒久的に解決できず Unresolved imports に
+      // 出すため、specifier パターンで除外する（上の ignoreDependencies とは別系統の検査）。
+      ignoreUnresolved: [/^~icons\//],
     },
     "packages/eslint-plugin": {},
     "packages/proto": {


### PR DESCRIPTION
## 概要

`pnpm run knip` が `~icons/lucide/*` を `Unresolved imports` として 91 件報告していたのを解消する。`knip.ts` の `apps/renderer` workspace に `ignoreUnresolved: [/^~icons\//]` を追加し、specifier パターンでまとめて除外する。

## 背景

`pnpm run knip` 実行時に、renderer の Vue SFC 全体から `~icons/lucide/*`（unplugin-icons の virtual module）への import が 91 件すべて `Unresolved imports` として報告され、knip が exit code 1 で fail していた。

`knip.ts` には既に `apps/renderer` workspace に `ignoreDependencies: ["@iconify-json/lucide"]` があるが、これは「依存パッケージが unused」という別系統の検査を抑えるためのもので、`~icons/...` という specifier がファイルに解決できない `Unresolved imports` 検査には作用しない。両者は knip 内部で独立した検査系統。

unplugin-icons の `~icons/lucide/*` は Vite プラグインが build 時に生成する virtual module であり、ディスク上に対応ファイルが存在しない。静的解析する knip からは恒久的に解決不能なので、`ignoreUnresolved` で specifier パターンを除外するのが正攻法。knip 6.17.1 のソース（`DependencyDeputy.ts` の `findMatch(manifest.ignoreUnresolved, issue.symbol)`）で、import specifier 文字列に対し regex マッチすること、workspace 単位で指定できることを確認した。

## 変更内容

### knip 設定

- `apps/renderer` workspace に `ignoreUnresolved: [/^~icons\//]` を追加
- 既存の `ignoreDependencies` とは別系統の検査である旨をコメントで明記

## 確認事項

- [ ] `pnpm run knip` が exit code 0 で完了し、`Unresolved imports` が消えること（手元で確認済み。残るのは informational な Configuration hints のみ）
