### PR TITLE
feat(preview): プレビュー中のファイルをデフォルトアプリで開く

### DIFF
--- a/apps/native/Sources/GozdCore/Rpc/RpcDispatcher+Window.swift
+++ b/apps/native/Sources/GozdCore/Rpc/RpcDispatcher+Window.swift
@@ -61,6 +61,10 @@ extension RpcDispatcher {
     let url = URL(fileURLWithPath: req.path)
     // 存在しないパスを NSWorkspace に渡すと無言で no-op になるため、ここで弾いて
     // renderer 側にエラーを返す（fallback せずエラーにする規律）。
+    // これは「無言 no-op を避けエラートーストを出す」ための前段チェックであり、
+    // アクセス制御の関所（セキュリティ境界）ではない。信頼境界は他 RPC (/pty/spawn 等) と
+    // 同じく renderer 内コードを信頼する前提で一貫させる。後続が fileExists を関所と誤読して
+    // ロジックを足さないこと。
     guard FileManager.default.fileExists(atPath: url.path) else {
       throw RpcError.invalidArgument("file not found: \(req.path)")
     }

--- a/apps/native/Sources/GozdCore/Rpc/RpcDispatcher+Window.swift
+++ b/apps/native/Sources/GozdCore/Rpc/RpcDispatcher+Window.swift
@@ -55,16 +55,23 @@ extension RpcDispatcher {
 
   func handleOpenFile(_ body: Data) throws -> Data {
     let req = try Gozd_V1_OpenFileRequest(jsonUTF8Data: body)
-    guard !req.path.isEmpty else {
-      throw RpcError.invalidArgument("empty path")
+    // path は renderer が joinAbsRel(worktree root, relPath) で解決済みの絶対パス契約。
+    // 相対→絶対の「解決」は基準ディレクトリ (worktree root) を持つ renderer の責務であり、
+    // それを native で再実装すると契約の SSOT が二重化するためここではしない。
+    //
+    // 一方この guard は解決ではなく、URL(fileURLWithPath:) が空文字・相対パスを CWD 基準で
+    // silent に絶対化する Foundation の暗黙 fallback を塞ぐ入口チェック。特に空文字は url.path が
+    // CWD そのものになり fileExists も true を返すため、NSWorkspace.open が Finder で CWD を
+    // 黙って開く誤動作になる。基準ディレクトリを使わない非絶対判定だけで両者を弾き、
+    // 暗黙 fallback を「fallback せずエラーにする」規律に従って明示エラーへ倒す。
+    guard req.path.hasPrefix("/") else {
+      throw RpcError.invalidArgument("path must be absolute: \(req.path)")
     }
     let url = URL(fileURLWithPath: req.path)
-    // 存在しないパスを NSWorkspace に渡すと無言で no-op になるため、ここで弾いて
-    // renderer 側にエラーを返す（fallback せずエラーにする規律）。
-    // これは「無言 no-op を避けエラートーストを出す」ための前段チェックであり、
-    // アクセス制御の関所（セキュリティ境界）ではない。信頼境界は他 RPC (/pty/spawn 等) と
-    // 同じく renderer 内コードを信頼する前提で一貫させる。後続が fileExists を関所と誤読して
-    // ロジックを足さないこと。
+    // fileExists は契約検証ではなく、renderer 側の描画 gate (resolveOpenablePath) を抜けた race
+    // (表示直後に実体が消えた等) 向けの safety net。存在しないパスを NSWorkspace に渡すと無言で
+    // no-op になるため、ここで弾いて renderer にエラーを返す (無言 no-op を避けエラートーストを
+    // 出す)。アクセス制御の関所 (セキュリティ境界) ではない。
     guard FileManager.default.fileExists(atPath: url.path) else {
       throw RpcError.invalidArgument("file not found: \(req.path)")
     }

--- a/apps/native/Sources/GozdCore/Rpc/RpcDispatcher+Window.swift
+++ b/apps/native/Sources/GozdCore/Rpc/RpcDispatcher+Window.swift
@@ -53,6 +53,24 @@ extension RpcDispatcher {
     return try Gozd_V1_OpenExternalResponse().jsonUTF8Data()
   }
 
+  func handleOpenFile(_ body: Data) throws -> Data {
+    let req = try Gozd_V1_OpenFileRequest(jsonUTF8Data: body)
+    guard !req.path.isEmpty else {
+      throw RpcError.invalidArgument("empty path")
+    }
+    let url = URL(fileURLWithPath: req.path)
+    // 存在しないパスを NSWorkspace に渡すと無言で no-op になるため、ここで弾いて
+    // renderer 側にエラーを返す（fallback せずエラーにする規律）。
+    guard FileManager.default.fileExists(atPath: url.path) else {
+      throw RpcError.invalidArgument("file not found: \(req.path)")
+    }
+    // NSWorkspace.open は @MainActor。actor 内から MainActor.run でホップする。
+    Task { @MainActor in
+      NSWorkspace.shared.open(url)
+    }
+    return try Gozd_V1_OpenFileResponse().jsonUTF8Data()
+  }
+
   func handleWindowClose(_ body: Data) throws -> Data {
     _ = try Gozd_V1_WindowCloseRequest(jsonUTF8Data: body)
     Task { @MainActor in

--- a/apps/native/Sources/GozdCore/Rpc/RpcDispatcher.swift
+++ b/apps/native/Sources/GozdCore/Rpc/RpcDispatcher.swift
@@ -157,6 +157,7 @@ public actor RpcDispatcher {
     case "/projectConfig/save": return try handleProjectConfigSave(body)
     // open / window
     case "/open/external": return try handleOpenExternal(body)
+    case "/open/file": return try handleOpenFile(body)
     case "/open/pickAndOpen": return try await handlePickAndOpen(body)
     case "/window/close": return try handleWindowClose(body)
     case "/window/setTitleContext": return try await handleWindowSetTitleContext(body)

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -47,7 +47,7 @@ import { useChangesStore, useChangesSummaryStore } from "../changes";
 import { getFileIconUrl, relDirOf, rpcFsReadFile, rpcFsReadFileAbsolute } from "../filer";
 import type { FsChangePayload } from "../filer";
 import { rpcGitReadBlob, useGitGraphStore, usePrDiffToggleStore } from "../git-graph";
-import { UNCOMMITTED_HASH, useGitStatusStore, useWorktreeStore } from "../worktree";
+import { joinAbsRel, UNCOMMITTED_HASH, useGitStatusStore, useWorktreeStore } from "../worktree";
 import type { GitChangeKind, Selection } from "../worktree";
 import ChangesSummaryView from "./ChangesSummaryView.vue";
 import CodePreview from "./CodePreview.vue";
@@ -56,13 +56,14 @@ import HtmlPreview from "./HtmlPreview.vue";
 import ImagePreview from "./ImagePreview.vue";
 import MarkdownPreview from "./MarkdownPreview.vue";
 import { previewCodeFontFamily, previewFontFamily, previewFontSize } from "./previewConfig";
-import { rpcGitShowCommitFile, rpcGitShowFile } from "./rpc";
+import { rpcGitShowCommitFile, rpcGitShowFile, rpcOpenFile } from "./rpc";
 import { shouldCloseForMissingFile } from "./shouldCloseForMissingFile";
 import { useBlamePopover } from "./useBlamePopover";
 import { useMarkdownHistoryStore } from "./useMarkdownHistoryStore";
 import { usePreviewStore } from "./usePreviewStore";
 import IconLucideArrowLeft from "~icons/lucide/arrow-left";
 import IconLucideArrowRight from "~icons/lucide/arrow-right";
+import IconLucideExternalLink from "~icons/lucide/external-link";
 import IconLucideEye from "~icons/lucide/eye";
 import IconLucideFileClock from "~icons/lucide/file-clock";
 import IconLucideFileDiff from "~icons/lucide/file-diff";
@@ -793,6 +794,30 @@ const imageUrl = computed(() => {
   return buildFileServerUrl(dir, serverPath, fetchVersionRef.value, isOriginal);
 });
 
+/**
+ * 表示中ファイルの実 (working tree) 絶対パス。OS のデフォルトアプリで開く入力に使う。
+ * 表示用の `selectedDisplayPath` は RPC 入力に使わない契約のため、selection の kind から実パスを組む。
+ * commit / PR diff モードでも対象は常に working tree の実ファイル（git 履歴の内容ではない）。
+ */
+const openableAbsPath = computed<string | undefined>(() => {
+  const sel = selection.value;
+  if (sel === undefined) return undefined;
+  if (sel.kind === "absolute") return sel.absPath;
+  const dir = worktreeStore.dir;
+  if (dir === undefined) return undefined;
+  return joinAbsRel(dir, sel.relPath);
+});
+
+/** 表示中ファイルを OS のデフォルトアプリで開く（macOS の `open` 相当）。 */
+async function openInDefaultApp() {
+  const path = openableAbsPath.value;
+  if (path === undefined) return;
+  const result = await tryCatch(rpcOpenFile({ path }));
+  if (!result.ok) {
+    notification.error(`Failed to open file: ${path}`, result.error);
+  }
+}
+
 /** preview チェックボックスを表示するか（diff モードでは非表示） */
 const showPreviewCheckbox = computed(() => {
   if (activeMode.value === "diff") return false;
@@ -978,8 +1003,19 @@ watch(
       </template>
       <span v-else class="text-sm text-foreground-low">Preview</span>
       <button
+        v-if="openableAbsPath"
         type="button"
         class="ml-auto shrink-0 text-foreground-low hover:text-foreground"
+        title="Open in default app"
+        aria-label="Open in default app"
+        @click="openInDefaultApp()"
+      >
+        <IconLucideExternalLink class="size-4" />
+      </button>
+      <button
+        type="button"
+        class="shrink-0 text-foreground-low hover:text-foreground"
+        :class="{ 'ml-auto': !openableAbsPath }"
         title="Close preview"
         aria-label="Close preview"
         @click="emit('close')"

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -47,7 +47,7 @@ import { useChangesStore, useChangesSummaryStore } from "../changes";
 import { getFileIconUrl, relDirOf, rpcFsReadFile, rpcFsReadFileAbsolute } from "../filer";
 import type { FsChangePayload } from "../filer";
 import { rpcGitReadBlob, useGitGraphStore, usePrDiffToggleStore } from "../git-graph";
-import { joinAbsRel, UNCOMMITTED_HASH, useGitStatusStore, useWorktreeStore } from "../worktree";
+import { UNCOMMITTED_HASH, useGitStatusStore, useWorktreeStore } from "../worktree";
 import type { GitChangeKind, Selection } from "../worktree";
 import ChangesSummaryView from "./ChangesSummaryView.vue";
 import CodePreview from "./CodePreview.vue";
@@ -56,6 +56,7 @@ import HtmlPreview from "./HtmlPreview.vue";
 import ImagePreview from "./ImagePreview.vue";
 import MarkdownPreview from "./MarkdownPreview.vue";
 import { previewCodeFontFamily, previewFontFamily, previewFontSize } from "./previewConfig";
+import { resolveOpenablePath } from "./resolveOpenablePath";
 import { rpcGitShowCommitFile, rpcGitShowFile, rpcOpenFile } from "./rpc";
 import { shouldCloseForMissingFile } from "./shouldCloseForMissingFile";
 import { useBlamePopover } from "./useBlamePopover";
@@ -795,18 +796,18 @@ const imageUrl = computed(() => {
 });
 
 /**
- * 表示中ファイルの実 (working tree) 絶対パス。OS のデフォルトアプリで開く入力に使う。
- * 表示用の `selectedDisplayPath` は RPC 入力に使わない契約のため、selection の kind から実パスを組む。
- * commit / PR diff モードでも対象は常に working tree の実ファイル（git 履歴の内容ではない）。
+ * 表示中ファイルを OS のデフォルトアプリで開く入力に使う実 (working tree) 絶対パス。
+ * working tree に実体が無い (notFound / deleted) ケースは undefined を返し、ボタン描画自体を
+ * gate して silent dead button を作らない。解決ロジックは純関数 `resolveOpenablePath` に切り出す。
  */
-const openableAbsPath = computed<string | undefined>(() => {
-  const sel = selection.value;
-  if (sel === undefined) return undefined;
-  if (sel.kind === "absolute") return sel.absPath;
-  const dir = worktreeStore.dir;
-  if (dir === undefined) return undefined;
-  return joinAbsRel(dir, sel.relPath);
-});
+const openableAbsPath = computed<string | undefined>(() =>
+  resolveOpenablePath({
+    selection: selection.value,
+    dir: worktreeStore.dir,
+    isNotFound: isNotFound.value,
+    effectiveGitChange: effectiveGitChange.value,
+  }),
+);
 
 /** 表示中ファイルを OS のデフォルトアプリで開く（macOS の `open` 相当）。 */
 async function openInDefaultApp() {

--- a/apps/renderer/src/features/preview/resolveOpenablePath.test.ts
+++ b/apps/renderer/src/features/preview/resolveOpenablePath.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import type { Selection } from "../worktree";
+import { resolveOpenablePath } from "./resolveOpenablePath";
+
+describe("resolveOpenablePath", () => {
+  const rel: Selection = { kind: "worktreeRelative", relPath: "src/a.ts" };
+  const abs: Selection = { kind: "absolute", absPath: "/tmp/outside/b.ts" };
+
+  test("worktreeRelative は dir と join した絶対パスを返す", () => {
+    expect(
+      resolveOpenablePath({
+        selection: rel,
+        dir: "/work/repo",
+        isNotFound: false,
+        effectiveGitChange: undefined,
+      }),
+    ).toBe("/work/repo/src/a.ts");
+  });
+
+  test("absolute は absPath を直に返す", () => {
+    expect(
+      resolveOpenablePath({
+        selection: abs,
+        dir: "/work/repo",
+        isNotFound: false,
+        effectiveGitChange: undefined,
+      }),
+    ).toBe("/tmp/outside/b.ts");
+  });
+
+  test("selection 無し → undefined", () => {
+    expect(
+      resolveOpenablePath({
+        selection: undefined,
+        dir: "/work/repo",
+        isNotFound: false,
+        effectiveGitChange: undefined,
+      }),
+    ).toBeUndefined();
+  });
+
+  test("isNotFound (working tree に実体無し) → undefined で silent dead button を防ぐ", () => {
+    expect(
+      resolveOpenablePath({
+        selection: rel,
+        dir: "/work/repo",
+        isNotFound: true,
+        effectiveGitChange: undefined,
+      }),
+    ).toBeUndefined();
+  });
+
+  test("絶対パス選択でも isNotFound なら undefined", () => {
+    expect(
+      resolveOpenablePath({
+        selection: abs,
+        dir: "/work/repo",
+        isNotFound: true,
+        effectiveGitChange: undefined,
+      }),
+    ).toBeUndefined();
+  });
+
+  test("deleted (commit / PR diff モードで削除済み版を表示中) → undefined", () => {
+    expect(
+      resolveOpenablePath({
+        selection: rel,
+        dir: "/work/repo",
+        isNotFound: false,
+        effectiveGitChange: "deleted",
+      }),
+    ).toBeUndefined();
+  });
+
+  test("worktreeRelative なのに dir 未確立 → undefined", () => {
+    expect(
+      resolveOpenablePath({
+        selection: rel,
+        dir: undefined,
+        isNotFound: false,
+        effectiveGitChange: undefined,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/renderer/src/features/preview/resolveOpenablePath.ts
+++ b/apps/renderer/src/features/preview/resolveOpenablePath.ts
@@ -1,0 +1,33 @@
+import type { GitChangeKind, Selection } from "../worktree";
+import { joinAbsRel } from "../worktree";
+
+/**
+ * 表示中ファイルを OS のデフォルトアプリで開くための実 (working tree) 絶対パスを解決する純粋関数。
+ * 開けない (working tree に実体が無い) ケースは undefined を返し、呼び出し側はボタン描画自体を
+ * gate する。これにより「押せるが native の存在チェックで必ず失敗する」silent dead button
+ * (DiffPreview docstring 規約 / `blameEnabled` と同じ規律) を構造的に作らない。
+ *
+ * 表示用の `selectedDisplayPath` は RPC 入力に使わない契約のため流用せず、selection の kind から
+ * 実パスを組む。commit / PR diff モードでも対象は常に working tree の実ファイル (git 履歴の内容
+ * ではない)。
+ *
+ * undefined を返す条件:
+ * - selection 無し (プレビュー未選択)
+ * - `isNotFound` (working tree から read できなかった = 実体が無い)。絶対パス選択の削除もここで拾う
+ * - `effectiveGitChange === "deleted"` (commit / PR diff モードで削除済み版を表示中、working tree に実体無し)
+ * - worktreeRelative なのに dir 未確立
+ */
+export function resolveOpenablePath(args: {
+  selection: Selection | undefined;
+  dir: string | undefined;
+  isNotFound: boolean;
+  effectiveGitChange: GitChangeKind | undefined;
+}): string | undefined {
+  const { selection, dir, isNotFound, effectiveGitChange } = args;
+  if (selection === undefined) return undefined;
+  if (isNotFound) return undefined;
+  if (effectiveGitChange === "deleted") return undefined;
+  if (selection.kind === "absolute") return selection.absPath;
+  if (dir === undefined) return undefined;
+  return joinAbsRel(dir, selection.relPath);
+}

--- a/apps/renderer/src/features/preview/rpc.ts
+++ b/apps/renderer/src/features/preview/rpc.ts
@@ -11,6 +11,8 @@ import {
   GitShowCommitFileResponse,
   GitShowFileRequest,
   GitShowFileResponse,
+  OpenFileRequest,
+  OpenFileResponse,
 } from "@gozd/proto";
 
 import { rpc } from "../../shared/rpc";
@@ -32,3 +34,7 @@ export const rpcGitBlameLine = (req: GitBlameLineRequest) =>
 
 export const rpcGitLogLine = (req: GitLogLineRequest) =>
   rpc("/git/logLine", req, GitLogLineRequest, GitLogLineResponse);
+
+/** 表示中ファイルを OS のデフォルトアプリで開く（macOS の `open` 相当）。path は絶対パス。 */
+export const rpcOpenFile = (req: OpenFileRequest) =>
+  rpc("/open/file", req, OpenFileRequest, OpenFileResponse);

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -122,7 +122,9 @@ git 変更ファイルには Original / Diff / Current の3タブを表示する
 - 対象は常に **working tree の実ファイル**。commit / PR diff モードで履歴版を表示中でも、開くのはディスク上の実体（git 履歴の内容ではない）。表示用の `selectedDisplayPath` は RPC 入力に使わない契約のため流用しない
 - RPC は専用の `/open/file`（`rpcOpenFile`）。native は `NSWorkspace.shared.open(URL(fileURLWithPath:))`。`openExternal`（`/open/external`）は OSC 8 リンク経由の任意 scheme 流入への防壁として scheme allowlist（http/https/mailto）で `file://` を弾くため、ローカルファイルを開く intent は別 RPC に分離する
 - 実パスの解決と描画 gate は純関数 `resolveOpenablePath`（テスト付き）が SSOT。working tree に実体があるときだけ selection の kind から実パスを解決し（`worktreeRelative` は `joinAbsRel(dir, relPath)`、`absolute` は `absPath` 直）、実体が無いケース（selection 無し / `isNotFound` / commit・PR diff モードで `deleted` 版を表示中）は undefined を返す。`openableAbsPath` がこれに委譲し、template の `v-if` がそのままボタン描画を gate するため、押せるが native の存在チェックで必ず失敗する silent dead button を作らない（`blameEnabled` の added file gate と同じ規律）
-- native はパス空・ファイル不在を `invalidArgument` で弾く（無言 no-op にせずエラーにする規律）。これは描画 gate を抜けた race（表示直後に実体が消えた等）の例外ケース向け safety net であり、アクセス制御の関所ではない。renderer 側は失敗を `useNotificationStore` のトーストで通知する
+- **相対→絶対の解決は基準ディレクトリ（worktree root）を持つ renderer の責務**。`/open/file` には常に解決済みの絶対パスが渡る契約で、native は基準ディレクトリを持たず解決を**再実装しない**（再実装すると契約の SSOT が二重化する）。この契約は proto の `OpenFileRequest.path` コメントと native handler に明記する
+- ただし native は入口で**非絶対パス（空文字含む）を `invalidArgument` で弾く**。これは解決（基準ディレクトリ依存）ではなく、`URL(fileURLWithPath:)` が空文字・相対パスを CWD 基準で silent に絶対化する Foundation の暗黙 fallback を塞ぐためのガード。特に空文字は `url.path` が CWD になり `fileExists` も true を返すため、`NSWorkspace.open` が Finder で CWD を黙って開く誤動作になる。`fallback せずエラーにする` 規律に従い明示エラーへ倒す
+- native の `fileExists` は契約検証ではなく、上記描画 gate を抜けた race（表示直後に実体が消えた等）向けの safety net。不在なら `invalidArgument` で弾き（無言 no-op を避ける）、renderer 側は失敗を `useNotificationStore` のトーストで通知する。アクセス制御の関所ではない
 
 ## データ取得
 

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -119,10 +119,10 @@ git 変更ファイルには Original / Diff / Current の3タブを表示する
 
 ヘッダの external-link ボタンで、表示中ファイルを OS のデフォルトアプリ（macOS の `open` 相当）で開く。
 
-- 対象は常に **working tree の実ファイル**。commit / PR diff モードで履歴版を表示中でも、開くのはディスク上の実体（git 履歴の内容ではない）。selection の kind から実パスを解決する（`worktreeRelative` は `joinAbsRel(dir, relPath)`、`absolute` は `absPath` 直）。表示用の `selectedDisplayPath` は RPC 入力に使わない契約のため流用しない
+- 対象は常に **working tree の実ファイル**。commit / PR diff モードで履歴版を表示中でも、開くのはディスク上の実体（git 履歴の内容ではない）。表示用の `selectedDisplayPath` は RPC 入力に使わない契約のため流用しない
 - RPC は専用の `/open/file`（`rpcOpenFile`）。native は `NSWorkspace.shared.open(URL(fileURLWithPath:))`。`openExternal`（`/open/external`）は OSC 8 リンク経由の任意 scheme 流入への防壁として scheme allowlist（http/https/mailto）で `file://` を弾くため、ローカルファイルを開く intent は別 RPC に分離する
-- native はパス空・ファイル不在を `invalidArgument` で弾く（無言 no-op にせずエラーにする規律）。renderer 側は失敗を `useNotificationStore` のトーストで通知する
-- selection が無い（プレビュー未選択）ときはボタン自体を非表示にする
+- 実パスの解決と描画 gate は純関数 `resolveOpenablePath`（テスト付き）が SSOT。working tree に実体があるときだけ selection の kind から実パスを解決し（`worktreeRelative` は `joinAbsRel(dir, relPath)`、`absolute` は `absPath` 直）、実体が無いケース（selection 無し / `isNotFound` / commit・PR diff モードで `deleted` 版を表示中）は undefined を返す。`openableAbsPath` がこれに委譲し、template の `v-if` がそのままボタン描画を gate するため、押せるが native の存在チェックで必ず失敗する silent dead button を作らない（`blameEnabled` の added file gate と同じ規律）
+- native はパス空・ファイル不在を `invalidArgument` で弾く（無言 no-op にせずエラーにする規律）。これは描画 gate を抜けた race（表示直後に実体が消えた等）の例外ケース向け safety net であり、アクセス制御の関所ではない。renderer 側は失敗を `useNotificationStore` のトーストで通知する
 
 ## データ取得
 

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -115,6 +115,15 @@ git 変更ファイルには Original / Diff / Current の3タブを表示する
   - 単一ファイル削除も親ディレクトリごとの削除も同じ経路で拾えるのは、FSWatcher が `kFSEventStreamCreateFlagFileEvents` 付きで配下ファイル単位の削除イベントを出し、その relDir が選択ファイルの親 relDir と一致するため（`apps/native/Sources/GozdCore/FSWatcher.swift`）
   - close 判定の SSOT は純粋関数 `shouldCloseForMissingFile`（summary 表示中 / 絶対パス / current 在 のいずれかなら閉じない、を集約）。PreviewPane 側の if は HEAD 在否確定 RPC を無駄撃ちしないための前段ガード
 
+### デフォルトアプリで開く
+
+ヘッダの external-link ボタンで、表示中ファイルを OS のデフォルトアプリ（macOS の `open` 相当）で開く。
+
+- 対象は常に **working tree の実ファイル**。commit / PR diff モードで履歴版を表示中でも、開くのはディスク上の実体（git 履歴の内容ではない）。selection の kind から実パスを解決する（`worktreeRelative` は `joinAbsRel(dir, relPath)`、`absolute` は `absPath` 直）。表示用の `selectedDisplayPath` は RPC 入力に使わない契約のため流用しない
+- RPC は専用の `/open/file`（`rpcOpenFile`）。native は `NSWorkspace.shared.open(URL(fileURLWithPath:))`。`openExternal`（`/open/external`）は OSC 8 リンク経由の任意 scheme 流入への防壁として scheme allowlist（http/https/mailto）で `file://` を弾くため、ローカルファイルを開く intent は別 RPC に分離する
+- native はパス空・ファイル不在を `invalidArgument` で弾く（無言 no-op にせずエラーにする規律）。renderer 側は失敗を `useNotificationStore` のトーストで通知する
+- selection が無い（プレビュー未選択）ときはボタン自体を非表示にする
+
 ## データ取得
 
 `PreviewPane` が RPC 経由で desktop からファイル内容を取得する。

--- a/packages/proto-ts/src/index.ts
+++ b/packages/proto-ts/src/index.ts
@@ -133,7 +133,12 @@ export {
   SortMode,
 } from "./generated/gozd/v1/git_ops";
 export { GitStatusRequest, GitStatusResponse } from "./generated/gozd/v1/git_status";
-export { OpenExternalRequest, OpenExternalResponse } from "./generated/gozd/v1/open_external";
+export {
+  OpenExternalRequest,
+  OpenExternalResponse,
+  OpenFileRequest,
+  OpenFileResponse,
+} from "./generated/gozd/v1/open_external";
 export { PickAndOpenRequest, PickAndOpenResponse } from "./generated/gozd/v1/open_target";
 export {
   ProjectConfigLoadRequest,

--- a/packages/proto/gozd/v1/open_external.proto
+++ b/packages/proto/gozd/v1/open_external.proto
@@ -18,7 +18,10 @@ message OpenExternalResponse {}
 // `openExternal` は scheme allowlist (http/https/mailto) で `file://` を弾く防壁を持つため、
 // ローカルファイルを開く intent は別 RPC として分離する。
 message OpenFileRequest {
-  // 開く対象の絶対パス。
+  // 開く対象の絶対パス。相対→絶対の解決は基準ディレクトリ (worktree root) を持つ renderer の
+  // 責務であり、ここには常に解決済みの絶対パスが渡る契約。native は基準ディレクトリを持たず
+  // 解決 (再実装) はしないが、URL(fileURLWithPath:) が非絶対入力を CWD 基準で silent に絶対化する
+  // Foundation の暗黙 fallback を塞ぐため、入口で非絶対 (空文字含む) を invalidArgument で弾く。
   string path = 1;
 }
 

--- a/packages/proto/gozd/v1/open_external.proto
+++ b/packages/proto/gozd/v1/open_external.proto
@@ -10,3 +10,16 @@ message OpenExternalRequest {
 }
 
 message OpenExternalResponse {}
+
+// ローカルファイルを OS のデフォルトアプリで開く。Swift 側で
+// `NSWorkspace.shared.open(URL(fileURLWithPath:))`（= macOS の `open` コマンド相当）。
+//
+// 用途: preview ペインのヘッダから表示中ファイルをデフォルトアプリで開く。
+// `openExternal` は scheme allowlist (http/https/mailto) で `file://` を弾く防壁を持つため、
+// ローカルファイルを開く intent は別 RPC として分離する。
+message OpenFileRequest {
+  // 開く対象の絶対パス。
+  string path = 1;
+}
+
+message OpenFileResponse {}


### PR DESCRIPTION
## 概要

preview ペインのヘッダに external-link ボタンを追加し、表示中のファイルを OS のデフォルトアプリ（macOS の `open` 相当）で開けるようにする。

## 背景

preview ペインはファイル内容の閲覧・diff 表示に特化しているが、「このファイルを実際のエディタ / 関連アプリで開きたい」導線が無かった。画像・SVG・HTML など、ネイティブアプリで開いた方が扱いやすいファイル種別でも一度ファイラーや外部ツールを経由する必要があった。

実装にあたり、既存の `openExternal` RPC ( `/open/external` ) の再利用を検討したが、これは OSC 8 リンクや WebLinksAddon 経由で任意 scheme が流れ込み得る経路への防壁として scheme allowlist ( `http` / `https` / `mailto` ) を持つ。`file://` を開くために allowlist を広げるとこの防御境界が壊れるため、ローカルファイルを開く intent は専用の `/open/file` RPC として分離した。

## 変更内容

### RPC スキーマ ( proto )

- `open_external.proto` に `OpenFileRequest { path }` / `OpenFileResponse` を追加
- `packages/proto-ts/src/index.ts` の barrel に `OpenFile*` を re-export

### native

- `RpcDispatcher+Window.swift` に `handleOpenFile` を追加。`NSWorkspace.shared.open(URL(fileURLWithPath:))` でデフォルトアプリ起動
- `RpcDispatcher.swift` に `/open/file` の routing を追加

### renderer

- `preview/rpc.ts` に `rpcOpenFile` を追加
- `PreviewPane.vue` のヘッダに external-link ボタンを追加
- 実パス解決と描画 gate を純関数 `resolveOpenablePath` ( + `resolveOpenablePath.test.ts` ) に切り出し。working tree に実体があるときだけ selection の kind から絶対パスを解決し ( `worktreeRelative` は `joinAbsRel(dir, relPath)`、`absolute` は `absPath` 直 )、実体が無いケース ( selection 無し / `isNotFound` / commit・PR diff モードで `deleted` 版を表示中 ) は undefined を返す
- template の `v-if` がそのまま描画 gate になり、押せるが必ず失敗する silent dead button を構造的に作らない ( 既存の `blameEnabled` の added file gate と同じ規律 )
- 失敗時は `useNotificationStore` のトーストで通知

### パス契約の確立

`/open/file` のパス解決責務を明確化した。

- **相対→絶対の解決は基準ディレクトリ ( worktree root ) を持つ renderer の責務**。`/open/file` には常に解決済みの絶対パスが渡る契約とし、native では基準ディレクトリでの解決を再実装しない ( SSOT 二重化を避ける )
- native は入口で**非絶対パス ( 空文字含む ) を `invalidArgument` で弾く**。これは解決ではなく、`URL(fileURLWithPath:)` が空文字・相対パスを CWD 基準で silent に絶対化する Foundation の暗黙 fallback を塞ぐためのガード。特に空文字は `url.path` が CWD になり `fileExists` も true を返すため、`NSWorkspace.open` が Finder で CWD を黙って開く誤動作になることを実機で確認した。`fallback せずエラーにする` 規律に従い明示エラーへ倒す
- `fileExists` は契約検証ではなく、描画 gate を抜けた race ( 表示直後に実体が消えた等 ) 向けの safety net
- この契約は proto の `OpenFileRequest.path` コメント / native handler / `docs/preview.md` に明記

### ドキュメント

- `docs/preview.md` に「デフォルトアプリで開く」節を追記

## 確認事項

- [x] dev 環境で preview ヘッダのボタンからデフォルトアプリで開けることを確認済み
- [ ] commit / PR diff モードで削除済みファイルを選択したとき open ボタンが非表示になること
- [ ] working tree から削除された直後 ( notFound ) のファイルで open ボタンが非表示になること
- [ ] 非絶対パス ( 空文字 / 相対パス ) を送ったとき Finder が開かずエラートーストが出ること
