### PR TITLE
fix(git-graph): keep old current branch visible in all-branches view

### DIFF
--- a/apps/native/Sources/GozdCore/Git/GitOps+Log.swift
+++ b/apps/native/Sources/GozdCore/Git/GitOps+Log.swift
@@ -120,7 +120,53 @@ extension GitOps {
     let commits = try await runLogStdin(
       dir: dir, refs: Array(refs), maxCount: maxCount,
       firstParentOnly: firstParentOnly, sortMode: sortMode)
-    return LogResult(commits: commits, defaultBranch: defaultBranch, branchHead: branchHead)
+
+    let merged = try await rescueCurrentBranch(
+      dir: dir, commits: commits, currentBranchOnly: currentBranchOnly, headExists: headExists,
+      maxCount: maxCount, firstParentOnly: firstParentOnly, sortMode: sortMode)
+    return LogResult(commits: merged, defaultBranch: defaultBranch, branchHead: branchHead)
+  }
+
+  /// 全ブランチ表示で現在ブランチ (HEAD) が結果から丸ごと欠落するケースを救済する。
+  ///
+  /// `currentBranchOnly == false` の walk は HEAD / `origin/<default>` / `@{upstream}` を
+  /// 始点に新しい順 `maxCount` 件で切る。default ブランチに HEAD tip より新しい commit が
+  /// `maxCount` 件以上あると HEAD 系統がウィンドウから押し出され、graph 上に現在ブランチが
+  /// 1 行も出ない。現在ブランチが見えないと "Scroll to HEAD" / lane 0 の HEAD 予約も機能しなくなる。
+  ///
+  /// 救済は HEAD が結果に含まれないときだけ HEAD-only walk を 1 本足し、末尾に append する
+  /// (OID dedup)。HEAD 系統は「新しい順 `maxCount` ウィンドウから押し出された」= all-refs 結果の最古
+  /// commit より必ず古いため、HEAD-only walk の全 commit は all-refs 結果の全 commit より古い。
+  /// よって単純 append で date / topo どちらの順序契約も保たれる (親が子より先に出ない制約も、
+  /// 古い祖先側を末尾に置くので維持される)。renderer は git の返却順をそのまま行に写すため、
+  /// この順序保証が描画の前提を満たす。
+  ///
+  /// HEAD の在否判定は parse 済み refs を見る (`%D` の `HEAD -> branch` / detached `HEAD` は
+  /// `parseRefs` が `"HEAD"` 要素に展開する)。別途 `rev-parse HEAD` を spawn せず済む。
+  /// `maxCount == 0` (無制限) では all-refs walk が HEAD も含めて全件返すため、この判定で
+  /// 自然に false になり追加 walk は走らない。
+  private static func rescueCurrentBranch(
+    dir: String, commits: [CommitInfo], currentBranchOnly: Bool, headExists: Bool,
+    maxCount: UInt32, firstParentOnly: Bool, sortMode: LogSortMode
+  ) async throws -> [CommitInfo] {
+    guard !currentBranchOnly, headExists else { return commits }
+    let headPresent = commits.contains { $0.refs.contains("HEAD") }
+    if headPresent { return commits }
+
+    let headCommits = try await runLogStdin(
+      dir: dir, refs: ["HEAD"], maxCount: maxCount,
+      firstParentOnly: firstParentOnly, sortMode: sortMode)
+    var seen = Set(commits.map { $0.hash })
+    var merged = commits
+    var isBoundary = true
+    for commit in headCommits where !seen.contains(commit.hash) {
+      // append セグメントの先頭 commit にだけ truncatedAbove を立て、renderer が
+      // 最新クラスタとの境界に「途切れ行」を描けるようにする。2 件目以降は通常の commit。
+      merged.append(isBoundary ? commit.withTruncatedAbove() : commit)
+      seen.insert(commit.hash)
+      isBoundary = false
+    }
+    return merged
   }
 
   /// `git log --stdin` で複数 ref を始点に走る単発 helper。

--- a/apps/native/Sources/GozdCore/Git/GitTypes.swift
+++ b/apps/native/Sources/GozdCore/Git/GitTypes.swift
@@ -25,9 +25,13 @@ public struct CommitInfo: Equatable, Sendable {
   public let message: String
   public let body: String
   public let refs: [String]
+  /// 直上で履歴が途切れている (上の行と連続しない別セグメントの先頭) 行か。
+  /// 全ブランチ表示で HEAD が窓から押し出され HEAD-only walk を append した境界の
+  /// 先頭 commit にだけ true が立つ。通常の commit は false。
+  public let truncatedAbove: Bool
   public init(
     hash: String, shortHash: String, parents: [String], author: String, date: Int64,
-    message: String, body: String, refs: [String]
+    message: String, body: String, refs: [String], truncatedAbove: Bool = false
   ) {
     self.hash = hash
     self.shortHash = shortHash
@@ -37,6 +41,14 @@ public struct CommitInfo: Equatable, Sendable {
     self.message = message
     self.body = body
     self.refs = refs
+    self.truncatedAbove = truncatedAbove
+  }
+
+  /// `truncatedAbove = true` の copy を返す。append セグメント境界の標識用。
+  public func withTruncatedAbove() -> CommitInfo {
+    CommitInfo(
+      hash: hash, shortHash: shortHash, parents: parents, author: author, date: date,
+      message: message, body: body, refs: refs, truncatedAbove: true)
   }
 }
 

--- a/apps/native/Sources/GozdCore/Rpc/RpcDispatcher+Git.swift
+++ b/apps/native/Sources/GozdCore/Rpc/RpcDispatcher+Git.swift
@@ -420,6 +420,7 @@ fileprivate func toGitCommitProto(_ c: CommitInfo) -> Gozd_V1_GitCommit {
   pb.message = c.message
   pb.body = c.body
   pb.refs = c.refs
+  pb.truncatedAbove = c.truncatedAbove
   return pb
 }
 

--- a/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
+++ b/apps/native/Tests/GozdCoreTests/GitOpsTests.swift
@@ -2150,6 +2150,98 @@ private func porcelainStatus(dir: String) async throws -> String {
   return String(decoding: stdout, as: UTF8.self)
 }
 
+@Suite("GitOps.log 古い現在ブランチの救済")
+struct GitOpsLogRescueTests {
+  /// 全ブランチ表示で default ブランチに HEAD tip より新しい commit が maxCount 件以上
+  /// あると、HEAD 系統が新しい順 maxCount 窓から押し出される。その場合に HEAD-only walk を
+  /// append して現在ブランチを結果に必ず含め、境界先頭に truncatedAbove を立てることを検証する。
+  ///
+  /// 構成 (epoch で date-order を固定):
+  ///   main:    seed(1000) → m1(2000) … m5(2004)   (origin/main = m5)
+  ///   feature: seed(1000) → feat(1100)            (HEAD = feat、main より古い)
+  private func makeOldBranchRepo() async throws -> (local: URL, origin: URL) {
+    let origin = try makeTempDir()
+    try await runTestGit(args: ["init", "-q", "--bare", "-b", "main"], cwd: origin.path)
+    let local = try await makeGitRepo()
+    try await commitAt(dir: local.path, message: "seed", epoch: 1000)
+    try await runTestGit(args: ["remote", "add", "origin", origin.path], cwd: local.path)
+    try await runTestGit(args: ["push", "-u", "origin", "main"], cwd: local.path)
+
+    // 古い feature ブランチ: seed から分岐し feat を 1 つ積む (main より古い epoch)。
+    try await runTestGit(args: ["checkout", "-q", "-b", "feature"], cwd: local.path)
+    try await commitAt(dir: local.path, message: "feat", epoch: 1100)
+
+    // main に新しい commit を 5 つ積み origin/main を前進させる。
+    try await runTestGit(args: ["checkout", "-q", "main"], cwd: local.path)
+    for index in 0..<5 {
+      try await commitAt(dir: local.path, message: "m\(index + 1)", epoch: 2000 + index)
+    }
+    try await runTestGit(args: ["push", "origin", "main"], cwd: local.path)
+    try await runTestGit(args: ["remote", "set-head", "origin", "main"], cwd: local.path)
+
+    // 現在ブランチを古い feature に戻す。
+    try await runTestGit(args: ["checkout", "-q", "feature"], cwd: local.path)
+    return (local, origin)
+  }
+
+  @Test("HEAD が窓から押し出されると HEAD-only walk を append し境界に truncatedAbove を立てる")
+  func rescuesOldCurrentBranch() async throws {
+    let (local, origin) = try await makeOldBranchRepo()
+    defer {
+      try? FileManager.default.removeItem(at: local)
+      try? FileManager.default.removeItem(at: origin)
+    }
+
+    // maxCount=3: 新しい順 3 件は m5/m4/m3 で埋まり feat(HEAD) は押し出される。
+    let result = try await GitOps.log(
+      dir: local.path, maxCount: 3, firstParentOnly: false, currentBranchOnly: false,
+      sortMode: .date)
+
+    // HEAD は append で必ず結果に含まれる。
+    #expect(result.commits.contains { $0.refs.contains("HEAD") })
+    // 途切れ標識は append 境界の先頭 (= HEAD tip feat) に 1 つだけ立つ。
+    let truncated = result.commits.filter { $0.truncatedAbove }
+    #expect(truncated.count == 1)
+    #expect(truncated.first?.refs.contains("HEAD") == true)
+    // 最新 3 件 (main 窓) + feat + seed = 5 件。
+    #expect(result.commits.count == 5)
+  }
+
+  @Test("currentBranchOnly では rescue せず truncatedAbove は立たない")
+  func noRescueWhenCurrentBranchOnly() async throws {
+    let (local, origin) = try await makeOldBranchRepo()
+    defer {
+      try? FileManager.default.removeItem(at: local)
+      try? FileManager.default.removeItem(at: origin)
+    }
+
+    let result = try await GitOps.log(
+      dir: local.path, maxCount: 3, firstParentOnly: false, currentBranchOnly: true,
+      sortMode: .date)
+
+    #expect(result.commits.contains { $0.refs.contains("HEAD") })
+    #expect(result.commits.allSatisfy { !$0.truncatedAbove })
+    // feature 系統 (feat, seed) のみ。
+    #expect(result.commits.count == 2)
+  }
+
+  @Test("maxCount が十分大きく HEAD が窓内に収まるなら rescue しない")
+  func noRescueWhenHeadFitsInWindow() async throws {
+    let (local, origin) = try await makeOldBranchRepo()
+    defer {
+      try? FileManager.default.removeItem(at: local)
+      try? FileManager.default.removeItem(at: origin)
+    }
+
+    let result = try await GitOps.log(
+      dir: local.path, maxCount: 100, firstParentOnly: false, currentBranchOnly: false,
+      sortMode: .date)
+
+    #expect(result.commits.contains { $0.refs.contains("HEAD") })
+    #expect(result.commits.allSatisfy { !$0.truncatedAbove })
+  }
+}
+
 private func makeTempDir() throws -> URL {
   let raw = FileManager.default.temporaryDirectory
     .appendingPathComponent("gozd-gitops-\(UUID().uuidString.prefix(8))")
@@ -2228,4 +2320,46 @@ private func runTestGit(args: [String], cwd: String) async throws {
       cont.resume(throwing: error)
     }
   }
+}
+
+/// `runTestGit` の env 注入版。`GIT_AUTHOR_DATE` / `GIT_COMMITTER_DATE` を固定して
+/// `--date-order` の並びを決定的にするために使う (同一秒に積むと tie-break が topo に
+/// 落ちて test が flaky になる)。
+private func runTestGitEnv(args: [String], cwd: String, extraEnv: [String: String]) async throws {
+  try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["git"] + args
+    process.currentDirectoryURL = URL(fileURLWithPath: cwd)
+    var env = ProcessInfo.processInfo.environment
+    for (key, value) in extraEnv { env[key] = value }
+    process.environment = env
+    process.standardOutput = FileHandle.nullDevice
+    let stderrPipe = Pipe()
+    process.standardError = stderrPipe
+    process.terminationHandler = { proc in
+      if proc.terminationStatus == 0 {
+        cont.resume()
+      } else {
+        let data = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderr =
+          String(bytes: data, encoding: .utf8) ?? "<non-UTF8 stderr (\(data.count) bytes)>"
+        cont.resume(
+          throwing: GitError.commandFailed(exitCode: proc.terminationStatus, stderr: stderr))
+      }
+    }
+    do {
+      try process.run()
+    } catch {
+      cont.resume(throwing: error)
+    }
+  }
+}
+
+/// 指定 epoch (Unix 秒) を author/committer date 両方に固定した empty commit を作る。
+private func commitAt(dir: String, message: String, epoch: Int) async throws {
+  let date = "@\(epoch) +0000"
+  try await runTestGitEnv(
+    args: ["commit", "--allow-empty", "-q", "-m", message], cwd: dir,
+    extraEnv: ["GIT_AUTHOR_DATE": date, "GIT_COMMITTER_DATE": date])
 }

--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -12,6 +12,19 @@ Git commit graph showing the current worktree branch and the default branch.
 - CommitDetailPane is shown as a toggleable right pane inside the graph
 - Commits are stored in `useGitGraphStore` and shared with ChangesPane
 
+## 古い current branch の途切れ表示
+
+全ブランチ表示 (`currentBranchOnly` OFF) は全 ref を始点に新しい順 `maxCount` 件で切るため、default
+ブランチに HEAD tip より新しい commit が `maxCount` 件以上あると現在ブランチ (HEAD) がウィンドウから
+押し出されて 1 行も出ない。これを防ぐため native (`GitOps.log`) は HEAD が結果に含まれないとき HEAD-only
+walk を末尾に append し、その境界の先頭 commit に `truncatedAbove` を立てる。
+
+renderer 側は `graphLayout.ts` で `truncatedAbove` の行の手前に **gap 行を 1 行挿入** し、あわせて上の
+クラスタの (cut された親を待つ) レーンを切断する。gap 行は SVG の dot を描かず、`Earlier history hidden`
+を graph 列の左端から 1 レーン分インデントして開始する全幅 separator として表示する (commit メッセージ列と
+紛れず、lane 0 のコネクタにも被らない)。gap 行も `layout.nodes` の 1 ノードとして 1 行枠を占有するため、
+SVG の行 index 座標系と DOM 行が一致し続ける。キーボードナビは gap 行を読み飛ばす。
+
 ## 右クリックメニュー
 
 commit 行を右クリックすると `CommitContextMenu` (singleton popover) が開き、「Reset (mixed) to here」で
@@ -56,6 +69,7 @@ import { useGitGraphStore } from "./useGitGraphStore";
 import { usePrListStore } from "./usePrListStore";
 import IconLucideGitCommitHorizontal from "~icons/lucide/git-commit-horizontal";
 import IconLucideGitMerge from "~icons/lucide/git-merge";
+import IconLucideMoreHorizontal from "~icons/lucide/more-horizontal";
 import IconLucidePanelRight from "~icons/lucide/panel-right";
 
 const rootRef = useTemplateRef<HTMLElement>("root");
@@ -699,11 +713,21 @@ function getGraphListSize(): number {
   return el?.offsetWidth ?? GRAPH_LIST_MIN_WIDTH;
 }
 
-/** 現在選択中のノードのインデックス。範囲選択中は compareHash（移動端）を返す */
+/** 現在選択中のノードの **行 (node) インデックス**。範囲選択中は compareHash（移動端）を返す。
+ * gap 行挿入で commit index と node index がずれるため、store の hashToIndex (commit index) では
+ * なく layout.nodes 上の位置を引く。未選択 / Working Tree は -1。 */
 function selectedIndex(): number {
   const { compareHash } = gitGraphStore;
   const hash = compareHash ?? gitGraphStore.selectedHash;
-  return gitGraphStore.hashToIndex.get(hash) ?? -1;
+  return layout.value.nodes.findIndex((n) => !n.gap && n.commit.hash === hash);
+}
+
+/** index から dir 方向へ gap 行を読み飛ばした最初の非 gap 行を返す。範囲外はそのまま返し caller が clamp する。 */
+function skipGapRows(index: number, dir: number): number {
+  const nodes = layout.value.nodes;
+  let i = index;
+  while (i >= 0 && i < nodes.length && nodes[i]?.gap) i += dir;
+  return i;
 }
 
 /** 選択を Uncommitted Changes に戻し、HEAD コミット付近にスクロール */
@@ -761,7 +785,8 @@ function onKeydown(e: KeyboardEvent) {
       scrollToIndex(0);
       return;
     }
-    const next = Math.min(step - 1, nodes.length - 1);
+    const next = skipGapRows(Math.min(step - 1, nodes.length - 1), 1);
+    if (next >= nodes.length) return;
     const hash = nodes[next].commit.hash;
     if (e.shiftKey) {
       gitGraphStore.selectCompare(hash);
@@ -785,9 +810,19 @@ function onKeydown(e: KeyboardEvent) {
   let next: number;
 
   if (isUp) {
-    next = current - step;
+    next = skipGapRows(current - step, -1);
+    // gap を上に抜けて Working Tree 域に出たら Working Tree 選択へ倒す。
+    if (next < 0) {
+      if (e.shiftKey) {
+        gitGraphStore.selectCompare(UNCOMMITTED_HASH);
+      } else {
+        gitGraphStore.select(UNCOMMITTED_HASH);
+      }
+      return;
+    }
   } else {
-    next = Math.min(nodes.length - 1, current + step);
+    next = skipGapRows(Math.min(nodes.length - 1, current + step), 1);
+    if (next >= nodes.length) return;
   }
 
   if (e.shiftKey) {
@@ -1146,9 +1181,10 @@ const isWorkingTreeActive = computed(
                 :stroke="colorFor(seg.color)"
                 stroke-width="2"
               />
-              <!-- コミットドット -->
+              <!-- コミットドット (gap 行は dot を描かない) -->
               <circle
                 v-for="(node, row) in layout.nodes"
+                v-show="!node.gap"
                 :key="`dot-${node.commit.hash}`"
                 :cx="laneX(node.lane)"
                 :cy="rowY(row)"
@@ -1165,69 +1201,87 @@ const isWorkingTreeActive = computed(
                  SVG は positioned absolute (layer 6) なので、CSS の painting order により z-index
                  を一切使わずに SVG が row 背景の上に描かれる。`relative` を足すと row が layer 6
                  に上がり、tree order で後発の row 背景が先発の SVG を塗りつぶす不具合が再発する。 -->
-            <div
-              v-for="node in layout.nodes"
-              :key="node.commit.hash"
-              class="_graph-row grid items-center text-xs"
-              :class="rowHighlightClass(node.commit.hash)"
-              :style="{
-                gridTemplateColumns: 'var(--graph-cols)',
-                height: `${ROW_HEIGHT}px`,
-              }"
-              @click="onRowClick(node.commit.hash, $event)"
-              @contextmenu="onCommitContextMenu(node.commit.hash, $event)"
-            >
-              <!-- col 1 (graph): SVG が absolute で覆うセル。右端の
+            <template v-for="(node, row) in layout.nodes" :key="`row-${row}`">
+              <!-- gap 行: 履歴の途切れ。全ブランチ表示で HEAD が新しい順 maxCount ウィンドウから
+                   押し出され HEAD-only walk が末尾 append された境界に挟まる。コミットメッセージ
+                   (col 2) と紛れないよう grid を使わず、graph 列の左端から 1 レーン分インデントして
+                   開始する全幅の separator として置く。lane 0 のコネクタ破線にも被らない。
+                   height は ROW_HEIGHT に固定し SVG の行 index 座標系を崩さない。 -->
+              <div
+                v-if="node.gap"
+                class="flex items-center gap-[0.5ch] bg-panel text-xs text-foreground-low select-none"
+                :style="{
+                  height: `${ROW_HEIGHT}px`,
+                  paddingLeft: `${GRAPH_PADDING_X + LANE_WIDTH}px`,
+                }"
+              >
+                <IconLucideMoreHorizontal class="size-3.5 shrink-0" />
+                <span>Earlier history hidden</span>
+              </div>
+
+              <div
+                v-else
+                class="_graph-row grid items-center text-xs"
+                :class="rowHighlightClass(node.commit.hash)"
+                :style="{
+                  gridTemplateColumns: 'var(--graph-cols)',
+                  height: `${ROW_HEIGHT}px`,
+                }"
+                @click="onRowClick(node.commit.hash, $event)"
+                @contextmenu="onCommitContextMenu(node.commit.hash, $event)"
+              >
+                <!-- col 1 (graph): SVG が absolute で覆うセル。右端の
                    HEAD_MARKER_RIGHT_PADDING 余白に HEAD marker を in-flow 右寄せで置く。
                    col 2 内の absolute 配置 (`right-full`) にすると col 2 の `truncate`
                    (overflow: hidden) が containing block ごとクリップして marker が消える。
                    非 positioned content (layer 4) なので row 背景 / SVG の painting order に
                    影響せず、余白内なので SVG の lane / dot とも x 帯が重ならない。 -->
-              <div class="flex items-center justify-end pr-1">
-                <span v-if="hasHead(node.commit.refs)" class="text-warning-text" title="HEAD">
-                  →
-                </span>
-              </div>
+                <div class="flex items-center justify-end pr-1">
+                  <span v-if="hasHead(node.commit.refs)" class="text-warning-text" title="HEAD">
+                    →
+                  </span>
+                </div>
 
-              <!-- col 2 (description) -->
-              <div class="flex min-w-0 items-center gap-1 truncate pr-2">
-                <IconLucideGitMerge
-                  v-if="isMergeCommit(node.commit)"
-                  class="size-3.5 shrink-0 text-foreground-low"
-                />
-                <RefBadge
-                  v-for="displayRef in computeDisplayRefs(
-                    node.commit.refs,
-                    currentBranch,
-                    defaultBranch,
-                    outOfSyncBranches,
-                  )"
-                  :key="`${displayRef.type}:${displayRef.label}`"
-                  :display-ref="displayRef"
-                  :pr-by-branch="prByBranch"
-                />
-                <span class="truncate">
-                  <CommitSegmentList
-                    :segments="commitMessageSegmentsByHash.get(node.commit.hash) ?? []"
+                <!-- col 2 (description) -->
+                <div class="flex min-w-0 items-center gap-1 truncate pr-2">
+                  <IconLucideGitMerge
+                    v-if="isMergeCommit(node.commit)"
+                    class="size-3.5 shrink-0 text-foreground-low"
                   />
-                </span>
-              </div>
+                  <RefBadge
+                    v-for="displayRef in computeDisplayRefs(
+                      node.commit.refs,
+                      currentBranch,
+                      defaultBranch,
+                      outOfSyncBranches,
+                    )"
+                    :key="`${displayRef.type}:${displayRef.label}`"
+                    :display-ref="displayRef"
+                    :pr-by-branch="prByBranch"
+                  />
+                  <span class="truncate">
+                    <CommitSegmentList
+                      :segments="commitMessageSegmentsByHash.get(node.commit.hash) ?? []"
+                    />
+                  </span>
+                </div>
 
-              <!-- col 3 (date) -->
-              <div class="text-foreground-low">
-                {{ formatDate(node.commit.date) }}
-              </div>
+                <!-- col 3 (date) -->
+                <div class="text-foreground-low">
+                  {{ formatDate(node.commit.date) }}
+                </div>
 
-              <!-- col 4 (author) -->
-              <div class="truncate text-foreground-low">
-                {{ node.commit.author }}
-              </div>
+                <!-- col 4 (author) -->
+                <div class="truncate text-foreground-low">
+                  {{ node.commit.author }}
+                </div>
 
-              <!-- col 5 (hash) -->
-              <div class="font-mono text-foreground-low">
-                {{ node.commit.shortHash }}
+                <!-- col 5 (hash) -->
+                <div class="font-mono text-foreground-low">
+                  {{ node.commit.shortHash }}
+                </div>
               </div>
-            </div>
+            </template>
           </div>
         </div>
       </div>

--- a/apps/renderer/src/features/git-graph/graphLayout.test.ts
+++ b/apps/renderer/src/features/git-graph/graphLayout.test.ts
@@ -3,8 +3,23 @@ import { describe, expect, test } from "bun:test";
 import { computeGraphLayout, HEAD_COLOR } from "./graphLayout";
 
 /** テスト用 commit を最小フィールドで生成する */
-function commit(hash: string, parents: string[], refs: string[] = []): GitCommit {
-  return { hash, shortHash: hash, parents, author: "", date: 0, message: "", body: "", refs };
+function commit(
+  hash: string,
+  parents: string[],
+  refs: string[] = [],
+  truncatedAbove = false,
+): GitCommit {
+  return {
+    hash,
+    shortHash: hash,
+    parents,
+    author: "",
+    date: 0,
+    message: "",
+    body: "",
+    refs,
+    truncatedAbove,
+  };
 }
 
 /** hash → lane の引きやすいマップに変換する */
@@ -56,7 +71,7 @@ describe("computeGraphLayout の HEAD 最左固定", () => {
   });
 
   test("HEAD 到達前の merge コミットの 2nd parent が予約 lane 0 を奪わない", () => {
-    // 上枝が内部 merge を持ち、HEAD (h0) は tip。merge (m) は headRow より前の行。
+    // 上枝が内部 merge を持ち、HEAD (h0) は tip。merge (m) は HEAD より前の行。
     // m の 2nd parent (u2) が lane 0 を取ると h0 が最左を確保できないため、
     // findEmptyLane の minLane=1 により u2 は lane 1 以降へ追いやられる必要がある。
     //   u0 → m ┬─ u1 ┐
@@ -232,5 +247,31 @@ describe("computeGraphLayout の HEAD 最左固定", () => {
     const commits = [commit("c0", ["c1"]), commit("c1", [])];
     const lanes = laneByHash(computeGraphLayout(commits, {}));
     expect(lanes.get("c0")).toBe(0);
+  });
+});
+
+describe("computeGraphLayout の途切れ境界 (truncatedAbove)", () => {
+  test("truncatedAbove の行の手前に gap 行を挿入しレーンを切断する", () => {
+    // 上クラスタ: u0 → u1 (u1 の親 "cut" は結果集合外 = maxCount 打ち切り相当)。
+    // 下クラスタ: h0 (truncatedAbove, HEAD) → h1。全ブランチ表示で HEAD-only walk を
+    // 末尾 append した境界に相当する。h0 の手前に gap 行が 1 行挿入され、上クラスタの
+    // 「cut 親待ち」レーンはそこで終端して下クラスタへ縦線を引き継がない。
+    const commits = [
+      commit("u0", ["u1"]),
+      commit("u1", ["cut"]),
+      commit("h0", ["h1"], ["HEAD"], true),
+      commit("h1", []),
+    ];
+    const layout = computeGraphLayout(commits, { headHash: "h0" });
+
+    // gap 行が h0 の直前 (node index 2) に入り、h0 は 1 行ぶん後ろにずれる。
+    expect(layout.nodes[2]?.gap).toBe(true);
+    expect(layout.nodes[3]?.commit.hash).toBe("h0");
+    // gap 行 (row 2) には線が一切繋がらない (上クラスタの線は手前で終端)。
+    expect(layout.lines.some((l) => l.y1 === 2 || l.y2 === 2)).toBe(false);
+    // 上クラスタ (row<=1) と下クラスタ (row>=3) を跨ぐ線は無い。
+    expect(layout.lines.filter((l) => l.y1 <= 1 && l.y2 >= 3)).toHaveLength(0);
+    // HEAD は切断後も最左 lane 0 に固定される。
+    expect(laneByHash(layout).get("h0")).toBe(0);
   });
 });

--- a/apps/renderer/src/features/git-graph/graphLayout.ts
+++ b/apps/renderer/src/features/git-graph/graphLayout.ts
@@ -29,7 +29,24 @@ interface GraphNode {
   lane: number;
   /** 色インデックス */
   color: number;
+  /** 履歴の途切れを示す gap 行か。true のとき `commit` は描画しない placeholder で、
+   *  template は diff の hunk-bar 相当の全幅バーを描く。SVG の dot は描かない。 */
+  gap?: boolean;
 }
+
+/** gap 行の placeholder commit。refs / hash を空にして HEAD 判定・選択・headNode 探索に
+ *  引っかからないようにする。gap 行は描画専用で commit データを持たない。 */
+const GAP_COMMIT: GitCommit = {
+  hash: "",
+  shortHash: "",
+  parents: [],
+  author: "",
+  date: 0,
+  message: "",
+  body: "",
+  refs: [],
+  truncatedAbove: false,
+};
 
 /** レーン計算の結果 */
 export interface GraphLayout {
@@ -86,24 +103,44 @@ export function computeGraphLayout(
   }
 
   // HEAD を最左 lane に固定するための予約判定。
-  // HEAD が表示順で先頭 (headRow === 0) なら貪欲割り当てで既に最左なので予約不要。
+  // HEAD が表示順で先頭 (commit index 0) なら貪欲割り当てで既に最左なので予約不要。
   // それ以外 (HEAD より上に他コミットが並ぶ) のときは、HEAD 到達前の行で lane 0 を
   // 空けて予約し、HEAD 行で lane 0 に固定する。HEAD がグラフ内に子を持つ (= 非 tip) 場合も、
   // 子の各レーンを HEAD 行で lane 0 へ合流させることで lane を壊さず固定できる。
-  const headRow = headHash === undefined ? -1 : (commitIndexMap.get(headHash) ?? -1);
-  const reserveHeadLane = headRow > 0;
+  const headCommitIndex = headHash === undefined ? -1 : (commitIndexMap.get(headHash) ?? -1);
+  const reserveHeadLane = headCommitIndex > 0;
+  // 出力行 (node index) は gap 挿入で commit index とずれるため、「HEAD に到達済みか」を
+  // フラグで持ち、数値の行 index に依存せず lane 0 予約の解除を判定する。
+  let headReached = false;
 
   const activeLanes: (LaneState | undefined)[] = [];
   // HEAD が表示集合内にあるなら色 0 は HEAD 専用に予約し、他レーンは 1 から採番する。
-  // HEAD 不在 (headRow < 0) なら予約不要なので従来どおり 0 から採番する。
-  let nextColor = headRow >= 0 ? 1 : 0;
+  // HEAD 不在 (headCommitIndex < 0) なら予約不要なので従来どおり 0 から採番する。
+  let nextColor = headCommitIndex >= 0 ? 1 : 0;
   let maxLanes = 0;
 
   const nodes: GraphNode[] = [];
   const lines: LineSegment[] = [];
 
-  for (let row = 0; row < commits.length; row++) {
-    const commit = commits[row];
+  for (let ci = 0; ci < commits.length; ci++) {
+    const commit = commits[ci];
+
+    // --- Phase 0: 途切れ境界で gap 行を挿入しレーンを切断 ---
+    // truncatedAbove は「直上で履歴が連続しない別セグメントの先頭」を示す
+    // (native が全ブランチ表示で HEAD-only walk を末尾 append した境界に立てる)。
+    // gap 行を 1 行挿入して最新クラスタと現在ブランチクラスタの間を視覚的に空ける
+    // (diff preview の「N unchanged lines」バー相当)。あわせて上のクラスタの末尾レーンは
+    // cut された親 (= 結果集合外) を待ったまま active に残るため、ここでクリアしないと
+    // Phase 1 が下のクラスタまで縦の通過線を垂れ流す。全 active レーンを undefined にして
+    // 上のクラスタの線を gap の手前で終端させ、下のクラスタを新規レーンで開始する。
+    if (ci > 0 && commit.truncatedAbove) {
+      nodes.push({ commit: GAP_COMMIT, lane: 0, color: 0, gap: true });
+      for (let i = 0; i < activeLanes.length; i++) activeLanes[i] = undefined;
+    }
+
+    // この commit の出力行 (gap 挿入を含めた node index)。SVG の dot / line 座標も
+    // この row を使い、行 DOM と SVG を同一 index 座標系に保つ。
+    const row = nodes.length;
 
     // --- Phase 1: この行に到達するセグメントを生成 ---
     // 前の行のレーン状態からこの行への遷移
@@ -117,14 +154,15 @@ export function computeGraphLayout(
     let lane: number;
     let color: number;
 
-    const isHead = row === headRow;
-    // HEAD 到達前は lane 0 を予約 (空き探索の下限を 1 に上げる) し、HEAD に確保しておく
-    const minLane = reserveHeadLane && row < headRow ? 1 : 0;
+    const isHead = headHash !== undefined && commit.hash === headHash;
+    // HEAD 到達前は lane 0 を予約 (空き探索の下限を 1 に上げる) し、HEAD に確保しておく。
+    // HEAD 行自身と HEAD 以降は予約解除 (minLane 0)。
+    const minLane = reserveHeadLane && !headReached && !isHead ? 1 : 0;
 
     if (isHead) {
       // HEAD は常に最左 lane (lane 0) と固定色 (HEAD_COLOR) に置く。
-      // 予約中 (headRow > 0) は確保済みの lane 0、HEAD が表示先頭 (headRow === 0) なら
-      // 貪欲割り当てでも lane 0 になる。子がある (matchingLanes あり) 場合も lane 0 を優先し、
+      // 予約中 (reserveHeadLane = headCommitIndex > 0) は確保済みの lane 0、HEAD が表示先頭
+      // (headCommitIndex === 0) なら貪欲割り当てでも lane 0 になる。子がある (matchingLanes あり) 場合も lane 0 を優先し、
       // 子の各レーンを下の合流処理で lane 0 へ寄せる。色は子に追従せず HEAD_COLOR に固定して
       // lane 0 = current branch の線を常に同色にし、Working Tree 行と揃える
       lane = reserveHeadLane ? 0 : findEmptyLane(activeLanes, minLane);
@@ -220,6 +258,8 @@ export function computeGraphLayout(
 
     maxLanes = Math.max(maxLanes, countActive(activeLanes));
     nodes.push({ commit, lane, color });
+    // HEAD 行を処理し終えたら lane 0 予約を解除する (以降の行は minLane 0)。
+    if (isHead) headReached = true;
   }
 
   return { nodes, lines, maxLanes: Math.max(maxLanes, 1) };

--- a/apps/renderer/src/features/git-graph/rangeHashes.test.ts
+++ b/apps/renderer/src/features/git-graph/rangeHashes.test.ts
@@ -13,6 +13,21 @@ import { buildRangeHashes } from "./rangeHashes";
  */
 const WT_SENTINEL = "__test-working-tree__";
 
+/** テスト用 commit を最小フィールドで生成する */
+function commit(hash: string, parents: string[], refs: string[] = []): GitCommit {
+  return {
+    hash,
+    shortHash: hash,
+    parents,
+    author: "",
+    date: 0,
+    message: "",
+    body: "",
+    refs,
+    truncatedAbove: false,
+  };
+}
+
 /**
  * テスト用 commit。first-parent walk のみ意味があるので parents[0] のみ設定する。
  * graph 形:
@@ -23,46 +38,10 @@ const WT_SENTINEL = "__test-working-tree__";
  */
 function makeCommits(): GitCommit[] {
   return [
-    {
-      hash: "c0",
-      shortHash: "c0",
-      parents: ["c1"],
-      author: "",
-      date: 0,
-      message: "",
-      body: "",
-      refs: ["HEAD"],
-    },
-    {
-      hash: "c1",
-      shortHash: "c1",
-      parents: ["c2"],
-      author: "",
-      date: 0,
-      message: "",
-      body: "",
-      refs: [],
-    },
-    {
-      hash: "c2",
-      shortHash: "c2",
-      parents: ["c3"],
-      author: "",
-      date: 0,
-      message: "",
-      body: "",
-      refs: [],
-    },
-    {
-      hash: "c3",
-      shortHash: "c3",
-      parents: [],
-      author: "",
-      date: 0,
-      message: "",
-      body: "",
-      refs: [],
-    },
+    commit("c0", ["c1"], ["HEAD"]),
+    commit("c1", ["c2"]),
+    commit("c2", ["c3"]),
+    commit("c3", []),
   ];
 }
 
@@ -116,18 +95,7 @@ describe("buildRangeHashes", () => {
   });
 
   test("HEAD ref を持つ commit が無いまま newer=WT_SENTINEL を渡すと空配列", () => {
-    const commits: GitCommit[] = [
-      {
-        hash: "c0",
-        shortHash: "c0",
-        parents: [],
-        author: "",
-        date: 0,
-        message: "",
-        body: "",
-        refs: [], // HEAD ref を持たない
-      },
-    ];
+    const commits: GitCommit[] = [commit("c0", [])]; // HEAD ref を持たない
     const map = makeMap(commits);
     expect(buildRangeHashes(WT_SENTINEL, WT_SENTINEL, map, commits, WT_SENTINEL)).toEqual([]);
   });

--- a/apps/renderer/src/features/git-graph/useGitGraphStore.ts
+++ b/apps/renderer/src/features/git-graph/useGitGraphStore.ts
@@ -15,6 +15,7 @@ const uncommittedCommit: GitCommit = {
   message: "Uncommitted Changes",
   body: "",
   refs: [],
+  truncatedAbove: false,
 };
 
 export const useGitGraphStore = defineStore("gitGraph", () => {

--- a/packages/proto/gozd/v1/common.proto
+++ b/packages/proto/gozd/v1/common.proto
@@ -109,6 +109,12 @@ message GitCommit {
   string message = 6;
   string body = 7;
   repeated string refs = 8;
+  // この commit の直上で履歴が途切れている (上の行とは連続しない別セグメントの先頭)
+  // ことを示す。全ブランチ表示で現在ブランチ (HEAD) が新しい順 max_count ウィンドウから
+  // 押し出されたとき、HEAD-only walk を末尾 append する境界の先頭 commit に立つ。
+  // renderer はこの行の上に「途切れ行」を描き、最新クラスタと現在ブランチクラスタの
+  // 不連続を可視化する。
+  bool truncated_above = 9;
 }
 
 message GitPullRequest {

--- a/packages/proto/gozd/v1/git_ops.proto
+++ b/packages/proto/gozd/v1/git_ops.proto
@@ -47,8 +47,11 @@ message GitLogRequest {
   SortMode sort_mode = 5;
 }
 message GitLogResponse {
-  // 全 ref を始点に 1 本の `git log --stdin` で walk した結果。child → parent 順、
-  // sort_mode に従って tie-break される。
+  // 全 ref を始点に `git log --stdin` で walk した結果。child → parent 順、
+  // sort_mode に従って tie-break される。current_branch_only=false で HEAD が
+  // 新しい順 max_count ウィンドウから押し出され結果に 1 件も含まれない場合のみ、HEAD-only
+  // walk を追加して末尾に append する (古い現在ブランチを graph 上で見えるように救済。
+  // HEAD 系統はウィンドウの最古 commit より古いため append で順序契約は保たれる)。
   repeated GitCommit commits = 1;
   // `git symbolic-ref refs/remotes/origin/HEAD` の結果 (例: `main`)。
   // 解決失敗時 / origin 未設定時は空文字。


### PR DESCRIPTION
## 概要

全ブランチ表示 ( Current Branch OFF ) で、古い current branch のコミットが Git Graph に 1 行も表示されない問題を修正する。HEAD が結果に必ず含まれるよう native 側で救済し、最新クラスタと現在ブランチクラスタの間に「途切れ行」を表示する。

## 背景

Git Graph の全ブランチ表示は HEAD / `origin/<default>` / `@{upstream}` を始点に **新しい順 maxCount 件** で `git log` を切る。default ブランチに HEAD tip より新しい commit が maxCount 件以上あると、HEAD 系統が窓から押し出されて現在ブランチが丸ごと欠落する。Current Branch ON のときだけ始点が HEAD のみになるため見える、という非対称が起きていた。

`maxCount` を増やす対症療法では HEAD tip が窓を大きく超える位置にあるケースを救えず、別の古いブランチでまた破綻するため、「HEAD を必ず結果に含める」方向で根本修正する。

## 変更内容

### native: 現在ブランチの救済 ( `GitOps.log` )

- 全ブランチ表示で HEAD が結果に含まれないときだけ HEAD-only walk を 1 本足し、末尾に append ( OID dedup ) する。HEAD 系統は「新しい順 `maxCount` 窓から押し出された」= all-refs 結果の最古 commit より必ず古いため、単純 append で date / topo どちらの順序契約も保たれる
- append 境界の先頭 commit に `truncated_above` を立てて renderer に伝える
- HEAD の在否は parse 済み refs ( `%D` の `HEAD` ) で判定し、追加の `rev-parse` を spawn しない

### proto

- `GitCommit` に `truncated_above` フィールドを追加 ( beta のため後方互換は作らない )

### renderer: 途切れ行の表示 ( `graphLayout.ts` / `GitGraphPane.vue` )

- `truncated_above` の行の手前に **gap 行を 1 ノード挿入**し、あわせて上クラスタの ( cut された親を待つ ) レーンを切断する。これをしないと上クラスタの縦線が下クラスタへ垂れ流れる
- gap 行も `layout.nodes` の 1 ノードとして 1 行枠を占有させ、SVG の行 index 座標系と DOM 行を一致させる
- gap 行は SVG の dot を描かず、`Earlier history hidden` を graph 列に 1 レーン分インデントして表示 ( commit メッセージ列と紛れず、lane 0 のコネクタ破線にも被らない )
- キーボードナビは gap 行を読み飛ばす。選択の行 index 引きも commit index ではなく node index ベースに変更

## 確認事項

- [ ] 古い current branch を開いた状態で Current Branch OFF にしたとき、最新 maxCount 件の下に途切れ行を挟んで現在ブランチが表示されること
- [ ] 途切れ行のテキストがレーン / コミットメッセージ列と被らないこと
- [ ] HEAD が窓内に収まる通常ブランチでは途切れ行が出ず従来どおりであること ( native test で担保 )
- [ ] キーボード上下移動で gap 行をスキップして選択が飛ぶこと
