### PR TITLE
Show typing indicator in terminal session preview while non-speech activity runs

### DIFF
--- a/apps/renderer/src/assets/main.css
+++ b/apps/renderer/src/assets/main.css
@@ -441,6 +441,28 @@
   }
 }
 
+/* セッションビューの「進行中」typing indicator (TerminalSessionPreview)。thinking / tool
+   などの発言以外のアクション中に「・」の数を周期的に増減させ、次の発言が来るまでの
+   作業継続をチャット UI の入力中表現で示す。content は非補間プロパティなので各
+   keyframe 区間の中間点で discrete に切り替わる (steps() 指定なしでも仕様上そう動く)。 */
+._fx-typing-dots::after {
+  content: "・";
+  animation: fx-typing-dots 1.2s ease-in-out infinite;
+}
+
+@keyframes fx-typing-dots {
+  0%,
+  100% {
+    content: "・";
+  }
+  33% {
+    content: "・・";
+  }
+  66% {
+    content: "・・・";
+  }
+}
+
 /* HUD のデジタル読み出し (時計等)。primary で淡く発光させる */
 ._fx-hud-readout {
   color: var(--color-primary-text);

--- a/apps/renderer/src/features/session-log/index.ts
+++ b/apps/renderer/src/features/session-log/index.ts
@@ -4,7 +4,7 @@
 // feature にまたがる (sidebar の task ⋮ メニュー dialog / terminal 右上の preview) ため、
 // 独立 feature として切り出している。共有データ取得は `useSessionLogLive` 1 つで賄い、
 // 表示の違いは各 consumer 側に閉じる。
-export { expandAskMessages, parseSessionLog } from "@gozd/claude-session-log";
+export { expandAskMessages, parseSessionLog, type TranscriptEvent } from "@gozd/claude-session-log";
 export { default as SessionLogDialog } from "./SessionLogDialog.vue";
 export { useSessionLogLive } from "./useSessionLogLive";
 export { useSessionLogViewer } from "./useSessionLogViewer";

--- a/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
+++ b/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
@@ -33,13 +33,21 @@ run 単位で kind ごとに件数を確保するため、assistant が連続応
 
 ## 進行中インジケータ
 
-各 overlay の bubble 列末尾に、transcript の直近が「発言以外のアクション中」なら
-`・` が増減する typing indicator (`_fx-typing-dots`) を assistant 吹き出しと同じ見た目で
-追加表示する。判定は `isSessionInProgress`
-(`terminalSessionPreviewMessages.ts`) が担い、ask 展開後の events 列の末尾 kind が
-thinking / tool なら進行中、user / assistant (発言) なら false にリセットする。
-preview は user/assistant/teammate 以外を filter で捨てるため、この判定だけは filter 前の
-events 列 (`parsePreview` の中間結果) を見る必要がある。
+各 overlay の bubble 列末尾に、「発言以外のアクション中」なら `・` が増減する typing
+indicator (`_fx-typing-dots`) を assistant 吹き出しと同じ見た目で追加表示する。transcript
+ベースの判定は `isSessionInProgress` (`terminalSessionPreviewMessages.ts`) が担い、ask 展開後の
+events 列の末尾 kind が thinking / tool なら進行中、user / assistant (発言) なら false
+にリセットする。preview は user/assistant/teammate 以外を filter で捨てるため、この判定だけは
+filter 前の events 列 (`parsePreview` の中間結果) を見る必要がある。
+
+main と sub で判定の確からしさが非対称になる。main は PTY を持ち、ClaudeStatus
+(`claudeStatus.ts`) が hooks + PTY 出力の interrupt パターンマッチで「本当に working か」を
+継続的に更新している。ユーザーが Ctrl+C/Escape で中断すると Claude Code は transcript に
+新規イベントを追記しない (interrupt 通知フックが無いため) ので、transcript 末尾だけで判定
+すると次の発言まで進行中表示が居座り続けて ClaudeStatus の badge (idle) と食い違う。そのため
+`mainInProgress` は `isSessionInProgress` の結果を `ClaudeStatus` (`getClaudeState(leafId)
+=== "working"`) で AND し、より確からしい信号を優先する。sub は Task ツールで起動される
+仮想セッションで PTY / ClaudeStatus を持たないため、transcript ベースの推定のみで妥協する。
 
 ## 折りたたみと高さ上限
 
@@ -174,7 +182,15 @@ const mainParsed = computed<ParsedPreview>(() => {
   const main = sessions.value.find((s) => s.kind === "main");
   return main === undefined ? { messages: [], inProgress: false } : parsePreview(main.content);
 });
-const mainInProgress = computed<boolean>(() => mainParsed.value.inProgress);
+// transcript 末尾が thinking/tool でも、ユーザーが Ctrl+C/Escape で中断した直後は
+// Claude Code が transcript に新規イベントを追記しない (interrupt 通知フックが無いため。
+// docs/claude-status.md 参照)。この場合 `ClaudeStatus` は PTY 出力のパターンマッチで
+// 既に idle に落ちているのに、transcript ベースの判定だけだと次の発言までインジケータが
+// 居座り続けて食い違う。main は PTY を持つため `ClaudeStatus` (TerminalLeafTitle の badge と
+// 同じ `getClaudeState`) で確定させ、transcript ベースの推定より優先する。
+const mainInProgress = computed<boolean>(
+  () => mainParsed.value.inProgress && terminalStore.getClaudeState(props.leafId) === "working",
+);
 
 // 最後に発話があった subagent 1 つの events + 表示ラベル (subagentTabLabel が組み立てた
 // agent 名 / workflow 見出し) + inProgress。「発話」は会話イベント (user / assistant) の
@@ -204,6 +220,8 @@ const newestSub = computed<
   return newest;
 });
 const subEvents = computed<PreviewEvent[]>(() => newestSub.value?.events ?? []);
+// sub は Task ツールで起動される仮想セッションで PTY を持たず ClaudeStatus が存在しないため、
+// main と異なり transcript ベースの推定 (`parsePreview` の inProgress) だけで判定する。
 const subInProgress = computed<boolean>(() => newestSub.value?.inProgress ?? false);
 // subLabel は <summary> の折り畳みハンドルを兼ねるため、subagentTabLabel が空文字
 // を返すケース (ロード途中 / meta.json 解析失敗) でも "Subagent" にフォールバック

--- a/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
+++ b/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
@@ -31,6 +31,16 @@ run 単位で kind ごとに件数を確保するため、assistant が連続応
 中間 span に逃がしている)。bubble が 0 件の overlay は非表示にし、両 overlay とも空なら
 何も描画しない。
 
+## 進行中インジケータ
+
+各 overlay の bubble 列末尾に、transcript の直近が「発言以外のアクション中」なら
+`・` が増減する typing indicator (`_fx-typing-dots`) を assistant 吹き出しと同じ見た目で
+追加表示する。判定は `isSessionInProgress`
+(`terminalSessionPreviewMessages.ts`) が担い、ask 展開後の events 列の末尾 kind が
+thinking / tool なら進行中、user / assistant (発言) なら false にリセットする。
+preview は user/assistant/teammate 以外を filter で捨てるため、この判定だけは filter 前の
+events 列 (`parsePreview` の中間結果) を見る必要がある。
+
 ## 折りたたみと高さ上限
 
 main / sub とも `<details><summary>` で bubble 群を折りたためる。summary は main が
@@ -96,7 +106,7 @@ import { usePopover } from "../../shared/popover";
 import { MarkdownBody } from "../preview";
 import { expandAskMessages, parseSessionLog, useSessionLogLive } from "../session-log";
 import type { PreviewEvent, PreviewMessage } from "./terminalSessionPreviewMessages";
-import { collectMessages } from "./terminalSessionPreviewMessages";
+import { collectMessages, isSessionInProgress } from "./terminalSessionPreviewMessages";
 import { useTerminalStore } from "./useTerminalStore";
 
 interface Props {
@@ -123,19 +133,27 @@ const { sessions } = useSessionLogLive(sessionId);
 // `expandAskMessages` で AskUserQuestion (kind: "ask") を「質問 = assistant 発言」
 // 「回答 = user 発言」に inline 展開する。展開後の events 列から user / assistant 以外
 // (thinking / tool / image / branch) を捨てるのは preview 側の責務 (どの kind を見せるかは
-// 表示制約。parser 側は ask 展開のみに閉じる)。
-function parsedEvents(content: string): PreviewEvent[] {
-  const out: PreviewEvent[] = [];
-  for (const ev of expandAskMessages(parseSessionLog(content).events)) {
+// 表示制約。parser 側は ask 展開のみに閉じる)。inProgress は展開後・filter 前の events 列
+// (末尾が thinking / tool かどうか) から判定するため、messages と同じ 1 回の parse 結果を
+// 両方の派生元にする。
+interface ParsedPreview {
+  messages: PreviewEvent[];
+  inProgress: boolean;
+}
+
+function parsePreview(content: string): ParsedPreview {
+  const events = expandAskMessages(parseSessionLog(content).events);
+  const messages: PreviewEvent[] = [];
+  for (const ev of events) {
     if (ev.kind === "user" || ev.kind === "assistant") {
-      out.push({ kind: ev.kind, text: ev.text, ts: ev.ts });
+      messages.push({ kind: ev.kind, text: ev.text, ts: ev.ts });
     } else if (ev.kind === "teammate") {
       // peer セッションからの受信発話は、この agent への inbound 入力として user 扱いで見せる
       // (subagent の spawn prompt も teammate でラップされるため、これを落とすと preview から消える)。
-      out.push({ kind: "user", text: ev.text, ts: ev.ts });
+      messages.push({ kind: "user", text: ev.text, ts: ev.ts });
     }
   }
-  return out;
+  return { messages, inProgress: isSessionInProgress(events) };
 }
 
 // 最後に「会話発話」(kind === user | assistant) があった ts。tool だけ走り続けている
@@ -150,21 +168,28 @@ function lastConversationTs(events: PreviewEvent[]): number {
   return 0;
 }
 
-// main session の events。サブで二度評価されるのを避けるため computed に切る。
-const mainEvents = computed<PreviewEvent[]>(() => {
+// main session の parse 結果 (messages + inProgress)。サブで二度評価されるのを避けるため
+// computed に切る。
+const mainParsed = computed<ParsedPreview>(() => {
   const main = sessions.value.find((s) => s.kind === "main");
-  return main === undefined ? [] : parsedEvents(main.content);
+  return main === undefined ? { messages: [], inProgress: false } : parsePreview(main.content);
 });
+const mainInProgress = computed<boolean>(() => mainParsed.value.inProgress);
 
 // 最後に発話があった subagent 1 つの events + 表示ラベル (subagentTabLabel が組み立てた
-// agent 名 / workflow 見出し)。「発話」は会話イベント (user / assistant) の最終 ts で判定し、
-// tool 単独走行の subagent はここでの最新性に寄与させない。events と label を 1 つの
-// computed にまとめておくと sub overlay の見出しと本文が同じ subagent から派生する不変条件を
-// 構造的に担保できる。
-const newestSub = computed<{ label: string; events: PreviewEvent[] } | undefined>(() => {
+// agent 名 / workflow 見出し) + inProgress。「発話」は会話イベント (user / assistant) の
+// 最終 ts で判定し、tool 単独走行の subagent はここでの最新性に寄与させない。events と
+// label を 1 つの computed にまとめておくと sub overlay の見出しと本文が同じ subagent から
+// 派生する不変条件を構造的に担保できる。
+const newestSub = computed<
+  { label: string; events: PreviewEvent[]; inProgress: boolean } | undefined
+>(() => {
   const subs = sessions.value
     .filter((s) => s.kind !== "main")
-    .map((s) => ({ label: s.label, events: parsedEvents(s.content) }))
+    .map((s) => {
+      const parsed = parsePreview(s.content);
+      return { label: s.label, events: parsed.messages, inProgress: parsed.inProgress };
+    })
     .filter((x) => x.events.length > 0);
   if (subs.length === 0) return undefined;
   let newest = subs[0];
@@ -179,6 +204,7 @@ const newestSub = computed<{ label: string; events: PreviewEvent[] } | undefined
   return newest;
 });
 const subEvents = computed<PreviewEvent[]>(() => newestSub.value?.events ?? []);
+const subInProgress = computed<boolean>(() => newestSub.value?.inProgress ?? false);
 // subLabel は <summary> の折り畳みハンドルを兼ねるため、subagentTabLabel が空文字
 // を返すケース (ロード途中 / meta.json 解析失敗) でも "Subagent" にフォールバック
 // して summary を必ず出す。summary を欠落させると UA デフォルト "Details" 表示に
@@ -190,7 +216,7 @@ const subLabel = computed<string>(() => {
 
 // bubble 選択は run 単位の純粋関数 `collectMessages` (terminalSessionPreviewMessages.ts) に
 // 委譲する。選択規則の詳細はそちらのコメントとテストを参照。
-const mainMessages = computed<PreviewMessage[]>(() => collectMessages(mainEvents.value));
+const mainMessages = computed<PreviewMessage[]>(() => collectMessages(mainParsed.value.messages));
 const subMessages = computed<PreviewMessage[]>(() => collectMessages(subEvents.value));
 
 // クリックで全文を出す popover。kind は吹き出し色を合わせるための discriminator、
@@ -280,6 +306,18 @@ const hasSub = computed(() => subMessages.value.length > 0);
               <span class="line-clamp-2">{{ msg.text }}</span>
             </button>
           </div>
+          <!-- 進行中インジケータ。transcript 末尾が thinking / tool (発言以外のアクション)
+               のときだけ出し、次の発言が来た瞬間 mainInProgress が false になって消える
+               (発言でリセット)。会話バブルの続きに見えるよう assistant 側と同じ吹き出し。 -->
+          <div v-if="mainInProgress" class="flex min-w-0">
+            <div
+              class="block rounded-lg bg-chat-incoming px-2 py-1 text-chat-incoming-text"
+              role="status"
+              aria-label="Working"
+            >
+              <span class="_fx-typing-dots inline-block w-9 text-center"></span>
+            </div>
+          </div>
         </div>
       </div>
     </details>
@@ -326,6 +364,16 @@ const hasSub = computed(() => subMessages.value.length > 0);
             >
               <span class="line-clamp-2">{{ msg.text }}</span>
             </button>
+          </div>
+          <!-- 進行中インジケータ。main と同じ規律 (末尾が thinking / tool のときだけ表示)。 -->
+          <div v-if="subInProgress" class="flex min-w-0">
+            <div
+              class="block rounded-lg bg-chat-incoming px-2 py-1 text-chat-incoming-text"
+              role="status"
+              aria-label="Working"
+            >
+              <span class="_fx-typing-dots inline-block w-9 text-center"></span>
+            </div>
           </div>
         </div>
       </div>

--- a/apps/renderer/src/features/terminal/terminalSessionPreviewMessages.test.ts
+++ b/apps/renderer/src/features/terminal/terminalSessionPreviewMessages.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import type { TranscriptEvent } from "../session-log";
 import type { PreviewEvent } from "./terminalSessionPreviewMessages";
-import { collectMessages } from "./terminalSessionPreviewMessages";
+import { collectMessages, isSessionInProgress } from "./terminalSessionPreviewMessages";
 
 // "u1" → user, "a3" → assistant のように先頭文字で kind を決め、ラベルを text に入れる。
 // ts は出現順の連番 (順序は ts に依存しない設計だが、実ログ同様に昇順で振っておく)
@@ -77,5 +78,43 @@ describe("collectMessages", () => {
   test("assistant 発言のみのログでも最新 run の末尾 3 件が出る", () => {
     const input = events("a1", "a2", "a3", "a4");
     expect(texts(input)).toEqual(["a2", "a3", "a4"]);
+  });
+});
+
+describe("isSessionInProgress", () => {
+  const tool: TranscriptEvent = {
+    kind: "tool",
+    name: "Bash",
+    input: {},
+    toolUseId: "t1",
+    ts: "2026-06-12T00:00:00Z",
+    result: undefined,
+  };
+  const thinking: TranscriptEvent = { kind: "thinking", text: "...", ts: "2026-06-12T00:00:00Z" };
+  const assistant: TranscriptEvent = {
+    kind: "assistant",
+    text: "done",
+    ts: "2026-06-12T00:00:00Z",
+  };
+  const user: TranscriptEvent = { kind: "user", text: "hi", ts: "2026-06-12T00:00:00Z" };
+
+  test("末尾が tool なら進行中", () => {
+    expect(isSessionInProgress([user, tool])).toBe(true);
+  });
+
+  test("末尾が thinking なら進行中", () => {
+    expect(isSessionInProgress([user, assistant, thinking])).toBe(true);
+  });
+
+  test("末尾が assistant (発言) ならリセットされる", () => {
+    expect(isSessionInProgress([user, tool, assistant])).toBe(false);
+  });
+
+  test("末尾が user (発言) ならリセットされる", () => {
+    expect(isSessionInProgress([assistant, tool, user])).toBe(false);
+  });
+
+  test("空配列は進行中でない", () => {
+    expect(isSessionInProgress([])).toBe(false);
   });
 });

--- a/apps/renderer/src/features/terminal/terminalSessionPreviewMessages.ts
+++ b/apps/renderer/src/features/terminal/terminalSessionPreviewMessages.ts
@@ -2,11 +2,24 @@
 // 「応答 (run) 単位」で preview に出すメッセージを選ぶ純粋関数。SFC から分離して
 // 回帰テスト (collectMessages.test.ts 相当) を書けるようにしている。
 
+import type { TranscriptEvent } from "../session-log";
+
 // parseSessionLog の events から user / assistant のみ残した会話イベント。
 export interface PreviewEvent {
   kind: "user" | "assistant";
   text: string;
   ts: string;
+}
+
+/**
+ * セッションが「発言以外のアクション中 (= 進行中)」かどうかを判定する。
+ * transcript の末尾イベントが thinking / tool なら、直近の発言以降まだ次の発言が
+ * 無い = 作業継続中とみなす。末尾が user / assistant (発言) なら進行中表示をリセットする。
+ * ask は expandAskMessages で user / assistant に展開済みの前提 (呼び出し側で展開してから渡す)。
+ */
+export function isSessionInProgress(events: TranscriptEvent[]): boolean {
+  const last = events[events.length - 1];
+  return last !== undefined && (last.kind === "thinking" || last.kind === "tool");
 }
 
 // 1 overlay 分の bubble。run 単位で表示対象を選び、events の出現順で並べる。


### PR DESCRIPTION
## 概要

ターミナル右上/右下に表示される Claude session preview (`TerminalSessionPreview.vue`) に、チャットツール風の「進行中」インジケータを追加した。会話 (user / assistant の発言) 以外のアクション (tool use / thinking) が続いている間、最後のバブルの後ろに `・` の数が周期的に増減するバブルを表示し、次の発言が来た瞬間に消える。

## 背景

Claude Code のセッションログはイベント列として「発言 (user / assistant)」と「発言以外のアクション (tool use / thinking)」に分かれる。session preview はこれまで発言だけを LINE 風バブルで表示しており、Claude が長時間ツールを実行し続けている間、preview 上は何も動きが無く見えるため「止まっているのか動いているのか」が読み取りづらかった。

既存の `ClaudeStatus` (`working` / `asking` / `done` 等) は PTY に紐づく hooks イベントベースの状態管理だが、これは main セッション (PTY を持つ) にしか適用できない。sub overlay に表示するサブエージェントは Task ツールで起動される仮想的なセッションで PTY を持たないため、hooks ベースの状態では main / sub 両方をカバーできない。そのため、preview が読んでいる transcript イベント列そのもの (末尾イベントの `kind` が発言以外の kind かどうか) から「進行中」を判定する方式にした。

ただし main は transcript ベースの判定だけでは不十分だった。ユーザーが Ctrl+C / Escape でツール実行を中断すると、Claude Code は interrupt 通知フックを持たないため transcript に新規イベントを追記しない。一方 `ClaudeStatus` は PTY 出力のパターンマッチでこの中断を検知して idle に落ちる設計になっている。この食い違いにより、transcript だけで判定すると次の発言まで進行中表示が居座り続けて `ClaudeStatus` の badge (idle) と矛盾しうる。そのため main は `ClaudeStatus` を優先信号として使う方式にした (`ClaudeStatus` 側の中断検知自体が正しく機能することが前提で、そこは本 PR のスコープ外)。

## 変更内容

### 進行中判定

- `terminalSessionPreviewMessages.ts` に `isSessionInProgress()` を追加。transcript の末尾イベントが `thinking` / `tool` なら true、`user` / `assistant` (発言) なら false を返す純粋関数
- `TerminalSessionPreview.vue` の `parsedEvents()` を `parsePreview()` に改名し、bubble 用の `messages` と `inProgress` を 1 回の parse から同時に導出するよう変更 (main / sub それぞれの二重 parse を避ける)
- main の `mainInProgress` は `isSessionInProgress` の結果を `ClaudeStatus` (`getClaudeState(leafId) === "working"`) で AND し、中断直後の食い違いを防ぐ。sub は PTY / ClaudeStatus を持たないため transcript ベースの推定のみで妥協する (main / sub の非対称は意図的な設計)

### UI

- main / sub 各 overlay の bubble 列末尾に、`inProgress` が true のときだけ assistant と同じ見た目のバブルで typing indicator を追加表示
- `main.css` に `._fx-typing-dots` + `@keyframes fx-typing-dots` を追加。CSS の `content` プロパティは補間できない discrete タイプのため、keyframe だけで JS タイマー無しに「・→・・→・・・」のドット数変化を実現している

### 型 / エクスポート

- `features/session-log/index.ts` で `TranscriptEvent` 型を re-export (実装・テスト双方から参照するため)

## 今回は対応しない

- `ClaudeStatus` の中断検知 (`detectInterrupt`、PTY 出力のパターンマッチ) 自体が中断後に正しく `idle` へ遷移するかどうかは別問題として扱う。本 PR は「`ClaudeStatus` が正しければ typing indicator も正しくなる」設計にとどめ、`detectInterrupt` 自体の信頼性向上は対象外とする

## 確認事項

- [ ] main session / subagent session それぞれで、tool 実行中に typing indicator が出て、次の発言で消えることを実機で確認
