### PR TITLE
fix(socket): クライアント socket に SO_NOSIGPIPE を設定して SIGPIPE 即死を防ぐ

### DIFF
--- a/apps/native/Package.swift
+++ b/apps/native/Package.swift
@@ -23,8 +23,14 @@ let package = Package(
     .executableTarget(
       name: "GozdCLI",
       dependencies: [
+        "GozdSocketClient",
         .product(name: "GozdProto", package: "GozdProto"),
       ]
+    ),
+    // Unix socket クライアント送信の SSOT。gozd-cli (短命プロセス) が GozdCore を
+    // リンクせずに済むよう、Darwin + Foundation のみ依存の軽量 target に分離する。
+    .target(
+      name: "GozdSocketClient"
     ),
     .target(
       name: "GozdCore",
@@ -42,7 +48,7 @@ let package = Package(
     ),
     .testTarget(
       name: "GozdCoreTests",
-      dependencies: ["GozdCore"]
+      dependencies: ["GozdCore", "GozdSocketClient"]
     ),
   ]
 )

--- a/apps/native/Sources/GozdCLI/main.swift
+++ b/apps/native/Sources/GozdCLI/main.swift
@@ -222,6 +222,19 @@ func sendOrExit(message: Gozd_V1_ClientMessage) async {
   }
   defer { close(fd) }
 
+  // SO_NOSIGPIPE: app 側が connection を close / reset した後の write は、これが無いと
+  // EPIPE ではなく SIGPIPE で CLI プロセスが即死し、hook イベントが stderr 出力もなく
+  // silent に消える (silent drop 禁止規律違反)。設定後は EPIPE が返り、下の write 失敗
+  // 経路が stderr へエラーを残して exit 1 する。
+  var noSigpipe: Int32 = 1
+  if setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &noSigpipe, socklen_t(MemoryLayout<Int32>.size))
+    != 0
+  {
+    FileHandle.standardError.write(
+      Data("Failed to set SO_NOSIGPIPE: \(String(cString: strerror(errno)))\n".utf8))
+    exit(1)
+  }
+
   var addr = sockaddr_un()
   addr.sun_family = sa_family_t(AF_UNIX)
   let pathBytes = Array(path.utf8)

--- a/apps/native/Sources/GozdCLI/main.swift
+++ b/apps/native/Sources/GozdCLI/main.swift
@@ -1,6 +1,7 @@
 import Darwin
 import Foundation
 import GozdProto
+import GozdSocketClient
 
 // gozd CLI（Swift 版）。
 //
@@ -194,15 +195,8 @@ func writeLaunchRequest(targetPath: String) throws {
 }
 
 /// 短命接続で 1 メッセージを送って終了する。失敗時は stderr + exit 1。
-///
-/// spike `gozd-spike` で検証した必須パターン:
-///   1. write
-///   2. shutdown(fd, SHUT_WR) で FIN を送信
-///   3. read drain（EOF まで読む）
-///   4. close
-///
-/// 直接 `close` すると NWListener が accept する前に FIN が届いて受信されない race が
-/// 起きるため、shutdown + drain で読み終わるまで待つ必要がある。
+/// socket の作成〜送信手順 (SO_NOSIGPIPE / write-all / shutdown + drain) は
+/// `GozdSocketClient.sendOverUnixSocket` が SSOT として持つ。
 func sendOrExit(message: Gozd_V1_ClientMessage) async {
   let payload: Data
   do {
@@ -213,84 +207,13 @@ func sendOrExit(message: Gozd_V1_ClientMessage) async {
     exit(1)
   }
 
-  let path = socketPath()
-  let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-  if fd < 0 {
-    FileHandle.standardError.write(
-      Data("Failed to create socket: \(String(cString: strerror(errno)))\n".utf8))
+  do {
+    try sendOverUnixSocket(path: socketPath(), payload: payload)
+  } catch SocketClientError.connect(let code) where code == ENOENT || code == ECONNREFUSED {
+    FileHandle.standardError.write(Data("gozd app is not running\n".utf8))
     exit(1)
-  }
-  defer { close(fd) }
-
-  // SO_NOSIGPIPE: app 側が connection を close / reset した後の write は、これが無いと
-  // EPIPE ではなく SIGPIPE で CLI プロセスが即死し、hook イベントが stderr 出力もなく
-  // silent に消える (silent drop 禁止規律違反)。設定後は EPIPE が返り、下の write 失敗
-  // 経路が stderr へエラーを残して exit 1 する。
-  var noSigpipe: Int32 = 1
-  if setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &noSigpipe, socklen_t(MemoryLayout<Int32>.size))
-    != 0
-  {
-    FileHandle.standardError.write(
-      Data("Failed to set SO_NOSIGPIPE: \(String(cString: strerror(errno)))\n".utf8))
+  } catch {
+    FileHandle.standardError.write(Data("\(error)\n".utf8))
     exit(1)
-  }
-
-  var addr = sockaddr_un()
-  addr.sun_family = sa_family_t(AF_UNIX)
-  let pathBytes = Array(path.utf8)
-  let maxLen = MemoryLayout.size(ofValue: addr.sun_path) - 1
-  if pathBytes.count > maxLen {
-    FileHandle.standardError.write(
-      Data("Socket path too long: \(path)\n".utf8))
-    exit(1)
-  }
-  withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
-    let buf = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self)
-    for (i, byte) in pathBytes.enumerated() {
-      buf[i] = CChar(bitPattern: byte)
-    }
-    buf[pathBytes.count] = 0
-  }
-
-  let connectResult = withUnsafePointer(to: &addr) { ptr in
-    ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
-      Darwin.connect(fd, sa, socklen_t(MemoryLayout<sockaddr_un>.size))
-    }
-  }
-  if connectResult < 0 {
-    let code = errno
-    if code == ENOENT || code == ECONNREFUSED {
-      FileHandle.standardError.write(Data("gozd app is not running\n".utf8))
-    } else {
-      FileHandle.standardError.write(
-        Data("Failed to connect: \(String(cString: strerror(code)))\n".utf8))
-    }
-    exit(1)
-  }
-
-  // write
-  payload.withUnsafeBytes { (buf: UnsafeRawBufferPointer) in
-    var remaining = buf.count
-    var ptr = buf.baseAddress!
-    while remaining > 0 {
-      let written = Darwin.write(fd, ptr, remaining)
-      if written < 0 {
-        FileHandle.standardError.write(
-          Data("write failed: \(String(cString: strerror(errno)))\n".utf8))
-        exit(1)
-      }
-      remaining -= written
-      ptr = ptr.advanced(by: written)
-    }
-  }
-
-  // shutdown(SHUT_WR) で書き終わりを通知してから drain
-  shutdown(fd, Int32(SHUT_WR))
-  var drainBuf = [UInt8](repeating: 0, count: 256)
-  while true {
-    let n = drainBuf.withUnsafeMutableBufferPointer {
-      Darwin.read(fd, $0.baseAddress, $0.count)
-    }
-    if n <= 0 { break }
   }
 }

--- a/apps/native/Sources/GozdSocketClient/SocketClient.swift
+++ b/apps/native/Sources/GozdSocketClient/SocketClient.swift
@@ -1,0 +1,126 @@
+import Darwin
+import Foundation
+
+// Unix Domain Socket クライアント送信の SSOT。
+//
+// gozd-cli の本番送信路 (`GozdCLI.sendOrExit`) と SocketServerTests の test helper が
+// 同一実装を共有する。かつては両者が同じ POSIX socket パターンを手写しで重複させており、
+// SO_NOSIGPIPE 欠落のような欠陥修正が一方に伝播しない構造だったため、単一 owner に集約した。
+//
+// `GozdCore` に畳まず専用の軽量 target にする理由: gozd-cli は Claude hooks の
+// イベントごとに起動される短命プロセスで、CPty / Network / FSEvents / git ops を抱える
+// `GozdCore` をリンクすると binary 肥大と初期化コストを負う (高頻度イベントを `nc` 直送に
+// 逃がしている「CLI を軽く保つ」設計意図と逆行する)。本 target は Darwin + Foundation
+// のみに依存する。
+//
+// 送信手順は spike `gozd-spike` で検証した必須パターン:
+//   1. write-all
+//   2. shutdown(SHUT_WR) で FIN を送信
+//   3. read drain (EOF まで読む)
+//   4. close
+//
+// 直接 `close` すると NWListener が accept する前に FIN が届いて受信されない race が
+// 起きるため、shutdown + drain で server 側が読み終わるまで待つ必要がある。
+
+public enum SocketClientError: Error, CustomStringConvertible {
+  case createSocket(errno: Int32)
+  case setNoSigpipe(errno: Int32)
+  case pathTooLong
+  case connect(errno: Int32)
+  case write(errno: Int32)
+
+  public var description: String {
+    switch self {
+    case .createSocket(let e): return "socket() failed: \(String(cString: strerror(e)))"
+    case .setNoSigpipe(let e):
+      return "setsockopt(SO_NOSIGPIPE) failed: \(String(cString: strerror(e)))"
+    case .pathTooLong: return "socket path too long"
+    case .connect(let e): return "connect() failed: \(String(cString: strerror(e)))"
+    case .write(let e): return "write() failed: \(String(cString: strerror(e)))"
+    }
+  }
+}
+
+/// 短命接続で 1 ペイロードを送り、server 側の受信完了 (EOF) まで待って返る。
+public func sendOverUnixSocket(path: String, payload: Data) throws {
+  let fd = try makeClientSocket()
+  defer { close(fd) }
+  try connectUnix(fd: fd, path: path)
+  try writeAll(fd: fd, data: payload)
+  shutdown(fd, Int32(SHUT_WR))
+  drainUntilEOF(fd: fd)
+}
+
+/// SO_NOSIGPIPE 設定済みのクライアント socket fd を作る。
+///
+/// SO_NOSIGPIPE: peer が connection を close / reset した後の write は、これが無いと
+/// EPIPE ではなく SIGPIPE をプロセス全体に配送する (default action は terminate)。
+/// gozd-cli では hook イベントが stderr 出力もなく silent に消え、swift-testing では
+/// 全 suite を単一プロセスで並列実行するため 1 回の race で swiftpm-testing-helper ごと
+/// signal 13 死して全テストが巻き添えになる (CI でのみ再現する flaky crash の正体)。
+/// 設定後は write が EPIPE を返し、`SocketClientError.write` として観察可能に throw される。
+func makeClientSocket() throws -> Int32 {
+  let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+  guard fd >= 0 else { throw SocketClientError.createSocket(errno: errno) }
+  var noSigpipe: Int32 = 1
+  guard
+    setsockopt(
+      fd, SOL_SOCKET, SO_NOSIGPIPE, &noSigpipe, socklen_t(MemoryLayout<Int32>.size)) == 0
+  else {
+    let e = errno
+    close(fd)
+    throw SocketClientError.setNoSigpipe(errno: e)
+  }
+  return fd
+}
+
+func connectUnix(fd: Int32, path: String) throws {
+  var addr = sockaddr_un()
+  addr.sun_family = sa_family_t(AF_UNIX)
+  let pathBytes = Array(path.utf8)
+  let maxLen = MemoryLayout.size(ofValue: addr.sun_path) - 1
+  guard pathBytes.count <= maxLen else { throw SocketClientError.pathTooLong }
+  withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+    let buf = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self)
+    for (i, byte) in pathBytes.enumerated() {
+      buf[i] = CChar(bitPattern: byte)
+    }
+    buf[pathBytes.count] = 0
+  }
+  let connectResult = withUnsafePointer(to: &addr) { ptr in
+    ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+      Darwin.connect(fd, sa, socklen_t(MemoryLayout<sockaddr_un>.size))
+    }
+  }
+  guard connectResult == 0 else { throw SocketClientError.connect(errno: errno) }
+}
+
+/// write-all (部分書き込みに loop 対応、EINTR は retry)。
+func writeAll(fd: Int32, data: Data) throws {
+  try data.withUnsafeBytes { (buf: UnsafeRawBufferPointer) in
+    var remaining = buf.count
+    guard var ptr = buf.baseAddress else { return }
+    while remaining > 0 {
+      let written = Darwin.write(fd, ptr, remaining)
+      if written < 0 {
+        if errno == EINTR { continue }
+        throw SocketClientError.write(errno: errno)
+      }
+      remaining -= written
+      ptr = ptr.advanced(by: written)
+    }
+  }
+}
+
+/// server 側が EOF まで読み取って close するのを待つ (EINTR は retry)。
+func drainUntilEOF(fd: Int32) {
+  var drainBuf = [UInt8](repeating: 0, count: 256)
+  while true {
+    let n = drainBuf.withUnsafeMutableBufferPointer {
+      Darwin.read(fd, $0.baseAddress, $0.count)
+    }
+    if n > 0 { continue }
+    if n < 0, errno == EINTR { continue }
+    break
+  }
+}

--- a/apps/native/Tests/GozdCoreTests/SocketClientTests.swift
+++ b/apps/native/Tests/GozdCoreTests/SocketClientTests.swift
@@ -1,0 +1,46 @@
+import Darwin
+import Foundation
+import Testing
+
+@testable import GozdSocketClient
+
+// SO_NOSIGPIPE の回帰テスト。これが外れると peer close 後の write が EPIPE ではなく
+// SIGPIPE をプロセス全体に配送し、swift-testing の単一プロセス並列実行では
+// swiftpm-testing-helper ごと signal 13 死して全テストが巻き添えになる
+// (CI でのみ再現していた flaky crash の正体)。gozd-cli では hook イベントの silent loss。
+@Suite("GozdSocketClient")
+struct SocketClientTests {
+  @Test("makeClientSocket は SO_NOSIGPIPE 設定済みの fd を返す")
+  func clientSocketHasNoSigpipe() throws {
+    let fd = try makeClientSocket()
+    defer { close(fd) }
+    var value: Int32 = 0
+    var len = socklen_t(MemoryLayout<Int32>.size)
+    #expect(getsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &value, &len) == 0)
+    #expect(value == 1)
+  }
+
+  @Test("peer close 済み socket への write は SIGPIPE ではなく EPIPE で throw する")
+  func writeAfterPeerCloseThrowsEpipe() throws {
+    // socketpair で peer を即 close し、「server が connection を reset した後に
+    // client が write する」race の当たり側を決定的に再現する。SO_NOSIGPIPE が
+    // 無ければこの write はプロセスを SIGPIPE で殺すため、テストが「fail する」
+    // のではなく test runner ごと消える。throw で観測できること自体が修正の証明。
+    var fds: [Int32] = [0, 0]
+    #expect(socketpair(AF_UNIX, SOCK_STREAM, 0, &fds) == 0)
+    defer { close(fds[0]) }
+    var noSigpipe: Int32 = 1
+    #expect(
+      setsockopt(
+        fds[0], SOL_SOCKET, SO_NOSIGPIPE, &noSigpipe, socklen_t(MemoryLayout<Int32>.size))
+        == 0)
+    close(fds[1])
+
+    #expect {
+      try writeAll(fd: fds[0], data: Data("x".utf8))
+    } throws: { error in
+      guard case SocketClientError.write(let e) = error else { return false }
+      return e == EPIPE
+    }
+  }
+}

--- a/apps/native/Tests/GozdCoreTests/SocketServerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/SocketServerTests.swift
@@ -111,6 +111,7 @@ private func fileExists(_ path: String) -> Bool {
 
 enum SocketClientError: Error, CustomStringConvertible {
   case createSocket(errno: Int32)
+  case setNoSigpipe(errno: Int32)
   case pathTooLong
   case connect(errno: Int32)
   case write(errno: Int32)
@@ -118,6 +119,8 @@ enum SocketClientError: Error, CustomStringConvertible {
   var description: String {
     switch self {
     case .createSocket(let e): return "socket() failed: \(String(cString: strerror(e)))"
+    case .setNoSigpipe(let e):
+      return "setsockopt(SO_NOSIGPIPE) failed: \(String(cString: strerror(e)))"
     case .pathTooLong: return "socket path too long"
     case .connect(let e): return "connect() failed: \(String(cString: strerror(e)))"
     case .write(let e): return "write() failed: \(String(cString: strerror(e)))"
@@ -133,6 +136,18 @@ private func sendOverUnixSocket(path: String, data: Data) throws {
   let fd = socket(AF_UNIX, SOCK_STREAM, 0)
   guard fd >= 0 else { throw SocketClientError.createSocket(errno: errno) }
   defer { close(fd) }
+
+  // SO_NOSIGPIPE: peer (server) が connection を close / reset した後の write は、
+  // これが無いと EPIPE ではなく SIGPIPE をプロセス全体に配送する (default action は
+  // terminate)。swift-testing は全 suite を単一プロセスで並列実行するため、1 回の
+  // race で swiftpm-testing-helper ごと signal 13 死し、全テストが巻き添えになる
+  // (CI でのみ再現する flaky crash の正体)。設定後は EPIPE が返り、下の write-all
+  // loop が SocketClientError.write として観察可能に throw する。
+  var noSigpipe: Int32 = 1
+  guard
+    setsockopt(
+      fd, SOL_SOCKET, SO_NOSIGPIPE, &noSigpipe, socklen_t(MemoryLayout<Int32>.size)) == 0
+  else { throw SocketClientError.setNoSigpipe(errno: errno) }
 
   var addr = sockaddr_un()
   addr.sun_family = sa_family_t(AF_UNIX)

--- a/apps/native/Tests/GozdCoreTests/SocketServerTests.swift
+++ b/apps/native/Tests/GozdCoreTests/SocketServerTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import GozdSocketClient
 import Testing
 
 @testable import GozdCore
@@ -25,7 +26,7 @@ struct SocketServerTests {
     // WaitUntil.swift 規律「使用可: OS event の到達待ち」に該当 (issue #710 系譜)。
     await waitUntil(timeout: .seconds(2)) { fileExists(path) }
 
-    try sendOverUnixSocket(path: path, data: Data(#"{"type":"ping"}\#n"#.utf8))
+    try sendOverUnixSocket(path: path, payload: Data(#"{"type":"ping"}\#n"#.utf8))
 
     let received = await bridge.collect(count: 1)
     #expect(received.count == 1)
@@ -54,7 +55,7 @@ struct SocketServerTests {
       {"i":3}
 
       """.utf8)
-    try sendOverUnixSocket(path: path, data: payload)
+    try sendOverUnixSocket(path: path, payload: payload)
 
     let received = await bridge.collect(count: 3).map { String(decoding: $0, as: UTF8.self) }
     #expect(received == [#"{"i":1}"#, #"{"i":2}"#, #"{"i":3}"#])
@@ -78,7 +79,7 @@ struct SocketServerTests {
     try await withThrowingTaskGroup(of: Void.self) { group in
       for i in 0..<5 {
         group.addTask {
-          try sendOverUnixSocket(path: path, data: Data(#"{"i":\#(i)}\#n"#.utf8))
+          try sendOverUnixSocket(path: path, payload: Data(#"{"i":\#(i)}\#n"#.utf8))
         }
       }
       try await group.waitForAll()
@@ -109,92 +110,8 @@ private func fileExists(_ path: String) -> Bool {
 // `waitUntil` は `WaitUntil.swift` の共有実装 ( dedicated NSThread 上で polling loop を完結 )。
 // timeout 時に `Issue.record` で tick 履歴を message に inline する。
 
-enum SocketClientError: Error, CustomStringConvertible {
-  case createSocket(errno: Int32)
-  case setNoSigpipe(errno: Int32)
-  case pathTooLong
-  case connect(errno: Int32)
-  case write(errno: Int32)
-
-  var description: String {
-    switch self {
-    case .createSocket(let e): return "socket() failed: \(String(cString: strerror(e)))"
-    case .setNoSigpipe(let e):
-      return "setsockopt(SO_NOSIGPIPE) failed: \(String(cString: strerror(e)))"
-    case .pathTooLong: return "socket path too long"
-    case .connect(let e): return "connect() failed: \(String(cString: strerror(e)))"
-    case .write(let e): return "write() failed: \(String(cString: strerror(e)))"
-    }
-  }
-}
-
-/// 本番 CLI（GozdCLI.sendOrExit）と同じ POSIX socket + write-all + shutdown(SHUT_WR) +
-/// drain パターンの test helper。NWConnection の `contentProcessed` 後に即 cancel すると
-/// NWListener が accept する前に FIN が届いて受信されない race（spike `gozd-spike` で
-/// 検証済み）が起き、CI で flaky に取りこぼす原因になる。production と同じ手順に揃える。
-private func sendOverUnixSocket(path: String, data: Data) throws {
-  let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-  guard fd >= 0 else { throw SocketClientError.createSocket(errno: errno) }
-  defer { close(fd) }
-
-  // SO_NOSIGPIPE: peer (server) が connection を close / reset した後の write は、
-  // これが無いと EPIPE ではなく SIGPIPE をプロセス全体に配送する (default action は
-  // terminate)。swift-testing は全 suite を単一プロセスで並列実行するため、1 回の
-  // race で swiftpm-testing-helper ごと signal 13 死し、全テストが巻き添えになる
-  // (CI でのみ再現する flaky crash の正体)。設定後は EPIPE が返り、下の write-all
-  // loop が SocketClientError.write として観察可能に throw する。
-  var noSigpipe: Int32 = 1
-  guard
-    setsockopt(
-      fd, SOL_SOCKET, SO_NOSIGPIPE, &noSigpipe, socklen_t(MemoryLayout<Int32>.size)) == 0
-  else { throw SocketClientError.setNoSigpipe(errno: errno) }
-
-  var addr = sockaddr_un()
-  addr.sun_family = sa_family_t(AF_UNIX)
-  let pathBytes = Array(path.utf8)
-  let maxLen = MemoryLayout.size(ofValue: addr.sun_path) - 1
-  guard pathBytes.count <= maxLen else { throw SocketClientError.pathTooLong }
-  withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
-    let buf = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self)
-    for (i, byte) in pathBytes.enumerated() {
-      buf[i] = CChar(bitPattern: byte)
-    }
-    buf[pathBytes.count] = 0
-  }
-  let connectResult = withUnsafePointer(to: &addr) { ptr in
-    ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
-      Darwin.connect(fd, sa, socklen_t(MemoryLayout<sockaddr_un>.size))
-    }
-  }
-  if connectResult < 0 { throw SocketClientError.connect(errno: errno) }
-
-  // write-all（部分書き込みに loop 対応）
-  try data.withUnsafeBytes { (buf: UnsafeRawBufferPointer) in
-    var remaining = buf.count
-    var ptr = buf.baseAddress!
-    while remaining > 0 {
-      let written = Darwin.write(fd, ptr, remaining)
-      if written < 0 {
-        if errno == EINTR { continue }
-        throw SocketClientError.write(errno: errno)
-      }
-      remaining -= written
-      ptr = ptr.advanced(by: written)
-    }
-  }
-
-  // shutdown(SHUT_WR) → drain。server 側が EOF まで読み取るのを待つ。
-  shutdown(fd, Int32(SHUT_WR))
-  var drainBuf = [UInt8](repeating: 0, count: 256)
-  while true {
-    let n = drainBuf.withUnsafeMutableBufferPointer {
-      Darwin.read(fd, $0.baseAddress, $0.count)
-    }
-    if n > 0 { continue }
-    if n < 0, errno == EINTR { continue }
-    break
-  }
-}
+// 送信は本番 CLI（GozdCLI.sendOrExit）と同一実装の `GozdSocketClient.sendOverUnixSocket` を
+// 使う。shutdown + drain 手順が必要な理由は SocketClient.swift の module コメントを参照。
 
 /// SocketServer の message callback を AsyncStream に直結する test 用 bridge。
 ///


### PR DESCRIPTION
## 概要

Unix domain socket へ生 `write(2)` するクライアント送信路に `SO_NOSIGPIPE` を設定し、peer が connection を close / reset した後の write が SIGPIPE（プロセス即死）ではなく EPIPE として既存のエラー経路に乗るようにする。あわせて、この欠陥を生んだ構造要因（CLI とテストヘルパーの手写し重複）を除去するため、socket クライアント送信を新設の軽量 target `GozdSocketClient` に SSOT として集約する。

## 背景

PR #883 の CI で swift-test が失敗し、再実行でも失敗した。ログを調査したところ、個々のテストの fail ではなく **swiftpm-testing-helper が signal 13（SIGPIPE）で即死**し、並走中の全テストが巻き添えになっていた。7/1 の別ブランチ（`fix/subagent-link-resolution`）の CI でも全く同じクラッシュが起きており、PR 差分とは無関係の既存欠陥である。

原因の絞り込みで、テストプロセス内で SIGPIPE を出せる書き込みを総当たりした:

- `GitRunner` の stdin pipe 書き込み（`FileHandle.write`）: git が fatal 終了して read 端が閉じた後の write を最小再現で実行しても死なない。Foundation の `Pipe` が fd に NOSIGPIPE を設定するため
- PTY master への write: character device のため SIGPIPE は発生しない（EIO になる）
- **`SocketServerTests.sendOverUnixSocket` の生 `Darwin.write`**: `SO_NOSIGPIPE` 未設定。peer close 済み socket への write で exit 141（= 128 + SIGPIPE）になることを最小再現で実証

swift-testing は全 suite を単一プロセスで並列実行するため、5 接続並行の `receivesFromMultipleConnections` 等で server 側の reset と client write が 1 回 race しただけでランナーごと死ぬ。ローカル（高速マシン）では 8 連続 pass、低速な CI runner でのみ顕在化する race であることとも整合する。

テストヘルパーは「本番 CLI と同じ POSIX socket パターン」を明示して写しており、`gozd-cli` 側にも同じ穴があった（app 側が connection を早期に落とすと CLI が SIGPIPE で silent 死し、Claude hooks イベントが stderr 出力もなく消える）。この「同一パターンの手写し重複により修正が一方に伝播しない」構造こそが欠陥の温床のため、対症の 2 箇所パッチではなく単一実装への集約で塞ぐ。

### 過去の flaky 修正でなぜ解決できなかったか

swift test の flaky 対策は 2026-05 に集中して行われている（FSEvents stale event の generation guard `2ed68b87`、PTY exit/drain 順序保証 `b1c22dbd`、並列 spawn EFAULT 回避 `931c6be4`、SocketServer test client の FIN race 修正 `3e97e137`、polling 排除の issue #710 系譜、PTY-TRACE 観測基盤 `2a958773`）。これらはそれぞれ独立した故障クラスの本物の root cause を潰しており、修正として正しかった。本クラッシュが残った理由は 2 つある。

- **故障シグネチャが質的に別物で、過去のデバッグ手法の入口に乗らない**。過去の flake はすべて「特定の名前のテストが fail する」症状で、落ちたテストを特定 → ローカル反復再現 → 修正 → 反復検証のループが回せた。PTY-TRACE 等の観測基盤も「fail したテストのログを事後復元する」装置である。一方 signal 13 はテストの fail ではなくランナープロセスの即死で、どのテストも失敗と報告されず、イベントストリームは途中で切断され、trace も部分 flush で終わる。「どのテストが原因か」を指す証拠が構造的に残らず、ローカルでも再現しない（8 連続 pass）
- **穴を開けたのは flaky 修正自身**。`3e97e137` は NWConnection ベースの test client が FIN race で message を取りこぼす flake を治すため、test client を本番 CLI の POSIX socket パターンの手写しコピーに置き換えた。FIN race は正しく治ったが、NWConnection が内部で処理していた NOSIGPIPE 相当の防御が、写した先の POSIX パターンには無かった（本番 `gozd-cli` に元からあった潜在欠陥ごとコピーされた）。本番では SIGPIPE で死ぬのは短命な CLI プロセス 1 個だが、単一プロセス並列実行のテストランナーに移植されたことで、1 回の race が全テストを巻き添えにする爆発半径に変わった

「flaky 修正 A が別クラスの flaky B を静かに植えた」構造であり、手写し重複の下では「本番と同じだから正しい」に見えてしまう（test helper のコメント自身が本番との一致を正当化根拠にしていた）。`GozdSocketClient` への SSOT 集約は、この再発経路そのものを断つための変更である。

## 変更内容

### GozdSocketClient（新設 target）

- 生 Unix socket NDJSON 送信（connect → write-all → `shutdown(SHUT_WR)` → drain）の SSOT。`SO_NOSIGPIPE` は socket 作成箇所（`makeClientSocket`）1 箇所だけに存在する
- Darwin + Foundation のみ依存の軽量 target。`GozdCore` に畳まないのは、hook イベントごとに起動される短命な `gozd-cli` に CPty / Network / FSEvents / git ops をリンクさせないため（高頻度イベントを `nc` 直送に逃がしている「CLI を軽く保つ」設計意図を維持）
- `writeAll` は EINTR を retry する。従来 CLI 側だけ retry がなかった非対称も解消。空 payload に対する force-unwrap（`baseAddress!`）も guard に置換

### gozd-cli

- `sendOrExit` の socket 処理を `GozdSocketClient.sendOverUnixSocket` 呼び出しに置換。connect の ENOENT / ECONNREFUSED → "gozd app is not running" + exit 1 という既存のエラー分岐は挙動保存

### テスト

- `SocketServerTests` の手写しヘルパーを削除し、本番と同一の `sendOverUnixSocket` を使用（「本番を写した並行コピーをテストする」状態の解消）
- 回帰テスト `SocketClientTests` を 2 本追加:
  - `makeClientSocket` が返す fd の `SO_NOSIGPIPE` を `getsockopt` で直接ガード
  - `socketpair` の peer close 後 write が `SocketClientError.write(EPIPE)` で throw されることを決定的に再現。自前で `SO_NOSIGPIPE` を張るため、将来 factory から設定が落ちてもランナーを殺さず前者のテストが clean に fail で捕える

## 確認事項

- [ ] `swift test` が pass する（ローカル 369 テスト / 55 suites 確認済み）
- [ ] peer close 済み socket への write が SIGPIPE でなく EPIPE になる（SO_NOSIGPIPE 無し: exit 141 で即死 / 有り: write が -1 / errno 32 (EPIPE) で返る、を最小再現で実証済み。回帰テストにも同構造をコード化）
- [ ] socket 不在時の `gozd-cli` が従来どおり "gozd app is not running" + exit 1 を返す（確認済み）
