### PR TITLE
fix(filer): material-icon-theme の SVG glob を alias 経由で配置非依存に解決する

### DIFF
--- a/apps/renderer/src/features/filer/useFileIcon.ts
+++ b/apps/renderer/src/features/filer/useFileIcon.ts
@@ -70,6 +70,17 @@ function buildIconMaps(): IconMaps {
     svgUrlByBasename.set(basename, url);
   }
 
+  // glob マッチ 0 件は build / typecheck を通過し、後段の per-icon エラー（"SVG x.svg not found"）が
+  // 単一ファイル欠落を誤示唆する。全滅は alias 解決・node_modules 配置・Vite バージョンといった
+  // 全体に及ぶ原因なので、ここで根本原因を名指しして throw する（silent drop 禁止の規律）
+  if (svgUrlByBasename.size === 0) {
+    throw new Error(
+      'material-icon-theme: import.meta.glob("$material-icons/*.svg") matched 0 files. ' +
+        "Check the $material-icons alias in vite.config.ts, the node_modules layout, " +
+        "and the Vite version (>= 8.0.8 for alias glob in production build; vitejs/vite issue 22193).",
+    );
+  }
+
   const iconUrlByName = buildIconUrlByName(manifest.iconDefinitions ?? {}, svgUrlByBasename);
 
   const fileNameMap = new Map<string, string>();

--- a/apps/renderer/src/features/filer/useFileIcon.ts
+++ b/apps/renderer/src/features/filer/useFileIcon.ts
@@ -51,14 +51,16 @@ function buildIconMaps(): IconMaps {
 
   /** Vite が SVG をハッシュ付き URL に変換した結果（basename → URL） */
   const svgUrlByBasename = new Map<string, string>();
-  const svgModules = import.meta.glob<string>("/node_modules/material-icon-theme/icons/*.svg", {
+  // "$material-icons" は vite.config.ts の alias。Node の module resolution で解決した
+  // material-icon-theme/icons の実体ディレクトリを指す（node_modules の物理配置に依存しない）
+  const svgModules = import.meta.glob<string>("$material-icons/*.svg", {
     eager: true,
     import: "default",
     query: "?url",
     exhaustive: true,
   });
   for (const [path, url] of Object.entries(svgModules)) {
-    // "/node_modules/material-icon-theme/icons/folder-development.clone.svg" → "folder-development.clone"
+    // ".../icons/folder-development.clone.svg" → "folder-development.clone"
     const [, basename] = path.match(/\/([^/]+)\.svg$/) ?? [];
     if (basename === undefined) {
       throw new Error(

--- a/apps/renderer/vite.config.ts
+++ b/apps/renderer/vite.config.ts
@@ -1,8 +1,20 @@
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import { docBlockPlugin } from "@miyaoka/vite-plugin-doc-block";
 import tailwindcss from "@tailwindcss/vite";
 import vue from "@vitejs/plugin-vue";
 import Icons from "unplugin-icons/vite";
 import { defineConfig } from "vite";
+
+// material-icon-theme の SVG を import.meta.glob で列挙するための alias。
+// nodeLinker: hoisted ではパッケージ実体が repo root の node_modules に置かれ、
+// Vite root (apps/renderer) 基準の "/node_modules/..." glob ではマッチしない。
+// Node の module resolution を SSOT に実体ディレクトリを解決し、配置方式に依存させない。
+const require = createRequire(import.meta.url);
+const materialIconsDir = join(
+  dirname(require.resolve("material-icon-theme/package.json")),
+  "icons",
+);
 
 // dev server port は env `GOZD_DEV_VITE_PORT` (root の `pnpm dev` script で設定) を SSOT として
 // 受け取る。Swift 側 (`RpcSchemeHandler` の Origin allowlist / `ExternalLinkNavigationDecider` の
@@ -23,6 +35,13 @@ export default defineConfig(() => {
     // font-size でサイズ指定している icon (text-xs 等) は 1em 基準が前提
     plugins: [docBlockPlugin(), tailwindcss(), vue(), Icons({ compiler: "vue3", scale: 1 })],
     base: "./",
+    resolve: {
+      alias: {
+        // "$" 始まりは実 fs パスへの alias の慣習 (SvelteKit $lib と同型)。"~" は
+        // unplugin-icons の virtual module (~icons/) と紛れるため使わない
+        "$material-icons": materialIconsDir,
+      },
+    },
     server: {
       port: portEnv !== undefined && portEnv !== "" ? Number(portEnv) : undefined,
       strictPort: true,


### PR DESCRIPTION
## 概要

ファイルツリー / Changes パネルの行が丸ごと描画されない不具合を修正する。material-icon-theme の SVG を列挙する `import.meta.glob` を `resolve.alias`（`$material-icons`）経由の解決に切り替え、node_modules の物理配置に依存しないようにする。あわせて、glob マッチ 0 件時に根本原因を名指しする診断 throw を追加する。

## 背景

electron-builder パッケージング対応（ #897 の 4d36e94d ）で `pnpm-workspace.yaml` に `nodeLinker: hoisted` が入り、依存パッケージの実体が repo root の `node_modules` に移動した。それ以降、以下の症状が発生していた。

- ファイルツリーでファイル行が描画されない（ディレクトリをクリックすると表示が消える）
- Changes パネルで件数だけ出て行の内容（ファイル名・アイコン）が一切表示されない

原因の連鎖:

- `import.meta.glob("/node_modules/material-icon-theme/icons/*.svg")` の `/` 始まりパターンは Vite root（apps/renderer）基準の**ファイルパス走査**であり、モジュール解決を通らない
- hoisted 化で `apps/renderer/node_modules/material-icon-theme` が消滅し、glob がマッチ 0 件になった（isolated linker 時代は workspace パッケージ直下への symlink 経由でマッチしていた）
- マッチ 0 件は build / typecheck を通過し、実行時に `buildIconUrlByName` が「SVG not found」で throw する
- `getFileIconUrl` / `getFolderIconUrl` を computed で呼ぶ全コンポーネント（FileTreeItem / ChangesTreeItem / ChangesSummaryItem / PreviewHeader）の render が失敗し、Vue 3 が該当コンポーネントをコメントノードに差し替えるため「行だけが静かに消える」症状になっていた

Vite の glob パターンは仕様上 3 形式（`./` 相対 / `/` root 絶対 / alias path）のみで、実装（`toAbsoluteGlob` → `resolveId` → alias plugin）上も依存パッケージ内部を配置非依存に指せるのは alias だけであることを vitejs/vite のソースと docs で確認した。

## 変更内容

### vite.config.ts

- `require.resolve("material-icon-theme/package.json")` で実体ディレクトリを解決し、`resolve.alias` の `$material-icons` に束ねる。Node のモジュール解決を SSOT にするため、hoisted / isolated どちらの linker でも壊れない
- alias 名は `$` 始まり（SvelteKit `$lib` と同型の実 fs パス alias 慣習）。`~` 始まりは unplugin-icons の virtual module（`~icons/`）と紛れるため避けた

### useFileIcon.ts

- SVG の glob は alias `$material-icons` 経由で解決し、node_modules の物理配置を知らない
- glob マッチ 0 件を検知して根本原因（alias 解決 / node_modules 配置 / Vite バージョン）を名指しする throw を追加。0 件時に後段の per-icon エラー「SVG x.svg not found」が単一ファイル欠落を誤示唆する問題への診断ネットで、alias glob の production build 回帰（vitejs/vite issue 22193 クラス）が再発した場合も runtime で原因が 1 行で特定できる

## 確認事項

- [ ] `pnpm --filter @gozd/renderer build` で `dist/assets/*.svg` が 1247 個出力される（修正前は 0 個）
- [ ] dev サーバーで glob が `/@fs/` URL に展開され SVG が HTTP 200 で配信される（検証済み）
- [ ] ファイルツリー / Changes パネルの行とアイコンが表示される
