### PR TITLE
fix(terminal): PTY replay ring buffer に総文字数上限を追加しターミナルあたり最大 16MiB に抑える

### DIFF
--- a/apps/renderer/src/features/terminal/ptySession.test.ts
+++ b/apps/renderer/src/features/terminal/ptySession.test.ts
@@ -1,0 +1,84 @@
+// ring buffer の容量契約（チャンク数 + 総文字数の二重上限）と replay の整合を検証する。
+// チャンクサイズは PTY read 単位でばらつくため、チャンク数上限だけでは総メモリが
+// 実質無制限になる（issue #894）。
+
+import { describe, expect, test } from "bun:test";
+import type { PaneEntry } from "./ptySession";
+import { createPtySessionManager, PTY_RING_BUFFER_MAX_CHARS } from "./ptySession";
+import { terminalScrollback } from "./terminalConfig";
+
+/** in-memory の pane registry を持つ manager を作り、leaf "leaf" を spawn 済みにする */
+async function setupManager() {
+  const registry = new Map<string, PaneEntry>([["leaf", { dir: "/work/repo" }]]);
+  const manager = createPtySessionManager({
+    panes: {
+      getPane: (leafId) => registry.get(leafId),
+      setSession: (leafId, session) => {
+        const entry = registry.get(leafId);
+        if (entry === undefined) return;
+        registry.set(leafId, { ...entry, session });
+      },
+      iterateEntries: () => registry.entries(),
+    },
+    requestPtySpawn: async () => 1,
+    sendPtyKill: () => {},
+  });
+  await manager.spawnPty("leaf", 80, 24);
+  return manager;
+}
+
+/** attach して replay されたチャンク列を回収する */
+function replayChunks(manager: Awaited<ReturnType<typeof setupManager>>): string[] {
+  const out: string[] = [];
+  const dispose = manager.attachTerminal("leaf", (data) => out.push(data));
+  dispose();
+  return out;
+}
+
+describe("ptySession ring buffer", () => {
+  test("上限未満のチャンクは受信順にそのまま replay される", async () => {
+    const manager = await setupManager();
+    manager.handlePtyData(1, "a");
+    manager.handlePtyData(1, "b");
+    manager.handlePtyData(1, "c");
+    expect(replayChunks(manager)).toEqual(["a", "b", "c"]);
+  });
+
+  test("チャンク数上限を超えると古いチャンクから破棄される", async () => {
+    const manager = await setupManager();
+    const overflow = 5;
+    const total = terminalScrollback + overflow;
+    for (let i = 0; i < total; i++) {
+      manager.handlePtyData(1, `c${i}`);
+    }
+    const replayed = replayChunks(manager);
+    expect(replayed.length).toBe(terminalScrollback);
+    expect(replayed[0]).toBe(`c${overflow}`);
+    expect(replayed[replayed.length - 1]).toBe(`c${total - 1}`);
+  });
+
+  test("総文字数上限を超えると古いチャンクから破棄される", async () => {
+    const manager = await setupManager();
+    // 3 チャンクで上限を超えるサイズ（各 3/8 上限 × 3 = 9/8 上限）
+    const chunkSize = (PTY_RING_BUFFER_MAX_CHARS / 8) * 3;
+    const [a, b, c] = ["a".repeat(chunkSize), "b".repeat(chunkSize), "c".repeat(chunkSize)];
+    manager.handlePtyData(1, a);
+    manager.handlePtyData(1, b);
+    manager.handlePtyData(1, c);
+    const replayed = replayChunks(manager);
+    expect(replayed.length).toBe(2);
+    expect(replayed[0]).toBe(b);
+    expect(replayed[1]).toBe(c);
+  });
+
+  test("単体で上限を超えるチャンクでも直近 1 個は必ず残す", async () => {
+    const manager = await setupManager();
+    const big = "x".repeat(PTY_RING_BUFFER_MAX_CHARS + 1);
+    manager.handlePtyData(1, big);
+    expect(replayChunks(manager)).toEqual([big]);
+
+    // 次のチャンクが来たら上限超過分（big）は破棄される
+    manager.handlePtyData(1, "y");
+    expect(replayChunks(manager)).toEqual(["y"]);
+  });
+});

--- a/apps/renderer/src/features/terminal/ptySession.test.ts
+++ b/apps/renderer/src/features/terminal/ptySession.test.ts
@@ -4,8 +4,11 @@
 
 import { describe, expect, test } from "bun:test";
 import type { PaneEntry } from "./ptySession";
-import { createPtySessionManager, PTY_RING_BUFFER_MAX_CHARS } from "./ptySession";
-import { terminalScrollback } from "./terminalConfig";
+import {
+  createPtySessionManager,
+  PTY_RING_BUFFER_CAPACITY,
+  PTY_RING_BUFFER_MAX_CHARS,
+} from "./ptySession";
 
 /** in-memory の pane registry を持つ manager を作り、leaf "leaf" を spawn 済みにする */
 async function setupManager() {
@@ -47,12 +50,12 @@ describe("ptySession ring buffer", () => {
   test("チャンク数上限を超えると古いチャンクから破棄される", async () => {
     const manager = await setupManager();
     const overflow = 5;
-    const total = terminalScrollback + overflow;
+    const total = PTY_RING_BUFFER_CAPACITY + overflow;
     for (let i = 0; i < total; i++) {
       manager.handlePtyData(1, `c${i}`);
     }
     const replayed = replayChunks(manager);
-    expect(replayed.length).toBe(terminalScrollback);
+    expect(replayed.length).toBe(PTY_RING_BUFFER_CAPACITY);
     expect(replayed[0]).toBe(`c${overflow}`);
     expect(replayed[replayed.length - 1]).toBe(`c${total - 1}`);
   });

--- a/apps/renderer/src/features/terminal/ptySession.ts
+++ b/apps/renderer/src/features/terminal/ptySession.ts
@@ -22,7 +22,7 @@ export interface PaneEntry {
 }
 
 /** ring buffer の容量（チャンク数）。scrollback（行数）とは単位が異なるが、十分な再生データを保持する目安として同じ値を使う */
-const PTY_RING_BUFFER_CAPACITY = terminalScrollback;
+export const PTY_RING_BUFFER_CAPACITY = terminalScrollback;
 
 /**
  * ring buffer が保持する総文字数の上限。JS string は UTF-16 なのでメモリ占有は約 2 倍のバイト数。

--- a/apps/renderer/src/features/terminal/ptySession.ts
+++ b/apps/renderer/src/features/terminal/ptySession.ts
@@ -8,6 +8,10 @@ interface PtySession {
   chunks: string[];
   /** 書き込み済み総チャンク数（ring buffer のインデックス計算用） */
   totalChunks: number;
+  /** 保持している最古チャンクの通し番号。これより前は容量上限で破棄済み */
+  startChunk: number;
+  /** 保持中チャンクの合計文字数（PTY_RING_BUFFER_MAX_CHARS との比較用） */
+  bufferedChars: number;
   /** PTY 終了済みか */
   exited: boolean;
 }
@@ -19,6 +23,42 @@ export interface PaneEntry {
 
 /** ring buffer の容量（チャンク数）。scrollback（行数）とは単位が異なるが、十分な再生データを保持する目安として同じ値を使う */
 const PTY_RING_BUFFER_CAPACITY = terminalScrollback;
+
+/**
+ * ring buffer が保持する総文字数の上限。JS string は UTF-16 なのでメモリ占有は約 2 倍のバイト数。
+ * チャンクサイズは PTY read 単位次第で数十 B〜数十 KB までばらつくため、チャンク数上限だけでは
+ * 総メモリが実質無制限になる（TUI の高頻度再描画で 1 ターミナルあたり 200MB 級。issue #894）。
+ * 8Mi 文字 ≈ 16 MiB/台。scrollback 10,000 行（ANSI エスケープ込み）の復元には十分な値
+ */
+export const PTY_RING_BUFFER_MAX_CHARS = 8 * 1024 * 1024;
+
+/**
+ * ring buffer にチャンクを追記する。チャンク数（PTY_RING_BUFFER_CAPACITY）と
+ * 総文字数（PTY_RING_BUFFER_MAX_CHARS）の二重上限で、古いチャンクから破棄する。
+ * 直近のチャンクは単体で上限を超えていても必ず 1 個残す
+ */
+function pushChunk(session: PtySession, data: string) {
+  // チャンク数が満杯なら、これから上書きする最古チャンクの分を先に差し引く
+  if (session.totalChunks - session.startChunk === PTY_RING_BUFFER_CAPACITY) {
+    session.bufferedChars -= session.chunks[session.startChunk % PTY_RING_BUFFER_CAPACITY].length;
+    session.startChunk++;
+  }
+  session.chunks[session.totalChunks % PTY_RING_BUFFER_CAPACITY] = data;
+  session.totalChunks++;
+  session.bufferedChars += data.length;
+
+  // 総文字数上限を超えたら最古チャンクから破棄する。空文字代入は、上書きで
+  // ring が一周するまで文字列参照が残り GC できないのを防ぐため
+  while (
+    session.bufferedChars > PTY_RING_BUFFER_MAX_CHARS &&
+    session.totalChunks - session.startChunk > 1
+  ) {
+    const oldestIdx = session.startChunk % PTY_RING_BUFFER_CAPACITY;
+    session.bufferedChars -= session.chunks[oldestIdx].length;
+    session.chunks[oldestIdx] = "";
+    session.startChunk++;
+  }
+}
 
 /** paneRegistry への session 読み書きアクセサ。store が所有する paneRegistry の session フィールドだけを操作する */
 interface PaneSessionAccessor {
@@ -90,10 +130,7 @@ export function createPtySessionManager(deps: PtySessionManagerDeps) {
     if (entry?.session === undefined) return;
 
     // ring buffer に追記
-    const session = entry.session;
-    const idx = session.totalChunks % PTY_RING_BUFFER_CAPACITY;
-    session.chunks[idx] = data;
-    session.totalChunks++;
+    pushChunk(entry.session, data);
 
     // attach 中の terminal に即時転送
     const writer = terminalWriters.get(leafId);
@@ -112,9 +149,7 @@ export function createPtySessionManager(deps: PtySessionManagerDeps) {
 
     // ring buffer に終了メッセージを追記
     const exitMsg = "\r\n[Process exited]\r\n";
-    const idx = session.totalChunks % PTY_RING_BUFFER_CAPACITY;
-    session.chunks[idx] = exitMsg;
-    session.totalChunks++;
+    pushChunk(session, exitMsg);
 
     const writer = terminalWriters.get(leafId);
     if (writer !== undefined) writer(exitMsg);
@@ -161,6 +196,8 @@ export function createPtySessionManager(deps: PtySessionManagerDeps) {
       ptyId,
       chunks: Array.from<string>({ length: PTY_RING_BUFFER_CAPACITY }),
       totalChunks: 0,
+      startChunk: 0,
+      bufferedChars: 0,
       exited: false,
     };
 
@@ -193,9 +230,7 @@ export function createPtySessionManager(deps: PtySessionManagerDeps) {
     if (entry?.session !== undefined) {
       // ring buffer replay
       const session = entry.session;
-      const stored = Math.min(session.totalChunks, PTY_RING_BUFFER_CAPACITY);
-      const startIdx = session.totalChunks - stored;
-      for (let i = startIdx; i < session.totalChunks; i++) {
+      for (let i = session.startChunk; i < session.totalChunks; i++) {
         writer(session.chunks[i % PTY_RING_BUFFER_CAPACITY]);
       }
     }


### PR DESCRIPTION
## 概要

PTY replay ring buffer の保持量を、従来のチャンク数 10,000 に加えて総文字数 8Mi（UTF-16 換算で約 16 MiB/ターミナル）で制限する。Claude 稼働ターミナル 1 台あたり約 200 MB に達していた renderer プロセスのメモリ消費が、この飽和値で頭打ちになる。

## 背景

issue #894 ( #894 ) で「ring buffer の上限がチャンク数でしか切られておらず総バイト数無制限」という仮説が立っていた。Electron 化 ( #897 ) 後の環境で実測して裏を取った。

- ターミナル表示直後に跳ねる +200 MB 級は GPU プロセス（xterm.js WebGL のグリフアトラス等）由来の弾性的な消費で、後で解放される別問題だった。Activity Monitor では GPU プロセスも無印「Gozd Helper」と表示されるため、renderer と混同しやすい
- renderer プロセスは Claude 稼働中のみ約 20 MB/分で成長し、アイドル 3 分間では ±2 MB の横ばいで解放もされない。蓄積型バッファの挙動そのもので、実測約 190 MB/台は issue #894 の実測 200 MB/台と量級一致
- 1 チャンクは PTY read 単位で数十 B〜数十 KB までばらつくため、チャンク数上限は総メモリの上限として機能しない。飽和値は「直近 10,000 チャンクの合計サイズ × 2 バイト」となり、画面全体を高頻度再描画する TUI ほど膨らむ

detach 時に xterm serialize addon でスナップショット化する案（issue #894 のもう一方の候補）は、detach 中も PTY が出力を続ける以上、生チャンク蓄積の総量上限がどのみち必要になるため今回は採らなかった。

## 変更内容

### ring buffer の二重上限

- 総文字数上限 `PTY_RING_BUFFER_MAX_CHARS`（8Mi 文字 ≈ 16 MiB）を追加し、超過時は最古チャンクから破棄する。直近 1 チャンクは単体で上限を超えていても必ず保持する
- チャンク数上限（10,000）は維持する。文字数上限単独だと、極小チャンクが大量に溜まったとき文字列オブジェクトのヘッダオーバーヘッドが支配する別の穴が開くため
- 破棄したスロットには空文字を代入し、ring が一周するまで文字列参照が残って GC できない問題を防ぐ

### テスト

- 容量契約（受信順 replay / チャンク数上限 / 総文字数上限 / 単体超過チャンクの保持）を `ptySession.test.ts` で固定

## 確認事項

- [ ] Claude 稼働ターミナルを複数開いた状態で、renderer プロセスの RSS が「ベースライン + 約 16 MiB × ターミナル数」で頭打ちになること
- [ ] 大量出力後に worktree を切り替えて戻ったとき、スクロールバックが従来どおり復元されること
