### PR TITLE
feat(terminal): Claude 作業中の pane を閉じる前に確認ダイアログを挟む

### DIFF
--- a/apps/renderer/src/features/terminal/ClosePaneConfirmDialog.vue
+++ b/apps/renderer/src/features/terminal/ClosePaneConfirmDialog.vue
@@ -40,12 +40,14 @@ function onDialogClick(event: MouseEvent) {
       <p class="text-sm">Claude is still working in this terminal. Close it anyway?</p>
       <div class="flex justify-end gap-2">
         <button
+          type="button"
           class="rounded-sm px-3 py-1.5 text-sm text-foreground-low hover:bg-panel"
           @click="requestClose"
         >
           Cancel
         </button>
         <button
+          type="button"
           class="rounded-sm bg-destructive px-3 py-1.5 text-sm text-foreground hover:bg-destructive-hover"
           @click="confirm"
         >

--- a/apps/renderer/src/features/terminal/ClosePaneConfirmDialog.vue
+++ b/apps/renderer/src/features/terminal/ClosePaneConfirmDialog.vue
@@ -1,0 +1,57 @@
+<doc lang="md">
+Claude が作業中 (working) の terminal pane を閉じる前の確認 dialog。
+
+`useClosePaneConfirm` の pendingAction が SSOT。ユーザー操作 (Cancel / backdrop / ESC) は
+すべて native `dialog.close()` を起点にし、`@close` → `cancel()` だけが pendingAction を
+undefined に同期する。OK は `confirm()` で pendingAction を消化し、watch 経由で同じ close
+経路に乗る（cancel は no-op になり二重実行しない）。
+</doc>
+
+<script setup lang="ts">
+import { ref, watch } from "vue";
+import { useClosePaneConfirm } from "./useClosePaneConfirm";
+
+const { pendingAction, cancel, confirm } = useClosePaneConfirm();
+const dialogRef = ref<HTMLDialogElement | undefined>(undefined);
+
+watch(pendingAction, (next) => {
+  const dialog = dialogRef.value;
+  if (dialog === undefined) return;
+  if (next === undefined) {
+    if (dialog.open) dialog.close();
+    return;
+  }
+  // 既に open な <dialog> への showModal は InvalidStateError を投げるためガードする
+  if (!dialog.open) dialog.showModal();
+});
+
+function requestClose() {
+  dialogRef.value?.close();
+}
+
+function onDialogClick(event: MouseEvent) {
+  if (event.target === dialogRef.value) requestClose();
+}
+</script>
+
+<template>
+  <dialog ref="dialogRef" class="backdrop:bg-overlay" @click="onDialogClick" @close="cancel">
+    <div class="space-y-4 rounded-lg border border-border bg-background p-4 text-foreground">
+      <p class="text-sm">Claude is still working in this terminal. Close it anyway?</p>
+      <div class="flex justify-end gap-2">
+        <button
+          class="rounded-sm px-3 py-1.5 text-sm text-foreground-low hover:bg-panel"
+          @click="requestClose"
+        >
+          Cancel
+        </button>
+        <button
+          class="rounded-sm bg-destructive px-3 py-1.5 text-sm text-foreground hover:bg-destructive-hover"
+          @click="confirm"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  </dialog>
+</template>

--- a/apps/renderer/src/features/terminal/TerminalPane.vue
+++ b/apps/renderer/src/features/terminal/TerminalPane.vue
@@ -17,6 +17,7 @@ import { useElementSize, useEventListener } from "@vueuse/core";
 import { computed, onUnmounted, useTemplateRef, watch } from "vue";
 import { useContextKeys } from "../../shared/command";
 import { useWorktreeStore } from "../worktree";
+import ClosePaneConfirmDialog from "./ClosePaneConfirmDialog.vue";
 import { registerTerminalCommands } from "./registerTerminalCommands";
 import SplitResizeHandle from "./SplitResizeHandle.vue";
 import {
@@ -210,5 +211,7 @@ function handleRectStyle(rect: PixelRect): Record<string, string> {
       :available-px="handle.availablePx"
       :style="handleRectStyle(handle.rect)"
     />
+    <!-- Claude 作業中 pane を閉じる前の確認 dialog（closed 時は display:none、open 時は top layer なので grid に影響しない） -->
+    <ClosePaneConfirmDialog />
   </div>
 </template>

--- a/apps/renderer/src/features/terminal/registerTerminalCommands.ts
+++ b/apps/renderer/src/features/terminal/registerTerminalCommands.ts
@@ -4,6 +4,7 @@
  */
 import type { Ref, ShallowRef } from "vue";
 import { useCommandRegistry } from "../../shared/command";
+import { useClosePaneConfirm } from "./useClosePaneConfirm";
 import { findNavigationTarget } from "./useSpatialNavigation";
 import { useTerminalStore } from "./useTerminalStore";
 
@@ -19,6 +20,7 @@ export function registerTerminalCommands(
 ): () => void {
   const registry = useCommandRegistry();
   const terminalStore = useTerminalStore();
+  const closeConfirm = useClosePaneConfirm();
 
   /** 現在の dir と layout を取得するヘルパー。無効なら undefined */
   function getActiveLayout() {
@@ -98,10 +100,20 @@ export function registerTerminalCommands(
       handler: () => {
         const active = getFocusedLayout();
         if (active === undefined) return false;
-        // 最後の1ペインでは closePane が false を返すので、レイアウトをリセットして新ターミナルを起動
-        if (!terminalStore.closePane(active.dir, active.layout.focusedLeafId)) {
-          terminalStore.resetLayout(active.dir);
+        const leafId = active.layout.focusedLeafId;
+        const close = () => {
+          // 最後の1ペインでは closePane が false を返すので、レイアウトをリセットして新ターミナルを起動
+          if (!terminalStore.closePane(active.dir, leafId)) {
+            terminalStore.resetLayout(active.dir);
+          }
+        };
+        // Claude が作業中の pane は PTY kill で作業が失われるため確認を挟む
+        // （done + pendingWork の「裏で作業継続中」も displayClaudeState が working に畳む）
+        if (terminalStore.getClaudeState(leafId) === "working") {
+          closeConfirm.request(close);
+          return true;
         }
+        close();
         return true;
       },
     }),

--- a/apps/renderer/src/features/terminal/useClosePaneConfirm.test.ts
+++ b/apps/renderer/src/features/terminal/useClosePaneConfirm.test.ts
@@ -51,10 +51,20 @@ describe("useClosePaneConfirm", () => {
     expect(pendingAction.value).toBeUndefined();
   });
 
-  test("request の上書き後は最後の action だけ実行される", () => {
+  test("確認中の request 再投入は無視される（先勝ち。close 対象の差し替え防止）", () => {
     const { request, confirm } = useClosePaneConfirm();
     const calls: string[] = [];
     request(() => calls.push("first"));
+    request(() => calls.push("second"));
+    confirm();
+    expect(calls).toEqual(["first"]);
+  });
+
+  test("確認を畳んだ後は再び request できる", () => {
+    const { request, confirm, cancel } = useClosePaneConfirm();
+    const calls: string[] = [];
+    request(() => calls.push("first"));
+    cancel();
     request(() => calls.push("second"));
     confirm();
     expect(calls).toEqual(["second"]);

--- a/apps/renderer/src/features/terminal/useClosePaneConfirm.test.ts
+++ b/apps/renderer/src/features/terminal/useClosePaneConfirm.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { useClosePaneConfirm } from "./useClosePaneConfirm";
+
+describe("useClosePaneConfirm", () => {
+  // module singleton なので各テスト前に確認状態を畳んでおく
+  beforeEach(() => {
+    useClosePaneConfirm().cancel();
+  });
+
+  test("request で pendingAction が立つ", () => {
+    const { pendingAction, request } = useClosePaneConfirm();
+    expect(pendingAction.value).toBeUndefined();
+    request(() => {});
+    expect(pendingAction.value).toBeDefined();
+  });
+
+  test("confirm は action を 1 回だけ実行して確認を畳む", () => {
+    const { pendingAction, request, confirm } = useClosePaneConfirm();
+    let count = 0;
+    request(() => {
+      count++;
+    });
+    confirm();
+    expect(count).toBe(1);
+    expect(pendingAction.value).toBeUndefined();
+    // 連打しても 2 回目は pendingAction が消えているので no-op
+    confirm();
+    expect(count).toBe(1);
+  });
+
+  test("confirm 後の cancel は action を再実行しない（@close 経路の二重実行防止）", () => {
+    const { request, confirm, cancel } = useClosePaneConfirm();
+    let count = 0;
+    request(() => {
+      count++;
+    });
+    // confirm が pendingAction を先に消化するため、後続の dialog @close → cancel は no-op になる
+    confirm();
+    cancel();
+    expect(count).toBe(1);
+  });
+
+  test("cancel は action を実行せず確認を畳む", () => {
+    const { pendingAction, request, cancel } = useClosePaneConfirm();
+    let count = 0;
+    request(() => {
+      count++;
+    });
+    cancel();
+    expect(count).toBe(0);
+    expect(pendingAction.value).toBeUndefined();
+  });
+
+  test("request の上書き後は最後の action だけ実行される", () => {
+    const { request, confirm } = useClosePaneConfirm();
+    const calls: string[] = [];
+    request(() => calls.push("first"));
+    request(() => calls.push("second"));
+    confirm();
+    expect(calls).toEqual(["second"]);
+  });
+});

--- a/apps/renderer/src/features/terminal/useClosePaneConfirm.ts
+++ b/apps/renderer/src/features/terminal/useClosePaneConfirm.ts
@@ -1,0 +1,31 @@
+/**
+ * Claude が作業中 (working) の pane を閉じる前の確認 state を保持する module singleton。
+ *
+ * `useSessionLogViewer` と同じく必要最小の値だけ保持する。close 処理そのものは
+ * コマンド handler 側の知識（closePane / resetLayout フォールバック）なので、
+ * ここは実行するクロージャを預かるだけにして層の知識を持ち込まない。
+ */
+import { ref } from "vue";
+
+const pendingAction = ref<(() => void) | undefined>(undefined);
+
+export function useClosePaneConfirm() {
+  /** 確認を要求する。OK されたら action が実行される */
+  function request(action: () => void) {
+    pendingAction.value = action;
+  }
+
+  /** 確認を取り下げる（Cancel / backdrop / ESC）。close 済みなら no-op */
+  function cancel() {
+    pendingAction.value = undefined;
+  }
+
+  /** OK: 預かった action を実行して確認を畳む */
+  function confirm() {
+    const action = pendingAction.value;
+    pendingAction.value = undefined;
+    action?.();
+  }
+
+  return { pendingAction, request, cancel, confirm };
+}

--- a/apps/renderer/src/features/terminal/useClosePaneConfirm.ts
+++ b/apps/renderer/src/features/terminal/useClosePaneConfirm.ts
@@ -10,8 +10,14 @@ import { ref } from "vue";
 const pendingAction = ref<(() => void) | undefined>(undefined);
 
 export function useClosePaneConfirm() {
-  /** 確認を要求する。OK されたら action が実行される */
+  /**
+   * 確認を要求する。OK されたら action が実行される。
+   * 確認中の再投入は無視する（先勝ち）。上書きを許すとダイアログ表示中に
+   * コマンドが再実行されたとき close 対象が別 pane に差し替わるため、
+   * focus 制御や keybinding の when 条件に依存せず構造的に防ぐ。
+   */
   function request(action: () => void) {
+    if (pendingAction.value !== undefined) return;
     pendingAction.value = action;
   }
 

--- a/apps/renderer/src/features/terminal/useClosePaneConfirm.ts
+++ b/apps/renderer/src/features/terminal/useClosePaneConfirm.ts
@@ -2,8 +2,8 @@
  * Claude が作業中 (working) の pane を閉じる前の確認 state を保持する module singleton。
  *
  * `useSessionLogViewer` と同じく必要最小の値だけ保持する。close 処理そのものは
- * コマンド handler 側の知識（closePane / resetLayout フォールバック）なので、
- * ここは実行するクロージャを預かるだけにして層の知識を持ち込まない。
+ * 呼び出し元の知識なので、ここは実行するクロージャを預かるだけにして
+ * 層の知識を持ち込まない。
  */
 import { ref } from "vue";
 

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -87,15 +87,15 @@ leafNode
 
 ### コマンド
 
-| コマンド                   | 動作                                    |
-| -------------------------- | --------------------------------------- |
-| `terminal.splitHorizontal` | アクティブ leaf を水平分割              |
-| `terminal.splitVertical`   | アクティブ leaf を垂直分割              |
-| `terminal.closePane`       | アクティブ leaf を閉じる（PTY も kill） |
-| `terminal.focusLeft`       | 左の leaf にフォーカス移動              |
-| `terminal.focusRight`      | 右の leaf にフォーカス移動              |
-| `terminal.focusUp`         | 上の leaf にフォーカス移動              |
-| `terminal.focusDown`       | 下の leaf にフォーカス移動              |
+| コマンド                   | 動作                                                                                                                                                                               |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `terminal.splitHorizontal` | アクティブ leaf を水平分割                                                                                                                                                         |
+| `terminal.splitVertical`   | アクティブ leaf を垂直分割                                                                                                                                                         |
+| `terminal.closePane`       | アクティブ leaf を閉じる（PTY も kill）。Claude が working の leaf は確認ダイアログを挟む（PTY kill で作業が失われるため。done + pendingWork の「裏で作業継続中」も working 扱い） |
+| `terminal.focusLeft`       | 左の leaf にフォーカス移動                                                                                                                                                         |
+| `terminal.focusRight`      | 右の leaf にフォーカス移動                                                                                                                                                         |
+| `terminal.focusUp`         | 上の leaf にフォーカス移動                                                                                                                                                         |
+| `terminal.focusDown`       | 下の leaf にフォーカス移動                                                                                                                                                         |
 
 ## Worktree ごとのレイアウト保持
 


### PR DESCRIPTION
## 概要

Claude が working 状態のターミナル pane を `terminal.closePane`（cmd+w / コマンドパレット）で閉じようとしたとき、確認ダイアログ（Cancel / Close）を挟むようにする。

## 背景

`terminal.closePane` は確認なしで即座に pane を破棄し PTY を kill する。Claude が作業中の pane を誤って cmd+w で閉じると、進行中の作業がそのまま失われる。作業中であることをユーザーに知らせ、意図しない kill を防ぐ確認ステップが必要だった。

実装にあたり sidebar の既存確認ダイアログ（`useDialogs`）の再利用を検討したが、dialog 要素が SidebarPane のテンプレートに閉じたインスタンススコープ設計で terminal feature から呼べないため、`useSessionLogViewer` と同じ module singleton composable パターンで terminal feature 内に新設した。

## 変更内容

### 確認ダイアログ

- `useClosePaneConfirm.ts` を新設。確認状態（実行を預かるクロージャ）を保持する module singleton composable
- `ClosePaneConfirmDialog.vue` を新設。ネイティブ `<dialog>` の確認 UI。close 経路は `SessionLogDialog` と同じ規律（ユーザー操作はすべて native `dialog.close()` 起点、`@close` が state 同期の単一点）で、OK は `confirm()` が pendingAction を先に消化するため二重実行しない
- `TerminalPane.vue` にダイアログをマウント

### closePane コマンドのガード

- `registerTerminalCommands.ts` の `terminal.closePane` ハンドラで `getClaudeState(leafId) === "working"` の場合は即閉じず確認に委譲
- working 判定は `displayClaudeState` 経由のため、「done だが background task が残る偽 done（pendingWork）」も working としてガードされる。`asking`（許可待ち）と真の `done` は従来どおり確認なしで閉じる

### テスト

- `useClosePaneConfirm.test.ts` を新設。confirm が action を 1 回だけ実行する / cancel は action を呼ばない（`@close` 経路の二重実行防止）/ request 上書きの契約を固定

### ドキュメント

- `docs/terminal.md` のコマンド表に確認ダイアログの挙動を追記

## 今回含めない点

- **今回は対応しない**: worktree 削除経由の全 pane 破棄（sidebar）はガード対象外。force remove には既存の確認ダイアログがあり、clean worktree の通常 remove まで working ガードを広げるかは別の判断になるためスコープ外とした

## 確認事項

- [ ] Claude が working 中の pane で cmd+w → 確認ダイアログが出る（Cancel / ESC / backdrop で閉じたとき pane が残る、Close で pane が閉じる）
- [ ] Claude 未起動 / idle / done の pane では従来どおり即閉じる
- [ ] 最後の 1 pane（resetLayout フォールバック）でも確認が挟まる
- [ ] ダイアログを閉じた後（Cancel / Close 双方）、期待する pane に focus が戻る
