### PR TITLE
chore(dev): dev runner の起動ログを撤去する

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -13,7 +13,7 @@
 import { spawnSync } from "node:child_process";
 import { realpathSync } from "node:fs";
 import { createServer } from "node:net";
-import { basename, resolve } from "node:path";
+import { resolve } from "node:path";
 import { derivePortBase, PORT_SWEEP } from "./devPort";
 
 const repoRoot = realpathSync(resolve(import.meta.dir, ".."));
@@ -37,7 +37,6 @@ async function pickVitePort(): Promise<number> {
 }
 
 const port = await pickVitePort();
-console.error(`[dev] worktree=${basename(repoRoot)} vite=http://localhost:${port}`);
 
 // bun は起動時の env snapshot を子プロセスのデフォルト継承に使うため、`process.env` への
 // 代入 / delete は spawnSync の子に反映されない。必ず明示の env オブジェクトで渡す


### PR DESCRIPTION
## 概要

`scripts/dev.ts`（並列 `pnpm dev` runner）が起動時に出していた `[dev] worktree=... vite=http://localhost:PORT` の 1 行を撤去する。

## 背景

この行は `console.error`（stderr）で出力されていたため、stderr を「エラー赤」で着色する terminal / task runner UI では、正常な起動通知が失敗ログのように赤く表示されていた。

「赤字を消したい」という起点から出力設計を見直した結果、次の 2 点が判明した。

- **stream の選択が誤り**: 起動 URL / port は info レベルの成功通知であり、Unix 慣習・clig.dev の指針でも info は stdout、error / warn のみ stderr。参照実装の Vite も `logger.info` を `console.log`（stdout）に流し、`➜ Local: ...` バナーを stdout に出している（`packages/vite/src/node/logger.ts`）
- **行そのものが情報として重複**: URL は Vite の startup banner が SSOT として出す。worktree 名は shell の cwd / プロンプトが示す。両者を差し引くと、この行が unique に担う情報は残らない

stdout へ移し ANSI 色で目立たせる案も検討したが、runner 固有の情報が無い以上、行を残す意義自体が無いと判断し撤去した。

## 変更内容

### dev runner

- `[dev] worktree=... vite=...` を出力する `console.error` 行を削除
- 未使用になった `basename` import を削除
- `port` は `GOZD_DEV_VITE_PORT` env で renderer / Electron に配る本来の役目で引き続き使用（表示のみ廃止）

## 確認事項

- [ ] `pnpm dev` 起動時に赤い `[dev]` 行が出ず、Vite の `➜ Local:` バナーで port を確認できること
- [ ] 複数 worktree の並列 `pnpm dev` が従来どおり別 port で起動すること
