### PR TITLE
feat(git-graph): 動的な Scroll-to-HEAD ボタンと subgrid カラムレイアウト

### DIFF
--- a/apps/renderer/src/assets/main.css
+++ b/apps/renderer/src/assets/main.css
@@ -33,6 +33,13 @@
      アルファは利用側で color-mix で適用し、primitive は不透明値を持つ。 */
   --fx-aurora-blue-primitive: oklch(0.45 0.1 250);
   --fx-mesh-violet-primitive: oklch(0.4 0.11 320);
+
+  /* scroll-to-HEAD pill (git-graph の HEAD ジャンプ用フローティングボタン)。
+     primary (主 CTA) とは役割が異なり、theme に追従しない固定の深い青 + 白文字
+     (Slack の new-messages pill 相当) にするため brand-fixed primitive として隔離する。 */
+  --scroll-pill-primitive: oklch(0.48 0.11 250);
+  --scroll-pill-hover-primitive: oklch(0.53 0.11 250);
+  --scroll-pill-foreground-primitive: oklch(1 0 0);
 }
 
 /* layout 定数: カスタムタイトルバー（TitleBar.vue）の高さ。
@@ -164,6 +171,11 @@
   /* arcade FX 装飾色 (brand-fixed primitive を参照する semantic alias) */
   --color-fx-aurora-blue: var(--fx-aurora-blue-primitive);
   --color-fx-mesh-violet: var(--fx-mesh-violet-primitive);
+
+  /* scroll-to-HEAD pill (brand-fixed primitive を参照する semantic alias) */
+  --color-scroll-pill: var(--scroll-pill-primitive);
+  --color-scroll-pill-hover: var(--scroll-pill-hover-primitive);
+  --color-scroll-pill-foreground: var(--scroll-pill-foreground-primitive);
 }
 
 @layer base {

--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -392,7 +392,6 @@ function onCommitContextmenu(payload: {
       v-model:sort-mode="sortMode"
       v-model:detail-open="detailOpen"
       :commit-count="commits.length"
-      @scroll-to-head="gitGraphStore.requestScrollToHead()"
     />
 
     <!-- Graph list + Detail pane (horizontal split) -->

--- a/apps/renderer/src/features/git-graph/GitGraphToolbar.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphToolbar.vue
@@ -19,10 +19,6 @@ const currentBranchOnly = defineModel<boolean>("currentBranchOnly", { required: 
 const sortMode = defineModel<SortMode>("sortMode", { required: true });
 const detailOpen = defineModel<boolean>("detailOpen", { required: true });
 
-const emit = defineEmits<{
-  scrollToHead: [];
-}>();
-
 function toggleSortMode() {
   sortMode.value = sortMode.value === "date" ? "topo" : "date";
 }
@@ -50,13 +46,6 @@ function toggleSortMode() {
     <ToggleChip :active="sortMode === 'topo'" @click="toggleSortMode">
       {{ sortMode === "date" ? "Date Order" : "Topo Order" }}
     </ToggleChip>
-    <button
-      type="button"
-      class="rounded-sm px-1.5 py-0.5 text-[10px] text-foreground-low hover:text-foreground"
-      @click="emit('scrollToHead')"
-    >
-      Scroll to HEAD
-    </button>
     <ToggleChip
       class="ml-auto"
       :active="detailOpen"

--- a/apps/renderer/src/features/git-graph/GitGraphToolbar.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphToolbar.vue
@@ -1,6 +1,6 @@
 <doc lang="md">
 Git Graph のヘッダーツールバー。表示オプション (first-parent / current-branch / sort order) の
-トグルと、HEAD へのスクロール要求・詳細ペイン開閉を扱う。状態はすべて v-model / emit で親が所有する。
+トグルと詳細ペイン開閉を扱う。状態はすべて v-model で親が所有する。
 </doc>
 
 <script setup lang="ts">

--- a/apps/renderer/src/features/git-graph/features/commit-list/CommitGraphList.vue
+++ b/apps/renderer/src/features/git-graph/features/commit-list/CommitGraphList.vue
@@ -92,11 +92,9 @@ const graphColumnWidth = computed(() => calcGraphColumnWidth(layout.value.maxLan
 const MIN_MESSAGE_WIDTH = "12rem";
 
 /**
- * grid の列定義。**親 grid (master) が唯一の定義元**で、WorkingTree 行 / commit 行は subgrid として
- * このトラックを共有する。共有ゆえ date/hash を `max-content` にしても全行で同一トラックに解決され、
- * 内容幅ぴったり (例: 全部 7 桁なら 7 桁幅、10 桁が混じればその幅) で列が揃う。
- * col2 message は最低幅を確保し、狭幅では min 0 の date/hash が先に縮む (truncate)。
- * author だけ内容依存だと極端に長い名前で膨らむため 7rem でキャップする。
+ * master grid の列トラック SSOT (subgrid 共有でこれを全行が引く。共有の理由は <doc> 参照)。
+ * col1 graph = 動的 px、col2 message = 最低幅つき 1fr、date/hash = 内容幅 (max-content)、
+ * author = 内容依存だと長い名前で膨らむため 7rem cap。狭幅では min 0 の date/hash が先に truncate する。
  */
 const graphCols = computed(
   () =>
@@ -133,9 +131,9 @@ const { height: viewportHeight } = useElementSize(scrollContainer);
 
 /**
  * HEAD 行がビューポート外にあるか。ボタンをどちらの端に出すかを決める。
- * - "above": HEAD が上に隠れている (上へスクロールで戻る)
- * - "below": HEAD が下に隠れている (下へスクロール)
- * - null: (部分的にでも) 見えている → ボタン不要
+ * - "above": HEAD の行 top が sticky WorkingTree 行の下端より上 (上端で一部でも隠れる)
+ * - "below": HEAD の行 bottom がビューポート下端を超える (下端で一部でも切れる)
+ * - null: HEAD が sticky 行の下〜ビューポート下端に**完全に**収まるときのみ (ボタン不要)
  *
  * 行位置は既存スクロール座標 (`index * ROW_HEIGHT`) で表す。sticky な WorkingTree 行が上端 1 行分を
  * 覆うため、下端判定では行自身の高さと合わせて 2 行分を可視域から差し引く。
@@ -301,9 +299,7 @@ function onRowClick(hash: string, e: MouseEvent) {
 </script>
 
 <template>
-  <!-- `--graph-cols` を SSOT として持つ。Working Tree 行 (sticky) と commit 行は 1 枚の master grid の
-       subgrid で、この列トラックを共有する。共有ゆえ date/hash を max-content にしても全行で揃う。
-       description 列は minmax(12rem, 1fr) — min 0 だと狭幅で真っ先に潰れるため最低幅を確保する。 -->
+  <!-- `--graph-cols` は master grid の列トラック SSOT (subgrid 共有の理由は <doc> 参照)。 -->
   <div
     class="relative flex min-w-0 flex-1 flex-col outline-none"
     :style="{ '--graph-cols': graphCols }"

--- a/apps/renderer/src/features/git-graph/features/commit-list/CommitGraphList.vue
+++ b/apps/renderer/src/features/git-graph/features/commit-list/CommitGraphList.vue
@@ -7,14 +7,22 @@ commit graph 本体。commits からレーンレイアウトを算出し、Worki
 行の v-for と SVG の dot は同じ layout を辿り、同じ行高で重なる。これで gap 行挿入を含め dot と行が
 常に整合する。片方だけに layout を持たせず 1 つを両方へ配る。
 
+## 列の縦揃えは subgrid で共有する
+
+Working Tree 行 (sticky) と commit 行を 1 枚の master grid の直接の子として並べ、各行は
+`grid-template-columns: subgrid` で master のトラックを共有する。共有トラックは全行のセル内容を
+合算して解決されるため、date/hash を content 幅 (max-content) にしても行間で列がズレない。
+別 grid ごとに `--graph-cols` を各自解決させると content 依存幅が行ごとにバラつくため subgrid で束ねる。
+
 ## HEAD スクロール
 
 data 取得側 (親) が出す scroll 要求 signal を watch して実スクロールする。DOM 反映後に走らせるため
-flush: "post"。列の縦揃えは Working Tree 行と commit 行が同じ `--graph-cols` を引くことで保つ。
+flush: "post"。
 </doc>
 
 <script setup lang="ts">
 import type { GitPullRequest } from "@gozd/rpc";
+import { useElementSize, useEventListener } from "@vueuse/core";
 import { storeToRefs } from "pinia";
 import { computed, ref, watch } from "vue";
 import { computeStatusIcons, UNCOMMITTED_HASH, useGitStatusStore } from "../../../worktree";
@@ -27,6 +35,8 @@ import { computeGraphLayout } from "./graphLayout";
 import { computeOutOfSyncBranches } from "./graphRefs";
 import GraphSvgOverlay from "./GraphSvgOverlay.vue";
 import WorkingTreeRow from "./WorkingTreeRow.vue";
+import IconLucideArrowDown from "~icons/lucide/arrow-down";
+import IconLucideArrowUp from "~icons/lucide/arrow-up";
 
 const props = defineProps<{
   /** デフォルトブランチ名 (ref を default タイプに分類する)。loadLog 結果由来で親が渡す */
@@ -74,8 +84,24 @@ const headNode = computed(() => {
 /** HEAD ノードの色インデックス。Working Tree のドット/接続線を HEAD と同色に揃える。不在時 0。 */
 const headColor = computed(() => headNode.value?.node.color ?? 0);
 
-/** Graph 列の幅。右側は HEAD marker 分の余白を確保する。 */
+/** Graph 列の幅。右側は最右 dot / リング用のガターを確保する。 */
 const graphColumnWidth = computed(() => calcGraphColumnWidth(layout.value.maxLanes));
+
+/** commit message (col 2) の最低幅。これを下回るまでは date/author/hash (min 0) が先に潰れ、
+ *  message はここまで幅を保つ (狭幅時に message が真っ先に潰れるのを防ぐ)。 */
+const MIN_MESSAGE_WIDTH = "12rem";
+
+/**
+ * grid の列定義。**親 grid (master) が唯一の定義元**で、WorkingTree 行 / commit 行は subgrid として
+ * このトラックを共有する。共有ゆえ date/hash を `max-content` にしても全行で同一トラックに解決され、
+ * 内容幅ぴったり (例: 全部 7 桁なら 7 桁幅、10 桁が混じればその幅) で列が揃う。
+ * col2 message は最低幅を確保し、狭幅では min 0 の date/hash が先に縮む (truncate)。
+ * author だけ内容依存だと極端に長い名前で膨らむため 7rem でキャップする。
+ */
+const graphCols = computed(
+  () =>
+    `${graphColumnWidth.value}px minmax(${MIN_MESSAGE_WIDTH}, 1fr) minmax(0, max-content) minmax(0, 7rem) minmax(0, max-content)`,
+);
 
 /** グラフ全体の高さ (行数 × 行高)。scroll 領域の minHeight に使う。 */
 const svgHeight = computed(() => layout.value.nodes.length * ROW_HEIGHT);
@@ -94,6 +120,39 @@ const commitMessageSegmentsByHash = computed(() => {
 // --- スクロール / キーボードナビ ---
 
 const scrollContainer = ref<HTMLElement | null>(null);
+
+// --- HEAD offscreen 検出 (フローティング Scroll-to-HEAD ボタン) ---
+
+/** scroll 位置を reactive に持つ。scroll イベント + プログラム的スクロール (scrollTop 代入) の両方で発火する。 */
+const scrollTop = ref(0);
+useEventListener(scrollContainer, "scroll", () => {
+  scrollTop.value = scrollContainer.value?.scrollTop ?? 0;
+});
+/** ビューポート高さ。resize / レイアウト変化に追従する (clientHeight 相当)。 */
+const { height: viewportHeight } = useElementSize(scrollContainer);
+
+/**
+ * HEAD 行がビューポート外にあるか。ボタンをどちらの端に出すかを決める。
+ * - "above": HEAD が上に隠れている (上へスクロールで戻る)
+ * - "below": HEAD が下に隠れている (下へスクロール)
+ * - null: (部分的にでも) 見えている → ボタン不要
+ *
+ * 行位置は既存スクロール座標 (`index * ROW_HEIGHT`) で表す。sticky な WorkingTree 行が上端 1 行分を
+ * 覆うため、下端判定では行自身の高さと合わせて 2 行分を可視域から差し引く。
+ */
+const headOffscreen = computed<"above" | "below" | null>(() => {
+  const head = headNode.value;
+  const vh = viewportHeight.value;
+  if (head === undefined || vh === 0) return null;
+  const rowTop = head.index * ROW_HEIGHT;
+  const st = scrollTop.value;
+  if (rowTop < st) return "above";
+  if (rowTop > st + vh - 2 * ROW_HEIGHT) return "below";
+  return null;
+});
+
+/** above ボタンを sticky WorkingTree 行の直下に置くための top offset。 */
+const aboveButtonTop = `${ROW_HEIGHT + 8}px`;
 
 /** 現在選択中のノードの **行 (node) インデックス**。範囲選択中は compareHash（移動端）を返す。
  * gap 行挿入で commit index と node index がずれるため layout.nodes 上の位置を引く。未選択 / WT は -1。 */
@@ -242,39 +301,72 @@ function onRowClick(hash: string, e: MouseEvent) {
 </script>
 
 <template>
-  <!-- `--graph-cols` を SSOT として持ち、Working Tree 行 / commit 行の双方が
-       grid-template-columns: var(--graph-cols) で同じ列幅を引く。sticky 行と scroll 配下の
-       commit 行は別 DOM container にあるため subgrid では繋げない。
-       description 列は minmax(0, 1fr) — 素の 1fr だと min-content を要求して truncate と両立しない。 -->
+  <!-- `--graph-cols` を SSOT として持つ。Working Tree 行 (sticky) と commit 行は 1 枚の master grid の
+       subgrid で、この列トラックを共有する。共有ゆえ date/hash を max-content にしても全行で揃う。
+       description 列は minmax(12rem, 1fr) — min 0 だと狭幅で真っ先に潰れるため最低幅を確保する。 -->
   <div
-    class="flex min-w-0 flex-1 flex-col outline-none"
-    :style="{ '--graph-cols': `${graphColumnWidth}px minmax(0, 1fr) 7rem 7rem 4rem` }"
+    class="relative flex min-w-0 flex-1 flex-col outline-none"
+    :style="{ '--graph-cols': graphCols }"
     tabindex="0"
     @keydown="onKeydown"
   >
-    <!-- スクロール可能なコミットリスト。Working Tree 行はこの中に sticky で置き、commit 行と
-         同じ effective 幅を共有させて column を揃える。 -->
-    <div ref="scrollContainer" class="min-h-0 flex-1 overflow-auto">
-      <WorkingTreeRow
-        :graph-column-width="graphColumnWidth"
-        :head-color="headColor"
-        :change-count="uncommittedChangeCount"
-        :status-icons="statusIcons"
-        :mtime="workingTreeMtime"
-        @row-click="onRowClick(UNCOMMITTED_HASH, $event)"
-      />
+    <!-- HEAD が画面外のとき、戻る方向の端にフローティング Scroll-to-HEAD ボタンを出す。
+         scrollContainer の外 (root 直下) に absolute で置き、スクロールに追従させない。
+         色は primary (主 CTA) ではなく scroll アフォーダンス専用の深い青 (Slack の new-messages pill 相当)。
+         theme 非依存の固定色で light/dark どちらでも同じ見え方にする。 -->
+    <button
+      v-if="headOffscreen === 'above'"
+      type="button"
+      class="absolute inset-x-0 z-20 mx-auto flex w-fit items-center gap-1 rounded-full bg-scroll-pill px-2.5 py-1 text-[10px] font-semibold text-scroll-pill-foreground shadow-lg hover:bg-scroll-pill-hover"
+      :style="{ top: aboveButtonTop }"
+      title="Scroll to HEAD"
+      @click="scrollHeadIntoView"
+    >
+      <IconLucideArrowUp class="size-3" />
+      HEAD
+    </button>
+    <button
+      v-else-if="headOffscreen === 'below'"
+      type="button"
+      class="absolute inset-x-0 bottom-4 z-20 mx-auto flex w-fit items-center gap-1 rounded-full bg-scroll-pill px-2.5 py-1 text-[10px] font-semibold text-scroll-pill-foreground shadow-lg hover:bg-scroll-pill-hover"
+      title="Scroll to HEAD"
+      @click="scrollHeadIntoView"
+    >
+      <IconLucideArrowDown class="size-3" />
+      HEAD
+    </button>
 
-      <div class="relative" :style="{ minHeight: `${svgHeight}px` }">
-        <GraphSvgOverlay
-          :layout="layout"
+    <!-- スクロール可能なコミットリスト。Working Tree 行 (sticky) と commit 行を 1 枚の master grid の
+         直接の子として並べ、各行は subgrid で master の列トラックを共有する。列整合の SSOT はここ。 -->
+    <div ref="scrollContainer" class="min-h-0 flex-1 overflow-auto">
+      <div class="relative grid" :style="{ gridTemplateColumns: 'var(--graph-cols)' }">
+        <WorkingTreeRow
           :graph-column-width="graphColumnWidth"
           :head-color="headColor"
-          :head-row="headNode?.index ?? -1"
+          :change-count="uncommittedChangeCount"
+          :status-icons="statusIcons"
+          :mtime="workingTreeMtime"
+          @row-click="onRowClick(UNCOMMITTED_HASH, $event)"
         />
 
-        <!-- Commit table rows: row には `position` を付けない (非 positioned = stacking layer 3)。
-             兄弟の overlay SVG は positioned absolute (layer 6) なので、CSS の painting order により
-             z-index を一切使わずに SVG が row 背景の上に描かれる。 -->
+        <!-- グラフの dot / lane を描く overlay。commit 行域 (WorkingTree 行の下) に重ねるため
+             ROW_HEIGHT 分下げて absolute 配置する。行 background の上に描かれる (positioned = 上位 layer)。 -->
+        <div
+          class="pointer-events-none absolute left-0"
+          :style="{
+            top: `${ROW_HEIGHT}px`,
+            width: `${graphColumnWidth}px`,
+            height: `${svgHeight}px`,
+          }"
+        >
+          <GraphSvgOverlay
+            :layout="layout"
+            :graph-column-width="graphColumnWidth"
+            :head-color="headColor"
+            :head-row="headNode?.index ?? -1"
+          />
+        </div>
+
         <template v-for="(node, row) in layout.nodes" :key="`row-${row}`">
           <GapRow v-if="node.gap" />
           <CommitRow

--- a/apps/renderer/src/features/git-graph/features/commit-list/CommitRow.vue
+++ b/apps/renderer/src/features/git-graph/features/commit-list/CommitRow.vue
@@ -11,7 +11,7 @@ import { formatCompactTime } from "../../../../shared/time";
 import CommitSegmentList from "../../CommitSegmentList";
 import type { CommitMessageSegment } from "../../linkifyCommitMessage";
 import { useGitGraphStore } from "../../useGitGraphStore";
-import { HEAD_ROW_BG } from "./graphColors";
+import { HEAD_ROW_BG, HEAD_ROW_BG_HOVER } from "./graphColors";
 import { ROW_HEIGHT } from "./graphGeometry";
 import type { GraphNode } from "./graphLayout";
 import { computeDisplayRefs } from "./graphRefs";
@@ -43,19 +43,23 @@ const gitGraphStore = useGitGraphStore();
 const isSelectedRow = computed(() => gitGraphStore.isSelectedRow(props.node.commit.hash));
 const isHeadRow = computed(() => props.node.commit.hash === gitGraphStore.headHash);
 
-// 選択と HEAD は別軸。選択を最優先、次に HEAD 行の持続背景 (帯は rowStyle が inline で敷く)、通常は hover のみ。
+// 選択と HEAD は別軸。選択を最優先、次に HEAD 行の持続背景、通常は hover のみ。
+// HEAD 帯は CSS 変数 (--head-bg / --head-bg-hover) を rowStyle が供給し、静的な bg / hover class で参照する。
+// 色を class リテラルに直書きしない (graphColors 由来で Tailwind の静的スキャンに乗らないため) が、
+// 変数名は固定なので class はスキャンでき、hover も cascade で効く (inline background だと hover が付けられない)。
 const highlightClass = computed(() => {
   if (isSelectedRow.value) return "bg-primary-subtle hover:bg-primary-subtle-hover";
-  if (isHeadRow.value) return "";
+  if (isHeadRow.value) return "bg-[var(--head-bg)] hover:bg-[var(--head-bg-hover)]";
   return "hover:bg-element-hover";
 });
 
-// HEAD 行の背景帯。色源は graphColors の HEAD lane 色 (リング / ドットと同一 SSOT)。
-// arbitrary class ではなく inline style で敷く (色が graphColors 由来で Tailwind の静的スキャン対象外のため)。
-// 選択が勝つときは敷かない (選択の primary 帯を inline background で潰さないため)。
+// HEAD 帯の色源は graphColors の HEAD lane 色 (リング / ドットと同一 SSOT)。選択が勝つときは供給しない。
 const rowStyle = computed<Record<string, string>>(() => {
   const style: Record<string, string> = { height: `${ROW_HEIGHT}px` };
-  if (isHeadRow.value && !isSelectedRow.value) style.background = HEAD_ROW_BG;
+  if (isHeadRow.value && !isSelectedRow.value) {
+    style["--head-bg"] = HEAD_ROW_BG;
+    style["--head-bg-hover"] = HEAD_ROW_BG_HOVER;
+  }
   return style;
 });
 

--- a/apps/renderer/src/features/git-graph/features/commit-list/CommitRow.vue
+++ b/apps/renderer/src/features/git-graph/features/commit-list/CommitRow.vue
@@ -39,11 +39,15 @@ const emit = defineEmits<{
 
 const gitGraphStore = useGitGraphStore();
 
-const highlightClass = computed(() =>
-  gitGraphStore.isSelectedRow(props.node.commit.hash)
-    ? "bg-primary-subtle hover:bg-primary-subtle-hover"
-    : "hover:bg-element-hover",
-);
+// 選択と HEAD は別軸。選択を最優先、次に HEAD 行の持続背景、通常は hover のみ。
+const highlightClass = computed(() => {
+  if (gitGraphStore.isSelectedRow(props.node.commit.hash))
+    return "bg-primary-subtle hover:bg-primary-subtle-hover";
+  // HEAD 行は lane 0 (HEAD 予約色 teal/green) 帯で示す。graph 専用色なので token 非依存で直接指定。
+  if (props.node.commit.hash === gitGraphStore.headHash)
+    return "bg-[#50da6336] hover:bg-[#50da634d]";
+  return "hover:bg-element-hover";
+});
 
 const displayRefs = computed(() =>
   computeDisplayRefs(
@@ -72,9 +76,9 @@ function onContextmenu(e: MouseEvent) {
 
 <template>
   <div
-    class="_graph-row grid items-center text-xs"
+    class="_graph-row col-span-full grid grid-cols-subgrid items-center text-xs"
     :class="highlightClass"
-    :style="{ gridTemplateColumns: 'var(--graph-cols)', height: `${ROW_HEIGHT}px` }"
+    :style="{ height: `${ROW_HEIGHT}px` }"
     @click="emit('rowClick', node.commit.hash, $event)"
     @contextmenu="onContextmenu"
   >
@@ -83,7 +87,7 @@ function onContextmenu(e: MouseEvent) {
     <div></div>
 
     <!-- col 2 (description) -->
-    <div class="flex min-w-0 items-center gap-1 truncate pr-2">
+    <div class="flex min-w-0 items-center gap-1 truncate px-1">
       <IconLucideGitMerge
         v-if="isMergeCommit(node.commit)"
         class="size-3.5 shrink-0 text-foreground-low"
@@ -100,17 +104,17 @@ function onContextmenu(e: MouseEvent) {
     </div>
 
     <!-- col 3 (date) -->
-    <div class="text-foreground-low">
+    <div class="truncate px-1 text-foreground-low">
       {{ formatCompactTime(node.commit.date) }}
     </div>
 
     <!-- col 4 (author) -->
-    <div class="truncate text-foreground-low">
+    <div class="truncate px-1 text-foreground-low">
       {{ node.commit.author }}
     </div>
 
     <!-- col 5 (hash) -->
-    <div class="font-mono text-foreground-low">
+    <div class="truncate px-1 font-mono text-foreground-low">
       {{ node.commit.shortHash }}
     </div>
   </div>

--- a/apps/renderer/src/features/git-graph/features/commit-list/CommitRow.vue
+++ b/apps/renderer/src/features/git-graph/features/commit-list/CommitRow.vue
@@ -58,10 +58,6 @@ function isMergeCommit(commit: GitCommit): boolean {
   return commit.parents.length > 1;
 }
 
-function hasHead(refs: string[]): boolean {
-  return refs.includes("HEAD");
-}
-
 function onContextmenu(e: MouseEvent) {
   if (!(e.currentTarget instanceof HTMLElement)) return;
   e.preventDefault();
@@ -82,12 +78,9 @@ function onContextmenu(e: MouseEvent) {
     @click="emit('rowClick', node.commit.hash, $event)"
     @contextmenu="onContextmenu"
   >
-    <!-- col 1 (graph): SVG が absolute で覆うセル。右端の HEAD marker 余白に marker を
-         in-flow 右寄せで置く。col 2 内の absolute 配置にすると col 2 の truncate が
-         containing block ごとクリップして marker が消える。 -->
-    <div class="flex items-center justify-end pr-1">
-      <span v-if="hasHead(node.commit.refs)" class="text-warning-text" title="HEAD"> → </span>
-    </div>
+    <!-- col 1 (graph): SVG が absolute で覆うセル。HEAD は SVG 側の dot リングで示すため、
+         ここにはマーカーを置かない。 -->
+    <div></div>
 
     <!-- col 2 (description) -->
     <div class="flex min-w-0 items-center gap-1 truncate pr-2">

--- a/apps/renderer/src/features/git-graph/features/commit-list/CommitRow.vue
+++ b/apps/renderer/src/features/git-graph/features/commit-list/CommitRow.vue
@@ -11,6 +11,7 @@ import { formatCompactTime } from "../../../../shared/time";
 import CommitSegmentList from "../../CommitSegmentList";
 import type { CommitMessageSegment } from "../../linkifyCommitMessage";
 import { useGitGraphStore } from "../../useGitGraphStore";
+import { HEAD_ROW_BG } from "./graphColors";
 import { ROW_HEIGHT } from "./graphGeometry";
 import type { GraphNode } from "./graphLayout";
 import { computeDisplayRefs } from "./graphRefs";
@@ -39,14 +40,23 @@ const emit = defineEmits<{
 
 const gitGraphStore = useGitGraphStore();
 
-// 選択と HEAD は別軸。選択を最優先、次に HEAD 行の持続背景、通常は hover のみ。
+const isSelectedRow = computed(() => gitGraphStore.isSelectedRow(props.node.commit.hash));
+const isHeadRow = computed(() => props.node.commit.hash === gitGraphStore.headHash);
+
+// 選択と HEAD は別軸。選択を最優先、次に HEAD 行の持続背景 (帯は rowStyle が inline で敷く)、通常は hover のみ。
 const highlightClass = computed(() => {
-  if (gitGraphStore.isSelectedRow(props.node.commit.hash))
-    return "bg-primary-subtle hover:bg-primary-subtle-hover";
-  // HEAD 行は lane 0 (HEAD 予約色 teal/green) 帯で示す。graph 専用色なので token 非依存で直接指定。
-  if (props.node.commit.hash === gitGraphStore.headHash)
-    return "bg-[#50da6336] hover:bg-[#50da634d]";
+  if (isSelectedRow.value) return "bg-primary-subtle hover:bg-primary-subtle-hover";
+  if (isHeadRow.value) return "";
   return "hover:bg-element-hover";
+});
+
+// HEAD 行の背景帯。色源は graphColors の HEAD lane 色 (リング / ドットと同一 SSOT)。
+// arbitrary class ではなく inline style で敷く (色が graphColors 由来で Tailwind の静的スキャン対象外のため)。
+// 選択が勝つときは敷かない (選択の primary 帯を inline background で潰さないため)。
+const rowStyle = computed<Record<string, string>>(() => {
+  const style: Record<string, string> = { height: `${ROW_HEIGHT}px` };
+  if (isHeadRow.value && !isSelectedRow.value) style.background = HEAD_ROW_BG;
+  return style;
 });
 
 const displayRefs = computed(() =>
@@ -78,7 +88,7 @@ function onContextmenu(e: MouseEvent) {
   <div
     class="_graph-row col-span-full grid grid-cols-subgrid items-center text-xs"
     :class="highlightClass"
-    :style="{ height: `${ROW_HEIGHT}px` }"
+    :style="rowStyle"
     @click="emit('rowClick', node.commit.hash, $event)"
     @contextmenu="onContextmenu"
   >

--- a/apps/renderer/src/features/git-graph/features/commit-list/GapRow.vue
+++ b/apps/renderer/src/features/git-graph/features/commit-list/GapRow.vue
@@ -10,7 +10,7 @@ import IconLucideMoreHorizontal from "~icons/lucide/more-horizontal";
 
 <template>
   <div
-    class="flex items-center gap-[0.5ch] bg-panel text-xs text-foreground-low select-none"
+    class="col-span-full flex items-center gap-[0.5ch] bg-panel text-xs text-foreground-low select-none"
     :style="{ height: `${ROW_HEIGHT}px`, paddingLeft: `${GRAPH_PADDING_X + LANE_WIDTH}px` }"
   >
     <IconLucideMoreHorizontal class="size-3.5 shrink-0" />

--- a/apps/renderer/src/features/git-graph/features/commit-list/GraphSvgOverlay.vue
+++ b/apps/renderer/src/features/git-graph/features/commit-list/GraphSvgOverlay.vue
@@ -34,6 +34,15 @@ const connectorPath = computed(() => {
   const x0 = laneX(0);
   return `M${x0},0L${x0},${rowY(props.headRow)}`;
 });
+
+/** HEAD リングを描く単一ノード。HEAD は高々 1 行なので headRow から直接引く (全ノード走査しない)。
+ *  不在 (-1) / gap 行のときは描かない。 */
+const headRingNode = computed(() => {
+  if (props.headRow === -1) return undefined;
+  const node = props.layout.nodes[props.headRow];
+  if (node === undefined || node.gap) return undefined;
+  return node;
+});
 </script>
 
 <template>
@@ -64,14 +73,12 @@ const connectorPath = computed(() => {
          選択と HEAD が一致してもしなくても両立する。dot より先に描き、fill を背景色にして
          dot と輪の隙間を通過する lane 線をマスクする (line が輪の中を貫通しないように)。 -->
     <circle
-      v-for="(node, row) in layout.nodes"
-      v-show="!node.gap && node.commit.hash === gitGraphStore.headHash"
-      :key="`head-ring-${node.commit.hash}`"
-      :cx="laneX(node.lane)"
-      :cy="rowY(row)"
+      v-if="headRingNode"
+      :cx="laneX(headRingNode.lane)"
+      :cy="rowY(headRow)"
       :r="DOT_RADIUS + HEAD_RING_GAP"
       fill="currentColor"
-      :stroke="laneTextColor(node.color)"
+      :stroke="laneTextColor(headRingNode.color)"
       stroke-width="1.5"
       class="text-background"
     />

--- a/apps/renderer/src/features/git-graph/features/commit-list/GraphSvgOverlay.vue
+++ b/apps/renderer/src/features/git-graph/features/commit-list/GraphSvgOverlay.vue
@@ -7,7 +7,7 @@ commit graph のレーン / ドットを描く SVG overlay。commit 行の上に
 import { computed } from "vue";
 import { useGitGraphStore } from "../../useGitGraphStore";
 import { laneTextColor } from "./graphColors";
-import { DOT_RADIUS, ROW_HEIGHT, laneX, rowY, segmentPath } from "./graphGeometry";
+import { DOT_RADIUS, HEAD_RING_GAP, ROW_HEIGHT, laneX, rowY, segmentPath } from "./graphGeometry";
 import type { GraphLayout } from "./graphLayout";
 
 const props = defineProps<{
@@ -59,6 +59,21 @@ const connectorPath = computed(() => {
       fill="none"
       :stroke="laneTextColor(seg.color)"
       stroke-width="2"
+    />
+    <!-- HEAD リング: 「今 HEAD がいる場所」を dot の外側の輪で示す。塗り (選択) とは別チャンネルなので
+         選択と HEAD が一致してもしなくても両立する。dot より先に描き、fill を背景色にして
+         dot と輪の隙間を通過する lane 線をマスクする (line が輪の中を貫通しないように)。 -->
+    <circle
+      v-for="(node, row) in layout.nodes"
+      v-show="!node.gap && node.commit.hash === gitGraphStore.headHash"
+      :key="`head-ring-${node.commit.hash}`"
+      :cx="laneX(node.lane)"
+      :cy="rowY(row)"
+      :r="DOT_RADIUS + HEAD_RING_GAP"
+      fill="currentColor"
+      :stroke="laneTextColor(node.color)"
+      stroke-width="1.5"
+      class="text-background"
     />
     <!-- コミットドット (gap 行は dot を描かない) -->
     <circle

--- a/apps/renderer/src/features/git-graph/features/commit-list/WorkingTreeRow.vue
+++ b/apps/renderer/src/features/git-graph/features/commit-list/WorkingTreeRow.vue
@@ -1,6 +1,7 @@
 <doc lang="md">
-commit graph の Working Tree 固定行。scroll 領域の中に sticky で置くことで commit 行と同じ
-effective 幅・`--graph-cols` grid を共有し、列が揃う (scroll bar の有無に影響されない)。
+commit graph の Working Tree 固定行。master grid の subgrid として commit 行と同じ列トラックを
+共有し (`grid-cols-subgrid`)、sticky で最上部に留まる。列整合は subgrid が保証する
+(scroll bar の有無やセル内容差に影響されない)。
 </doc>
 
 <script setup lang="ts">
@@ -42,9 +43,9 @@ const highlightClass = computed(() =>
 
 <template>
   <div
-    class="_graph-row sticky top-0 z-10 grid items-center border-b border-border-subtle bg-background text-xs"
+    class="_graph-row sticky top-0 z-10 col-span-full grid grid-cols-subgrid items-center border-b border-border-subtle bg-background text-xs"
     :class="highlightClass"
-    :style="{ gridTemplateColumns: 'var(--graph-cols)', height: `${ROW_HEIGHT}px` }"
+    :style="{ height: `${ROW_HEIGHT}px` }"
     @click="emit('rowClick', $event)"
   >
     <!-- Working Tree 行の SVG: lane 0 にドット、下端へダッシュ線。grid 上に absolute で重ねる -->
@@ -77,14 +78,14 @@ const highlightClass = computed(() =>
     <div />
 
     <!-- col 2 (description) -->
-    <div class="flex min-w-0 items-center gap-1 truncate pr-2">
+    <div class="flex min-w-0 items-center gap-1 truncate px-1">
       <span class="truncate font-semibold text-foreground-low">Working Tree</span>
       <span v-if="changeCount === 0" class="text-foreground-low italic"> (Clean) </span>
       <StatusIcons v-else :entries="statusIcons" icon-size="size-4" />
     </div>
 
     <!-- col 3 (date): 変更ファイルの mtime 最大値。clean / 未取得時は空表示。 -->
-    <div class="text-foreground-low">
+    <div class="truncate px-1 text-foreground-low">
       {{ formatCompactTime(mtime) }}
     </div>
     <!-- col 4 (author) / col 5 (hash) は空セル。grid template が幅を確保する。 -->

--- a/apps/renderer/src/features/git-graph/features/commit-list/graphColors.ts
+++ b/apps/renderer/src/features/git-graph/features/commit-list/graphColors.ts
@@ -29,3 +29,10 @@ export function laneTextColor(index: number): string {
   const s = LANE_SPECS[index % LANE_SPECS.length];
   return `oklch(${s.l} ${s.c} ${s.h})`;
 }
+
+/**
+ * HEAD 行の背景帯。HEAD lane (lane 0 = HEAD 予約色) の色を低 alpha で敷き、リング / ドットと
+ * 同一の色源に揃える (graph の色 SSOT は本 palette)。選択行 (primary 青) とは hue が異なるため、
+ * alpha を混ぜても「選択と別 hue で HEAD 位置を示す」区別は保たれる。
+ */
+export const HEAD_ROW_BG = `color-mix(in oklch, ${laneTextColor(0)} 22%, transparent)`;

--- a/apps/renderer/src/features/git-graph/features/commit-list/graphColors.ts
+++ b/apps/renderer/src/features/git-graph/features/commit-list/graphColors.ts
@@ -31,8 +31,10 @@ export function laneTextColor(index: number): string {
 }
 
 /**
- * HEAD 行の背景帯。HEAD lane (lane 0 = HEAD 予約色) の色を低 alpha で敷き、リング / ドットと
- * 同一の色源に揃える (graph の色 SSOT は本 palette)。選択行 (primary 青) とは hue が異なるため、
- * alpha を混ぜても「選択と別 hue で HEAD 位置を示す」区別は保たれる。
+ * HEAD 行の背景帯 (通常 / hover)。HEAD lane (lane 0 = HEAD 予約色) の色を低 alpha で敷き、
+ * リング / ドットと同一の色源に揃える (graph の色 SSOT は本 palette)。選択行 (primary 青) とは
+ * hue が異なるため、alpha を混ぜても「選択と別 hue で HEAD 位置を示す」区別は保たれる。
+ * hover は他行 (通常 / 選択) と一貫させるため alpha を上げて明るくする。
  */
 export const HEAD_ROW_BG = `color-mix(in oklch, ${laneTextColor(0)} 22%, transparent)`;
+export const HEAD_ROW_BG_HOVER = `color-mix(in oklch, ${laneTextColor(0)} 32%, transparent)`;

--- a/apps/renderer/src/features/git-graph/features/commit-list/graphGeometry.ts
+++ b/apps/renderer/src/features/git-graph/features/commit-list/graphGeometry.ts
@@ -13,16 +13,14 @@ export const HEAD_RING_GAP = 3;
 export const GRAPH_PADDING_X = 12;
 
 /**
- * col 1 (graph 列) の右側に確保する HEAD marker `→` 用余白 (px)。
- * marker は col 1 内に in-flow 右寄せ配置されるため、SVG が描く lane / dot と marker の
- * x 帯が物理的に重ならない width をここで予約する。
- * 内訳: marker glyph ~14 + col 2 との padding 4 + 安全余白 2 = 20。
+ * col 1 (graph 列) の右側に確保するガター (px)。最右レーンの dot / HEAD リング (半径 ~7) が
+ * col 2 の description に密着しないための余白。HEAD marker `→` は廃止済み (HEAD は dot リングで表示)。
  */
-const HEAD_MARKER_RIGHT_PADDING = 20;
+const GRAPH_RIGHT_GUTTER = 8;
 
-/** Graph 列の幅。右側は HEAD marker 分の余白を確保する。 */
+/** Graph 列の幅。右側に最右 dot / リング用のガターを確保する。 */
 export function graphColumnWidth(maxLanes: number): number {
-  return GRAPH_PADDING_X + maxLanes * LANE_WIDTH + HEAD_MARKER_RIGHT_PADDING;
+  return GRAPH_PADDING_X + maxLanes * LANE_WIDTH + GRAPH_RIGHT_GUTTER;
 }
 
 /** レーン番号 → X ピクセル座標 */

--- a/apps/renderer/src/features/git-graph/features/commit-list/graphGeometry.ts
+++ b/apps/renderer/src/features/git-graph/features/commit-list/graphGeometry.ts
@@ -7,6 +7,9 @@
 export const LANE_WIDTH = 16;
 export const ROW_HEIGHT = 24;
 export const DOT_RADIUS = 4;
+/** HEAD ドットの外側リング半径をドット本体からどれだけ離すか (px)。塗り/選択とは別チャンネルで
+ *  「今 HEAD がいる場所」を輪で示す。 */
+export const HEAD_RING_GAP = 3;
 export const GRAPH_PADDING_X = 12;
 
 /**


### PR DESCRIPTION
## 概要

git-graph のコミットリスト UI を刷新する。HEAD をリスト上で見つけやすくし、狭幅でも列レイアウトが崩れないようにする。

- HEAD 表示: 矢印マーカーを廃し、グラフの dot 外側リング + HEAD 行の背景帯で示す
- Scroll-to-HEAD: ツールバー常設ボタンを廃し、HEAD が画面外のときだけ上/下端にフローティングボタンを出す
- カラムレイアウト: Working Tree 行と commit 行を subgrid で 1 枚の master grid に統合し、列整合と横 overflow 解消を両立する

## 背景

従来の HEAD 表示は commit 行左端の矢印 `→` マーカーだった。位置が分かりづらく、detached HEAD の判別もできなかった。前段の作業で dot をリング表示に変えたが、HEAD がリスト外にスクロールされると現在地が全く分からなくなる。ツールバーの常設 "Scroll to HEAD" ボタンは、必要なとき以外も出ていて存在に気づきにくく、押しても画面のどこに HEAD があるか掴めなかった。

さらに、date / author / hash の 3 列が固定幅で縮まないため、グラフのレーン数が多い repo（graph 列が太い）ではコミットメッセージ列が先に潰れ、横スクロールバーが出ていた。これを直そうと列幅を content 幅（max-content）にしたところ、sticky な Working Tree 行と scroll 配下の commit 行が**別々の grid container**であるために列幅が行ごとに独立解決され、時刻表示などが横にズレる問題が発生した。

`max-content` の独立解決は CSS Grid の仕様上避けられないため、両者を 1 枚の親 grid の subgrid にして列トラックを共有する構成に変更した。これにより content 幅のまま全行で列が揃う。狭幅時の列折り畳みは、JS 幅計測や CSS container query では動的な graph 列幅を判定に織り込めないため採らず、message 列に最低幅を与えて date/hash を先に truncate させる純 CSS 方式にした。

## 変更内容

### HEAD の可視化

- グラフの HEAD dot の外側にリングを描画（dot より先に描き、背景色で lane 線の貫通をマスク）
- commit 行左端の矢印 `→` マーカーと `hasHead()` を撤去
- HEAD 行に lane 0（HEAD 予約色 teal/green）の背景帯を敷き、選択行（青）と別 hue で位置を常時示す

### Scroll-to-HEAD ボタン

- ツールバーの常設ボタンと `scrollToHead` emit / handler を撤去（`requestScrollToHead` トークン機構は初期ロード・worktree 切替の自動スクロール用に残す）
- HEAD が画面外のときだけ、戻る方向（上/下）の端にフローティングボタンを表示
- 可視判定は `scrollTop` + `viewportHeight` の算術で行い、sticky な Working Tree 行ぶんを閾値に織り込む
- 色は primary（主 CTA）ではなく scroll アフォーダンス専用の深い青（theme 非依存の固定色）

### カラムレイアウト（subgrid）

- Working Tree 行 / commit 行 / gap 行を master grid の subgrid 化し、列トラックを共有
- SVG overlay は master grid 内に absolute で重ね、Working Tree 行ぶん下げて commit 行域に合わせる
- date / hash を content 幅（max-content）、message は `minmax(12rem, 1fr)` の最低幅、author は 7rem cap
- 狭幅では min 0 の date/hash が先に truncate し、横スクロールバーが出ない
- メタ列セルに両側パディング（px-1）と truncate を付与

## 確認事項

- [ ] HEAD dot のリングと HEAD 行の背景帯が正しく出るか（通常 / detached / merge commit）
- [ ] Scroll-to-HEAD ボタンが HEAD 画面外のときだけ上/下に出て、押すと HEAD が中央に来るか
- [ ] date / author / hash が Working Tree 行と commit 行で縦に揃っているか（subgrid）
- [ ] グラフのレーン数が多い repo で横スクロールバーが出ず、狭幅で date/hash が truncate するか
- [ ] hash が実桁数ぴったりの幅（余白過多なし）で表示されるか
