### PR TITLE
fix(pty): close ptmx on teardown to stop exit SIGABRT and orphan servers

### DIFF
--- a/apps/electron/src/routes.ts
+++ b/apps/electron/src/routes.ts
@@ -166,10 +166,10 @@ import { taskStore } from "./taskStore";
 import { checkEngine, launch as voicevoxLaunch, listSpeakers, speak } from "./voicevox";
 
 const ptys = new Map<number, IPty>();
-// ptyId → onData/onExit listener を dispose する closure。
-// node-pty の onData/onExit は native NAPI ThreadSafeFunction callback を登録する。
-// dispose せずに kill / quit すると stale callback が node::FreeEnvironment() まで生き残り、
-// 破壊済み env 上で NAPI が呼び出そうとして SIGABRT する（アプリ終了時クラッシュの真因）。
+// ptyId → onData/onExit listener を dispose する closure。onData/onExit は純粋な JS
+// EventEmitter なので、dispose しても node-pty 内部の exit ThreadSafeFunction は止まらない
+// （終了時 SIGABRT 回避の主因は closePtyMaster 側。下記参照）。dispose の役割は、破棄中に
+// 遅延 onExit が発火して破棄済み webContents への ctx.push を呼ぶのを防ぐ多重防御。
 const ptyDisposers = new Map<number, () => void>();
 let nextPtyId = 1;
 
@@ -178,19 +178,27 @@ function disposePtyListeners(id: number): void {
   ptyDisposers.delete(id);
 }
 
-/** ptmx master を閉じて fd を解放する。node-pty の destroy() は socket close 時に
- * `kill('SIGHUP')` を撃つが、子 reaped 後は pid が別プロセスに再利用されて誤爆しうる。
- * destroy 前に kill を no-op 化してこの遅延 SIGHUP を無効化する。master を閉じると
- * カーネルが tty hangup で foreground process group に SIGHUP を配り、閉じ忘れた
- * サーバー子プロセスも落とせる。destroy は public 型に無いため cast で呼ぶ。 */
+/** ptmx master を閉じる。これが終了時 SIGABRT 回避の主因。
+ * node-pty の exit callback（native waitpid ベースの ThreadSafeFunction）は listener の
+ * dispose では止まらず、子 reaped 時に必ず JS の onexit closure を呼ぶ。その closure は
+ * socket 未 close（`_emittedClose === false`）だと `setTimeout` を張る分岐に入り、env 破棄中
+ * (FreeEnvironment) にこれを踏むと NAPI が throw して SIGABRT する。destroy() が socket を
+ * 閉じて `_emittedClose` を立てると、遅れて着弾する native onexit は純 JS の emit 分岐へ
+ * 落ちて無害化する。併せて ptmx fd を解放し、tty hangup で foreground process group
+ * （閉じ忘れたサーバー子プロセス）を掃除する。destroy() は close 時に `kill('SIGHUP')` を
+ * 撃つが、子 reaped 後は pid が別プロセスに再利用され誤爆しうるため、destroy 前に kill を
+ * no-op 化して無効化する。destroy は public 型に無いため cast で呼ぶ。 */
 function closePtyMaster(pty: IPty): void {
   const handle = pty as unknown as { kill: (sig?: string) => void; destroy?: () => void };
   handle.kill = () => {};
-  tryCatch(() => handle.destroy?.());
+  const result = tryCatch(() => handle.destroy?.());
+  if (!result.ok) {
+    console.error(`[closePtyMaster] destroy failed: ${result.error}`);
+  }
 }
 
-/** PTY を明示的に破棄する（単一 kill / 終了時の全 kill 共通）。listener の dispose を
- * kill より先に行い、FreeEnvironment 中の stale callback による SIGABRT を防ぐ。 */
+/** PTY を明示的に破棄する（単一 kill / 終了時の全 kill 共通）。closePtyMaster が終了時
+ * SIGABRT 回避の主因、dispose は破棄中の ctx.push を防ぐ多重防御。 */
 function teardownPty(id: number, pty: IPty): void {
   disposePtyListeners(id);
   pty.kill();
@@ -267,8 +275,8 @@ function handlePtySpawn(body: unknown, ctx: RpcContext): unknown {
     ctx.push("ptyText", { id, text });
   });
   const exitDisposable = pty.onExit(({ exitCode, signal }) => {
-    // 自然終了。子 reaped 直後に closePtyMaster で kill を無効化して、destroy の
-    // 遅延 SIGHUP が recycled pid に着弾する window を閉じ、ptmx fd も解放する
+    // 自然終了。closePtyMaster で ptmx fd を解放し、destroy の遅延 SIGHUP を
+    // 無効化する（子 reaped 後の recycled pid への誤爆を防ぐ）
     closePtyMaster(pty);
     disposePtyListeners(id);
     ptys.delete(id);

--- a/apps/electron/src/routes.ts
+++ b/apps/electron/src/routes.ts
@@ -166,14 +166,46 @@ import { taskStore } from "./taskStore";
 import { checkEngine, launch as voicevoxLaunch, listSpeakers, speak } from "./voicevox";
 
 const ptys = new Map<number, IPty>();
+// ptyId → onData/onExit listener を dispose する closure。
+// node-pty の onData/onExit は native NAPI ThreadSafeFunction callback を登録する。
+// dispose せずに kill / quit すると stale callback が node::FreeEnvironment() まで生き残り、
+// 破壊済み env 上で NAPI が呼び出そうとして SIGABRT する（アプリ終了時クラッシュの真因）。
+const ptyDisposers = new Map<number, () => void>();
 let nextPtyId = 1;
+
+function disposePtyListeners(id: number): void {
+  ptyDisposers.get(id)?.();
+  ptyDisposers.delete(id);
+}
+
+/** ptmx master を閉じて fd を解放する。node-pty の destroy() は socket close 時に
+ * `kill('SIGHUP')` を撃つが、子 reaped 後は pid が別プロセスに再利用されて誤爆しうる。
+ * destroy 前に kill を no-op 化してこの遅延 SIGHUP を無効化する。master を閉じると
+ * カーネルが tty hangup で foreground process group に SIGHUP を配り、閉じ忘れた
+ * サーバー子プロセスも落とせる。destroy は public 型に無いため cast で呼ぶ。 */
+function closePtyMaster(pty: IPty): void {
+  const handle = pty as unknown as { kill: (sig?: string) => void; destroy?: () => void };
+  handle.kill = () => {};
+  tryCatch(() => handle.destroy?.());
+}
+
+/** PTY を明示的に破棄する（単一 kill / 終了時の全 kill 共通）。listener の dispose を
+ * kill より先に行い、FreeEnvironment 中の stale callback による SIGABRT を防ぐ。 */
+function teardownPty(id: number, pty: IPty): void {
+  disposePtyListeners(id);
+  pty.kill();
+  closePtyMaster(pty);
+  ptys.delete(id);
+  unregisterExit(id);
+}
 
 /** will-quit で全 PTY を始末する */
 export function killAllPtys(): void {
-  for (const pty of ptys.values()) {
-    pty.kill();
+  // teardownPty は自分がイテレート中の現在の id だけを ptys から削除する。
+  // Map は現在エントリの削除に対してイテレーションを安全に継続するため直接回せる
+  for (const [id, pty] of ptys) {
+    teardownPty(id, pty);
   }
-  ptys.clear();
 }
 
 // 実行中サーバーの周期検出（Swift 版 PortScanner 対応物）。push 先の window は
@@ -231,10 +263,14 @@ function handlePtySpawn(body: unknown, ctx: RpcContext): unknown {
   // resume 失敗（SessionStart 不達）と判定する
   registerSpawn(id, req.worktreePath, req.env.GOZD_RESUME_CLAUDE_SESSION ?? "");
 
-  pty.onData((text) => {
+  const dataDisposable = pty.onData((text) => {
     ctx.push("ptyText", { id, text });
   });
-  pty.onExit(({ exitCode, signal }) => {
+  const exitDisposable = pty.onExit(({ exitCode, signal }) => {
+    // 自然終了。子 reaped 直後に closePtyMaster で kill を無効化して、destroy の
+    // 遅延 SIGHUP が recycled pid に着弾する window を閉じ、ptmx fd も解放する
+    closePtyMaster(pty);
+    disposePtyListeners(id);
     ptys.delete(id);
     unregisterExit(id);
     // Swift PTYExitReason と同形の payload（terminal/rpc.ts の PtyExitReason 契約）
@@ -243,6 +279,11 @@ function handlePtySpawn(body: unknown, ctx: RpcContext): unknown {
         ? { kind: "signaled", signal }
         : { kind: "exited", exitCode };
     ctx.push("ptyExit", { id, reason });
+  });
+  // onData/onExit の IDisposable を保持し、teardownPty / 自然 exit で dispose する
+  ptyDisposers.set(id, () => {
+    dataDisposable.dispose();
+    exitDisposable.dispose();
   });
 
   return ({ ptyId: id }) satisfies PtySpawnResponse;
@@ -268,8 +309,7 @@ function handlePtyKill(body: unknown): unknown {
   const req = body as PtyKillRequest;
   const pty = ptys.get(req.ptyId);
   if (pty === undefined) throw new Error(`pty/kill: unknown ptyId ${req.ptyId}`);
-  pty.kill();
-  ptys.delete(req.ptyId);
+  teardownPty(req.ptyId, pty);
   return ({}) satisfies PtyKillResponse;
 }
 

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -49,9 +49,10 @@ sequenceDiagram
     end
 
     R->>N: ptyKill({ id })
-    N->>P: kill(pid, SIGHUP)
-    P-->>N: waitpid(pid) → exit reason
-    N-->>R: ptyExit({ id, reason })
+    N->>N: dispose onData/onExit（FreeEnvironment SIGABRT 回避）
+    N->>P: kill(pid, SIGHUP) + destroy(masterFd)
+
+    Note over P,R: 自然終了は waitpid → ptyExit({ id, reason }) を push
 ```
 
 - shell: `/bin/zsh`（renderer 側で固定。`apps/renderer/src/features/terminal/useTerminalStore.ts` の `DEFAULT_SHELL`）
@@ -265,6 +266,7 @@ write() 後（onWriteParsed で集約）:
 ## main 側の PTY 管理
 
 - PTY の実体は node-pty。instance の所有は `apps/electron/src/routes.ts`、PTY ⇔ Claude session の紐付けは `ptySessions.ts` が持つ
-- アプリ終了時 (`will-quit`) は `killAllPtys` で全 PTY に SIGHUP を送る（orphan 化防止）
+- アプリ終了時 (`will-quit`) の `killAllPtys`・個別 kill・worktree 削除は共通の破棄経路（`teardownPty`）を通す。順序が契約: **node-pty の onData/onExit listener を kill より先に dispose する**。dispose を怠ると native の ThreadSafeFunction callback が `node::FreeEnvironment()`（env 破棄）まで生き残り、破壊済み env 上で NAPI が呼び出そうとして SIGABRT で落ちる（アプリ終了時クラッシュの真因）
+- kill（shell への SIGHUP）だけでは配下のサーバー子プロセスが orphan 化して残る。`destroy()` で ptmx master を閉じると、カーネルが tty hangup で foreground process group に SIGHUP を配り、閉じ忘れた子まで落ちる（同時に master fd リークも防ぐ）。ただし node-pty の destroy は socket close 時に遅延 SIGHUP を撃ち、子 reaped 後は pid が別プロセスに再利用されて誤爆しうるため、destroy 前に kill を no-op 化して無効化する
 - worktree 削除時は worktreePath で該当 PTY を特定して kill
 - spawn のワイヤ契約は argv 全体（args[0] = プログラム名）。node-pty は argv[0] を含めない流儀のため main 側で `args.slice(1)` して渡す

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -49,8 +49,8 @@ sequenceDiagram
     end
 
     R->>N: ptyKill({ id })
-    N->>N: dispose onData/onExit（FreeEnvironment SIGABRT 回避）
-    N->>P: kill(pid, SIGHUP) + destroy(masterFd)
+    N->>N: dispose onData/onExit（破棄中 push の多重防御）
+    N->>P: kill(pid, SIGHUP) + destroy(masterFd)（socket close で終了時 SIGABRT を回避）
 
     Note over P,R: 自然終了は waitpid → ptyExit({ id, reason }) を push
 ```
@@ -266,7 +266,8 @@ write() 後（onWriteParsed で集約）:
 ## main 側の PTY 管理
 
 - PTY の実体は node-pty。instance の所有は `apps/electron/src/routes.ts`、PTY ⇔ Claude session の紐付けは `ptySessions.ts` が持つ
-- アプリ終了時 (`will-quit`) の `killAllPtys`・個別 kill・worktree 削除は共通の破棄経路（`teardownPty`）を通す。順序が契約: **node-pty の onData/onExit listener を kill より先に dispose する**。dispose を怠ると native の ThreadSafeFunction callback が `node::FreeEnvironment()`（env 破棄）まで生き残り、破壊済み env 上で NAPI が呼び出そうとして SIGABRT で落ちる（アプリ終了時クラッシュの真因）
-- kill（shell への SIGHUP）だけでは配下のサーバー子プロセスが orphan 化して残る。`destroy()` で ptmx master を閉じると、カーネルが tty hangup で foreground process group に SIGHUP を配り、閉じ忘れた子まで落ちる（同時に master fd リークも防ぐ）。ただし node-pty の destroy は socket close 時に遅延 SIGHUP を撃ち、子 reaped 後は pid が別プロセスに再利用されて誤爆しうるため、destroy 前に kill を no-op 化して無効化する
+- アプリ終了時 (`will-quit`) の `killAllPtys`・個別 kill・worktree 削除は共通の破棄経路（`teardownPty`）を通す
+- **アプリ終了時 SIGABRT 回避の主因は `destroy()`（ptmx master を閉じる）**。node-pty の exit callback（native waitpid ベースの ThreadSafeFunction）は listener の dispose では止まらず、子 reaped 時に必ず内部の onexit closure を呼ぶ。この closure は socket 未 close だと `setTimeout` を張る分岐に入り、env 破棄中（`FreeEnvironment`）にこれを踏むと NAPI が throw して SIGABRT する。`destroy()` が socket を閉じ `_emittedClose` を立てると、遅れて着弾する native onexit は純 JS の emit 分岐へ落ちて無害化する。onData/onExit listener の dispose は、破棄中に遅延 onExit が破棄済み webContents への `ctx.push` を呼ぶのを防ぐ多重防御（crash の主因対策ではない）
+- `destroy()` は同時に、kill（shell への SIGHUP）だけでは残る配下のサーバー子プロセスを掃除する。ptmx master を閉じるとカーネルが tty hangup で foreground process group に SIGHUP を配り、閉じ忘れた子まで落ちる（master fd リークも防ぐ）。ただし node-pty の destroy は socket close 時に遅延 SIGHUP を撃ち、子 reaped 後は pid が別プロセスに再利用されて誤爆しうるため、destroy 前に kill を no-op 化して無効化する
 - worktree 削除時は worktreePath で該当 PTY を特定して kill
 - spawn のワイヤ契約は argv 全体（args[0] = プログラム名）。node-pty は argv[0] を含めない流儀のため main 側で `args.slice(1)` して渡す


### PR DESCRIPTION
## 概要

アプリ終了時に Electron main プロセスが `SIGABRT` で crash する問題と、ターミナルペインを閉じても配下のサーバー子プロセスが残る問題を、node-pty の破棄経路を見直して同時に解消する。

- PTY 破棄を `teardownPty` に一元化し、`will-quit` の `killAllPtys`・個別 kill・worktree 削除で共有する
- **`destroy()` で ptmx master を閉じる**。これが終了時 SIGABRT 回避の主因であり、同時に閉じ忘れたサーバー子プロセスの掃除と master fd リーク防止も担う
- node-pty の `onData` / `onExit` の `IDisposable` を保持し kill 前に dispose する（破棄中の `ctx.push` を防ぐ多重防御）

## 背景

起動終了時に macOS のクラッシュダイアログ（`Electron が予期しない理由で終了しました`）が出る事象のクラッシュレポートを調査したところ、スタックが以下だった:

```text
node::FreeEnvironment → RunCleanup → CleanupHandles → uv_run
  → pty.node ThreadSafeFunction::CallJS → Napi::Error::ThrowAsJavaScriptException
  → __cxa_throw → terminate → abort
```

main プロセスの環境破棄中に、node-pty の exit callback（native の waitpid ベース ThreadSafeFunction = `SetupExitCallback`）が JS へ入ったところで落ちている。

`microsoft/node-pty` の該当バージョン（`1.2.0-beta.14`）の実ソースを exact tag でチェックアウトして機構を特定した:

- `onData` / `onExit` は純粋な JS の `EventEmitter`。**listener を dispose しても内部の exit ThreadSafeFunction は止まらず**、子 reaped 時に必ず内部の `onexit` closure を JS へ呼び込む
- その `onexit` closure は socket 未 close（`_emittedClose === false`）だと `setTimeout` を張る分岐に入る。env 破棄中（`FreeEnvironment`）にこれを踏むと NAPI が throw し、破棄済み env 上で catch されず `SIGABRT` する（上記スタック）
- `destroy()` が master socket を閉じて `_emittedClose` を立てると、遅れて着弾する native `onexit` は純 JS の `emit('exit')` 分岐へ落ちて無害化する。**つまり終了時 crash 回避の主因は `destroy()`**

「ターミナルを閉じてもサーバーが残る」件も同じ `destroy()` 未呼び出しが原因。`pty.kill()`（node-pty は単一 pid への `SIGHUP`）だけでは ptmx master が閉じず、tty hangup による foreground process group への `SIGHUP` 配送が起きないため、閉じ忘れた子プロセスが残っていた。gozd は従来 listener の `IDisposable` を捨て、かつ `destroy()` を一度も呼んでいなかった。

### 方針の検証と転換

当初は「`before-quit` で `preventDefault` して全 `onExit` を待ってから quit ＋ `process.kill(-pid)` のグループ kill ＋ SIGKILL エスカレーション」を検討したが、`microsoft/node-pty`・`microsoft/vscode`・`stablyai/orca` のソースを直接読んで検証した結果、これはベストプラクティスでないと判断して転換した:

- 非同期待ちは不要。`destroy()` が socket を閉じて遅延 `onexit` を無害化するため、`will-quit` は同期のままでよい（orca / VS Code とも同期破棄）
- 子孫に `SIGHUP` を届ける正攻法は `destroy()`（ptmx master を閉じる）による tty hangup。`process.kill(-pid)` はどちらの参照実装も採っていない
- `destroy()` は socket close 時に遅延 `SIGHUP` を撃つが、子 reaped 後は pid が別プロセスに再利用されて誤爆しうる。これを避けるため destroy 前に `kill` を no-op 化する（orca が明示的に対処している hazard）

参照: microsoft/vscode は node-pty を UtilityProcess（pty host）に隔離して main の env teardown と分離する gold standard を採るが、gozd 規模では dispose + destroy で十分と判断した。

## 変更内容

### apps/electron/src/routes.ts

- `teardownPty(id, pty)` を追加し、`killAllPtys`・個別 kill (`handlePtyKill`) の破棄経路を一元化
- `closePtyMaster(pty)`: node-pty の `kill` を no-op 化してから `destroy()` を呼ぶ。socket を閉じて `_emittedClose` を立て遅延 `onexit` を無害化（終了時 SIGABRT 回避の主因）、ptmx fd 解放、foreground group への tty hangup、遅延 `SIGHUP` の pid recycling 誤爆防止を担う。`destroy()` 失敗は `[closePtyMaster]` タグで観察ログに残す
- spawn 時に `onData` / `onExit` の `IDisposable` を per-id で保持し、kill 前に dispose（破棄中に遅延 `onExit` が破棄済み webContents への `ctx.push` を呼ぶのを防ぐ多重防御）
- 自然 exit ハンドラにも `closePtyMaster` を通し、正常終了時の ptmx fd リークも封じる

### docs/terminal.md

- 「main 側の PTY 管理」に、終了時 SIGABRT 回避の主因が `destroy()`（socket close で `_emittedClose` を立て遅延 `onexit` を無害化）であること、dispose は多重防御であること、`destroy()` が orphan と fd リークを塞ぐ理由を追記
- PT ライフサイクルの sequence 図を、明示 kill 時は `ptyExit` を push せず（listener を dispose するため）自然終了が push 元である実態に合わせて修正

## 確認事項

gozd は Electron デスクトップアプリのため手元では駆動不可。実機で以下を確認してほしい:

- [ ] ターミナルペインでサーバー（`pnpm dev` 等）を起動 → ペインを閉じてプロセスが消えるか（`lsof -i :PORT`）
- [ ] アプリ終了（`pnpm dev` 停止 / Cmd+Q）でクラッシュダイアログが出ないか・exit code が 0 か
- [ ] 通常のターミナル操作・自然終了（`exit`）で `[Process exited]` 表示と再 spawn が従来通り動くか
