### PR TITLE
chore(package-meta): package.json の author 追加と description 更新

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -3,7 +3,8 @@
   "productName": "Gozd",
   "version": "0.0.0",
   "private": true,
-  "description": "Electron shell spike (issue #895): BrowserWindow + typed IPC + node-pty + xterm.js",
+  "author": "miyaoka",
+  "description": "Gozd — Git Orchestrated Zone for Development. Electron main process for managing parallel AI agent development.",
   "type": "module",
   "main": "dist/main.cjs",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "gozd",
   "version": "0.0.0",
   "private": true,
-  "description": "AI Agent Orchestrator",
+  "description": "Gozd — Git Orchestrated Zone for Development. Desktop app for managing parallel AI agent development.",
+  "author": "miyaoka",
   "type": "module",
   "scripts": {
     "dev": "bun scripts/dev.ts",


### PR DESCRIPTION
## 概要

`apps/electron` と root の package.json に `author` を追加し、陳腐化していた `description` を現行のプロダクト定義に更新する。

## 背景

`pnpm --filter @gozd/electron build:app` 実行時に electron-builder が `author is missed in the package.json` を警告していた。electron-builder はパッケージ対象の `apps/electron/package.json` を読み、`author` をコピーライト表記（将来の署名時）などに使うため、欠落していると警告する。

あわせて `apps/electron` の description が spike 期（issue 895）のままの実装メモ（`Electron shell spike: BrowserWindow + typed IPC + node-pty + xterm.js`）で、プロダクト実態と乖離していた。root は `AI Agent Orchestrator` と簡潔すぎて CLAUDE.md の定義とズレていた。

他の 8 つの workspace パッケージも確認したが、いずれも `private: true` で publish もパッケージングもされず、`author` / `description` を消費するツールが存在しないため、対応は不要と判断した。

## 変更内容

### author

- `apps/electron` / root に `"author": "miyaoka"` を追加。メールアドレスは含めない

### description

- `apps/electron`: `Gozd — Git Orchestrated Zone for Development. Electron main process for managing parallel AI agent development.`（パッケージ責務に合わせる）
- root: `Gozd — Git Orchestrated Zone for Development. Desktop app for managing parallel AI agent development.`（リポジトリ全体に合わせる）

## 今回含めない点

### 今回は対応しない

- 他の workspace パッケージ（`@gozd/renderer` 等 8 個）への author / description 追加。すべて `private: true` で消費するツールがなく、追加は SSOT / YAGNI に反するため

## 確認事項

- [ ] `build:app` の `author is missed` 警告が消えること
