### PR TITLE
chore(knip): 死んだ ~icons ignoreUnresolved 設定を削除

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -28,10 +28,6 @@ const config: KnipConfig = {
         // ため、knip からは unused に見える
         "@iconify-json/lucide",
       ],
-      // unplugin-icons の `~icons/lucide/*` は Vite が build 時に生成する virtual module で
-      // ディスク上に実体がない。静的解析する knip は恒久的に解決できず Unresolved imports に
-      // 出すため、specifier パターンで除外する（上の ignoreDependencies とは別系統の検査）。
-      ignoreUnresolved: [/^~icons\//],
     },
     "packages/eslint-plugin": {},
     "packages/rpc": {},


### PR DESCRIPTION
## 概要

`knip.ts` の `apps/renderer` ワークスペースから `ignoreUnresolved: [/^~icons\//]` を削除する。

## 背景

`apps/renderer/tsconfig.json` に `"paths": { "~icons/*": ["./iconStub.ts"] }` が追加された（Bun test が tsconfig paths を runtime 解決に使うため、`~icons/*` を iconStub.ts にマップする目的）。

これにより knip も tsconfig の paths を尊重して `~icons/` を解決するようになり、もう Unresolved imports に出さなくなった。結果として、それを抑制していた `ignoreUnresolved` エントリが何も抑制しない dead config となり、`bun run knip` が Configuration hints で `Remove from ignoreUnresolved` と通知していた。

## 変更内容

### knip 設定

- `apps/renderer` の `ignoreUnresolved: [/^~icons\//]`（説明コメント2行含む）を削除
- `ignoreDependencies: ["@iconify-json/lucide"]` は残す。これは virtual module 経由で動的に読まれる package を unused 判定から除外する別系統の検査で、tsconfig paths が specifier を解決しても package 自体の静的 import は依然存在しないため今も機能している

## 確認事項

- [ ] `bun run knip` が Configuration hints を出さずにパスする
