### PR TITLE
feat(settings): サイドバー repo メニューから project 設定を開く

### DIFF
--- a/apps/renderer/src/features/settings/SettingsModal.vue
+++ b/apps/renderer/src/features/settings/SettingsModal.vue
@@ -9,9 +9,11 @@
 
 ## Project タブの対象
 
-Project 設定はアクティブ worktree が属するプロジェクトを対象にする（`worktreeStore.dir` から
-`resolveProjectKey` で解決）。アクティブ worktree が無いと対象が定まらず、保存経路が dir 不在で
-握りつぶすため、Project タブを無効化する（対象名も UI に明示して複数 repo 時の曖昧さを消す）。
+Project 設定はデフォルトでアクティブ worktree が属するプロジェクトを対象にする
+（`worktreeStore.dir` から `resolveProjectKey` で解決）。ただし repo メニューから開いた場合は
+`targetProjectDir`（その repo の rootDir）で対象を固定する（clicked resource 優先）。対象が
+定まらないと保存経路が dir 不在で握りつぶすため、Project タブを無効化する（対象名も UI に
+明示して複数 repo 時の曖昧さを消す）。
 </doc>
 
 <script setup lang="ts">
@@ -35,28 +37,27 @@ import {
   rpcProjectConfigLoad,
 } from "./rpc";
 import SettingSection from "./SettingSection.vue";
-import { useSettingsModal } from "./useSettingsModal";
+import { useSettingsModal, type SettingsTab } from "./useSettingsModal";
 import IconLucideX from "~icons/lucide/x";
 
-type TabId = "global" | "project";
-
-const TABS: readonly { id: TabId; label: string }[] = [
+const TABS: readonly { id: SettingsTab; label: string }[] = [
   { id: "global", label: "Global" },
   { id: "project", label: "Project" },
 ];
 
 const { Dialog, isOpen, show, close } = useDialog();
-const { isOpen: modalIsOpen } = useSettingsModal();
+const { isOpen: modalIsOpen, initialTab, targetProjectDir } = useSettingsModal();
 const voicevoxStore = useVoicevoxStore();
 const worktreeStore = useWorktreeStore();
 const repoStore = useRepoStore();
 const notify = useNotificationStore();
 
 /**
- * project 設定の対象 dir（= アクティブな worktree）。undefined なら対象プロジェクトが
- * 定まらないため Project タブは無効化する（対象不在で編集を握りつぶさないため）。
+ * project 設定の対象 dir。repo メニューから明示指定された `targetProjectDir` を優先し、
+ * 無ければアクティブな worktree に追従する。undefined なら対象プロジェクトが定まらないため
+ * Project タブは無効化する（対象不在で編集を握りつぶさないため）。
  */
-const projectDir = computed(() => worktreeStore.dir);
+const projectDir = computed(() => targetProjectDir.value ?? worktreeStore.dir);
 
 /** 対象プロジェクトの表示名。設定 UI にどの project を編集中かを明示する */
 const projectName = computed(() => {
@@ -65,7 +66,7 @@ const projectName = computed(() => {
   return repoStore.findRepoOwning(dir)?.repoName ?? dir;
 });
 
-const activeTab = ref<TabId>("global");
+const activeTab = ref<SettingsTab>("global");
 const loading = ref(true);
 const globalValues = ref<Record<string, unknown>>({});
 const projectValues = ref<Record<string, unknown>>({});
@@ -78,9 +79,9 @@ watch(projectDir, (dir) => {
 
 async function openWithSettings() {
   loading.value = true;
-  const dir = worktreeStore.dir;
-  // 対象不在で開いた場合は Global に固定して開く（Project タブは無効表示になる）
-  if (dir === undefined) activeTab.value = "global";
+  const dir = projectDir.value;
+  // 初期タブは要求値。ただし対象が定まらないと Project タブは無効なので Global に落とす
+  activeTab.value = dir === undefined ? "global" : initialTab.value;
   const [globalResult, projectResult] = await Promise.all([
     tryCatch(rpcLoadAppConfig()),
     dir !== undefined ? tryCatch(rpcProjectConfigLoad({ dir })) : Promise.resolve(undefined),
@@ -161,7 +162,7 @@ async function handleGlobalChange(key: string, value: unknown) {
 /** プロジェクト設定の値変更ハンドラー */
 async function handleProjectChange(key: string, value: unknown) {
   projectValues.value[key] = value;
-  const dir = worktreeStore.dir;
+  const dir = projectDir.value;
   if (dir === undefined) return;
   const result = await tryCatch(patchProjectConfig(dir, { [key]: value }));
   if (!result.ok) notify.error("Failed to save project settings", result.error);

--- a/apps/renderer/src/features/settings/SettingsModal.vue
+++ b/apps/renderer/src/features/settings/SettingsModal.vue
@@ -71,12 +71,12 @@ const loading = ref(true);
 const globalValues = ref<Record<string, unknown>>({});
 const projectValues = ref<Record<string, unknown>>({});
 
-/** モーダルを開くときに設定を読み込む。load 完了後に dialog を表示する */
 // 対象プロジェクトが外れたら Project タブに留まらせない（無効タブでの空編集を防ぐ）
 watch(projectDir, (dir) => {
   if (dir === undefined && activeTab.value === "project") activeTab.value = "global";
 });
 
+/** モーダルを開くときに設定を読み込む。load 完了後に dialog を表示する */
 async function openWithSettings() {
   loading.value = true;
   const dir = projectDir.value;

--- a/apps/renderer/src/features/settings/useSettingsModal.test.ts
+++ b/apps/renderer/src/features/settings/useSettingsModal.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { parseOpenArgs } from "./useSettingsModal";
+
+describe("parseOpenArgs", () => {
+  test("非オブジェクト入力は空オプションに落とす", () => {
+    expect(parseOpenArgs(undefined)).toEqual({ tab: undefined, projectDir: undefined });
+    expect(parseOpenArgs(null)).toEqual({ tab: undefined, projectDir: undefined });
+    expect(parseOpenArgs("project")).toEqual({ tab: undefined, projectDir: undefined });
+  });
+
+  test("既知の tab はそのまま、未知値は undefined に落とす", () => {
+    expect(parseOpenArgs({ tab: "project" }).tab).toBe("project");
+    expect(parseOpenArgs({ tab: "global" }).tab).toBe("global");
+    expect(parseOpenArgs({ tab: "unknown" }).tab).toBeUndefined();
+    expect(parseOpenArgs({ tab: 1 }).tab).toBeUndefined();
+  });
+
+  test("rootDir は非空文字列のみ projectDir に採る", () => {
+    expect(parseOpenArgs({ rootDir: "/repo" }).projectDir).toBe("/repo");
+    expect(parseOpenArgs({ rootDir: "" }).projectDir).toBeUndefined();
+    expect(parseOpenArgs({ rootDir: 123 }).projectDir).toBeUndefined();
+  });
+
+  test("repo メニュー相当の引数を tab / projectDir に分解する", () => {
+    expect(parseOpenArgs({ tab: "project", rootDir: "/repo" })).toEqual({
+      tab: "project",
+      projectDir: "/repo",
+    });
+  });
+});

--- a/apps/renderer/src/features/settings/useSettingsModal.ts
+++ b/apps/renderer/src/features/settings/useSettingsModal.ts
@@ -6,9 +6,28 @@
 import { ref } from "vue";
 import { useCommandRegistry } from "../../shared/command";
 
-const isOpen = ref(false);
+export type SettingsTab = "global" | "project";
 
-function open() {
+const isOpen = ref(false);
+/** 開いたときに最初に表示するタブ。open() ごとに設定し直す */
+const initialTab = ref<SettingsTab>("global");
+/**
+ * Project タブの対象 project dir を明示指定するオーバーライド。undefined なら
+ * アクティブ worktree に追従する（コマンドパレット / Cmd+, 経由）。repo メニューから
+ * 開いたときだけ、その repo の rootDir で対象を固定する（VSCode の SCM コマンドと
+ * 同型: clicked resource 優先）。
+ */
+const targetProjectDir = ref<string | undefined>(undefined);
+
+/** open のオプション。省略時は Global タブ / アクティブ worktree 追従で開く */
+interface OpenOptions {
+  tab?: SettingsTab;
+  projectDir?: string;
+}
+
+function open(options: OpenOptions = {}) {
+  initialTab.value = options.tab ?? "global";
+  targetProjectDir.value = options.projectDir;
   isOpen.value = true;
 }
 
@@ -16,18 +35,28 @@ function close() {
   isOpen.value = false;
 }
 
+/** command args から tab / 対象 repo（rootDir）を取り出す。未指定は undefined */
+function parseOpenArgs(args: unknown): OpenOptions {
+  if (typeof args !== "object" || args === null) return {};
+  const { tab, rootDir } = args as { tab?: unknown; rootDir?: unknown };
+  return {
+    tab: tab === "project" || tab === "global" ? tab : undefined,
+    projectDir: typeof rootDir === "string" && rootDir !== "" ? rootDir : undefined,
+  };
+}
+
 /** コマンド登録。MainLayout で一度だけ呼び出す */
 export function registerSettingsCommand(): () => void {
   const registry = useCommandRegistry();
   return registry.register("settings.open", {
     label: "Settings: Open",
-    handler: () => {
-      open();
+    handler: (args?: unknown) => {
+      open(parseOpenArgs(args));
       return true;
     },
   });
 }
 
 export function useSettingsModal() {
-  return { isOpen, open, close };
+  return { isOpen, initialTab, targetProjectDir, open, close };
 }

--- a/apps/renderer/src/features/settings/useSettingsModal.ts
+++ b/apps/renderer/src/features/settings/useSettingsModal.ts
@@ -36,7 +36,7 @@ function close() {
 }
 
 /** command args から tab / 対象 repo（rootDir）を取り出す。未指定は undefined */
-function parseOpenArgs(args: unknown): OpenOptions {
+export function parseOpenArgs(args: unknown): OpenOptions {
   if (typeof args !== "object" || args === null) return {};
   const { tab, rootDir } = args as { tab?: unknown; rootDir?: unknown };
   return {

--- a/apps/renderer/src/features/sidebar/RepoMenu.vue
+++ b/apps/renderer/src/features/sidebar/RepoMenu.vue
@@ -1,8 +1,8 @@
 <doc lang="md">
-repo セクションヘッダの ⋮ ポップオーバーメニュー。現状は「Revive session」1 項目。
+repo セクションヘッダの ⋮ ポップオーバーメニュー。repo スコープのアクション
+(Revive session / Project settings) を command registry 経由で rootDir 付き dispatch する。
 state は `useRepoMenu` (module singleton) 経由で SidebarPane と共有する。
-Revive session は command registry 経由で `workspace.reviveSession` を rootDir 付きで dispatch
-する。command はコマンドパレットからも起動でき (その場合 active repo が対象)、サイドバーからは
+command はコマンドパレットからも起動でき (その場合 active repo が対象)、サイドバーからは
 明示 rootDir を渡す — VSCode の SCM コマンド (clicked resource 優先 / 無ければ picker) と同型。
 palette / command registry を直接 import せず command bus 経由にすることで sidebar→palette の
 import 循環を避ける。
@@ -12,6 +12,7 @@ import 循環を避ける。
 import { useCommandRegistry } from "../../shared/command";
 import { useRepoMenu } from "./useRepoMenu";
 import IconLucideHistory from "~icons/lucide/history";
+import IconLucideSettings from "~icons/lucide/settings";
 
 const { Popover, context, close } = useRepoMenu();
 const registry = useCommandRegistry();
@@ -21,6 +22,13 @@ function handleRevive() {
   const { rootDir } = context.value;
   close();
   registry.execute("workspace.reviveSession", { rootDir });
+}
+
+function handleProjectSettings() {
+  if (!context.value) return;
+  const { rootDir } = context.value;
+  close();
+  registry.execute("settings.open", { tab: "project", rootDir });
 }
 </script>
 
@@ -40,6 +48,13 @@ function handleRevive() {
       >
         <IconLucideHistory class="text-xs" />
         Revive session
+      </button>
+      <button
+        class="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-panel"
+        @click="handleProjectSettings"
+      >
+        <IconLucideSettings class="text-xs" />
+        Project settings
       </button>
     </template>
   </Popover>

--- a/apps/renderer/src/features/sidebar/useRepoMenu.ts
+++ b/apps/renderer/src/features/sidebar/useRepoMenu.ts
@@ -2,9 +2,7 @@
  * repo セクションヘッダの ⋮ menu の module singleton。
  *
  * 親 (SidebarPane) から `open(anchorEl, { rootDir })` を呼び、RepoMenu.vue が context を
- * 購読して描画する。メニュー内アクション (Revive session) は command registry 経由で
- * `workspace.reviveSession` を rootDir 付きで dispatch する (picker dialog は modal なので
- * anchor 不要)。
+ * 購読して描画する。メニュー内アクションは command registry 経由で rootDir 付き dispatch する。
  */
 import { usePopover } from "../../shared/popover";
 


### PR DESCRIPTION
## 概要

サイドバーの repo 詳細メニュー（⋮）に「Project settings」項目を追加した。クリックすると、その repo のプロジェクトを対象にした設定モーダルが Project タブで開く。

## 背景

これまで project 設定を開く導線はコマンドパレット / Cmd+, 経由の `settings.open` のみで、対象は常にアクティブ worktree が属するプロジェクトに依存していた。サイドバーで複数 repo を同居させる gozd では「今クリックした repo の project 設定を開きたい」という導線が無く、対象 repo をピンポイントで指定できなかった。

既存の「Revive session」項目が単一コマンドを command bus 経由で dispatch し、サイドバーからは明示 `rootDir` を渡す（VSCode の SCM コマンドと同型: clicked resource 優先）流儀を採っているため、これを踏襲して project 設定にも同じ導線を用意した。

## 変更内容

### settings

- `useSettingsModal` の `open` を `{ tab?, projectDir? }` を受け取れるよう拡張。既存コマンド `settings.open` を新設せず args 拡張で再利用し、palette / Cmd+, 起動（args なし）は Global タブ・アクティブ worktree 追従のまま挙動を変えない
- `SettingsModal` の対象 dir を `targetProjectDir ?? worktreeStore.dir` に変更。menu から開いたときはその repo の `rootDir` で対象を固定し、開いた後にアクティブ worktree が動いても対象がブレないようにした（clicked resource 優先）
- load / save 双方が同じ `projectDir` を見るよう `openWithSettings` / `handleProjectChange` を統一
- command args の解釈を担う `parseOpenArgs` を純関数として切り出し、防御分岐（非オブジェクト / 不正 tab / 空文字 rootDir）の単体テストを追加

### sidebar

- `RepoMenu` に「Project settings」項目を追加。`registry.execute("settings.open", { tab: "project", rootDir })` を command bus 経由で dispatch し、sidebar→settings の import 循環を回避

## 確認事項

- [ ] repo ⋮ メニューの「Project settings」でその repo の Project タブが開くこと
- [ ] menu から開いた後にアクティブ worktree を切り替えても対象 project が固定されたままであること
- [ ] Cmd+, / コマンドパレットからの起動は従来通り Global タブ・active worktree 追従であること
- [ ] アクティブ worktree も対象 repo も無いときに Project タブが無効化されること
