### PR TITLE
fix(git-graph): worktree 構成でグラフ列が見切れる幅計算を修正

### DIFF
--- a/apps/renderer/src/features/git-graph/features/commit-list/graphLayout.test.ts
+++ b/apps/renderer/src/features/git-graph/features/commit-list/graphLayout.test.ts
@@ -196,6 +196,26 @@ describe("computeGraphLayout の HEAD 最左固定", () => {
     expect(lanes.get("c")).toBe(0);
   });
 
+  test("HEAD より上の枝が HEAD へ合流するだけでも maxLanes は使用レーン全体を覆う", () => {
+    // バグ再現形: 他 worktree がチェックアウトした先行コミットが HEAD の上に並ぶ構成。
+    //   u0 → u1 (lane 1, HEAD 予約で lane 0 を避ける)
+    //   h0 (HEAD, lane 0) ← u1 が合流
+    // lane 0 (予約中は空) と lane 1 (HEAD 行で解放) が同時に active になる瞬間がないため、
+    // 「同時 active 数」で数えると maxLanes = 1 になり lane 1 の dot / 曲線が描画幅から見切れる。
+    const commits = [
+      commit("u0", ["u1"]),
+      commit("u1", ["h0"]),
+      commit("h0", ["base"], ["HEAD"]),
+      commit("base", []),
+    ];
+    const layout = computeGraphLayout(commits, { headHash: "h0" });
+    const lanes = laneByHash(layout);
+    expect(lanes.get("u0")).toBe(1);
+    expect(lanes.get("h0")).toBe(0);
+    // lane 1 が描画幅に含まれる
+    expect(layout.maxLanes).toBe(2);
+  });
+
   test("HEAD には固定色 (HEAD_COLOR) を割り当て、上に並ぶ他枝には別色を割り当てる", () => {
     // バグ再現形: HEAD が tip で、上に divergent な origin 枝が並ぶ。
     // 先着順採番だと origin が色 0 を取り HEAD が色 1 になり、Working Tree (常に色 0) と

--- a/apps/renderer/src/features/git-graph/features/commit-list/graphLayout.ts
+++ b/apps/renderer/src/features/git-graph/features/commit-list/graphLayout.ts
@@ -117,7 +117,6 @@ export function computeGraphLayout(
   // HEAD が表示集合内にあるなら色 0 は HEAD 専用に予約し、他レーンは 1 から採番する。
   // HEAD 不在 (headCommitIndex < 0) なら予約不要なので従来どおり 0 から採番する。
   let nextColor = headCommitIndex >= 0 ? 1 : 0;
-  let maxLanes = 0;
 
   const nodes: GraphNode[] = [];
   const lines: LineSegment[] = [];
@@ -256,13 +255,16 @@ export function computeGraphLayout(
       activeLanes[mergeLane] = { hash: parentHash, color: mergeColor, originLane: lane };
     }
 
-    maxLanes = Math.max(maxLanes, countActive(activeLanes));
     nodes.push({ commit, lane, color });
     // HEAD 行を処理し終えたら lane 0 予約を解除する (以降の行は minLane 0)。
     if (isHead) headReached = true;
   }
 
-  return { nodes, lines, maxLanes: Math.max(maxLanes, 1) };
+  // maxLanes は「使われた最大レーン番号 + 1」(描画幅の根拠)。同時 active 数を数えると、
+  // HEAD 予約で lane 0 が空のまま上のコミットが lane 1 に置かれるケース (HEAD が表示先頭でない
+  // worktree 構成の典型) で幅が不足し、右端レーンの dot / 曲線が見切れる。activeLanes は解放時も
+  // undefined 代入のみで length を縮めないため、最終 length がそのまま最大レーン番号 + 1 になる。
+  return { nodes, lines, maxLanes: Math.max(activeLanes.length, 1) };
 }
 
 /**
@@ -273,12 +275,4 @@ function findEmptyLane(lanes: (LaneState | undefined)[], minLane = 0): number {
     if (lanes[i] === undefined) return i;
   }
   return Math.max(lanes.length, minLane);
-}
-
-function countActive(lanes: (LaneState | undefined)[]): number {
-  let count = 0;
-  for (const lane of lanes) {
-    if (lane !== undefined) count++;
-  }
-  return count;
 }


### PR DESCRIPTION
## 概要

git graph のグラフ列 (レーン / dot / 合流曲線を描く SVG 領域) の幅計算を修正する。他 worktree がチェックアウトした先行コミットが HEAD より上に並ぶ構成で、右端レーンの dot と曲線が列の右端でちょうど半分見切れていた。

## 背景

グラフ列の幅は `computeGraphLayout` が返す `maxLanes` から算出するが、これを「**同時に** active なレーン数」(`countActive`) で数えていた。幅の根拠として必要なのは「**使われた最大レーン番号 + 1**」であり、両者は HEAD の最左固定 (lane 0 予約) と組み合わさるとずれる。

見切れが起きる典型は worktree 運用時:

- HEAD が表示先頭にないため lane 0 が HEAD 用に予約され、**空のまま** カウント対象外になる
- HEAD より上のコミット (他 worktree のチェックアウト先) は lane 1 に置かれるが、HEAD 行で lane 0 へ合流して **即解放** される

この 2 つにより lane 0 と lane 1 が同時に active になる瞬間が存在せず `maxLanes = 1` となる。列幅は 36px になる一方、lane 1 の dot 中心はちょうど x = 36px にあるため、dot と合流曲線が SVG 右端で半分切れていた。

修正後に dev で確認し、従来過小幅で clip されていたレーン群 (200 コミット分の並行 merge 枝) が全幅で描画されることを確認済み。

## 変更内容

### graph レイアウト

- `graphLayout.ts`: グラフ列幅の根拠となる `maxLanes` は「使われた最大レーン番号 + 1」( = `activeLanes` の最終 length) から算出する

### テスト

- `graphLayout.test.ts`: HEAD より上の枝が HEAD へ合流するだけの構成で `maxLanes` が使用レーン全体を覆うことを検証する回帰テストを追加

## 確認事項

- [ ] HEAD が表示先頭にない worktree 構成で、右端レーンの dot / 曲線が見切れないこと
- [ ] HEAD が表示先頭にある通常構成でグラフ幅が従来と変わらないこと
