### PR TITLE
perf(arcade): 常時アニメーションする aurora 環境光を削除して GPU 常時負荷を解消

### DIFF
--- a/apps/renderer/src/assets/main.css
+++ b/apps/renderer/src/assets/main.css
@@ -26,14 +26,6 @@
   --chat-outgoing-text-primitive: #000000;
   --chat-code-primitive: #c4b5fd;
 
-  /* arcade FX 装飾色 (ゲームジュース層の環境光メッシュ / オーロラ)。
-     Adobe Leonardo は gray + intent hues (blue/red/green/amber/orange) のみ生成し、
-     ここで使う violet / 中間 blue は intent に存在しない。演出専用の固定色で
-     theme 追従パイプラインに乗らないため brand-fixed primitive として隔離する (chat-* と同じ扱い)。
-     アルファは利用側で color-mix で適用し、primitive は不透明値を持つ。 */
-  --fx-aurora-blue-primitive: oklch(0.45 0.1 250);
-  --fx-mesh-violet-primitive: oklch(0.4 0.11 320);
-
   /* scroll-to-HEAD pill (git-graph の HEAD ジャンプ用フローティングボタン)。
      primary (主 CTA) とは役割が異なり、theme に追従しない固定の深い青 + 白文字
      (Slack の new-messages pill 相当) にするため brand-fixed primitive として隔離する。 */
@@ -167,10 +159,6 @@
   --color-chat-outgoing: var(--chat-outgoing-primitive);
   --color-chat-outgoing-text: var(--chat-outgoing-text-primitive);
   --color-chat-code: var(--chat-code-primitive);
-
-  /* arcade FX 装飾色 (brand-fixed primitive を参照する semantic alias) */
-  --color-fx-aurora-blue: var(--fx-aurora-blue-primitive);
-  --color-fx-mesh-violet: var(--fx-mesh-violet-primitive);
 
   /* scroll-to-HEAD pill (brand-fixed primitive を参照する semantic alias) */
   --color-scroll-pill: var(--scroll-pill-primitive);

--- a/apps/renderer/src/features/arcade/ArcadeLayer.vue
+++ b/apps/renderer/src/features/arcade/ArcadeLayer.vue
@@ -21,11 +21,11 @@
 ## パフォーマンス
 
 - canvas パーティクルはイベント発火時のみ rAF を回し、空になれば停止する (idle 時の rAF ゼロ)
-- **常時アニメーションを置かない**。かつて全画面 drift する aurora (blur 80px +
-  mix-blend-mode: screen の環境光) を常時演出として持っていたが、知覚できないほど
-  遅い動きでも compositor は毎フレーム全画面の blend + blur 再合成を強制され、
-  さらに backdrop-filter パネルの blur キャッシュを毎フレーム無効化して GPU プロセスの
-  負荷が常時数十% に達したため削除した。静的なビネットは合成負荷を持たないので残す
+- **常時アニメーションを置かない**。全画面を常時 drift させる演出 (blur +
+  mix-blend-mode の環境光など) は、知覚できないほど遅い動きでも compositor に
+  毎フレーム全画面の blend + blur 再合成を強制し、背後の backdrop-filter パネルの
+  blur キャッシュも毎フレーム無効化するため、GPU プロセスの負荷が常時数十% に達する。
+  静的なビネットは合成負荷を持たないので使ってよい
 </doc>
 
 <script setup lang="ts">

--- a/apps/renderer/src/features/arcade/ArcadeLayer.vue
+++ b/apps/renderer/src/features/arcade/ArcadeLayer.vue
@@ -1,6 +1,6 @@
 <doc lang="md">
 ゲームジュース層の全画面オーバーレイ。UI 最前面 (pointer-events: none) に
-パーティクル canvas / ビネット / オーロラ / イベントフラッシュを重ねる。
+パーティクル canvas / ビネット / イベントフラッシュを重ねる。
 
 ## 重ね順と操作透過
 
@@ -21,9 +21,11 @@
 ## パフォーマンス
 
 - canvas パーティクルはイベント発火時のみ rAF を回し、空になれば停止する (idle 時の rAF ゼロ)
-- 一方 aurora / 各種グローは CSS 合成による**常時演出**。GPU レイヤーは
-  保持され続けるため、canvas のような完全停止はせず idle 時も合成負荷が残る。
-  aurora は `will-change: transform` で常時 drift するため、無負荷ではない点に注意
+- **常時アニメーションを置かない**。かつて全画面 drift する aurora (blur 80px +
+  mix-blend-mode: screen の環境光) を常時演出として持っていたが、知覚できないほど
+  遅い動きでも compositor は毎フレーム全画面の blend + blur 再合成を強制され、
+  さらに backdrop-filter パネルの blur キャッシュを毎フレーム無効化して GPU プロセスの
+  負荷が常時数十% に達したため削除した。静的なビネットは合成負荷を持たないので残す
 </doc>
 
 <script setup lang="ts">
@@ -120,8 +122,6 @@ onUnmounted(() => {
 
 <template>
   <div class="pointer-events-none fixed inset-0" aria-hidden="true">
-    <!-- ゆっくり漂う環境光 (additive blend で暗部だけ持ち上げる) -->
-    <div class="_fx-aurora absolute inset-0"></div>
     <!-- 周辺減光で中央に視線を集める -->
     <div class="_fx-vignette absolute inset-0"></div>
     <!-- パーティクル -->
@@ -134,62 +134,6 @@ onUnmounted(() => {
 <style>
 ._fx-vignette {
   background: radial-gradient(ellipse 120% 100% at 50% 45%, transparent 60%, oklch(0 0 0 / 0.3));
-}
-
-._fx-aurora {
-  opacity: 0.5;
-  mix-blend-mode: screen;
-}
-
-._fx-aurora::before,
-._fx-aurora::after {
-  content: "";
-  position: absolute;
-  width: 60vw;
-  height: 60vh;
-  border-radius: 50%;
-  filter: blur(80px);
-  will-change: transform;
-}
-
-._fx-aurora::before {
-  background: radial-gradient(
-    circle,
-    color-mix(in oklch, var(--color-fx-aurora-blue) 16%, transparent),
-    transparent 70%
-  );
-  top: -20%;
-  left: -10%;
-  animation: fx-drift-a 26s ease-in-out infinite alternate;
-}
-
-._fx-aurora::after {
-  background: radial-gradient(
-    circle,
-    color-mix(in oklch, var(--color-fx-mesh-violet) 12%, transparent),
-    transparent 70%
-  );
-  bottom: -25%;
-  right: -10%;
-  animation: fx-drift-b 34s ease-in-out infinite alternate;
-}
-
-@keyframes fx-drift-a {
-  from {
-    transform: translate(0, 0) scale(1);
-  }
-  to {
-    transform: translate(30vw, 20vh) scale(1.3);
-  }
-}
-
-@keyframes fx-drift-b {
-  from {
-    transform: translate(0, 0) scale(1.2);
-  }
-  to {
-    transform: translate(-25vw, -15vh) scale(0.9);
-  }
 }
 
 /* イベント発生時に画面端を発光させるフラッシュ。色は data-kind で切り替える */


### PR DESCRIPTION
## 概要

ArcadeLayer の aurora（全画面をゆっくり漂う環境光）を削除する。アプリがアイドルでも GPU プロセス（Gozd Helper）が CPU 46% / GPU 61% を消費し続け、ノート PC でファンが回る問題の対処。

## 背景

アクティビティモニタで gozd の GPU プロセスが常時高負荷になっているとの報告から調査した。原因は aurora の構造にある:

- 60vw×60vh の擬似要素 2 枚に `filter: blur(80px)` + `mix-blend-mode: screen` + `will-change: transform` を載せ、26s / 34s の infinite transform アニメーションで漂わせ続けていた
- `mix-blend-mode: screen` の全画面レイヤーが毎フレーム動くため、コンポジタは 60〜120fps で全画面の blend + blur 再合成を止められない
- さらに `_fx-panel` / `_fx-toolbar` の `backdrop-filter: blur(14px)` は「背後が静止していればキャッシュが効く」性質だが、背後で aurora が毎フレーム動くせいで全パネルの blur が毎フレーム再計算に化けていた

一方、演出としての aurora は透明度が低く（レイヤー opacity 0.5 × 色 16% / 12% mix）、blur 80px でエッジがなく、移動速度は分針並みで、**ユーザーには知覚できない**。「見えない演出」に恒久的な毎フレームコストを払っていたため、最適化（opacity 合成化・非フォーカス時停止）ではなく削除を選んだ。

レビューでの静的検証により、aurora がアイドル時に走る唯一の常時アニメーションであること（残る infinite アニメーションはすべて claude 状態依存でアイドル非アクティブ）を確認済み。

## 変更内容

### ArcadeLayer.vue

- aurora の div / `._fx-aurora` 系 CSS / `fx-drift-a` `fx-drift-b` keyframes を削除
- `<doc>` のパフォーマンス節を「常時アニメーションを置かない」という現在形の一般規律 + 理由に書き換え（同種演出の再導入を抑止）
- 静的なビネットは合成負荷を持たないため残す

### main.css

- aurora 専用だったカラートークンを削除（Tier 1 brand-fixed の `--fx-aurora-blue-primitive` / `--fx-mesh-violet-primitive` と Tier 2 alias の `--color-fx-aurora-blue` / `--color-fx-mesh-violet`）。参照元は aurora のみだった

## 今回は対応しない

- worktree カードの状態オーラ（`fx-aura-breathe` / `fx-aura-blink` の box-shadow keyframe）と working タスク行のスキャンライン（`fx-scan` の `left` keyframe）は main-thread paint を毎フレーム走らせるため renderer プロセス側の負荷源として残っている。ただしこれらは claude が working / asking のときだけ動く可視の機能的フィードバックであり「見えない常時負荷」ではないため、本 PR の削除対象から外した。opacity / transform ベースへの書き換えは別 PR で対応する

## 確認事項

- [ ] アイドル状態で GPU プロセス（Gozd Helper）の % GPU が数%台まで落ちること（アクティビティモニタで確認）
- [ ] 削除後の見た目に違和感がないこと（aurora は知覚困難なため差は出ないはずだが、暗部の持ち上げがなくなる分わずかに画面が沈む可能性がある）
