### PR TITLE
feat(claude-status): Stop hook の pendingWork 算出元を観測するログを追加

### DIFF
--- a/apps/electron/src/cli/cliOps.test.ts
+++ b/apps/electron/src/cli/cliOps.test.ts
@@ -119,6 +119,12 @@ describe("buildHookMessage", () => {
       session_crons: [],
     });
   });
+
+  test("pendingWorkDetail は片キーのみでも組み立て、4000 文字で切り詰める", () => {
+    const hook = buildHookMessage("done", { background_tasks: [{ command: "x".repeat(5000) }] }, {});
+    expect(hook.pendingWorkDetail.startsWith('{"background_tasks":')).toBe(true);
+    expect(hook.pendingWorkDetail.length).toBe(4000);
+  });
 });
 
 describe("parseStdinJson", () => {

--- a/apps/electron/src/cli/cliOps.test.ts
+++ b/apps/electron/src/cli/cliOps.test.ts
@@ -106,6 +106,19 @@ describe("buildHookMessage", () => {
     expect(buildHookMessage("done", { background_tasks: [{}] }, {}).pendingWork).toBe(true);
     expect(buildHookMessage("done", { session_crons: [{}] }, {}).pendingWork).toBe(true);
   });
+
+  test("pendingWorkDetail は算出元の生配列スナップショット（両キー不在は空文字列）", () => {
+    expect(buildHookMessage("done", {}, {}).pendingWorkDetail).toBe("");
+    const hook = buildHookMessage(
+      "done",
+      { background_tasks: [{ status: "completed", id: "t1" }], session_crons: [] },
+      {},
+    );
+    expect(JSON.parse(hook.pendingWorkDetail)).toEqual({
+      background_tasks: [{ status: "completed", id: "t1" }],
+      session_crons: [],
+    });
+  });
 });
 
 describe("parseStdinJson", () => {

--- a/apps/electron/src/cli/cliOps.ts
+++ b/apps/electron/src/cli/cliOps.ts
@@ -39,6 +39,10 @@ export function writeLaunchRequest(targetPath: string, socketPath: string): void
   writeFileSync(join(dir, `${randomUUID()}.json`), JSON.stringify({ targetPath }));
 }
 
+/** pendingWorkDetail の最大長。生配列をそのまま運ぶとコマンド文字列等で肥大しうるため、
+ * ログ用途に十分な長さで切り詰める（途中で切れて JSON として壊れてもログとしては読める） */
+const PENDING_WORK_DETAIL_MAX = 4000;
+
 /** Claude Code が stdin で渡す hook JSON から HookMessage を組み立てる。
  * 代表フィールドの取り出しと pending_work の畳み込みは Swift `hookCommand` と同一 */
 export function buildHookMessage(
@@ -62,6 +66,15 @@ export function buildHookMessage(
   const backgroundCount = Array.isArray(stdinJson.background_tasks) ? stdinJson.background_tasks.length : 0;
   const cronCount = Array.isArray(stdinJson.session_crons) ? stdinJson.session_crons.length : 0;
 
+  // 観測ログ用: pending_work 算出元の生配列スナップショット。length だけで畳む現行判定が
+  // 「完了済み entry の残留 / 長寿命 background process / 発火済み cron」で false positive に
+  // なっていないかを main 側のログで観測するために運ぶ（HookMessage.pendingWorkDetail 参照）
+  const pendingArrays: Record<string, unknown> = {};
+  if (Array.isArray(stdinJson.background_tasks)) pendingArrays.background_tasks = stdinJson.background_tasks;
+  if (Array.isArray(stdinJson.session_crons)) pendingArrays.session_crons = stdinJson.session_crons;
+  const pendingWorkDetail =
+    Object.keys(pendingArrays).length > 0 ? JSON.stringify(pendingArrays).slice(0, PENDING_WORK_DETAIL_MAX) : "";
+
   return {
     event,
     ptyId,
@@ -71,6 +84,7 @@ export function buildHookMessage(
     sessionId: typeof stdinJson.session_id === "string" ? stdinJson.session_id : "",
     source: typeof stdinJson.source === "string" ? stdinJson.source : "",
     pendingWork: backgroundCount + cronCount > 0,
+    pendingWorkDetail,
   };
 }
 

--- a/apps/electron/src/socketMessages.test.ts
+++ b/apps/electron/src/socketMessages.test.ts
@@ -85,7 +85,11 @@ describe("socketMessages", () => {
 
   test("複数行は submit 順に逐次処理される", async () => {
     const pushed: Array<{ event: string }> = [];
-    const handle = createSocketMessageHandler((_type, payload) => pushed.push(payload as { event: string }));
+    // done イベントは観測用の debugLog push も飛ぶため、順序検証対象の hook push だけ拾う
+    const handle = createSocketMessageHandler((type, payload) => {
+      if (type !== "hook") return;
+      pushed.push(payload as { event: string });
+    });
     handle('{"hook":{"event":"running","ptyId":1}}');
     handle('{"hook":{"event":"tool-done","ptyId":1}}');
     handle('{"hook":{"event":"done","ptyId":1}}');

--- a/apps/electron/src/socketMessages.ts
+++ b/apps/electron/src/socketMessages.ts
@@ -105,6 +105,7 @@ const HOOK_MESSAGE_DEFAULTS: HookMessage = {
   toolInput: "",
   sessionId: "",
   pendingWork: false,
+  pendingWorkDetail: "",
   source: "",
 };
 
@@ -134,6 +135,17 @@ async function handleSocketMessage(line: string, push: PushFn): Promise<void> {
     const hook = msg.hook;
     if (hook.event === "session-start" || hook.event === "session-end") {
       await applyClaudeSessionHook(hook, worktreePathFor(hook.ptyId), push);
+    }
+    if (hook.event === "done") {
+      // pendingWork false positive（完了済み entry の残留 / 長寿命 background process /
+      // 発火済み cron による working 表示の固着）の実態観測ログ。console.error floor +
+      // event-log push の二段構え（routes.ts makeDebugLogPush と同じ規律）。
+      // Stop はターンごとに 1 回なので常時出しても低頻度
+      const detail = `pty=${hook.ptyId} pendingWork=${hook.pendingWork} ${
+        hook.pendingWorkDetail !== "" ? hook.pendingWorkDetail : "(no arrays)"
+      }`;
+      console.error(`[claude-hook] Stop: ${detail}`);
+      push("debugLog", { channel: "claude-hook", label: "Stop", repo: "", detail });
     }
     // Swift onHook と同形の payload（renderer useTerminalStore handleHookEvent 契約）
     push("hook", {

--- a/packages/rpc/src/clientMessage.ts
+++ b/packages/rpc/src/clientMessage.ts
@@ -38,6 +38,13 @@ export interface HookMessage {
    * ターンは終わったが裏で作業が継続中（= 再起動する）ため、真の done ではない。 */
   pendingWork: boolean;
 
+  /** "done" (Stop) のみ。pendingWork の算出元（stdin の background_tasks / session_crons
+   * 生配列）の JSON スナップショット。「完了しているのに working 表示が残る」false positive
+   * （完了済み entry の残留 / 長寿命 background process / 発火済み cron）の実態を観測する
+   * ための一時的な診断フィールド。main 側 (socketMessages) がログに出すだけで renderer には
+   * 転送しない。両キー不在（旧バージョン / nc 直送）は空文字列。 */
+  pendingWorkDetail: string;
+
   /** session-start のみ。"startup" / "resume" / "clear" / "compact" 等 */
   source: string;
 }

--- a/packages/rpc/src/clientMessage.ts
+++ b/packages/rpc/src/clientMessage.ts
@@ -42,7 +42,11 @@ export interface HookMessage {
    * 生配列）の JSON スナップショット。「完了しているのに working 表示が残る」false positive
    * （完了済み entry の残留 / 長寿命 background process / 発火済み cron）の実態を観測する
    * ための一時的な診断フィールド。main 側 (socketMessages) がログに出すだけで renderer には
-   * 転送しない。両キー不在（旧バージョン / nc 直送）は空文字列。 */
+   * 転送しない。両キー不在（旧バージョン / nc 直送）は空文字列。
+   *
+   * 撤去条件: false positive の原因が実データで特定され、pendingWork 判定が status を考慮した
+   * 形に修正された時点で、本フィールド / cliOps の snapshot 生成 / socketMessages の
+   * done 分岐ログをまとめて撤去する。 */
   pendingWorkDetail: string;
 
   /** session-start のみ。"startup" / "resume" / "clear" / "compact" 等 */


### PR DESCRIPTION
## 概要

「Claude が完了しているのにサイドバーの badge が working のまま残る」事象の原因調査のため、`pendingWork` の算出元（Stop hook stdin の `background_tasks` / `session_crons` 生配列）を main まで運んで観測ログに出す。

## 背景

working 表示の固着は、状態機械上の `working`（OSC タイトル駆動）ではなく **`done + pendingWork` を working として描画する表示経路**（`displayClaudeState()`）で起きている可能性が高い。純粋な `working` 固着は、Stop hook が欠落しても OSC タイトルの「スピナー → `✳`」で `idle` に倒れるため、hook とタイトルの両方を同時に失わないと成立しない。

一方、`pendingWork` の算出（`cliOps.ts` の `buildHookMessage`）は `background_tasks` / `session_crons` の **配列長だけ** を見ており、entry の status を見ていない。Claude Code 側の仕様（v2.1.145+）と突き合わせると false positive の候補が 3 つある:

- `background_tasks` の entry は `status`（`running` / `starting` / `completed` / `failed`）を持ち、完了済み entry が残留していれば実作業ゼロでも `pendingWork: true` になる
- `run_in_background` で起動した長寿命プロセス（dev サーバー等）は正当に `running` のまま残り続け、「次の Stop で配列が空になる」前提が永遠に成立しない
- `session_crons` には発火済みの one-shot cron / recurring cron（`/loop` 等）が残留し、loop 停止後は「次の Stop」自体が来ない

どの経路が実際に起きているかは stdin の実データを見ないと確定できないが、hook stdin を受ける CLI プロセスの stderr は Claude Code の hook 実行系に吸われて不可視。そのためワイヤ（`HookMessage`）に載せて main まで運ぶのが唯一の観測経路になる。

## 変更内容

### ワイヤ（@gozd/rpc）

- `HookMessage` に一時的な診断フィールド `pendingWorkDetail: string` を追加。算出元 2 配列の JSON スナップショット（両キー不在は空文字列）
- 撤去条件を doc コメントに明記: false positive の原因が特定され pendingWork 判定が status を考慮した形に修正された時点で、本フィールド / snapshot 生成 / done 分岐ログをまとめて撤去する

### CLI

- `buildHookMessage` でスナップショットを組み立てる。ログ用途のため `PENDING_WORK_DETAIL_MAX = 4000` 文字で切り詰める（途中で切れて JSON として壊れてもログとしては読める）

### main（socketMessages）

- `done` イベント受信時に `[claude-hook] Stop: pty=N pendingWork=B {...}` を出力。`console.error` floor + `debugLog` push（event-log パネル）の二段構え（`makeDebugLogPush` と同じ規律）。Stop はターンごとに 1 回のため常時出力でも低頻度
- renderer への `hook` push payload には detail を同梱しない（状態機械の契約に診断データを混ぜない）

### テスト

- `cliOps.test.ts`: `pendingWorkDetail` の契約を固定（スナップショット / 両キー不在は空 / 片キーのみの組み立て / 4000 文字 truncation）
- `socketMessages.test.ts`: done イベントは観測用の `debugLog` push も飛ぶため、逐次処理テストの順序検証は `hook` push だけを対象にする

## 確認事項

- [ ] packaged（stable）で「完了したのに working のまま」再現時に、event-log パネルで `[claude-hook] Stop:` 行が観測できること（Claude セッションを持続的に走らせるのは stable のみのため、観測は stable 前提。反映には `pnpm --filter @gozd/electron build:app` での再ビルドが必要）
