### PR TITLE
fix(preview): DiffPreview を閉じるときの Monaco model dispose 順序を修正

### DIFF
--- a/apps/renderer/src/features/preview/DiffPreview.vue
+++ b/apps/renderer/src/features/preview/DiffPreview.vue
@@ -979,9 +979,11 @@ async function mountMonacoDiffEditor() {
 function unmountMonacoDiffEditor() {
   mountGeneration++; // in-flight な mountMonacoDiffEditor (dynamic import 待ち) を無効化する
   const model = monacoDiffEditor?.getModel();
+  // editor → model の順で破棄する。アタッチ中の model を先に dispose すると Monaco が
+  // "TextModel got disposed before DiffEditorWidget model got reset" を throw する (issue #970)
+  monacoDiffEditor?.dispose();
   model?.original.dispose();
   model?.modified.dispose();
-  monacoDiffEditor?.dispose();
   monacoDiffEditor = undefined;
   blameHandles = []; // トリガー本体は editor.dispose() で解放される (wireGutterBlame の契約)
 }


### PR DESCRIPTION
## 概要

DiffPreview の編集パス（Monaco `createDiffEditor`）の teardown で、TextModel を DiffEditor より先に dispose していた順序を editor → model に入れ替える。

## 背景

packaged app の DevTools console に uncaught error が繰り返し出ていた（ #970 ）。

```text
Error: TextModel got disposed before DiffEditorWidget model got reset
```

Monaco の `DiffEditorWidget` はセット中の TextModel にリスナーを張っており、アタッチされたままの model を `dispose()` すると model 側の `onWillDispose` 通知でこのエラーを throw する。`unmountMonacoDiffEditor` は `props.editable` が false になったときと `onUnmounted` の両方から呼ばれるため、worktree 切り替えで diff preview が閉じるたびに発火していた（console の `PR diff turned off: worktree changed` ログと交互に出ていた観測と一致）。

`editor.dispose()` は model を解放せずデタッチするだけなので、`createModel` で自前生成した model の明示 dispose 自体は必要であり、実行順序だけが問題だった。

issue #970 に併記されている `Cannot read properties of null (reading 'compileAG')` は別系統の症状（原因未特定）のため、本 PR では扱わない。

## 変更内容

### DiffPreview.vue

- `unmountMonacoDiffEditor` の破棄順序を model → editor から editor → model に入れ替え
- model 参照の取得（`getModel()`）は editor 破棄前に行う必要があるため先頭に据え置き

## 確認事項

- [ ] packaged app で diff preview を閉じたとき（worktree 切り替え等）に DevTools console へ当該エラーが出なくなったこと。修正機構は Monaco ソースで裏取り済みだが、実証は packaged 実行時の console でのみ観測可能
