### PR TITLE
feat(git-graph): commit 右クリックメニューに Copy commit hash を追加

### DIFF
--- a/apps/renderer/src/features/event-log/EventLogPanel.vue
+++ b/apps/renderer/src/features/event-log/EventLogPanel.vue
@@ -12,9 +12,9 @@
 </doc>
 
 <script setup lang="ts">
-import { tryCatch } from "@gozd/shared";
 import { useEventListener } from "@vueuse/core";
 import { computed, useTemplateRef, watch } from "vue";
+import { writeClipboardText } from "../../shared/clipboard";
 import { useDebugLog } from "../../shared/debug";
 import { useNotificationStore } from "../../shared/notification";
 import { useEventLogStore } from "./useEventLogStore";
@@ -48,8 +48,7 @@ function fmtLine(e: {
  * 表示の newest-first ではなくログ慣習の oldest-first で出す。 */
 async function copyAll(): Promise<void> {
   const text = events.value.map(fmtLine).join("\n");
-  // navigator.clipboard 参照時点の同期 throw も拾うため async IIFE で Promise 化してから tryCatch
-  const result = await tryCatch((async () => navigator.clipboard.writeText(text))());
+  const result = await writeClipboardText(text);
   if (result.ok) {
     notify.info("Event log copied to clipboard");
   } else {

--- a/apps/renderer/src/features/filer/FileActionMenuItems.vue
+++ b/apps/renderer/src/features/filer/FileActionMenuItems.vue
@@ -14,6 +14,7 @@ Open / Copy file は `openable` (working tree に実体がある) のときだ�
 
 <script setup lang="ts">
 import { tryCatch } from "@gozd/shared";
+import { writeClipboardText } from "../../shared/clipboard";
 import { useNotificationStore } from "../../shared/notification";
 import { copyFileToOsClipboard } from "./copyFileToOsClipboard";
 import { rpcOpenFile } from "./rpc";
@@ -61,8 +62,7 @@ async function handleCopyPath() {
   const { absPath, commitHash } = props;
   const text = commitHash === undefined ? absPath : `${commitHash}\n${absPath}`;
   emit("close");
-  // navigator.clipboard 参照時の同期 throw も拾うため async IIFE で Promise 化してから tryCatch に渡す
-  const result = await tryCatch((async () => navigator.clipboard.writeText(text))());
+  const result = await writeClipboardText(text);
   if (!result.ok) {
     notify.error("Failed to copy path", result.error);
   }

--- a/apps/renderer/src/features/git-graph/features/commit-context-menu/CommitContextMenu.vue
+++ b/apps/renderer/src/features/git-graph/features/commit-context-menu/CommitContextMenu.vue
@@ -8,6 +8,7 @@ light-dismiss 回避は `useCommitContextMenuTrigger.ts` を参照。
 <script setup lang="ts">
 import { tryCatch } from "@gozd/shared";
 import { computed } from "vue";
+import { writeClipboardText } from "../../../../shared/clipboard";
 import { useNotificationStore } from "../../../../shared/notification";
 import { rpcGitResetMixed } from "../../rpc";
 import { useCommitContextMenu } from "./useCommitContextMenu";
@@ -38,8 +39,7 @@ async function handleCopyHash() {
   if (!context.value) return;
   const { hash } = context.value;
   close();
-  // navigator.clipboard 参照時の同期 throw も拾うため async IIFE で Promise 化してから tryCatch に渡す
-  const result = await tryCatch((async () => navigator.clipboard.writeText(hash))());
+  const result = await writeClipboardText(hash);
   if (!result.ok) {
     notify.error("Failed to copy commit hash", result.error);
   }

--- a/apps/renderer/src/features/git-graph/features/commit-context-menu/CommitContextMenu.vue
+++ b/apps/renderer/src/features/git-graph/features/commit-context-menu/CommitContextMenu.vue
@@ -1,8 +1,8 @@
 <doc lang="md">
-git-graph の commit 行の右クリックメニュー。「Reset (mixed) to here」を描画し、snapshot した
-dir / hash に対して `git reset --mixed` を実行する。context の snapshot・位置決めは
-`useCommitContextMenu.ts`、pointerup まで open を遅延させる light-dismiss 回避は
-`useCommitContextMenuTrigger.ts` を参照。
+git-graph の commit 行の右クリックメニュー。「Copy commit hash」(full hash を clipboard へ) と
+「Reset (mixed) to here」(snapshot した dir / hash へ `git reset --mixed`) を描画する。
+context の snapshot・位置決めは `useCommitContextMenu.ts`、pointerup まで open を遅延させる
+light-dismiss 回避は `useCommitContextMenuTrigger.ts` を参照。
 </doc>
 
 <script setup lang="ts">
@@ -11,6 +11,7 @@ import { computed } from "vue";
 import { useNotificationStore } from "../../../../shared/notification";
 import { rpcGitResetMixed } from "../../rpc";
 import { useCommitContextMenu } from "./useCommitContextMenu";
+import IconLucideCopy from "~icons/lucide/copy";
 import IconLucideUndo2 from "~icons/lucide/undo-2";
 
 const { Popover, context, close } = useCommitContextMenu();
@@ -33,6 +34,17 @@ const popoverStyle = computed(() => {
 /** メニュー表示用の短縮 hash (7 桁)。full hash は RPC にそのまま渡す */
 const shortHash = computed(() => context.value?.hash.slice(0, 7) ?? "");
 
+async function handleCopyHash() {
+  if (!context.value) return;
+  const { hash } = context.value;
+  close();
+  // navigator.clipboard 参照時の同期 throw も拾うため async IIFE で Promise 化してから tryCatch に渡す
+  const result = await tryCatch((async () => navigator.clipboard.writeText(hash))());
+  if (!result.ok) {
+    notify.error("Failed to copy commit hash", result.error);
+  }
+}
+
 async function handleResetMixed() {
   if (!context.value) return;
   const { dir, hash } = context.value;
@@ -49,6 +61,14 @@ async function handleResetMixed() {
     class="m-0 min-w-44 rounded-lg border border-border bg-background py-1 text-sm text-foreground shadow-lg"
     :style="popoverStyle"
   >
+    <button
+      v-if="context"
+      class="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-panel"
+      @click="handleCopyHash"
+    >
+      <IconLucideCopy class="text-xs" />
+      Copy commit hash <span class="font-mono text-foreground-low">{{ shortHash }}</span>
+    </button>
     <button
       v-if="context"
       class="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-panel"

--- a/apps/renderer/src/features/git-graph/features/commit-context-menu/useCommitContextMenu.ts
+++ b/apps/renderer/src/features/git-graph/features/commit-context-menu/useCommitContextMenu.ts
@@ -1,7 +1,6 @@
 /**
  * git-graph の commit 行の右クリックメニュー (module singleton)。popover の open / context 購読を
- * 担い、CommitContextMenu.vue が描画する。menu アクションは「Reset (mixed) to here」1 個で、
- * context の `hash` へ `git reset --mixed` を実行する (`rpcGitResetMixed`)。
+ * 担い、CommitContextMenu.vue が描画する。menu アクションは CommitContextMenu.vue の doc を参照。
  *
  * `dir` / `hash` は右クリック時点で snapshot して context に焼き付ける。後で worktree 切替 /
  * commit 選択 / git log 再取得が走っても、その右クリックで指した当時の値を一貫して使う

--- a/apps/renderer/src/features/layout/NotificationToastItem.vue
+++ b/apps/renderer/src/features/layout/NotificationToastItem.vue
@@ -11,8 +11,8 @@
 </doc>
 
 <script setup lang="ts">
-import { tryCatch } from "@gozd/shared";
 import { computed, ref, type FunctionalComponent, type SVGAttributes } from "vue";
+import { writeClipboardText } from "../../shared/clipboard";
 import { formatCauseChain } from "./formatCause";
 import IconLucideCheck from "~icons/lucide/check";
 import IconLucideChevronDown from "~icons/lucide/chevron-down";
@@ -78,11 +78,7 @@ function toggle() {
 
 async function copyDetail() {
   const text = `${props.message}\n\n${detail.value}`;
-  // navigator.clipboard 自体が undefined の環境（古い WebView / 非 secure context）で
-  // .writeText 参照時点の同期 throw も拾うため、async IIFE で Promise 化してから tryCatch に渡す。
-  // tryCatch の関数版は Result<Promise<T>> を返すだけで Promise の reject を拾わないため、
-  // ここでは Promise 版に流し込む必要がある。
-  const result = await tryCatch((async () => navigator.clipboard.writeText(text))());
+  const result = await writeClipboardText(text);
   copyState.value = result.ok ? "copied" : "failed";
   setTimeout(() => {
     copyState.value = "idle";

--- a/apps/renderer/src/shared/clipboard/index.ts
+++ b/apps/renderer/src/shared/clipboard/index.ts
@@ -1,0 +1,1 @@
+export { writeClipboardText } from "./writeClipboardText";

--- a/apps/renderer/src/shared/clipboard/writeClipboardText.ts
+++ b/apps/renderer/src/shared/clipboard/writeClipboardText.ts
@@ -1,0 +1,15 @@
+import { tryCatch, type Result } from "@gozd/shared";
+
+/**
+ * navigator.clipboard へのテキスト書き込みを Result で返す。
+ *
+ * navigator.clipboard 自体が undefined の環境（古い WebView / 非 secure context）では
+ * `.writeText` 参照時点で同期 throw するため、async IIFE で Promise 化してから tryCatch の
+ * Promise 版に流し込む（関数版は Result<Promise<T>> を返すだけで Promise の reject を拾えない）。
+ *
+ * 成功 / 失敗時のフィードバック（トースト文言・状態表示）は call site ごとに異なるため
+ * 呼び出し側の責務とする。
+ */
+export function writeClipboardText(text: string): Promise<Result<void>> {
+  return tryCatch((async () => navigator.clipboard.writeText(text))());
+}


### PR DESCRIPTION
## 概要

gitgraph の commit 行の右クリックメニューに「Copy commit hash」項目を追加する。クリックすると full hash がクリップボードにコピーされる。

## 背景

gitgraph 上の commit hash を参照したい場面（別ターミナルでの `git show` / issue・PR への貼り付け等）で、これまで hash を取得する UI 手段がなかった。既存の右クリックメニューは「Reset (mixed) to here」1 項目のみだったため、同じメニューにコピー操作を追加する。

また、クリップボード書き込みの「async IIFE で Promise 化してから `tryCatch` に渡す」パターンとその理由コメントが renderer 内の 3 箇所（filer / event-log / layout）に重複しており、本 PR の追加で 4 箇所目になるため、shared モジュールへの SSOT 化を同時に行う。

## 変更内容

### commit-context-menu

- `CommitContextMenu.vue` に「Copy commit hash」メニュー項目を追加。ラベルには短縮 7 桁 hash（既存の `shortHash` computed）を表示し、クリップボードには曖昧さのない full hash を書き込む
- メニューアクションの一覧は描画側 `CommitContextMenu.vue` の doc を SSOT とし、`useCommitContextMenu.ts` の doc はそこを参照する

### shared/clipboard（新規）

- `writeClipboardText(text): Promise<Result<void>>` を `src/shared/clipboard` に切り出し。`navigator.clipboard` が undefined の環境で `.writeText` 参照時点に起きる同期 throw を拾うための async IIFE + `tryCatch` の rationale コメントはこのヘルパー 1 箇所に置く
- 成功 / 失敗時のフィードバック（トースト文言・コピー状態表示）は call site ごとに異なるため呼び出し側の責務のまま
- 既存 3 箇所（`FileActionMenuItems.vue` / `EventLogPanel.vue` / `NotificationToastItem.vue`）と本 PR 追加分をこのヘルパー呼び出しに置き換え

## 確認事項

- [ ] gitgraph の commit 行を右クリック → Copy commit hash で full hash がクリップボードに入る
- [ ] 既存の Reset (mixed) to here が従来どおり動作する
- [ ] 置き換えた既存コピー機能（filer の Copy path / event-log の Copy all / トーストの Copy detail）が従来どおり動作する
