### PR TITLE
feat(git-graph): HEAD 行マーカーを左端の右向き三角形にする

### DIFF
--- a/apps/renderer/src/features/git-graph/features/commit-list/CommitGraphList.vue
+++ b/apps/renderer/src/features/git-graph/features/commit-list/CommitGraphList.vue
@@ -84,7 +84,7 @@ const headNode = computed(() => {
 /** HEAD ノードの色インデックス。Working Tree のドット/接続線を HEAD と同色に揃える。不在時 0。 */
 const headColor = computed(() => headNode.value?.node.color ?? 0);
 
-/** Graph 列の幅。右側は最右 dot / リング用のガターを確保する。 */
+/** Graph 列の幅。右側は最右レーンの dot 用のガターを確保する。 */
 const graphColumnWidth = computed(() => calcGraphColumnWidth(layout.value.maxLanes));
 
 /** commit message (col 2) の最低幅。これを下回るまでは date/author/hash (min 0) が先に潰れ、

--- a/apps/renderer/src/features/git-graph/features/commit-list/CommitRow.vue
+++ b/apps/renderer/src/features/git-graph/features/commit-list/CommitRow.vue
@@ -11,7 +11,6 @@ import { formatCompactTime } from "../../../../shared/time";
 import CommitSegmentList from "../../CommitSegmentList";
 import type { CommitMessageSegment } from "../../linkifyCommitMessage";
 import { useGitGraphStore } from "../../useGitGraphStore";
-import { HEAD_ROW_BG, HEAD_ROW_BG_HOVER } from "./graphColors";
 import { ROW_HEIGHT } from "./graphGeometry";
 import type { GraphNode } from "./graphLayout";
 import { computeDisplayRefs } from "./graphRefs";
@@ -41,26 +40,12 @@ const emit = defineEmits<{
 const gitGraphStore = useGitGraphStore();
 
 const isSelectedRow = computed(() => gitGraphStore.isSelectedRow(props.node.commit.hash));
-const isHeadRow = computed(() => props.node.commit.hash === gitGraphStore.headHash);
 
-// 選択と HEAD は別軸。選択を最優先、次に HEAD 行の持続背景、通常は hover のみ。
-// HEAD 帯は CSS 変数 (--head-bg / --head-bg-hover) を rowStyle が供給し、静的な bg / hover class で参照する。
-// 色を class リテラルに直書きしない (graphColors 由来で Tailwind の静的スキャンに乗らないため) が、
-// 変数名は固定なので class はスキャンでき、hover も cascade で効く (inline background だと hover が付けられない)。
-const highlightClass = computed(() => {
+// 背景塗りは選択 / hover のみが担う。HEAD は SVG overlay の三角マーカー (別チャンネル) で示すため、
+// 行の背景では表現しない (背景塗りで HEAD を敷くと選択 / hover と同一 layer を奪い合い区別できない)。
+const backgroundClass = computed(() => {
   if (isSelectedRow.value) return "bg-primary-subtle hover:bg-primary-subtle-hover";
-  if (isHeadRow.value) return "bg-[var(--head-bg)] hover:bg-[var(--head-bg-hover)]";
   return "hover:bg-element-hover";
-});
-
-// HEAD 帯の色源は graphColors の HEAD lane 色 (リング / ドットと同一 SSOT)。選択が勝つときは供給しない。
-const rowStyle = computed<Record<string, string>>(() => {
-  const style: Record<string, string> = { height: `${ROW_HEIGHT}px` };
-  if (isHeadRow.value && !isSelectedRow.value) {
-    style["--head-bg"] = HEAD_ROW_BG;
-    style["--head-bg-hover"] = HEAD_ROW_BG_HOVER;
-  }
-  return style;
 });
 
 const displayRefs = computed(() =>
@@ -91,12 +76,12 @@ function onContextmenu(e: MouseEvent) {
 <template>
   <div
     class="_graph-row col-span-full grid grid-cols-subgrid items-center text-xs"
-    :class="highlightClass"
-    :style="rowStyle"
+    :class="backgroundClass"
+    :style="{ height: `${ROW_HEIGHT}px` }"
     @click="emit('rowClick', node.commit.hash, $event)"
     @contextmenu="onContextmenu"
   >
-    <!-- col 1 (graph): SVG が absolute で覆うセル。HEAD は SVG 側の dot リングで示すため、
+    <!-- col 1 (graph): SVG が absolute で覆うセル。HEAD は SVG 側の三角マーカーで示すため、
          ここにはマーカーを置かない。 -->
     <div></div>
 

--- a/apps/renderer/src/features/git-graph/features/commit-list/GraphSvgOverlay.vue
+++ b/apps/renderer/src/features/git-graph/features/commit-list/GraphSvgOverlay.vue
@@ -7,7 +7,14 @@ commit graph のレーン / ドットを描く SVG overlay。commit 行の上に
 import { computed } from "vue";
 import { useGitGraphStore } from "../../useGitGraphStore";
 import { laneTextColor } from "./graphColors";
-import { DOT_RADIUS, HEAD_RING_GAP, ROW_HEIGHT, laneX, rowY, segmentPath } from "./graphGeometry";
+import {
+  DOT_RADIUS,
+  ROW_HEIGHT,
+  headMarkerPoints,
+  laneX,
+  rowY,
+  segmentPath,
+} from "./graphGeometry";
 import type { GraphLayout } from "./graphLayout";
 
 const props = defineProps<{
@@ -35,13 +42,12 @@ const connectorPath = computed(() => {
   return `M${x0},0L${x0},${rowY(props.headRow)}`;
 });
 
-/** HEAD リングを描く単一ノード。HEAD は高々 1 行なので headRow から直接引く (全ノード走査しない)。
- *  不在 (-1) / gap 行のときは描かない。 */
-const headRingNode = computed(() => {
+/** 行左端の右向き三角マーカーの points。不在 (-1) / gap 行のときは描かない。 */
+const headMarker = computed(() => {
   if (props.headRow === -1) return undefined;
   const node = props.layout.nodes[props.headRow];
   if (node === undefined || node.gap) return undefined;
-  return node;
+  return headMarkerPoints(props.headRow);
 });
 </script>
 
@@ -69,19 +75,9 @@ const headRingNode = computed(() => {
       :stroke="laneTextColor(seg.color)"
       stroke-width="2"
     />
-    <!-- HEAD リング: 「今 HEAD がいる場所」を dot の外側の輪で示す。塗り (選択) とは別チャンネルなので
-         選択と HEAD が一致してもしなくても両立する。dot より先に描き、fill を背景色にして
-         dot と輪の隙間を通過する lane 線をマスクする (line が輪の中を貫通しないように)。 -->
-    <circle
-      v-if="headRingNode"
-      :cx="laneX(headRingNode.lane)"
-      :cy="rowY(headRow)"
-      :r="DOT_RADIUS + HEAD_RING_GAP"
-      fill="currentColor"
-      :stroke="laneTextColor(headRingNode.color)"
-      stroke-width="1.5"
-      class="text-background"
-    />
+    <!-- HEAD マーカー: 行左端の縦バーを右へ尖らせた右向き三角形。塗り (選択) とは別チャンネルなので
+         選択と HEAD が一致してもしなくても両立する。 -->
+    <polygon v-if="headMarker" :points="headMarker" :fill="laneTextColor(headColor)" />
     <!-- コミットドット (gap 行は dot を描かない) -->
     <circle
       v-for="(node, row) in layout.nodes"

--- a/apps/renderer/src/features/git-graph/features/commit-list/graphColors.ts
+++ b/apps/renderer/src/features/git-graph/features/commit-list/graphColors.ts
@@ -29,12 +29,3 @@ export function laneTextColor(index: number): string {
   const s = LANE_SPECS[index % LANE_SPECS.length];
   return `oklch(${s.l} ${s.c} ${s.h})`;
 }
-
-/**
- * HEAD 行の背景帯 (通常 / hover)。HEAD lane (lane 0 = HEAD 予約色) の色を低 alpha で敷き、
- * リング / ドットと同一の色源に揃える (graph の色 SSOT は本 palette)。選択行 (primary 青) とは
- * hue が異なるため、alpha を混ぜても「選択と別 hue で HEAD 位置を示す」区別は保たれる。
- * hover は他行 (通常 / 選択) と一貫させるため alpha を上げて明るくする。
- */
-export const HEAD_ROW_BG = `color-mix(in oklch, ${laneTextColor(0)} 22%, transparent)`;
-export const HEAD_ROW_BG_HOVER = `color-mix(in oklch, ${laneTextColor(0)} 32%, transparent)`;

--- a/apps/renderer/src/features/git-graph/features/commit-list/graphGeometry.ts
+++ b/apps/renderer/src/features/git-graph/features/commit-list/graphGeometry.ts
@@ -18,7 +18,7 @@ const HEAD_MARKER_HEIGHT = 12;
  */
 const GRAPH_RIGHT_GUTTER = 8;
 
-/** Graph 列の幅。右側に最右 dot / リング用のガターを確保する。 */
+/** Graph 列の幅。右側に最右レーンの dot 用のガターを確保する。 */
 export function graphColumnWidth(maxLanes: number): number {
   return GRAPH_PADDING_X + maxLanes * LANE_WIDTH + GRAPH_RIGHT_GUTTER;
 }

--- a/apps/renderer/src/features/git-graph/features/commit-list/graphGeometry.ts
+++ b/apps/renderer/src/features/git-graph/features/commit-list/graphGeometry.ts
@@ -7,14 +7,14 @@
 export const LANE_WIDTH = 16;
 export const ROW_HEIGHT = 24;
 export const DOT_RADIUS = 4;
-/** HEAD ドットの外側リング半径をドット本体からどれだけ離すか (px)。塗り/選択とは別チャンネルで
- *  「今 HEAD がいる場所」を輪で示す。 */
-export const HEAD_RING_GAP = 3;
 export const GRAPH_PADDING_X = 12;
+/** HEAD マーカー: 行左端に置く右向き三角形。apex が右にどれだけ伸びるか / base の縦幅 (px)。 */
+const HEAD_MARKER_WIDTH = 8;
+const HEAD_MARKER_HEIGHT = 12;
 
 /**
- * col 1 (graph 列) の右側に確保するガター (px)。最右レーンの dot / HEAD リング (半径 ~7) が
- * col 2 の description に密着しないための余白。HEAD marker `→` は廃止済み (HEAD は dot リングで表示)。
+ * col 1 (graph 列) の右側に確保するガター (px)。最右レーンの dot が col 2 の description に
+ * 密着しないための余白。HEAD は行左端の右向き三角マーカーで示す (グラフ座標系に置く)。
  */
 const GRAPH_RIGHT_GUTTER = 8;
 
@@ -31,6 +31,16 @@ export function laneX(lane: number): number {
 /** 行番号 → Y ピクセル座標（行の中央） */
 export function rowY(row: number): number {
   return row * ROW_HEIGHT + ROW_HEIGHT / 2;
+}
+
+/**
+ * HEAD マーカーの polygon points。行左端 (x=0) に縦の base を立て、apex を右に尖らせた右向き三角形。
+ * 左ボーダーの縦バーを右へ尖らせた形で、HEAD 行と進行方向 (コミット側) を指す。
+ */
+export function headMarkerPoints(row: number): string {
+  const cy = rowY(row);
+  const halfH = HEAD_MARKER_HEIGHT / 2;
+  return `0,${cy - halfH} ${HEAD_MARKER_WIDTH},${cy} 0,${cy + halfH}`;
 }
 
 /**


### PR DESCRIPTION
## 概要

git graph の HEAD 行の示し方を変更する。従来の「行全体の背景帯 + コミット dot 外周のリング（二重丸）」をやめ、行左端に置いた右向き三角マーカー（SVG）で HEAD を示す。

## 背景

HEAD 行はこれまで teal の背景帯（低 alpha）で強調していたが、選択行（`bg-primary-subtle` の青背景）・hover 行（`bg-element-hover`）も同じ「背景塗り」レイヤーを使うため、3 状態が同一チャンネルを奪い合って区別しづらかった。

HEAD（今どこにいるか）と選択（ユーザーが選んだ行）は直交する軸で、1 行が同時に両方になりうる。にもかかわらず旧実装は排他分岐（選択 > HEAD > hover）だったため、HEAD 行を選択すると HEAD の背景帯が消えて青一色になり、「HEAD かつ選択」を同時表現できていなかった。

そこで HEAD を背景塗りレイヤーから追い出し、別チャンネル（グラフ座標系に置く前景マーカー）へ分離する。背景塗りは選択 / hover に専念させ、HEAD・選択・hover を独立に読めるようにする。マーカー形状は、進行方向（コミット dot 側）を指す right-pointing triangle とした。

## 変更内容

### HEAD マーカーの実装（SVG overlay）

- `GraphSvgOverlay` に、HEAD 行の左端（x=0）を base、apex を右に尖らせた右向き三角形を描く `<polygon>` を追加
- マーカー色は `laneTextColor(headColor)` で dot / lane 線と同一の teal（graph 色 SSOT）
- 座標算出は `graphGeometry.headMarkerPoints(row)` に集約。寸法は `HEAD_MARKER_WIDTH` / `HEAD_MARKER_HEIGHT` 定数で持つ

### 旧マーカーの撤去

- HEAD 行の背景帯（`graphColors` の `HEAD_ROW_BG` / `HEAD_ROW_BG_HOVER`）を削除
- コミット dot 外周のリング（二重丸。`headRingNode` + `HEAD_RING_GAP`）を削除
- `CommitRow` の HEAD 用背景分岐（`highlightClass` の HEAD 帯）を撤去し、背景は選択 / hover のみを担う `backgroundClass` に整理

### 維持するもの

- Working Tree 行 → HEAD への破線コネクタ、および HEAD lane を lane 0 の teal に固定する挙動は変更なし

## 旧実装からの挙動変更・後退

- **HEAD 行の背景帯がなくなる**: HEAD 行に敷かれていた teal の背景色による強調が消える。代替として左端の三角マーカーで HEAD を示す
- **コミット dot の外周リング（二重丸）がなくなる**: HEAD の dot が他の dot と同じ見た目になる。HEAD 位置は左端三角マーカー + lane 0 の teal 色 + Working Tree からの破線コネクタで示す

いずれも意図した変更。HEAD と選択 / hover の視覚チャンネルを分離するのが目的で、HEAD 自体は引き続き示される。

## 確認事項

- [ ] HEAD 行 / 選択行 / hover 行 / 「HEAD かつ選択」の 4 状態が実画面で区別できるか
- [ ] 三角マーカーの寸法（幅 8 × 高さ 12px）が dot と重ならず、視認しやすいバランスか
