### PR TITLE
feat(git-graph): ブランチ表示範囲を current/default/all で切替可能にする

### DIFF
--- a/apps/electron/src/git/gitBranch.ts
+++ b/apps/electron/src/git/gitBranch.ts
@@ -53,6 +53,22 @@ export async function headOidExists(dir: string): Promise<boolean> {
 }
 
 /**
+ * ローカル / リモートの全ブランチ ref 名を返す（例: `refs/heads/main` /
+ * `refs/remotes/origin/foo`）。git graph の全ブランチ表示で `git log --stdin` の
+ * 始点に投入する。full refname で返すため log の始点として曖昧さがない。
+ *
+ * `refs/remotes/origin/HEAD`（symref）も含まれるが、指す先が origin/<default> と同一で
+ * git log の OID dedup に吸収されるため無害。tags は含めない（branch graph の対象外）。
+ */
+export async function allBranchRefs(dir: string): Promise<string[]> {
+  const stdout = await runGit(
+    ["for-each-ref", "--format=%(refname)", "refs/heads", "refs/remotes"],
+    dir,
+  );
+  return stdout.split("\n").filter((line) => line !== "");
+}
+
+/**
  * worktree 作成の起点として使う ref を返す。`git worktree add -b <new> <abs> <ref>` の
  * `<ref>` にそのまま渡せる文字列（`origin/main` / `main` 等）が caller の期待値。
  *

--- a/apps/electron/src/git/gitLog.test.ts
+++ b/apps/electron/src/git/gitLog.test.ts
@@ -124,7 +124,7 @@ describe("log (integration)", () => {
       dir,
       maxCount: 50,
       firstParentOnly: false,
-      currentBranchOnly: false,
+      branchScope: "default",
       sortMode: "topo",
     });
     expect(result.branchHead).toBe("main");
@@ -132,6 +132,33 @@ describe("log (integration)", () => {
     expect(result.commits.map((c) => c.message)).toEqual(["second", "first"]);
     expect(result.commits[0].refs).toContain("HEAD");
     expect(result.commits[1].parents).toEqual([]);
+  });
+
+  test('branchScope "all" は HEAD 非到達の別ブランチ commit も walk する', async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gozd-gitlog-all-"));
+    tempDirs.push(dir);
+    runGitCmd(["init", "-b", "main"], dir);
+    runGitCmd(["config", "user.email", "t@example.com"], dir);
+    runGitCmd(["config", "user.name", "t"], dir);
+    writeFileSync(join(dir, "a.txt"), "a\n");
+    runGitCmd(["add", "."], dir);
+    runGitCmd(["commit", "-m", "base"], dir);
+    // main から分岐した別ブランチに、main へマージされない独立 commit を積む
+    runGitCmd(["checkout", "-b", "feature"], dir);
+    writeFileSync(join(dir, "f.txt"), "f\n");
+    runGitCmd(["add", "."], dir);
+    runGitCmd(["commit", "-m", "feature-only"], dir);
+    // HEAD を main に戻す。feature-only は HEAD 系統から到達不可になる
+    runGitCmd(["checkout", "main"], dir);
+
+    const common = { dir, maxCount: 50, firstParentOnly: false, sortMode: "topo" as const };
+    const defaultScope = await log({ ...common, branchScope: "default" });
+    const allScope = await log({ ...common, branchScope: "all" });
+
+    // default (HEAD 起点のみ、origin 未設定) では feature-only は見えない
+    expect(defaultScope.commits.map((c) => c.message)).toEqual(["base"]);
+    // all では feature ブランチ tip を始点に加えるため feature-only も現れる
+    expect(allScope.commits.map((c) => c.message).sort()).toEqual(["base", "feature-only"]);
   });
 
   test("unborn branch（commit 無し）は空 commits で正常応答する", async () => {
@@ -143,7 +170,7 @@ describe("log (integration)", () => {
       dir,
       maxCount: 50,
       firstParentOnly: false,
-      currentBranchOnly: false,
+      branchScope: "default",
       sortMode: "topo",
     });
     expect(result.commits).toEqual([]);

--- a/apps/electron/src/git/gitLog.test.ts
+++ b/apps/electron/src/git/gitLog.test.ts
@@ -161,6 +161,40 @@ describe("log (integration)", () => {
     expect(allScope.commits.map((c) => c.message).sort()).toEqual(["base", "feature-only"]);
   });
 
+  test('branchScope "all" で HEAD が maxCount 窓外に押し出されても rescue で末尾 append する', async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gozd-gitlog-all-rescue-"));
+    tempDirs.push(dir);
+    runGitCmd(["init", "-b", "main"], dir);
+    runGitCmd(["config", "user.email", "t@example.com"], dir);
+    runGitCmd(["config", "user.name", "t"], dir);
+    // main（= HEAD）を古い commit にする
+    writeFileSync(join(dir, "a.txt"), "a\n");
+    runGitCmd(["add", "."], dir);
+    runGitCmd(["commit", "-m", "old-head"], dir);
+    // main から分岐した feature に、より新しい独立 commit を積む
+    runGitCmd(["checkout", "-b", "feature"], dir);
+    writeFileSync(join(dir, "f.txt"), "f\n");
+    runGitCmd(["add", "."], dir);
+    runGitCmd(["commit", "-m", "newer-feature"], dir);
+    runGitCmd(["checkout", "main"], dir);
+
+    // maxCount=1 の all walk は topo 先頭の feature tip だけを返し HEAD(main) を窓外に落とす。
+    // rescue が HEAD-only walk を末尾 append し、境界先頭に truncatedAbove を立てる。
+    const result = await log({
+      dir,
+      maxCount: 1,
+      firstParentOnly: false,
+      branchScope: "all",
+      sortMode: "topo",
+    });
+    expect(result.commits.map((c) => c.message)).toEqual(["newer-feature", "old-head"]);
+    // all walk 側 (feature tip) は境界でない
+    expect(result.commits[0].truncatedAbove).toBe(false);
+    // append された HEAD セグメントの先頭に境界マーカーが立つ
+    expect(result.commits[1].refs).toContain("HEAD");
+    expect(result.commits[1].truncatedAbove).toBe(true);
+  });
+
   test("unborn branch（commit 無し）は空 commits で正常応答する", async () => {
     const dir = mkdtempSync(join(tmpdir(), "gozd-gitlog-unborn-"));
     tempDirs.push(dir);

--- a/apps/electron/src/git/gitLog.ts
+++ b/apps/electron/src/git/gitLog.ts
@@ -2,8 +2,15 @@
 // `git log --stdin` で N ref を 1 walk する `log` を中核に置き、後続 RPC（logLine / blame
 // anchored history）が共有する `LOG_FORMAT` と `parseLogRecords` SSOT を本ファイルに閉じる。
 
+import type { BranchScope } from "@gozd/rpc";
 import { tryCatch } from "@gozd/shared";
-import { branchHeadName, defaultBranchName, headOidExists, upstreamRefName } from "./gitBranch";
+import {
+  allBranchRefs,
+  branchHeadName,
+  defaultBranchName,
+  headOidExists,
+  upstreamRefName,
+} from "./gitBranch";
 import { runGit, runGitWithStdin } from "./gitRunner";
 import { isAllZeroHex, validateRev } from "./gitValidate";
 
@@ -46,7 +53,7 @@ export interface LogParams {
   dir: string;
   maxCount: number;
   firstParentOnly: boolean;
-  currentBranchOnly: boolean;
+  branchScope: BranchScope;
   sortMode: LogSortMode;
 }
 
@@ -68,7 +75,7 @@ export interface LogParams {
  * - spawn 失敗（git CLI 不在等）: rethrow して上位の notify.error まで通す
  */
 export async function log(params: LogParams): Promise<LogResult> {
-  const { dir, maxCount, firstParentOnly, currentBranchOnly, sortMode } = params;
+  const { dir, maxCount, firstParentOnly, branchScope, sortMode } = params;
   // ref 解決を並列起動。fallback は正常パスだが「設定壊れ」等の異常系と区別できるよう
   // stderr に 1 行残す（silent drop 禁止規律）
   const [defaultBranchResult, upstreamRefResult, branchHeadResult, headExists] = await Promise.all([
@@ -90,21 +97,25 @@ export async function log(params: LogParams): Promise<LogResult> {
     `log: branchHeadName fallback to "" (detached HEAD?) dir=${dir}`,
   );
 
-  // 始点 ref を Set dedup で集める。currentBranchOnly では HEAD のみ。
+  // 始点 ref を Set dedup で集める。branchScope で範囲を決める。
   // unborn branch（HEAD が commit を指さない）では HEAD を始点にすると exit 128 で
   // throw するため、始点 refs から HEAD を除外する
   const refs = new Set<string>();
   if (headExists) refs.add("HEAD");
-  if (!currentBranchOnly) {
+  if (branchScope === "default") {
     if (defaultBranch !== "") refs.add(`origin/${defaultBranch}`);
     if (upstreamRef !== "") refs.add(upstreamRef);
+  } else if (branchScope === "all") {
+    // ローカル / リモート全ブランチ ref を始点に投入。git 自身が walk 中に OID dedup するため
+    // renderer 側の merge は不要（default モードと同じ walk 契約）。
+    for (const ref of await allBranchRefs(dir)) refs.add(ref);
   }
 
   const commits = await runLogStdin(dir, [...refs], maxCount, firstParentOnly, sortMode);
   const merged = await rescueCurrentBranch(
     dir,
     commits,
-    currentBranchOnly,
+    branchScope,
     headExists,
     maxCount,
     firstParentOnly,
@@ -132,13 +143,14 @@ function fallbackEmpty(result: { ok: true; value: string } | { ok: false; error:
 async function rescueCurrentBranch(
   dir: string,
   commits: CommitInfo[],
-  currentBranchOnly: boolean,
+  branchScope: BranchScope,
   headExists: boolean,
   maxCount: number,
   firstParentOnly: boolean,
   sortMode: LogSortMode,
 ): Promise<CommitInfo[]> {
-  if (currentBranchOnly || !headExists) return commits;
+  // "current" は始点が HEAD のみで押し出しが起きないため救済不要。"default" / "all" のみ対象。
+  if (branchScope === "current" || !headExists) return commits;
   // HEAD の在否判定は parse 済み refs を見る（%D の `HEAD -> branch` / detached `HEAD` は
   // parseRefs が "HEAD" 要素に展開する）。maxCount == 0（無制限）では all-refs walk が
   // HEAD も含めて全件返すため自然に false になり追加 walk は走らない

--- a/apps/electron/src/routes.ts
+++ b/apps/electron/src/routes.ts
@@ -582,7 +582,7 @@ async function handleGitLog(body: unknown): Promise<unknown> {
     dir: req.dir,
     maxCount: req.maxCount,
     firstParentOnly: req.firstParentOnly,
-    currentBranchOnly: req.currentBranchOnly,
+    branchScope: req.branchScope,
     sortMode: req.sortMode,
   });
   return (result) satisfies GitLogResponse;

--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -1,6 +1,7 @@
 <doc lang="md">
-Git commit graph pane。active worktree のブランチとデフォルトブランチの commit graph を表示する。
-git log の取得と各部の合成を担うコンテナで、描画自体は持たない。
+Git commit graph pane。active worktree の commit graph を表示する。walk の始点 ref 範囲は
+toolbar の branch scope (current / default / all) で切替可能。git log の取得と各部の合成を担う
+コンテナで、描画自体は持たない。
 
 ## HEAD スクロールが間接経路な理由
 
@@ -14,7 +15,7 @@ HEAD-only walk を末尾 append し境界に `truncatedAbove` を立てる。ren
 </doc>
 
 <script setup lang="ts">
-import { SortMode, type GitCommit } from "@gozd/rpc";
+import { BranchScope, SortMode, type GitCommit } from "@gozd/rpc";
 import { tryCatch } from "@gozd/shared";
 import { useElementSize, useIntervalFn, useWindowFocus } from "@vueuse/core";
 import { storeToRefs } from "pinia";
@@ -51,9 +52,9 @@ const focused = useWindowFocus();
 
 const defaultBranch = ref<string | undefined>();
 const firstParentOnly = ref(false);
-// SSOT: ワイヤ型 SortMode をそのまま UI 状態として持ち、RPC 呼び出しで変換不要にする。
+// SSOT: ワイヤ型 SortMode / BranchScope をそのまま UI 状態として持ち、RPC 呼び出しで変換不要にする。
 const sortMode = ref<SortMode>("date");
-const currentBranchOnly = ref(false);
+const branchScope = ref<BranchScope>("default");
 
 /** refs 配列に "HEAD" を持つコミットを探す */
 function findHeadCommit(rawCommits: GitCommit[]): GitCommit | undefined {
@@ -126,7 +127,7 @@ async function runLoadLog(): Promise<boolean> {
       dir,
       maxCount: 200,
       firstParentOnly: firstParentOnly.value,
-      currentBranchOnly: currentBranchOnly.value,
+      branchScope: branchScope.value,
       sortMode: sortMode.value,
     }),
   );
@@ -185,7 +186,7 @@ watch(
   },
 );
 
-// firstParentOnly / sortMode / currentBranchOnly 切替時に再取得
+// firstParentOnly / sortMode / branchScope 切替時に再取得
 watch(firstParentOnly, () => {
   gitGraphStore.resetSelection();
   void loadLog();
@@ -194,7 +195,7 @@ watch(sortMode, () => {
   gitGraphStore.resetSelection();
   void loadLog();
 });
-watch(currentBranchOnly, () => {
+watch(branchScope, () => {
   gitGraphStore.resetSelection();
   void loadLog();
 });
@@ -462,7 +463,7 @@ function onCommitContextmenu(payload: {
   <div ref="root" class="flex size-full flex-col overflow-hidden bg-background text-foreground">
     <GitGraphToolbar
       v-model:first-parent-only="firstParentOnly"
-      v-model:current-branch-only="currentBranchOnly"
+      v-model:branch-scope="branchScope"
       v-model:sort-mode="sortMode"
       v-model:detail-open="detailOpen"
       :commit-count="commits.length"

--- a/apps/renderer/src/features/git-graph/GitGraphPane.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphPane.vue
@@ -186,16 +186,10 @@ watch(
   },
 );
 
-// firstParentOnly / sortMode / branchScope 切替時に再取得
-watch(firstParentOnly, () => {
-  gitGraphStore.resetSelection();
-  void loadLog();
-});
-watch(sortMode, () => {
-  gitGraphStore.resetSelection();
-  void loadLog();
-});
-watch(branchScope, () => {
+// firstParentOnly / sortMode / branchScope 切替時に再取得。3 つとも callback が同一
+// (resetSelection + loadLog) なので source 配列で 1 effect に束ねる。worktree.dir の watch は
+// callback が別 (scroll + closure リセット) なのでここには含めない。
+watch([firstParentOnly, sortMode, branchScope], () => {
   gitGraphStore.resetSelection();
   void loadLog();
 });

--- a/apps/renderer/src/features/git-graph/GitGraphToolbar.vue
+++ b/apps/renderer/src/features/git-graph/GitGraphToolbar.vue
@@ -1,11 +1,22 @@
 <doc lang="md">
-Git Graph のヘッダーツールバー。表示オプション (first-parent / current-branch / sort order) の
+Git Graph のヘッダーツールバー。表示オプション (first-parent / branch scope / sort order) の
 トグルと詳細ペイン開閉を扱う。状態はすべて v-model で親が所有する。
+
+## branch scope の segmented control
+
+始点 ref 範囲は current / default / all の 3 排他値。トグル (2 状態 / aria-pressed) では表せないため
+segmented control にする。track (凹んだ `bg-element` コンテナ) の中で選択セグメントだけを thumb として
+塗り、3 ボタンが 1 つの塊に見える形にする (iOS / Primer 等 2026 の主流パターン)。選択色は同ツールバーの
+ToggleChip の "on" 状態 (`bg-primary-subtle`) と揃え、ツールバー内で「選択 = primary tint」を一貫させる。
+`role="group"` + group label でグループを、`aria-pressed` で選択状態を SR に伝える (SidebarPane の
+viewMode と同じ排他選択 idiom)。all はローカル / リモート全ブランチを walk するため、遠い分岐が多い
+repo では列幅と描画コストが増える (取得はローカル walk のみでネットワークは発生しない)。
 </doc>
 
 <script setup lang="ts">
-import type { SortMode } from "@gozd/rpc";
+import type { BranchScope, SortMode } from "@gozd/rpc";
 import ToggleChip from "./ToggleChip.vue";
+import IconLucideGitBranch from "~icons/lucide/git-branch";
 import IconLucideGitCommitHorizontal from "~icons/lucide/git-commit-horizontal";
 import IconLucidePanelRight from "~icons/lucide/panel-right";
 
@@ -15,9 +26,17 @@ defineProps<{
 }>();
 
 const firstParentOnly = defineModel<boolean>("firstParentOnly", { required: true });
-const currentBranchOnly = defineModel<boolean>("currentBranchOnly", { required: true });
+const branchScope = defineModel<BranchScope>("branchScope", { required: true });
 const sortMode = defineModel<SortMode>("sortMode", { required: true });
 const detailOpen = defineModel<boolean>("detailOpen", { required: true });
+
+// segment の並び順は範囲の狭い順 (current → default → all)。label は各ボタンに表示する scope 名、
+// title は hover 時の補足説明。
+const BRANCH_SCOPE_SEGMENTS: { scope: BranchScope; label: string; title: string }[] = [
+  { scope: "current", label: "Current", title: "Show current branch (HEAD) only" },
+  { scope: "default", label: "Default", title: "Show current + default branch" },
+  { scope: "all", label: "All", title: "Show all local and remote branches" },
+];
 
 function toggleSortMode() {
   sortMode.value = sortMode.value === "date" ? "topo" : "date";
@@ -36,13 +55,31 @@ function toggleSortMode() {
     >
       First Parent
     </ToggleChip>
-    <ToggleChip
-      :active="currentBranchOnly"
-      title="Hide default branch and show current branch only"
-      @click="currentBranchOnly = !currentBranchOnly"
-    >
-      Current Branch
-    </ToggleChip>
+    <div class="flex items-center gap-1">
+      <IconLucideGitBranch class="size-3 text-foreground-low" />
+      <div
+        role="group"
+        aria-label="Branch scope"
+        class="flex items-center gap-0.5 rounded-sm bg-element p-0.5"
+      >
+        <button
+          v-for="segment in BRANCH_SCOPE_SEGMENTS"
+          :key="segment.scope"
+          type="button"
+          :aria-pressed="branchScope === segment.scope"
+          :title="segment.title"
+          class="rounded-xs px-1.5 py-0.5 text-[10px] transition-colors"
+          :class="
+            branchScope === segment.scope
+              ? 'bg-primary-subtle text-primary-text'
+              : 'text-foreground-low hover:text-foreground'
+          "
+          @click="branchScope = segment.scope"
+        >
+          {{ segment.label }}
+        </button>
+      </div>
+    </div>
     <ToggleChip :active="sortMode === 'topo'" @click="toggleSortMode">
       {{ sortMode === "date" ? "Date Order" : "Topo Order" }}
     </ToggleChip>

--- a/apps/renderer/src/features/git-graph/features/commit-list/CommitGraphList.vue
+++ b/apps/renderer/src/features/git-graph/features/commit-list/CommitGraphList.vue
@@ -227,7 +227,7 @@ function onKeydown(e: KeyboardEvent) {
   const movingHash = gitGraphStore.compareHash ?? gitGraphStore.selectedHash;
 
   // selectedIndex の -1 は「移動端が真に Working Tree」と「選択コミットが表示から消えた
-  // (currentBranchOnly 等の filter / stale)」の両方で起きるため、移動端 hash が UNCOMMITTED_HASH か
+  // (branchScope 等の filter / stale)」の両方で起きるため、移動端 hash が UNCOMMITTED_HASH か
   // で区別する。filter で消えただけの -1 は起点が無いので Working Tree に倒し、次操作に委ねる。
   if (current === -1) {
     if (movingHash !== UNCOMMITTED_HASH) {

--- a/apps/renderer/src/features/git-graph/features/commit-list/graphRefs.ts
+++ b/apps/renderer/src/features/git-graph/features/commit-list/graphRefs.ts
@@ -6,9 +6,9 @@ import type { DisplayRef } from "./displayRef";
  * 同じコミットにローカルとリモートが両方あれば synced（computeDisplayRefs で処理）。
  * 別コミットに分かれていれば out-of-sync としてここで検出する。
  *
- * 検出範囲は `commits` に出現する ref に限定される。`currentBranchOnly` が ON のとき
+ * 検出範囲は `commits` に出現する ref に限定される。branchScope が "current" のとき
  * native 側の `git log` 始点 ref が HEAD のみに絞られ origin/<default> 系の commit が消えるため、
- * HEAD 系統から到達しない ref ペアの out-of-sync は検出できない (toggle 意味の直接の帰結)。
+ * HEAD 系統から到達しない ref ペアの out-of-sync は検出できない (scope 意味の直接の帰結)。
  */
 export function computeOutOfSyncBranches(commits: GitCommit[]): Set<string> {
   const localCommits = new Map<string, string>();

--- a/packages/rpc/src/gitOps.ts
+++ b/packages/rpc/src/gitOps.ts
@@ -23,6 +23,12 @@ export interface GitWorktreeListResponse {
  * - "date": `--date-order` で commit date 降順を厳守 */
 export type SortMode = "topo" | "date";
 
+/** git graph が walk の始点にする ref の範囲。
+ * - "current": HEAD だけを始点にする（現在ブランチのみ）
+ * - "default": HEAD + `origin/<default>` + `@{upstream}` を始点にする（標準の 2 系統表示）
+ * - "all": ローカル / リモートの全ブランチ ref を始点にする */
+export type BranchScope = "current" | "default" | "all";
+
 // gitLog: HEAD / `origin/<default>` / `@{upstream}` の各 ref を始点に
 // 1 回の `git log --stdin --decorate=short` で walk する。
 //
@@ -42,15 +48,14 @@ export interface GitLogRequest {
   dir: string;
   maxCount: number;
   firstParentOnly: boolean;
-  /** true のとき `origin/<default>` と `@{upstream}` を始点 ref から除外し、
-   * HEAD だけを始点にする。`defaultBranch` 文字列は `git symbolic-ref` で
-   * 引き続き解決して返す。 */
-  currentBranchOnly: boolean;
+  /** walk の始点 ref 範囲。`defaultBranch` 文字列は scope に依らず
+   * `git symbolic-ref` で解決して返す。 */
+  branchScope: BranchScope;
   sortMode: SortMode;
 }
 export interface GitLogResponse {
-  /** 全 ref を始点に `git log --stdin` で walk した結果。child → parent 順、
-   * sortMode に従って tie-break される。currentBranchOnly=false で HEAD が
+  /** 始点 ref を `git log --stdin` で walk した結果。child → parent 順、
+   * sortMode に従って tie-break される。branchScope !== "current" で HEAD が
    * 新しい順 maxCount ウィンドウから押し出され結果に 1 件も含まれない場合のみ、HEAD-only
    * walk を追加して末尾に append する (古い現在ブランチを graph 上で見えるように救済。
    * HEAD 系統はウィンドウの最古 commit より古いため append で順序契約は保たれる)。 */

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -126,6 +126,7 @@ export type {
   GitWorktreeListResponse,
   GitWorktreeRemoveRequest,
   GitWorktreeRemoveResponse,
+  BranchScope,
   SortMode,
 } from "./gitOps";
 export type { GitStatusRequest, GitStatusResponse } from "./gitStatus";


### PR DESCRIPTION
## 概要

Git Graph の walk 始点 ref 範囲を、これまでの `current` / `default` の 2 択（Current Branch トグル）から `current` / `default` / `all` の 3 択に拡張する。`all` はローカル・リモートの全ブランチを graph に表示する。ツールバーのコントロールも、2 状態専用のトグルから 3 排他値を並べて見せる segmented control に置き換える。

- `current`: HEAD のみを始点にする（現在ブランチ）
- `default`: HEAD + `origin/<default>` + `@{upstream}`（従来のデフォルト表示）
- `all`: ローカル・リモートの全ブランチ ref を始点にする

## 背景

「全ブランチを表示する場合に取得コストがかかるか」という問いが発端。調査の結果:

- `git log` の walk は完全ローカル処理で、`all` にしてもネットワーク fetch は一切発生しない。remote-tracking ref (`origin/*`) は fetch 済みのローカルミラーを読むだけ
- `maxCount=200` で出力コミット数が頭打ちのため、始点 ref が 2 → 全ブランチ（このリポジトリで 27 ref）に増えても walk コストは実測 0.00〜0.01 秒で誤差レベル
- コストが問題にならないと分かったので、single-branch トグルを scope 切替機能へ発展させた

## 変更内容

### walk 範囲を scope で選ぶ

始点 ref 範囲を `BranchScope = "current" | "default" | "all"` の 3 値で表す。`all` は全ブランチ ref（`for-each-ref refs/heads refs/remotes`、tags は含めない）を始点に加えるが、`git log --stdin` に N ref を Set で渡す既存 walk 経路（git 自身が OID dedup する SSOT）はそのまま使い、renderer 側 merge を増やさない。HEAD 押し出し救済（`rescueCurrentBranch`）は `current` 以外の全 scope が対象で、`all` でも「現在ブランチが maxCount 窓外」なら HEAD-only walk を末尾 append して現在ブランチを見失わない。

`GitLogRequest` のフィールドは旧 `currentBranchOnly: boolean` を廃し `branchScope` に置換する（永続化されないリクエスト型のため後方互換は作らず rename する方針）。scope は `SortMode` と同じくワイヤ型をそのまま UI 状態に持ち、変換層を挟まない。

### toolbar を segmented control にする

3 排他値はトグル（2 状態 / `aria-pressed`）では表せないため segmented control にする。track（`bg-element` の凹んだコンテナ）の中で選択セグメントだけを thumb（`bg-primary-subtle`）として塗り、3 ボタンを 1 つの塊として見せる（iOS / Primer 等 2026 の主流パターン）。選択色は同ツールバー ToggleChip の on 状態と揃え、ツールバー内で「選択 = primary tint」を一貫させる。`role="group"` + `aria-label` でグループを、各ボタンの `aria-pressed` で選択状態を SR に伝える。

### テスト

`all` scope が HEAD 非到達の別ブランチ commit も walk すること、および HEAD が maxCount 窓外に押し出されたとき rescue が HEAD-only walk を末尾 append し境界に `truncatedAbove` を立てることを、実 git repo の統合テストで検証する。

## 旧実装からの挙動変更・後退

- **UI コントロールの置換**: 「Current Branch」トグル 1 個 → segmented control 3 ボタン + 先頭アイコン。ツールバーの横幅がその分増える
- **単一選択セマンティクスは厳密な radiogroup ではない**: 2026 のアクセシビリティ指針では単一選択に `role="radiogroup"` + `role="radio"` + 矢印キーナビゲーションが推奨される。今回は既存コードベースの `viewMode` コントロールと同じ `role="group"` + `aria-pressed` idiom に揃えた（矢印キー移動は未実装）。旧トグルにも矢印キー操作は無かったため機能後退ではないが、SR での単一選択の伝わり方は radiogroup ほど厳密でない。radiogroup + 矢印キーへの移行は `viewMode` も含めた横断リファクタとして別途扱う
- 機能面の後退はなし。`default` の表示内容は従来と同一で、`current` も引き続き選べる

## 確認事項

- [ ] `pnpm dev` で Git Graph ツールバーの segmented control が track+thumb として 1 つの塊に見えるか（light / dark 両テーマ）
- [ ] `all` に切替時、他ブランチの系統が graph に増え、レーン（列幅）が破綻なく描画されるか
