### PR TITLE
fix(cli): reject nonexistent paths before open dispatch

### DIFF
--- a/apps/electron/src/cli.ts
+++ b/apps/electron/src/cli.ts
@@ -13,7 +13,7 @@
 
 import type { ClientMessage } from "@gozd/rpc";
 import { tryCatch } from "@gozd/shared";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { buildHookMessage, parseStdinJson, resolveSocketPath, writeLaunchRequest } from "./cli/cliOps";
 import { sendClientMessage } from "./cli/socketClient";
@@ -43,6 +43,15 @@ async function sendOrExit(message: ClientMessage): Promise<void> {
 
 async function openCommand(target: string): Promise<void> {
   const absolute = resolve(process.cwd(), target);
+
+  // 存在しないパスはここで fail fast する。socket は一方向 NDJSON で main 側で弾いても
+  // ターミナルに何も返せないため、実行者にエラーを伝えられるのは送信前のこの位置だけ。
+  // gozd には新規ファイル編集機能がなく、存在しないパスを受けても実現手段がない
+  // （通すとサイドバーに幽霊 repo が登録され fs watch が恒久的に失敗し続ける）
+  if (!existsSync(absolute)) {
+    process.stderr.write(`gozd: path does not exist: ${absolute}\n`);
+    process.exit(1);
+  }
 
   // cold start: socket が無い前提で launch request ファイルを書き出す
   // （bin/gozd シェルラッパーがアプリ未起動時にこの経路を取らせる）

--- a/apps/electron/src/main.ts
+++ b/apps/electron/src/main.ts
@@ -250,6 +250,8 @@ app.whenReady().then(() => {
     const target = consumeLaunchRequest(launchRequestDir);
     if (target === undefined) return;
     void buildGozdOpenPayload(target).then((payload) => {
+      // undefined = 不在パス（launch request 書き出し後に消えた TOCTOU 等）。push しない
+      if (payload === undefined) return;
       socketPush("gozdOpen", payload);
     });
   });

--- a/apps/electron/src/openTarget.ts
+++ b/apps/electron/src/openTarget.ts
@@ -2,6 +2,9 @@
 // の対応物。pickAndOpen（ダイアログ選択）と、将来の CLI / socket 経由 OpenMessage の
 // 共通エントリポイント。
 //
+// - 存在しないパスは undefined を返す（呼び出し元は「push しない」として扱う契約）。
+//   gozd に新規ファイル編集機能はなく、通すと renderer が幽霊 repo を addRepo して
+//   fs watch が恒久的に失敗し続ける
 // - git repo 内のパスなら `git rev-parse --show-toplevel` で repo root を解決し、
 //   main repo の basename を repoName として使う（worktree から開いた場合 toplevel は
 //   その worktree 自身のため、表示用には main repo 名を使う）
@@ -24,13 +27,21 @@ async function repoTopLevel(dir: string): Promise<string> {
   throw result.error;
 }
 
-export async function buildGozdOpenPayload(targetPath: string): Promise<Record<string, unknown>> {
-  const exists = existsSync(targetPath);
-  const isDir = exists && statSync(targetPath).isDirectory();
+export async function buildGozdOpenPayload(
+  targetPath: string,
+): Promise<Record<string, unknown> | undefined> {
+  // CLI も送信前に同じ検証で弾くが、cold start は launch request 書き出しから消費までに
+  // 時間差があり、その間にパスが消える TOCTOU が残る。3 つの呼び出し元（socket open /
+  // launch request 消費 / ファイルピッカー）が合流するここを不変条件の SSOT にする
+  if (!existsSync(targetPath)) {
+    console.error(`[buildGozdOpenPayload] target does not exist, skip open: ${targetPath}`);
+    return undefined;
+  }
+  const isDir = statSync(targetPath).isDirectory();
 
   let probeDir: string;
   let selection: Record<string, unknown> | undefined;
-  if (exists && !isDir) {
+  if (!isDir) {
     // ファイル指定 → parent を dir にして selection を埋める
     probeDir = dirname(targetPath);
     selection = { kind: "file", relPath: basename(targetPath), lineNumber: 0 };

--- a/apps/electron/src/routes.ts
+++ b/apps/electron/src/routes.ts
@@ -890,7 +890,9 @@ async function handlePickAndOpen(_body: unknown, ctx: RpcContext): Promise<unkno
   // ユーザーがキャンセルした場合は何もしない
   const [pickedPath = ""] = result.filePaths;
   if (!result.canceled && pickedPath !== "") {
-    ctx.push("gozdOpen", await buildGozdOpenPayload(pickedPath));
+    // undefined = 不在パス。ダイアログ選択では実質発生しないが契約に従い push しない
+    const payload = await buildGozdOpenPayload(pickedPath);
+    if (payload !== undefined) ctx.push("gozdOpen", payload);
   }
   return ({}) satisfies PickAndOpenResponse;
 }

--- a/apps/electron/src/socketMessages.test.ts
+++ b/apps/electron/src/socketMessages.test.ts
@@ -74,6 +74,18 @@ describe("socketMessages", () => {
     expect(payload.switchToDir).toBe("");
   });
 
+  test("open メッセージの不在パスは gozdOpen を push しない（観察ログのみ）", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gozd-socket-open-notexist-"));
+    tempDirs.push(dir);
+    const pushed: unknown[] = [];
+    const handle = createSocketMessageHandler((type) => pushed.push(type));
+    handle(JSON.stringify({ open: { targetPath: join(dir, "notexist") } }));
+    // 逐次キューの完了を後続 hook の到達で観測し、gozdOpen が飛んでいないことを固定する
+    handle('{"hook":{"event":"running","ptyId":1}}');
+    await waitFor(() => pushed.length === 1);
+    expect(pushed).toEqual(["hook"]);
+  });
+
   test("JSON として壊れた行は push せずに落とす（観察ログのみ）", async () => {
     const pushed: unknown[] = [];
     const handle = createSocketMessageHandler((type) => pushed.push(type));

--- a/apps/electron/src/socketMessages.ts
+++ b/apps/electron/src/socketMessages.ts
@@ -160,7 +160,9 @@ async function handleSocketMessage(line: string, push: PushFn): Promise<void> {
     return;
   }
   if (msg.open !== undefined) {
-    push("gozdOpen", await buildGozdOpenPayload(msg.open.targetPath));
+    // undefined = 不在パス（buildGozdOpenPayload が観察ログを出して弾く）。push しない
+    const payload = await buildGozdOpenPayload(msg.open.targetPath);
+    if (payload !== undefined) push("gozdOpen", payload);
     return;
   }
   console.error(`[SocketServer] ClientMessage with empty oneof: ${line.slice(0, 200)}`);


### PR DESCRIPTION
## 概要

存在しないパスを `gozd open` の対象として受け付けないようにする。

- CLI: 送信前に `existsSync` で検証し、`gozd: path does not exist: <absolute path>` を stderr に出して exit 1
- main: gozdOpen payload の生成点 `buildGozdOpenPayload` の冒頭で不在パスを弾いて `undefined` を返し、呼び出し元は push しない（観察ログのみ）

## 背景

`gozd notexist` のように存在しないパスを開くと、サイドバーに repo として登録されてしまい、fs watch の同期が「Failed to sync FS watches (1)」で失敗し続ける問題があった。

調査で判明した経緯:

- `buildGozdOpenPayload` は `existsSync` の結果を「file か dir か」の分岐にしか使っておらず、存在しないパスは dir 指定として素通りしていた
- 存在しない dir を cwd に git を spawn すると Node は `spawn /opt/homebrew/bin/git ENOENT` を報告する（cwd 不在でも実行ファイルパス側の ENOENT に見える）ため、エラーが git バイナリ解決失敗として誤分類され、renderer は payload を通常どおり処理して `addRepo` していた
- 登録された dir は `fsWatchTargetDirs` に入り、`/fs/watch` RPC 内の `gitDirs` が同じ ENOENT で reject し、sync パスのたびにエラートーストが出続ける

もともとは VS Code のように「存在しないパス = 新規ファイルとしてそのプロジェクトで開く」挙動が意図されていたが、gozd の preview は実在するファイルのみを対象とし、新規ファイルを直接編集する機能がないため、この意図は実現手段を持たない。実現できない入力は入口で fail fast させる。

検証を二層にしているのは役割が異なるため:

- CLI 側: socket は一方向 NDJSON で main 側で弾いてもターミナルにエラーを返せないため、実行者へのフィードバックは送信前が唯一の位置。cold start 経路もゲートより後ろにあるため、存在しないパスのために `.app` が起動することもなくなる
- main 側: 「不在パスの repo は登録しない」という不変条件の SSOT。cold start では launch request の書き出しから app 起動後の消費まで時間差があり、その間にパスが消えると CLI の検証をすり抜ける（TOCTOU）。また socket の `OpenMessage` は CLI 以外のクライアントも送れる信頼できない入力であり、受信側での検証が必要。3 つの呼び出し元（socket open / launch request 消費 / ファイルピッカー）が `buildGozdOpenPayload` に合流するため、ここが検証の一点になる

## 変更内容

### CLI

- `openCommand` でパス絶対化の直後・cold start / warm start 分岐の手前に `existsSync` チェックを追加。不在なら解決済み絶対パス入りのエラーを stderr に出して exit 1

### main

- `buildGozdOpenPayload` の冒頭で不在パスを検証し、観察ログを出して `undefined` を返す契約に変更（戻り値型を `Record<string, unknown> | undefined` に）
- 3 つの呼び出し元（`socketMessages.ts` / `main.ts` の launch request 消費 / `routes.ts` の `handlePickAndOpen`）で `undefined` のとき `gozdOpen` を push しないようにした

### テスト

- `socketMessages.test.ts` に「open メッセージの不在パスは gozdOpen を push しない」回帰テストを追加

## 旧実装からの挙動変更・後退

- 存在しないパスを指定した `gozd` / `gozd open` は、従来「サイドバーに登録される（壊れた状態）」だったが、exit 1 のエラーになる。新規ファイルを開く用途には使えない（従来もその用途は機能していない）

## 確認事項

- [ ] packaged `.app`（stable channel）の cold start 経路でも、存在しないパス指定時に `.app` が起動しないこと（dev では warm start 経路のみ確認済み）
