### PR TITLE
fix(terminal): セッションプレビュー popover がタイトルバーに食い込みドラッグ不能になる問題を修正

### DIFF
--- a/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
+++ b/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
@@ -113,10 +113,28 @@ proxy が守るのは v-for の作り替えまでで、overlay root 自体が v-
 flip 規則 (`positionTryFallbacks`) は両 origin で共通のため、開いた後の縁ぶつかり時の
 逆転挙動は維持される。
 
+popover はカスタムタイトルバー帯 (`-webkit-app-region: drag`) へ食い込ませない。
+Electron の drag region はペイント順 (top layer) と無関係に平面で効くため、重なった帯は
+window ドラッグ判定に取られて popover ヘッダの undock ドラッグが効かなくなり、視覚的にも
+タイトルバーを覆う (FloatingWindow が top を titlebar 高で clamp しているのと同じ問題)。
+制約は inset keep-out + max-height クランプの 2 点セットで入れる。position-area は選んだ
+region を containing block にするが**サイズの自動クランプはしない** (仕様上、要素は
+containing block を overflow できる) ため、keep-out inset (`top: var(--titlebar-height)`)
+だけでは高さが region を超えた瞬間に突き抜ける。% が region 高さ基準で解決されることを
+利用し `max-height: calc(100% - var(--titlebar-height))` で「region − keep-out」に高さを
+クランプする (外側 popover を flex-col、中間 box を min-h-0 にしてクランプを scroll 面まで
+伝播させる)。下向き基準の main は bottom に同値を置き、flip-block が block 軸 inset ごと
+flip する仕様で flip 後の top keep-out にする。クランプ導入後は高さ不足で flip しなくなる
+(縮んでスクロールする) が、min-content すら入らない極端ケースの flip は残る。その base
+配置 overflow 経路が仕様上残るため、TitleBar のボタン群と同じ `-webkit-app-region:
+no-drag` の切り抜きも敷く (Electron 公式の drag 帯プラクティス)。
+
 DOM 構造は三段:
 
-- 外側 popover element (`bg-transparent border-none overflow-visible px-0 py-3` のみ)
-  位置決めと縦 padding だけを担う透明枠。UA default の `[popover] { overflow: auto }` は
+- 外側 popover element (`bg-transparent border-none overflow-visible p-0` のみ)
+  位置決めだけを担う透明枠。padding は持たない (透明 padding があると keep-out clamp 時に
+  タイトルバーとの間へスキマが出る。`p-0` は UA default の `[popover]` padding の打ち消し)。
+  UA default の `[popover] { overflow: auto }` は
   `overflow-visible` で明示的に打ち消す (打ち消さないと内側 box の `shadow-xl` が外側
   border-box で clip され shadow がほぼ見えなくなる)
 - 中間 box (`max-h-[60vh] flex-col overflow-hidden rounded-md border border-border-strong
@@ -449,6 +467,44 @@ function onPreviewHeaderPointerUp(event: PointerEvent) {
   headerDrag = undefined;
 }
 
+// 全文 popover の配置スタイル。開く向きのデフォルトは origin で反転させる (<doc> の
+// 「全文 preview」参照)。タイトルバー帯への食い込み防止は inset keep-out + max-height
+// クランプの 2 点セット (詳細は <doc> の「全文 preview」参照):
+//   - 上に開く placement に `top: var(--titlebar-height)` の keep-out。position-area の
+//     region が containing block になるため、inset は region 縁からの通常の abspos offset
+//     として効き、anchor 側 alignment は保たれる
+//   - `max-height: calc(100% - var(--titlebar-height))`。position-area はサイズを自動
+//     クランプしない (仕様: 要素は containing block を overflow できる) ため、inset だけ
+//     では高さが region を超えた瞬間に keep-out ごと突き抜ける。% は region 高さ基準で
+//     解決されるので、この calc が「region から keep-out を引いた高さ」に一致する
+//   - flip-block fallback は block 軸の inset も一緒に flip するため、下向き基準の main は
+//     bottom に同値を置いておくと flip して上向きになったとき top keep-out として効く
+// `-webkit-app-region: no-drag` は Electron の drag region 対策 (タイトルバーの
+// `app-region: drag` はペイント順と無関係に平面で効き、重なった領域の pointer event を
+// window ドラッグに奪う)。keep-out で通常は重ならないが、極端に狭い window で flip が
+// 全滅して base 配置が overflow する経路が仕様上残るため、TitleBar のボタン群と同じ
+// no-drag 切り抜きを敷いておく。
+const previewPopoverStyle = computed(() => {
+  const base = {
+    position: "fixed",
+    maxHeight: "calc(100% - var(--titlebar-height))",
+    positionTryFallbacks: "flip-block, flip-inline, flip-block flip-inline",
+    "-webkit-app-region": "no-drag",
+  } as const;
+  if (previewContext.value?.origin === "sub") {
+    return {
+      ...base,
+      positionArea: "block-start span-inline-start",
+      top: "var(--titlebar-height)",
+    };
+  }
+  return {
+    ...base,
+    positionArea: "block-end span-inline-start",
+    bottom: "var(--titlebar-height)",
+  };
+});
+
 // 各 overlay の折り畳み状態。`<details>` の `open` 属性を SSOT にすると v-if /
 // subagent 切替で <details> が unmount → mount される度に静的 `open` で展開状態に
 // 戻ってしまうため、Vue 側 ref を SSOT にして `<details :open>` でバインドし、
@@ -624,15 +680,8 @@ watch([hasMain, hasSub], ([main, sub]) => {
        (popover 外 click / ESC) で閉じる。
        本文描画は SessionLogMessageBody に委譲 (assistant のみ markdown 解釈)。 -->
   <PreviewPopover
-    class="m-0 w-3xl max-w-[80vw] overflow-visible border-none bg-transparent px-0 py-3 text-base"
-    :style="{
-      position: 'fixed',
-      positionArea:
-        previewContext?.origin === 'sub'
-          ? 'block-start span-inline-start'
-          : 'block-end span-inline-start',
-      positionTryFallbacks: 'flip-block, flip-inline, flip-block flip-inline',
-    }"
+    class="m-0 flex w-3xl max-w-[80vw] flex-col overflow-visible border-none bg-transparent p-0 text-base"
+    :style="previewPopoverStyle"
   >
     <template v-if="previewContext">
       <!-- 全文 popover はメッセージを読む / コピーする面なので select-text で選択可にする
@@ -642,7 +691,7 @@ watch([hasMain, hasSub], ([main, sub]) => {
            painting clip は overflow-hidden が担う。 -->
       <div
         ref="previewBox"
-        class="flex max-h-[60vh] flex-col overflow-hidden rounded-md border border-border-strong shadow-xl select-text"
+        class="flex max-h-[60vh] min-h-0 flex-col overflow-hidden rounded-md border border-border-strong shadow-xl select-text"
         :class="previewContext.msg.kind === 'assistant' ? 'bg-chat-incoming' : 'bg-chat-outgoing'"
       >
         <!-- ヘッダはドラッグで undock + そのまま移動できる (しきい値超過で発火)。

--- a/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
+++ b/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
@@ -131,9 +131,11 @@ no-drag` の切り抜きも敷く (Electron 公式の drag 帯プラクティス
 
 DOM 構造は三段:
 
-- 外側 popover element (`bg-transparent border-none overflow-visible p-0` のみ)
-  位置決めだけを担う透明枠。padding は持たない (透明 padding があると keep-out clamp 時に
-  タイトルバーとの間へスキマが出る。`p-0` は UA default の `[popover]` padding の打ち消し)。
+- 外側 popover element (`bg-transparent border-none overflow-visible p-0` + `flex flex-col`)
+  位置決めと max-height クランプの伝播を担う透明枠。flex-col は中間 box (min-h-0) を
+  クランプ内へ縮めてスクロール面に高さ制約を届けるための指定。padding は持たない
+  (透明 padding があると keep-out clamp 時にタイトルバーとの間へスキマが出る。`p-0` は
+  UA default の `[popover]` padding の打ち消し)。
   UA default の `[popover] { overflow: auto }` は
   `overflow-visible` で明示的に打ち消す (打ち消さないと内側 box の `shadow-xl` が外側
   border-box で clip され shadow がほぼ見えなくなる)
@@ -467,23 +469,12 @@ function onPreviewHeaderPointerUp(event: PointerEvent) {
   headerDrag = undefined;
 }
 
-// 全文 popover の配置スタイル。開く向きのデフォルトは origin で反転させる (<doc> の
-// 「全文 preview」参照)。タイトルバー帯への食い込み防止は inset keep-out + max-height
-// クランプの 2 点セット (詳細は <doc> の「全文 preview」参照):
-//   - 上に開く placement に `top: var(--titlebar-height)` の keep-out。position-area の
-//     region が containing block になるため、inset は region 縁からの通常の abspos offset
-//     として効き、anchor 側 alignment は保たれる
-//   - `max-height: calc(100% - var(--titlebar-height))`。position-area はサイズを自動
-//     クランプしない (仕様: 要素は containing block を overflow できる) ため、inset だけ
-//     では高さが region を超えた瞬間に keep-out ごと突き抜ける。% は region 高さ基準で
-//     解決されるので、この calc が「region から keep-out を引いた高さ」に一致する
-//   - flip-block fallback は block 軸の inset も一緒に flip するため、下向き基準の main は
-//     bottom に同値を置いておくと flip して上向きになったとき top keep-out として効く
-// `-webkit-app-region: no-drag` は Electron の drag region 対策 (タイトルバーの
-// `app-region: drag` はペイント順と無関係に平面で効き、重なった領域の pointer event を
-// window ドラッグに奪う)。keep-out で通常は重ならないが、極端に狭い window で flip が
-// 全滅して base 配置が overflow する経路が仕様上残るため、TitleBar のボタン群と同じ
-// no-drag 切り抜きを敷いておく。
+// 全文 popover の配置スタイル。タイトルバー keep-out / max-height クランプ / flip の
+// 設計根拠は <doc> の「全文 preview」が SSOT。ここは編集時の防波堤のみ:
+//   - main 側の `bottom: var(--titlebar-height)` は base 配置 (下開き・start 整列) では
+//     不活性に見えるが、flip-block が block 軸 inset を反転して top keep-out になるため消さない
+//   - `-webkit-app-region: no-drag` は keep-out で通常タイトルバーと重ならなくても消さない
+//     (min-content が max-height を超える退化幾何で base 配置が overflow する経路の防御)
 const previewPopoverStyle = computed(() => {
   const base = {
     position: "fixed",


### PR DESCRIPTION
## 概要

ターミナルのセッションプレビューで bubble クリック時に開く全文 popover が、コンテンツ領域を超えてカスタムタイトルバー帯に重なる問題を修正する。重なった帯はウィンドウドラッグ判定に取られるため、popover ヘッダの undock ドラッグが効かなくなっていた。

## 背景

タイトルバー (`TitleBar.vue`) は `-webkit-app-region: drag` の帯で、Electron の drag region はペイント順 (top layer) と無関係に「drag 指定要素の領域 − no-drag 指定要素の領域」の平面集合で決まる。top layer に描画される popover でも、帯に重なった部分の pointer イベントはウィンドウドラッグに奪われる。

popover は CSS Anchor Positioning (`position-area`) で配置しており、調査で次の仕様挙動が判明した (Chromium 上の最小再現で数値実測して確認):

- `position-area` は選んだ region を containing block にするが、**サイズの自動クランプはしない** (仕様上、要素は containing block を overflow できる)。そのため keep-out inset を入れるだけでは、コンテンツ高が region を超えた瞬間に inset ごと突き抜ける
- `max-height` の `%` は region 高さ基準で解決されるため、`calc(100% - var(--titlebar-height))` が「region − keep-out」の高さに一致する (border-box 前提。Tailwind preflight で担保)
- `position-try-fallbacks` の `flip-block` は block 軸の inset / padding も一緒に反転する。下向き基準の placement に `bottom` の予約を置いておくと、flip して上向きになったとき top keep-out として効く

同種の制約は undock 先の `FloatingWindow.vue` が `top: clamp(var(--titlebar-height), ...)` で既に持っており、popover 側にも揃える。

## 変更内容

### popover の配置制約 (TerminalSessionPreview.vue)

- 配置スタイルを computed `previewPopoverStyle` に切り出し、origin ごとに keep-out inset (`top` / `bottom: var(--titlebar-height)`) を追加
- `max-height: calc(100% - var(--titlebar-height))` で高さを「region − keep-out」にクランプ。外側 popover を flex-col 化し中間 box に `min-h-0` を追加して、クランプをスクロール面まで伝播させる (収まらない分は popover 内スクロール)
- `-webkit-app-region: no-drag` を付与。min-content すら入らない極端な window で flip が全滅し base 配置が overflow する経路が仕様上残るため、TitleBar のボタン群と同じ切り抜きを敷く (Electron 公式の drag 帯プラクティス)
- 外側透明枠の `py-3` を撤去し `p-0` に変更。透明 padding があると clamp 時にタイトルバーとの間へスキマが出て、タイトルバーにぴったり接する FloatingWindow と揃わないため
- `<doc>` の「全文 preview」「DOM 構造」を上記の設計判断に合わせて更新

## 旧実装からの挙動変更・後退

- **高さ不足による block flip が起きなくなる**: 旧実装はコンテンツが収まらない側では反対側へ flip して全高 (60vh) で表示していた。新実装は既定の向きのまま縮んで内部スクロールになる (native select のドロップダウンと同型)。flip 自体は min-content が入らない極端ケースと inline 軸で引き続き機能する
- **anchor バブルとの 12px 間隔が消える**: 旧実装は透明枠の `py-3` で popover とクリック元 bubble の間に間隔があった。撤去により popover は bubble に直接接する
- **popover 表示中はその矩形上でウィンドウドラッグできない**: `no-drag` の切り抜きにより、仮に popover がタイトルバー帯へ重なった場合でもその部分で window は掴めない (通常は keep-out で重ならないため実害は極端に狭い window のみ)

## 確認事項

- [ ] 長いメッセージの popover 上端がタイトルバー下端 (36px) にぴったり接して止まり、はみ出さず内部スクロールになる
- [ ] popover ヘッダのドラッグ / undock ボタンで FloatingWindow へ切り離せる
- [ ] sub 側 (右下) bubble からの popover、および flip 発生時 (縁ぶつかり) も同様に食い込まない
