### PR TITLE
fix(release): sync ~/Applications via mise postinstall on update

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ gozd はスロベニア語で「森」（[ɡɔ́st]、「ゴスト」）。
 
 ## インストール
 
-[mise](https://mise.jdx.dev/) でインストールする。
+[mise](https://mise.jdx.dev/) でインストールする。`postinstall` がインストール直後に `~/Applications/Gozd.app` へアプリを配置する。
 
 ### canary（開発版）を追う
 
 main への機能 merge ごとに自動リリースされる。
 
 ```bash
-mise use -g 'github:miyaoka/gozd[prerelease=true]'
+mise use -g 'github:miyaoka/gozd[prerelease=true,postinstall="\"$MISE_TOOL_INSTALL_PATH/bin/gozd\" sync-app"]'
 ```
 
 ### stable のみを追う
@@ -59,17 +59,17 @@ mise use -g 'github:miyaoka/gozd[prerelease=true]'
 手動リリースされる安定版だけを取得する。
 
 ```bash
-mise use -g github:miyaoka/gozd
+mise use -g 'github:miyaoka/gozd[postinstall="\"$MISE_TOOL_INSTALL_PATH/bin/gozd\" sync-app"]'
 ```
 
 ### 起動
 
 ```bash
-gozd   # 初回起動で ~/Applications/Gozd.app に配置される
+gozd
 ```
 
-- `gozd` コマンドの起動時に `~/Applications/Gozd.app` へアプリが配置・更新される。Dock ピン留めと Spotlight 起動はこの固定パスで安定する
-- 更新は `mise up` → 次回 `gozd` 起動時に反映（詳細は [docs/release.md](docs/release.md)）
+- Dock ピン留めと Spotlight 起動は `~/Applications/Gozd.app` の固定パスで安定する
+- 更新は `mise up` の実行時に postinstall が固定パスを差し替えて反映する。アプリ稼働中に更新した場合は次回起動から新版になる（詳細は [docs/release.md](docs/release.md)）
 
 `gozd` CLI で任意のパスを開く。アプリが未起動であれば自動で起動する。
 

--- a/apps/electron/resources/bin/gozd
+++ b/apps/electron/resources/bin/gozd
@@ -10,6 +10,8 @@
 #
 # 動作:
 #   - hook サブコマンド or -- で始まる引数: アプリ起動チェックなしで CLI を直接呼ぶ
+#   - sync-app サブコマンド: ~/Applications/Gozd.app へ自己同期して終了する（stable のみ）。
+#     mise の postinstall から呼ばれる更新伝播の主経路
 #   - open（デフォルト）: ソケット稼働中なら warm start、なければ cold start で
 #     CLI に launch request を書かせてから .app を `open` で起動する
 #
@@ -50,8 +52,8 @@ SOCKET_PATH="${GOZD_SOCKET_PATH:-${TMPDIR_NORMALIZED%/}/gozd-${CHANNEL:-stable}.
 INSTALL_APP="${HOME}/Applications/Gozd.app"
 
 # mise 側 .app と固定パスの CFBundleVersion を比較し、差異があれば APFS clone（cp -c）で
-# 複製してから mv で atomic に差し替える。稼働中バンドルの検査はしない（cold start 経路
-# 限定なのでアプリは未起動。起動中に mise up しても次回 cold start まで反映されない契約）
+# 複製してから mv で atomic に差し替える。アプリ稼働中の swap も安全（旧プロセスは開いた
+# inode を掴んだまま動き続け、次回起動から新版になる。Homebrew cask の upgrade と同じ扱い）
 sync_installed_app() {
   local src src_ver dest_ver tmp old
   src="$(cd "${APP_BUNDLE}" && pwd -P)"
@@ -99,6 +101,18 @@ should_launch_app() {
   [[ "${1:-}" == "hook" || "${1:-}" == -* ]] && return 1
   return 0
 }
+
+# mise の postinstall（'"$MISE_TOOL_INSTALL_PATH/bin/gozd" sync-app'）から呼ばれる同期
+# エントリポイント。インストール直後に走るため、Dock / Spotlight しか使わないユーザーにも
+# 更新が伝播する。cold start 同期は postinstall 未設定環境向けのバックアップ（docs/release.md）
+if [[ "${1:-}" == "sync-app" ]]; then
+  if [[ "${CHANNEL}" != "stable" ]]; then
+    echo "gozd: sync-app is only for the stable channel (channel: ${CHANNEL:-unset})" >&2
+    exit 1
+  fi
+  sync_installed_app
+  exit 0
+fi
 
 if should_launch_app "$@"; then
   # cold start: CLI に launch request ファイルを書かせてからアプリを起動

--- a/apps/electron/resources/bin/gozd
+++ b/apps/electron/resources/bin/gozd
@@ -51,7 +51,7 @@ SOCKET_PATH="${GOZD_SOCKET_PATH:-${TMPDIR_NORMALIZED%/}/gozd-${CHANNEL:-stable}.
 # 固定パスへの実体 copy を起動対象にする（symlink は Spotlight に index されない）
 INSTALL_APP="${HOME}/Applications/Gozd.app"
 
-# mise 側 .app と固定パスの CFBundleVersion を比較し、差異があれば APFS clone（cp -c）で
+# mise 側 .app と固定パスの CFBundleVersion を比較し、差異があれば APFS clone（cp -Rc）で
 # 複製してから mv で atomic に差し替える。アプリ稼働中の swap も安全（旧プロセスは開いた
 # inode を掴んだまま動き続け、次回起動から新版になる。Homebrew cask の upgrade と同じ扱い）
 sync_installed_app() {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -123,10 +123,13 @@ Gozd.app/Contents/
   （読み取り失敗でも対象ファイルは削除する。壊れた request の残留は起動のたびに失敗し続けるため）
 - **warm start**（アプリ起動済み）: CLI がソケット経由で `OpenMessage` を送信 → renderer に push
 - **hook コマンド**: アプリ起動チェックをスキップし、CLI を直接実行
+- **sync-app コマンド**: `~/Applications/Gozd.app` へ自己同期して終了（stable channel のみ）。
+  mise の postinstall から呼ばれる更新伝播の主経路
 
-stable channel の wrapper は cold start 時に `~/Applications/Gozd.app` へ自己同期
-（`CFBundleVersion` 比較 + APFS clone の atomic 差し替え）してから固定パス側を `open` する。
-Dock ピン / Spotlight が固定パスを指し続けるための機構（[release.md](release.md)）。
+Dock ピン / Spotlight が指す固定パス `~/Applications/Gozd.app` への同期
+（`CFBundleVersion` 比較 + APFS clone の atomic 差し替え）は、mise の postinstall が実行する
+`sync-app` が主経路で、stable channel の cold start 時の自己同期はバックアップ
+（[release.md](release.md)）。
 
 ### gozd-cli（TS 実装）
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -61,27 +61,40 @@ gozd-macos-arm64.tar.gz
 [tools."github:miyaoka/gozd"]
 version = "latest"
 prerelease = true
+postinstall = '"$MISE_TOOL_INSTALL_PATH/bin/gozd" sync-app'
 
 # stable のみ
 [tools."github:miyaoka/gozd"]
 version = "latest"
+postinstall = '"$MISE_TOOL_INSTALL_PATH/bin/gozd" sync-app'
 ```
+
+- `postinstall` は README の `mise use` ワンライナー（bracket 構文）で設定される。
+  tool-level postinstall は「そのツールの新バージョンがインストールされた直後」に走り、
+  `MISE_TOOL_INSTALL_PATH` がインストール先を指す（mise の契約）
 
 1 ユーザーが追うのはどちらか片方の前提で、同時併用はしない（アプリ identity はどちらも
 同じ stable channel の「Gozd」）。
 
-## 更新の反映（wrapper 同期）
+## 更新の反映（~/Applications への同期）
 
 `mise up` は mise 側の実体を差し替えるだけで、Dock ピン / Spotlight が指す固定パスは動かない。
-wrapper `bin/gozd` が cold start 経路で同期する。
+固定パスへの同期はどちらの経路も wrapper `bin/gozd` の `sync_installed_app`
+（`CFBundleVersion` 比較 + APFS clone `cp -Rc` + mv の atomic 差し替え）を通る冪等な操作で、
+stable channel だけが行う。
 
-- mise 側 `.app` と `~/Applications/Gozd.app` の `CFBundleVersion` を比較し、差異があれば
-  APFS clone（`cp -Rc`）+ mv で atomic に差し替えてから固定パス側を `open` する
-- 同期は stable channel の wrapper だけが行う。warm start（アプリ稼働中）は差し替えない
+- **主経路: mise の postinstall**。`mise up` で新バージョンが入った直後に
+  `"$MISE_TOOL_INSTALL_PATH/bin/gozd" sync-app` が走り、起動動線（Dock / Spotlight /
+  ターミナル）に依存せず更新が伝播する。更新の反映を起動時ではなく更新時に行う
+  Homebrew cask と同じモデル
+- **バックアップ: cold start 同期**。wrapper がターミナル起動の cold start 時に同期する。
+  postinstall 未設定の環境でもターミナル動線なら追従する
+- アプリ稼働中の同期も安全。旧プロセスは開いた inode を掴んだまま動き続け、次回起動から
+  新版になる（cask の upgrade と同じセマンティクス）
+- `sync-app` を stable 以外の channel で呼ぶとエラーで止める（`Gozd Local.app` が
+  `~/Applications/Gozd.app` を乗っ取る事故の防止）
 - Spotlight は `~/Applications` 配下の実体 copy を index する（symlink は index されない。
   Homebrew cask が symlink 方式を廃止した既知の理由）
-- Dock / Spotlight からのみ起動し続けると wrapper を経由せず更新が伝播しない。ターミナルの
-  `gozd` が日常動線である前提で許容する
 
 ## channel identity
 


### PR DESCRIPTION
## 概要

`mise up` での更新を Dock / Spotlight 起動にも伝播させる。wrapper `bin/gozd` に `sync-app` サブコマンドを追加し、mise の tool-level `postinstall` から新バージョンのインストール直後に `~/Applications/Gozd.app` を差し替える。更新の反映を「起動時（wrapper cold start）」から「更新時（mise postinstall）」へ移す。

## 背景

mise 配布導入（ #1003 / PR #1004 / PR #1007 ）の更新伝播は「ターミナルの `gozd`（= mise 側 wrapper）を通る cold start 時に固定パスへ同期する」という 1 本の経路に依存し、docs/release.md にも「ターミナルの `gozd` が日常動線である前提で許容する」と明記していた。

実運用初回でこの前提が破綻した。Dock から起動するユーザーには wrapper を通る機会がなく、`mise up` で canary.2 を入れても `~/Applications/Gozd.app` は canary.0 のまま永久凍結され、About パネルが旧バージョンを表示し続けた。

対応方針の調査結果:

- macOS Electron アプリの業界標準（署名 + electron-updater / Squirrel.Mac、または Sparkle）は署名が必須要件のため、未署名配布の gozd では使えない
- 未署名 + パッケージマネージャ配布での確立されたモデルは Homebrew cask（`brew upgrade` がインストール時に /Applications の実体を差し替える = update-time 伝播）
- mise には tool-level `postinstall` オプションがあり、github backend でも新バージョンのインストール直後に発火し `MISE_TOOL_INSTALL_PATH` でインストール先を受け取れることを実機で確認した（mise 2026.7.11）
- `postinstall` は `mise use` の bracket 構文（TOML inline table としてパース）から設定でき、config.toml へ永続化されることを mise ソース（`replace_versions`）と実機の両方で確認した

これにより cask と同じ update-time 伝播が mise 設定 1 行で成立する。同期ロジック自体は配布物側（wrapper）に置き、ユーザー config には呼び出し 1 行だけを置く分担にする（config にロジックを埋め込むと、リリース側の修正が既存ユーザーの config に届かない）。

## 変更内容

### wrapper（resources/bin/gozd）

- `sync-app` サブコマンドを追加。既存の `sync_installed_app`（CFBundleVersion 比較 + APFS clone + atomic swap）を呼んで終了する
- stable 以外の channel では即エラー（`Gozd Local.app` が `~/Applications/Gozd.app` を乗っ取る事故の防止）
- `sync_installed_app` の「cold start 経路限定なのでアプリは未起動」という stale なコメントを、稼働中 swap の安全性（旧プロセスは開いた inode で動き続け、次回起動から新版。cask の upgrade と同じセマンティクス）の説明に更新

### README

- インストール手順の `mise use` ワンライナーに `postinstall="\"$MISE_TOOL_INSTALL_PATH/bin/gozd\" sync-app"` を組み込み（canary / stable 両方）
- 起動節の「更新は次回 `gozd` 起動時に反映」を「`mise up` 実行時に postinstall が固定パスを差し替えて反映」に更新

### docs

- docs/release.md: 「更新の反映」を postinstall 主経路 + cold start 同期バックアップの 2 経路構成に書き換え。「ターミナルが日常動線である前提で許容する」の記述を廃止。mise インストール節の toml 例に postinstall を追記
- docs/architecture.md: wrapper の動作列挙に `sync-app` を追加し、固定パス同期の説明を「postinstall が主経路、cold start はバックアップ」の現在契約に更新

## 旧実装からの挙動変更・後退

- 更新伝播の主経路が postinstall になるため、**README の新ワンライナーで設定していないユーザーは従来どおり cold start 同期のみ**になる（後退ではなく現状維持だが、postinstall の恩恵を受けるには `mise use` の再実行が必要）
- `postinstall` 設定済みで `sync-app` を含まない旧リリース（canary.2 以前）を新規インストールすると、旧 wrapper が `sync-app` を open コマンドとして解釈してしまう。この PR の merge 後最初のリリース以降は、postinstall が実行するのは常に「いま入った新バージョンの wrapper」なので自己整合する

## 確認事項

- [ ] merge 後の canary リリースで `mise up` → postinstall が発火し `~/Applications/Gozd.app` が新バージョンに差し替わるか（隔離 HOME での sync-app 単体・冪等性・channel ガードは検証済み。mise 実配線の end-to-end は実リリースでしか確認できない）
- [ ] Dock からの再起動で About パネルが新バージョンを表示するか
