### PR TITLE
feat(workspace): 起動時に最後に開いていた worktree を復元してターミナルを開く

### DIFF
--- a/apps/electron/src/stores.ts
+++ b/apps/electron/src/stores.ts
@@ -102,6 +102,10 @@ function normalizeAppState(raw: unknown): AppState {
         worktrees,
       } as SidebarRepo;
     }),
+    // 「未選択 = キー不在」の optional 契約。文字列以外 / 空文字は unset に正規化する
+    // （undefined 値は JSON.stringify で落ちるため、save 時にキー不在へ戻る）
+    activeDir:
+      typeof dict.activeDir === "string" && dict.activeDir !== "" ? dict.activeDir : undefined,
   };
 }
 

--- a/apps/renderer/src/features/sidebar/restoreActiveDir.test.ts
+++ b/apps/renderer/src/features/sidebar/restoreActiveDir.test.ts
@@ -1,0 +1,62 @@
+import type { WorktreeEntry } from "@gozd/rpc";
+import { describe, expect, test } from "bun:test";
+import { createPinia, setActivePinia } from "pinia";
+import { useRepoStore } from "../../shared/repo";
+import { useWorktreeStore } from "../worktree";
+import { restoreActiveDir } from "./restoreActiveDir";
+
+function wt(path: string, branch: string, isMain = false): WorktreeEntry {
+  return {
+    path,
+    head: "",
+    branch,
+    isMain,
+    gitStatuses: {},
+    renameOldPaths: {},
+    tasks: [],
+    upstream: undefined,
+    latestMtime: 0,
+  };
+}
+
+function setupRepo() {
+  setActivePinia(createPinia());
+  const repoStore = useRepoStore();
+  repoStore.addRepo({
+    rootDir: "/r1",
+    repoName: "r1",
+    isGitRepo: true,
+    worktrees: [wt("/r1", "main", true), wt("/r1/wt-1", "feat")],
+  });
+  return { repoStore, worktreeStore: useWorktreeStore() };
+}
+
+describe("restoreActiveDir", () => {
+  test("保存された dir が repo 所有なら setOpen で復元する（選択イベントも発火）", () => {
+    const { repoStore, worktreeStore } = setupRepo();
+    restoreActiveDir("/r1/wt-1");
+    expect(repoStore.selectedDir).toBe("/r1/wt-1");
+    expect(worktreeStore.selectionVersion).toBe(1);
+  });
+
+  test("既に選択済み（gozdOpen 先着）なら復元せず明示 open を優先する", () => {
+    const { repoStore, worktreeStore } = setupRepo();
+    worktreeStore.setOpen("/r1");
+    restoreActiveDir("/r1/wt-1");
+    expect(repoStore.selectedDir).toBe("/r1");
+    // 復元による選択イベントの二重発火もない（setOpen 1 回分のまま）
+    expect(worktreeStore.selectionVersion).toBe(1);
+  });
+
+  test("どの repo にも属さない dir は復元しない", () => {
+    const { repoStore } = setupRepo();
+    restoreActiveDir("/gone/wt-x");
+    expect(repoStore.selectedDir).toBeUndefined();
+  });
+
+  test("activeDir 未保存（undefined）は no-op", () => {
+    const { repoStore } = setupRepo();
+    restoreActiveDir(undefined);
+    expect(repoStore.selectedDir).toBeUndefined();
+  });
+});

--- a/apps/renderer/src/features/sidebar/restoreActiveDir.ts
+++ b/apps/renderer/src/features/sidebar/restoreActiveDir.ts
@@ -1,0 +1,23 @@
+import { useRepoStore } from "../../shared/repo";
+import { useWorktreeStore } from "../worktree";
+
+/**
+ * 前回終了時の active worktree（app-state.json の activeDir）を復元し、TerminalPane の
+ * dir watch 経由でターミナルを自動で開く。hydrate 直後に 1 回だけ呼ぶ。復元しないケース:
+ * - 既に選択済み（cold start の launch request 由来の gozdOpen が hydrate と並走して
+ *   先に setOpen したケース）。明示 open を復元より優先する。逆順で gozdOpen が後着した
+ *   場合も setOpen の後勝ちで明示 open が勝つため、到達順に依らず優先順位が保たれる
+ * - 保存された dir がどの repo にも属さない（worktree キャッシュごと消えた / 手で
+ *   編集された state）。外部削除で「キャッシュには居るが実体が無い」dir は
+ *   updateRepoData の orphan fallback が rootDir へ倒すため、ここでは実在検証しない
+ *   （その場合、復元が先に発火させる PTY spawn は削除済み dir で失敗しエラートーストが
+ *   出るが、選択は fallback で自己回復する。稀なエッジとして受容する）
+ */
+export function restoreActiveDir(activeDir: string | undefined): void {
+  const repoStore = useRepoStore();
+  const worktreeStore = useWorktreeStore();
+  if (activeDir === undefined || activeDir === "") return;
+  if (worktreeStore.dir !== undefined) return;
+  if (repoStore.findRepoOwning(activeDir) === undefined) return;
+  worktreeStore.setOpen(activeDir);
+}

--- a/apps/renderer/src/features/sidebar/useSidebarData.ts
+++ b/apps/renderer/src/features/sidebar/useSidebarData.ts
@@ -427,8 +427,26 @@ export function useSidebarData() {
     const result = await tryCatch(rpcAppStateLoad({}));
     if (result.ok && result.value.state !== undefined) {
       repoStore.hydrateFromAppState(result.value.state);
+      restoreActiveDir(result.value.state.activeDir);
     }
     hydrated = true;
+  }
+
+  /**
+   * 前回終了時の active worktree を復元し、TerminalPane の dir watch 経由でターミナルを
+   * 自動で開く。復元しないケース:
+   * - 既に選択済み（cold start の launch request 由来の gozdOpen が hydrate と並走して
+   *   先に setOpen したケース）。明示 open を復元より優先する。逆順で gozdOpen が後着した
+   *   場合も setOpen の後勝ちで明示 open が勝つため、到達順に依らず優先順位が保たれる
+   * - 保存された dir がどの repo にも属さない（worktree キャッシュごと消えた / 手で
+   *   編集された state）。外部削除で「キャッシュには居るが実体が無い」dir は
+   *   updateRepoData の orphan fallback が rootDir へ倒すため、ここでは検査しない
+   */
+  function restoreActiveDir(activeDir: string | undefined) {
+    if (activeDir === undefined || activeDir === "") return;
+    if (worktreeStore.dir !== undefined) return;
+    if (repoStore.findRepoOwning(activeDir) === undefined) return;
+    worktreeStore.setOpen(activeDir);
   }
 
   // snapshot を JSON シリアライズした文字列を watch source にする。

--- a/apps/renderer/src/features/sidebar/useSidebarData.ts
+++ b/apps/renderer/src/features/sidebar/useSidebarData.ts
@@ -7,6 +7,7 @@ import { onMessage } from "../../shared/rpc";
 import { stripClaudeTitlePrefix, useTerminalStore } from "../terminal";
 import type { HookPayload } from "../terminal";
 import { useWorktreeStore } from "../worktree";
+import { restoreActiveDir } from "./restoreActiveDir";
 import {
   rpcAppStateLoad,
   rpcAppStateSave,
@@ -430,23 +431,6 @@ export function useSidebarData() {
       restoreActiveDir(result.value.state.activeDir);
     }
     hydrated = true;
-  }
-
-  /**
-   * 前回終了時の active worktree を復元し、TerminalPane の dir watch 経由でターミナルを
-   * 自動で開く。復元しないケース:
-   * - 既に選択済み（cold start の launch request 由来の gozdOpen が hydrate と並走して
-   *   先に setOpen したケース）。明示 open を復元より優先する。逆順で gozdOpen が後着した
-   *   場合も setOpen の後勝ちで明示 open が勝つため、到達順に依らず優先順位が保たれる
-   * - 保存された dir がどの repo にも属さない（worktree キャッシュごと消えた / 手で
-   *   編集された state）。外部削除で「キャッシュには居るが実体が無い」dir は
-   *   updateRepoData の orphan fallback が rootDir へ倒すため、ここでは検査しない
-   */
-  function restoreActiveDir(activeDir: string | undefined) {
-    if (activeDir === undefined || activeDir === "") return;
-    if (worktreeStore.dir !== undefined) return;
-    if (repoStore.findRepoOwning(activeDir) === undefined) return;
-    worktreeStore.setOpen(activeDir);
   }
 
   // snapshot を JSON シリアライズした文字列を watch source にする。

--- a/apps/renderer/src/shared/repo/useRepoStore.test.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.test.ts
@@ -241,3 +241,26 @@ describe("setGithubIdentity", () => {
     expect(store.repos["/r1"]?.githubIdentity).toEqual({ owner: "miyaoka", repo: "gozd" });
   });
 });
+
+describe("buildAppStateSnapshot", () => {
+  test("選択中の worktree を activeDir として含める", () => {
+    setActivePinia(createPinia());
+    const store = useRepoStore();
+    store.addRepo({
+      rootDir: "/r1",
+      repoName: "r1",
+      isGitRepo: true,
+      worktrees: [wt("/r1", "main", true), wt("/r1/wt-1", "feat")],
+    });
+    store.selectDir("/r1/wt-1");
+    expect(store.buildAppStateSnapshot().activeDir).toBe("/r1/wt-1");
+  });
+
+  test("未選択なら activeDir は undefined（JSON 化でキー不在になる）", () => {
+    setActivePinia(createPinia());
+    const store = useRepoStore();
+    const snapshot = store.buildAppStateSnapshot();
+    expect(snapshot.activeDir).toBeUndefined();
+    expect(JSON.parse(JSON.stringify(snapshot))).not.toHaveProperty("activeDir");
+  });
+});

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -422,6 +422,9 @@ export const useRepoStore = defineStore("repo", () => {
           })),
         };
       }),
+      // 次回起動時の active worktree 復元用。未選択（undefined）は JSON.stringify で
+      // キーごと落ちるため、save 側の shallow merge で stale な値が残らない
+      activeDir: selectedDir.value,
     };
   }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -387,7 +387,7 @@ zsh 起動
 
 ```text
 ~/.local/state/gozd/
-├── app-state.json                        # state: sidebar repo 並び順 / 折りたたみ / worktree 一覧キャッシュ
+├── app-state.json                        # state: sidebar repo 並び順 / 折りたたみ / worktree 一覧キャッシュ / active worktree
 └── electron-window.json                  # state: window frame（shell 固有。close 時に保存）
 
 ~/.config/gozd/

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -32,7 +32,7 @@
 
 `~/.local/state/gozd/app-state.json`（XDG state ディレクトリ）に最後の sidebar 状態を保存し、次回起動時に sidebar として hydrate する。dev / stable で同じファイルを共有する。
 
-save の発火条件は `buildAppStateSnapshot()` のシリアライズ結果が前回と変化した時のみ。snapshot に含めるのは `dirOrder` / `collapsedRoots` / 各 repo の `repoName` / `isGitRepo` と、各 worktree の `path` / `branch` / `isMain`（worktree 一覧キャッシュ）。`gitStatuses` / `task` は snapshot に含めないため、git status push / Task title 同期では save が走らない（`selectedDir` も snapshot 非対象）。発火するのは上記フィールドが実際に変化した時のみ。
+save の発火条件は `buildAppStateSnapshot()` のシリアライズ結果が前回と変化した時のみ。snapshot に含めるのは `dirOrder` / `collapsedRoots` / `selectedDir`（`activeDir` として保存）/ 各 repo の `repoName` / `isGitRepo` と、各 worktree の `path` / `branch` / `isMain`（worktree 一覧キャッシュ）。`gitStatuses` / `task` は snapshot に含めないため、git status push / Task title 同期では save が走らない。発火するのは上記フィールドが実際に変化した時のみ。
 
 > [!WARNING]
 > dev / stable を同時起動して両方の sidebar を編集した場合、最後に save したプロセスが他方の sidebar 状態を上書きする。プロセス間ロックは未実装。詳細は [architecture.md](./architecture.md#データ永続化) を参照。
@@ -41,11 +41,12 @@ save の発火条件は `buildAppStateSnapshot()` のシリアライズ結果が
 
 - sidebar に表示中の repo 一覧（`sidebarRepos`: rootDir / repoName / isGitRepo / collapsed）
 - 各 repo の worktree 一覧キャッシュ（`sidebarRepos[].worktrees`: path / branch / isMain）。起動直後の layout shift を消すための楽観描画用。SSOT は git で、`rpcGitWorktreeList` の真値が来たら上書きされる
+- 最後に選択していた worktree（`activeDir`: worktree path、非 git project は rootDir。未選択はキー不在）
 
 起動時の挙動:
 
 - CLI の launch request ファイル（`gozd <dir>` 時）があればその dir を開く
-- それ以外（Dock/Finder / `pnpm dev` 起動時）は launch request なし → renderer が `app-state.json` を hydrate して sidebar を復元する。active dir の自動選択は未実装で、ユーザーが sidebar から手動選択する
+- それ以外（Dock/Finder / `pnpm dev` 起動時）は launch request なし → renderer が `app-state.json` を hydrate して sidebar を復元し、`activeDir` の worktree を自動選択する（`setOpen` 経由なので TerminalPane がターミナルを開く）。既に gozdOpen で選択済み / `activeDir` がどの repo にも属さない場合は復元しない
 - 初回起動時（state なし）は空の sidebar で待機する
 
 ## プロジェクト管理
@@ -64,11 +65,10 @@ save の発火条件は `buildAppStateSnapshot()` のシリアライズ結果が
 
 ### 永続化
 
-`app-state.json` の `sidebarRepos` で同居中の repo 一覧（rootDir / repoName / collapsed 状態）+ 各 repo の worktree 一覧キャッシュを永続化済み。
+`app-state.json` の `sidebarRepos` で同居中の repo 一覧（rootDir / repoName / collapsed 状態）+ 各 repo の worktree 一覧キャッシュ、`activeDir` で最後に選択していた worktree を永続化済み。
 
 未実装:
 
-- 起動時の active worktree 自動復元（最後に選択していた worktree の記憶・復元は未実装）
 - worktree ごとの setup / teardown スクリプト（`pnpm install` 等の初期化自動化）
 
 将来的に永続化対象が大きく増えた場合は SQLite への移行を検討する。

--- a/packages/rpc/src/appState.ts
+++ b/packages/rpc/src/appState.ts
@@ -11,6 +11,10 @@ import type { EmptyMessage } from "./common";
 export interface AppState {
   /** window 内に同居するサイドバー repo リスト。順序は表示順と一致する */
   sidebarRepos: SidebarRepo[];
+  /** 最後に選択していた worktree path（非 git project は rootDir）。次回起動時に
+   * 復元してターミナルを自動で開く。未選択はキー不在（undefined）で表現する。
+   * CLI の launch request（`gozd <dir>`）がある起動では復元より明示 open を優先する。 */
+  activeDir?: string;
 }
 
 /** サイドバー上の 1 repo の永続化エントリ。 */


### PR DESCRIPTION
## 概要

起動時に最後に選択していた worktree を `app-state.json` に記憶した `activeDir` から復元し、自動で選択する。選択に連動して既存のターミナル起動機構（`TerminalPane` の dir watch → `visit` → PTY spawn）が走るため、起動直後からターミナルが開いた状態になる。

## 背景

これまで起動時は sidebar の repo 一覧だけが hydrate され、active worktree は未選択のままだった（docs/workspace.md にも「active dir の自動選択は未実装」と明記されていた）。そのためコールド起動のたびにメイン領域が空で、ユーザーが sidebar から手動で worktree を選び直す必要があった。

調査の結果、以下の既存機構に相乗りできることが分かり、新規の永続化経路・ターミナル起動コードなしで実現できる構造だった:

- 保存: `buildAppStateSnapshot()` の JSON 文字列を watch source にした debounce save が既にあり、snapshot にフィールドを足すだけで保存が回る
- ターミナル起動: `worktreeStore.setOpen()` を呼べば `TerminalPane` の watch が `visit()` を発火して PTY を spawn する（gozdOpen ハンドラと同じ経路）

## 変更内容

### schema（@gozd/rpc）

- `AppState` に `activeDir?: string` を追加。未選択はキー不在（undefined）で表現する既存の optional 契約に揃える

### 保存（renderer / main）

- `buildAppStateSnapshot()` が `selectedDir` を `activeDir` として snapshot に含める。worktree 切り替えのたび既存の debounce save で書き戻される
- main 側 `normalizeAppState` で文字列以外・空文字を unset に正規化（永続ファイルは信頼できない入力）
- `saveAppState` の shallow merge は `activeDir: undefined` を代入してから `JSON.stringify` が undefined 値を落とすため、未選択に戻った場合に stale キーが自然に消える

### 復元（renderer）

- sidebar feature の独立モジュール `restoreActiveDir` を追加し、`hydrateAppState()` 直後に呼ぶ。保存された dir がいずれかの repo に属していれば `worktreeStore.setOpen()` で選択する
- CLI の launch request（`gozd <dir>`）由来の gozdOpen とは到達順が不定に並走するが、「復元は `selectedDir` 未設定のときだけ」のガードで先着なら復元が譲り、後着なら `setOpen` の後勝ちで上書きされるため、順序に依らず明示 open が優先される
- 復元時の worktree 実在検証はしない。アプリ終了中に外部削除された dir を復元した場合、復元が発火させる PTY spawn は削除済み dir で失敗しエラートーストが 1 回表示されるが、選択自体は `updateRepoData` の orphan fallback（rootDir へ切り替え + info トースト）で自己回復する。実在検証（stat RPC）を復元前に挟むのは起動レイテンシと引き換えに稀なエッジのトーストを消すだけなので採らない

### docs / テスト

- docs/workspace.md の「active dir の自動選択は未実装」記述を現在の契約に更新、docs/architecture.md の app-state.json 説明に active worktree を追記
- `buildAppStateSnapshot` の activeDir 反映と「未選択時はキー不在」のテスト、`restoreActiveDir` のガード分岐（有効時 setOpen / 既選択 skip / 非所有 skip / 未保存 no-op）のテストを追加

## 確認事項

- [ ] worktree を選択した状態でアプリを再起動し、同じ worktree が選択されターミナルが開くこと
- [ ] `gozd <dir>` で起動した場合、復元より CLI 指定の dir が優先されること
- [ ] worktree 未選択のまま終了 → 再起動で、従来どおり未選択のまま起動すること


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now remembers the last selected worktree.
  * The previously selected worktree is automatically restored when the app starts, when available.
  * Explicit directory launches and already-open directories take precedence over automatic restoration.

* **Bug Fixes**
  * Empty or invalid saved directory selections are ignored safely.

* **Documentation**
  * Updated app-state and workspace documentation to describe active worktree persistence and restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->