### PR TITLE
fix(repo-icon): show empty placeholder while GitHub identity resolves

### DIFF
--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -240,6 +240,9 @@ function undockPreview(handoff?: UndockDragHandoff) {
   undockPreviewWindow(
     {
       repoName: repo?.repoName ?? "",
+      // undocked window は live な identity 更新を受けない凍結 snapshot のため、
+      // 解決中 (undefined) は identicon ("") に倒す。live 消費者と違い `?? ""` を
+      // 外してはいけない (外すと解決中に undock した window が恒久的に空白になる)
       repoOwner: repo?.githubIdentity?.owner ?? "",
       branch,
       fileName: path.split("/").pop() ?? path,

--- a/apps/renderer/src/features/repo-icon/RepoIcon.vue
+++ b/apps/renderer/src/features/repo-icon/RepoIcon.vue
@@ -1,7 +1,11 @@
 <doc lang="md">
-repo の識別アイコン。GitHub owner (org / 個人ユーザー) が解決できたらアバター単体、
-owner 未解決 (非 github.com remote / remote 未設定) と画像ロード失敗 (オフライン等) は
-identicon (RepoEmblem) を出す。
+repo の識別アイコン。owner は 3 値で描き分ける:
+
+- `undefined`（解決中）: 枠だけ確保した空プレースホルダー。identicon を出すと解決直後に
+  avatar へ描き替わってちらつくため、確定するまで何も描かない
+- `""`（解決済み・GitHub owner なし = 非 github.com remote / remote 未設定 / 非 git）:
+  identicon (RepoEmblem)
+- owner あり: アバター単体。画像ロード失敗 (オフライン等) は identicon にフォールバック
 
 アバター URL は `https://github.com/<owner>.png` (GitHub 公式の redirect エンドポイント、
 org / 個人ユーザー共通)。owner さえあれば追加の API 呼び出しなしで解決できる。
@@ -16,8 +20,8 @@ import RepoEmblem from "./RepoEmblem.vue";
 const props = defineProps<{
   /** identicon の種 (repo 名) */
   name: string;
-  /** GitHub owner。空文字は未解決 */
-  owner: string;
+  /** GitHub owner。undefined は解決中、空文字は解決済みで owner なし */
+  owner: string | undefined;
 }>();
 
 /** 表示は 24px (size-6)。Retina 向けに 2x を要求する */
@@ -34,8 +38,9 @@ watch(
 </script>
 
 <template>
+  <span v-if="owner === undefined" class="size-6 shrink-0" aria-hidden="true"></span>
   <img
-    v-if="owner !== '' && !failed"
+    v-else-if="owner !== '' && !failed"
     :src="`https://github.com/${owner}.png?size=${AVATAR_FETCH_SIZE}`"
     alt=""
     aria-hidden="true"

--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -337,8 +337,8 @@ const addableRootDirs = computed(() =>
 function repoNameOf(rootDir: string): string {
   return repoStore.repos[rootDir]?.repoName ?? rootDir;
 }
-function repoOwnerOf(rootDir: string): string {
-  return repoStore.repos[rootDir]?.githubIdentity?.owner ?? "";
+function repoOwnerOf(rootDir: string): string | undefined {
+  return repoStore.repos[rootDir]?.githubIdentity?.owner;
 }
 
 /** RepoSection の ✕ が window 解除（破壊的）になるか。ラベル出し分けに使う */

--- a/apps/renderer/src/features/sidebar/features/repo/RepoSection.vue
+++ b/apps/renderer/src/features/sidebar/features/repo/RepoSection.vue
@@ -106,8 +106,9 @@ const collapsed = computed(() => repoStore.isCollapsed(props.rootDir));
 
 const active = computed(() => repoStore.selectedRootDir === props.rootDir);
 
-/** GitHub owner (org / 個人ユーザー)。取得は useSidebarData、SSOT は repoStore.githubIdentity */
-const githubOwner = computed(() => repo.value?.githubIdentity?.owner ?? "");
+/** GitHub owner (org / 個人ユーザー)。取得は useSidebarData、SSOT は repoStore.githubIdentity。
+ * undefined は解決中 (RepoIcon が空プレースホルダーを出す) */
+const githubOwner = computed(() => repo.value?.githubIdentity?.owner);
 
 const worktrees = computed(() => repo.value?.worktrees ?? []);
 

--- a/apps/renderer/src/features/sidebar/useSidebarData.ts
+++ b/apps/renderer/src/features/sidebar/useSidebarData.ts
@@ -94,18 +94,27 @@ export function useSidebarData() {
    * remote URL のローカル parse (外部通信なし)。repo 追加時に 1 回だけ取得する
    * (remote URL の変更を検知する push 経路は無く、都度 refetch する価値がない)。
    *
-   * 失敗 (git CLI launch 不能等のグローバル条件) はトーストしない。identity 未解決は
+   * 失敗 (git CLI launch 不能等のグローバル条件) はトーストしない。owner なしは
    * 「sidebar は identicon、git-graph は issue リンク無し」という定義済みの劣化に倒れる
    * progressive enhancement であり、per-repo に N 回同一トーストを出しても actionable
    * でないため、console.debug で観察可能性だけ残す。非 github.com / remote 未設定は
    * native 側が空文字に正規化して ok で返るので、そもそもここには来ない。
+   *
+   * githubIdentity undefined は「解決中」の契約 (RepoIcon が空プレースホルダーを出す)。
+   * 非 git repo と fetch 失敗も空 identity を書いて解決済みに倒し、undefined のまま
+   * 残さない (残すとプレースホルダーが永続し identicon に到達しない)。
    */
   async function fetchGithubIdentity(rootDir: string) {
     const repo = repoStore.repos[rootDir];
-    if (repo === undefined || !repo.isGitRepo) return;
+    if (repo === undefined) return;
+    if (!repo.isGitRepo) {
+      repoStore.setGithubIdentity(rootDir, { owner: "", repo: "" });
+      return;
+    }
     const result = await tryCatch(rpcGitGithubIdentity({ dir: rootDir }));
     if (!result.ok) {
       notify.debug(`[useSidebarData] github identity fetch failed: ${rootDir}`, result.error);
+      repoStore.setGithubIdentity(rootDir, { owner: "", repo: "" });
       return;
     }
     repoStore.setGithubIdentity(rootDir, {

--- a/apps/renderer/src/features/terminal/TerminalLeafTitle.vue
+++ b/apps/renderer/src/features/terminal/TerminalLeafTitle.vue
@@ -42,8 +42,8 @@ const visual = computed(() =>
 /** dir が属する repo。起動直後の未登録時は undefined */
 const repo = computed(() => repoStore.findRepoOwning(props.dir));
 const repoName = computed(() => repo.value?.repoName ?? "");
-/** GitHub owner。空文字は未解決（RepoIcon が identicon にフォールバックする） */
-const repoOwner = computed(() => repo.value?.githubIdentity?.owner ?? "");
+/** GitHub owner。undefined は解決中（RepoIcon が空プレースホルダーを出す） */
+const repoOwner = computed(() => repo.value?.githubIdentity?.owner);
 
 /** leaf → ptyId → sessionId → Task → 表示タイトル。Task 未到達時は undefined */
 const title = computed<string | undefined>(() => {

--- a/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
+++ b/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
@@ -414,6 +414,9 @@ function undockPreview(handoff?: UndockDragHandoff) {
     {
       kind: ctx.msg.kind,
       repoName: repo?.repoName ?? "",
+      // undocked window は live な identity 更新を受けない凍結 snapshot のため、
+      // 解決中 (undefined) は identicon ("") に倒す。live 消費者と違い `?? ""` を
+      // 外してはいけない (外すと解決中に undock した window が恒久的に空白になる)
       repoOwner: repo?.githubIdentity?.owner ?? "",
       title: title === "" ? "Session log" : title,
       text: ctx.msg.text,

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -17,7 +17,10 @@ export interface RepoState {
   worktrees: WorktreeEntry[];
   /**
    * origin remote から解決した GitHub identity（repo 単位、全 worktree で共通）。
-   * 未取得は undefined、非 github.com remote / remote 未設定は owner / repo が空文字。
+   * undefined は「解決中」で transient（useSidebarData の fetch 経路が非 git repo /
+   * fetch 失敗も空 identity で必ず settle させる契約。RepoIcon は undefined の間だけ
+   * 空プレースホルダーを出す）。owner / repo の空文字は「解決済みで identity なし」
+   * （非 github.com remote / remote 未設定 / 非 git / fetch 失敗）。
    * sidebar の org アバターと git-graph の issue リンク base URL が共有する SSOT。
    */
   githubIdentity?: { owner: string; repo: string };


### PR DESCRIPTION
## 概要

起動時にサイドバーの repo アイコンが identicon（hash 由来の紋章アイコン）で一瞬描かれ、GitHub identity の解決後に avatar へ描き替わってちらつく問題を修正する。解決中は枠だけ確保した空のプレースホルダーを描き、確定してから identicon / avatar を出す。

## 背景

`RepoIcon` は owner 空文字を identicon 表示にフォールバックする設計だが、呼び出し側が `githubIdentity?.owner ?? ""` で値を潰していたため、「identity をまだ取得していない（RPC 往復中）」と「取得済みだが GitHub owner がない（非 github.com remote / remote 未設定）」が区別できず、どちらも identicon になっていた。`githubIdentity` は persist しない派生値で毎起動 undefined から始まるため、GitHub repo でも起動のたびに identicon → avatar の描き替えが必ず発生していた。

修正は owner の 3 値化:

- `undefined` = 解決中 → 空プレースホルダー（size-6 の透明 span でレイアウトだけ確保）
- `""` = 解決済みで owner なし → identicon
- owner あり → avatar（画像ロード失敗時は identicon フォールバック、従来どおり）

これが成立するには「全経路が必ず解決済み状態に到達する」保証が必要になる。従来 `fetchGithubIdentity` は非 git repo を early return し、fetch 失敗（git CLI launch 不能等）も store を書かずに終わっており、これらは `githubIdentity` が undefined のまま残る経路だった。放置するとプレースホルダーが永続して identicon に到達しないため、両経路とも空 identity（`{ owner: "", repo: "" }`）を書いて解決済みに倒す。`buildRepoBaseUrl` は元から空文字 identity を「リンクなし」として弾くため git-graph 側への影響はない。

呼び出し側で `isGitRepo` を見て空文字に倒す案は、「解決済みかどうか」の判定が各 caller に分散するため却下し、fetch 経路（`useSidebarData`）で settle する方に寄せた。

undock snapshot 経路（floating preview / session log window）は live な identity 更新を受けない凍結値のため `?? ""` を残す。ここで `undefined` を通すと、解決中に undock した window が恒久的に空白プレースホルダーになる。live 消費者との非対称は該当 2 箇所のコメントで明示した。

## 変更内容

### repo-icon

- `RepoIcon` の `owner` prop を `string | undefined` に変更し、`undefined`（解決中）で空プレースホルダーを描画する分岐を追加

### sidebar

- `useSidebarData.fetchGithubIdentity`: 非 git repo と fetch 失敗時に空 identity を書き、`githubIdentity === undefined` を「解決中」に限定する契約に変更
- `RepoSection` / `SidebarPane` の owner 導出から `?? ""` を外し、解決中の `undefined` をそのまま `RepoIcon` へ通す

### terminal

- `TerminalLeafTitle` の owner 導出も同様に `?? ""` を外す（repo アイコンの SSOT をサイドバーと共有しているため同じ 3 値契約に揃える）

### ドキュメント・コメント

- `RepoState.githubIdentity` の SSOT 型 doc を 3 値契約（undefined = 解決中で必ず settle される / 空文字 = 解決済みで identity なし）に更新
- undock snapshot 経路（`PreviewPane` / `TerminalSessionPreview`）の `?? ""` 残置に「外すと恒久空白になる」防波堤コメントを追加

## 旧実装からの挙動変更・後退

- identity 解決中（起動直後〜RPC 応答までの短時間）は repo アイコン位置に何も表示されない。従来はこの間 identicon が表示されていた（本 PR の目的そのもの）
- この空白化はサイドバーだけでなく、`RepoIcon` を共有する terminal leaf タイトルと編集モードの「Add from other lists」候補行にも適用される
- identity fetch 失敗（git CLI launch 不能等のグローバル条件）時、store に空 identity が書き込まれるようになる。表示は従来と同じ identicon で、`buildRepoBaseUrl` も空文字を弾くため観測可能な差はない

## 今回含めない点

- **今回は対応しない**: `fetchGithubIdentity` の settle 挙動（非 git / fetch 失敗 → 空 identity）の自動テスト。settle 分岐は 3 行の自明な写像でテストが実装の再記述になり、`useSidebarData` に test harness が無く新設コストが見合わない。下記確認事項の人間動作確認で担保する

## 確認事項

- [ ] 起動直後のサイドバーで、GitHub repo のアイコンが identicon を経由せず 空白 → avatar で表示されること
- [ ] 非 github remote / remote 未設定の repo と非 git project で identicon が表示され続けること（プレースホルダーのまま残らないこと）
