### PR TITLE
fix(sidebar): follow repo list to active worktree and show claude view scope label

### DIFF
--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -355,13 +355,13 @@ function onDragEnd(event: DragEndEvent) {
 //
 // アクティブターミナル（= worktreeStore.dir）が変わったら、その wt がサイドバーで
 // 見えるようにする。サイドバー操作で切り替えた場合は既に可視なので副作用なし
-// （scrollIntoView block:nearest は範囲内なら no-op、属する repo は開いている）。
-// ターミナルペイン側でのフォーカス移動など、サイドバー外の経路で dir が変わった
-// ときに効く。immediate で起動直後 / フルリロード後（hydrate 済みの selectedDir）も
-// 初回表示で追従させる。flush:post で常に DOM 更新後にコールバックを走らせ、immediate
-// 初回でも scrollContainer / WtCard が mount 済みになることを Vue 内部のスケジューリングに
-// 依存せず保証する。コールバック内の nextTick は expand（store 変更→再レンダー）と scroll
-// の間で別途必要なため残す。
+// （setActiveRepoList / scrollIntoView block:nearest は範囲内なら no-op、属する repo は
+// 開いている）。claude ビューのタイルフォーカスやターミナルペイン側でのフォーカス移動など、
+// サイドバー外の経路で dir が変わったときに効く。immediate で起動直後 / フルリロード後
+// （hydrate 済みの selectedDir）も初回表示で追従させる。flush:post で常に DOM 更新後に
+// コールバックを走らせ、immediate 初回でも scrollContainer / WtCard が mount 済みになる
+// ことを Vue 内部のスケジューリングに依存せず保証する。コールバック内の nextTick は
+// list 切り替え / expand（store 変更→再レンダー）と scroll の間で別途必要なため残す。
 const scrollContainer = useTemplateRef<HTMLElement>("scrollContainer");
 
 watch(
@@ -369,12 +369,22 @@ watch(
   async (dir) => {
     if (dir === undefined) return;
     // 編集モード中は全 section が強制 collapse され WtCard が描画されないため、
-    // スクロール先が存在しない。追従はスキップする。
+    // スクロール先が存在しない。list 切り替えも編集対象が足元で変わると混乱するため、
+    // 追従はまとめてスキップする。
     if (editMode.value) return;
-    // 畳まれた repo の中にいると WtCard が v-if で出ていないので、まず開く。
     const owner = repoStore.findRepoOwning(dir);
-    if (owner !== undefined) repoStore.expand(owner.rootDir);
-    // expand による WtCard の出現を待ってからスクロール先を引く。
+    if (owner !== undefined) {
+      // アクティブ repo list がその repo を含まないと、wt ビューに戻ったとき active wt が
+      // サイドバーに見えない（claude ビューは poolDirs 母集団なので別 list の repo でも
+      // 選択できる）。含む list（複数所属なら repoLists 先頭側）へ表示も追従させる。
+      if (!repoStore.dirOrder.includes(owner.rootDir)) {
+        const [owningList] = repoStore.repoListsContaining(owner.rootDir);
+        if (owningList !== undefined) repoStore.setActiveRepoList(owningList.id);
+      }
+      // 畳まれた repo の中にいると WtCard が v-if で出ていないので開く。
+      repoStore.expand(owner.rootDir);
+    }
+    // list 切り替え / expand による WtCard の出現を待ってからスクロール先を引く。
     await nextTick();
     const container = scrollContainer.value;
     if (container === null) return;

--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -6,8 +6,11 @@
 
 - **トップツールバー**: 左に view mode トグル (active worktree / claude terminals)、右に時計 / SFX
 - **repo list バー**: 編集トグルをツールバーではなくこのバーに置くのは、編集の対象がこの
-  バー以下のリストエリアに閉じるため（配置と作用範囲の対応づけ）。表示は 2 態:
+  バー以下のリストエリアに閉じるため（配置と作用範囲の対応づけ）。表示は 3 態:
   - 通常モード: chip 列（クリックでアクティブ repo list を切り替えるだけ）+ 右端に鉛筆
+  - claude ビュー中（非編集）: chip 列の代わりにスコープ表記（bot アイコン + "Claude
+    terminals"）。repo セクションが poolDirs 母集団になり list と対応しなくなるため、
+    chip（= アクティブ list の表示機能）を出すと表示とスコープが食い違う
   - 編集モード: 専用ヘッダ（左に "Edit list" タイトル / 右に Done ボタン）+ 全幅の縦一覧
     (`ListRow`)。行 drag で list の並び替え、行クリックで切り替え、行 hover の ⋮ で
     ListMenu（Rename → ListEditDialog / Delete → 確認ダイアログ）。末尾に `New list`。
@@ -446,7 +449,18 @@ watch(
          配置で対応づける -->
     <!-- 通常モード: chip 列（切り替えのみ）+ 右端に鉛筆 -->
     <div v-if="!editMode" class="flex items-start gap-1 px-2 pt-3 pb-1">
-      <div class="flex min-w-0 flex-1 flex-wrap items-center gap-1">
+      <!-- claude ビュー中は chip 列をスコープ表記に置き換える。chip は「アクティブ repo list の
+           表示」機能だが、claude ビューの repo セクションは poolDirs 母集団で list 外の repo も
+           出るため、chip を出すと「切り替えても表示が変わらない / list に無い repo が見える」
+           という表示とスコープの不一致が生じる。表記は view mode トグルと同語彙で対応づける -->
+      <div
+        v-if="terminalStore.viewMode === 'claude'"
+        class="flex min-w-0 flex-1 items-center gap-1.5 px-1 py-0.5 text-xs text-foreground-low"
+      >
+        <IconLucideBot class="size-3.5 shrink-0" />
+        <span class="truncate">Claude terminals</span>
+      </div>
+      <div v-else class="flex min-w-0 flex-1 flex-wrap items-center gap-1">
         <button
           v-for="pl in repoStore.repoLists"
           :key="pl.id"

--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -358,8 +358,8 @@ function onDragEnd(event: DragEndEvent) {
 //
 // アクティブターミナル（= worktreeStore.dir）が変わったら、その wt がサイドバーで
 // 見えるようにする。サイドバー操作で切り替えた場合は既に可視なので副作用なし
-// （setActiveRepoList / scrollIntoView block:nearest は範囲内なら no-op、属する repo は
-// 開いている）。claude ビューのタイルフォーカスやターミナルペイン側でのフォーカス移動など、
+// （activateRepoListContaining / scrollIntoView block:nearest は範囲内なら no-op、属する
+// repo は開いている）。claude ビューのタイルフォーカスやターミナルペイン側でのフォーカス移動など、
 // サイドバー外の経路で dir が変わったときに効く。immediate で起動直後 / フルリロード後
 // （hydrate 済みの selectedDir）も初回表示で追従させる。flush:post で常に DOM 更新後に
 // コールバックを走らせ、immediate 初回でも scrollContainer / WtCard が mount 済みになる
@@ -379,11 +379,8 @@ watch(
     if (owner !== undefined) {
       // アクティブ repo list がその repo を含まないと、wt ビューに戻ったとき active wt が
       // サイドバーに見えない（claude ビューは poolDirs 母集団なので別 list の repo でも
-      // 選択できる）。含む list（複数所属なら repoLists 先頭側）へ表示も追従させる。
-      if (!repoStore.dirOrder.includes(owner.rootDir)) {
-        const [owningList] = repoStore.repoListsContaining(owner.rootDir);
-        if (owningList !== undefined) repoStore.setActiveRepoList(owningList.id);
-      }
+      // 選択できる）。含む list へ表示も追従させる（選定ポリシーは store 側が SSOT）。
+      repoStore.activateRepoListContaining(owner.rootDir);
       // 畳まれた repo の中にいると WtCard が v-if で出ていないので開く。
       repoStore.expand(owner.rootDir);
     }

--- a/apps/renderer/src/shared/repo/useRepoStore.test.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.test.ts
@@ -312,6 +312,29 @@ describe("repoLists", () => {
     expect(store.dirOrder).toEqual(["/b"]);
   });
 
+  test("activateRepoListContaining: アクティブ list 内は no-op / list 外は含む先頭 list へ切り替える", () => {
+    setActivePinia(createPinia());
+    const store = useRepoStore();
+    store.addRepo(repo("/a"));
+    const firstId = store.activeRepoListId;
+    const secondId = store.addRepoList("second");
+    store.addRepo(repo("/b"));
+    const thirdId = store.addRepoList("third");
+    store.ensureInActiveRepoList("/b");
+
+    // アクティブ list (third) が既に含む repo は no-op
+    store.activateRepoListContaining("/b");
+    expect(store.activeRepoListId).toBe(thirdId);
+
+    // 単一所属: /a を含むのは first のみ
+    store.activateRepoListContaining("/a");
+    expect(store.activeRepoListId).toBe(firstId);
+
+    // 複数所属: /b は second / third に属する → repoLists 先頭側の second に倒す
+    store.activateRepoListContaining("/b");
+    expect(store.activeRepoListId).toBe(secondId);
+  });
+
   test("removeRepoList は最後の 1 個を拒否し、孤児 repo を先頭 repo list へ移す", () => {
     setActivePinia(createPinia());
     const store = useRepoStore();

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -325,6 +325,18 @@ export const useRepoStore = defineStore("repo", () => {
   }
 
   /**
+   * rootDir を含む先頭 repo list をアクティブにする（アクティブ list が既に含むなら no-op）。
+   * 「アクティブ list に無い repo が選択されたら、含む list（複数所属なら repoLists 先頭側）へ
+   * 表示を追従させる」選定ポリシーの SSOT。選択追従（SidebarPane の watcher）と removeRepo の
+   * 選択フォールバックが共有する。プール外の rootDir はどの list にも含まれないため no-op。
+   */
+  function activateRepoListContaining(rootDir: string) {
+    if (dirOrder.value.includes(rootDir)) return;
+    const [owningList] = repoListsContaining(rootDir);
+    if (owningList !== undefined) activeRepoListId.value = owningList.id;
+  }
+
+  /**
    * 既存 repo の worktrees を更新（rpcGitWorktreeList 結果の反映）。
    *
    * `gitStatusesGenSnapshot` には fetch 開始時に各 wt について `getGitStatusGen` で
@@ -505,10 +517,7 @@ export const useRepoStore = defineStore("repo", () => {
         // プール先頭へ倒れた（= アクティブ list に無い repo を選択した）場合は、その repo を
         // 含む list へアクティブも切り替える。切り替えないと「サイドバーは empty state なのに
         // terminal / filer は別 list の repo を開いている」という表示のずれが残る
-        if (firstRoot !== undefined && !dirOrder.value.includes(firstRoot)) {
-          const owningList = repoLists.value.find((p) => p.dirOrder.includes(firstRoot));
-          if (owningList !== undefined) activeRepoListId.value = owningList.id;
-        }
+        if (firstRoot !== undefined) activateRepoListContaining(firstRoot);
       }
     }
   }
@@ -697,6 +706,7 @@ export const useRepoStore = defineStore("repo", () => {
     renameRepoList,
     removeRepoList,
     setActiveRepoList,
+    activateRepoListContaining,
     selectedDir,
     selectedRepo,
     selectedIsGitRepo,

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -171,6 +171,8 @@ repo 一覧は **repo list** 単位で表示する（機能名は repo list、UI
 
 `gozd <path>` で既存プール repo を開いた場合、その repo がアクティブ repo list に無ければ末尾に追加される（開いたのに何も見えない状態を作らない）。
 
+アクティブ worktree がサイドバー外の経路（claude ビューのタイルフォーカス / ターミナルペインのフォーカス移動等）で切り替わり、その repo がアクティブ repo list に無い場合は、その repo を含む list（複数所属なら repoLists 先頭側）へアクティブ repo list も追従する。追従しないと wt ビューに戻ったときアクティブ worktree がサイドバーに見えないずれが残る。編集モード中は追従しない（編集対象が足元で変わるため）。
+
 各 repo セクションの中身:
 
 - ヘッダ: 展開トグル + folder アイコン（git / 非 git で区別）+ repo 名。編集モード中は ✕ 表示。✕ は他 repo list にも属する repo なら「アクティブ repo list から外す」（非破壊・確認なし）、最後の所属なら「window から解除」（確認 + PTY cleanup）

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -157,7 +157,7 @@ repo 一覧は **repo list** 単位で表示する（機能名は repo list、UI
 - **トップツールバー**:
   - 左にビューモードトグル: アクティブな worktree のターミナル / 動いている Claude ターミナル一覧
   - 右に時計
-- **repo list バー**: 右端に編集モードトグル（編集の作用範囲がこのバー以下のリストエリアに閉じるため、ツールバーではなくここに置く）。通常モードは chip 列（クリックでアクティブ repo list を切り替え）。編集モードは縦一覧に切り替わり、行 drag で list の並び替え、行 hover の ⋮ メニューから Rename（編集ダイアログ）/ Delete（確認ダイアログ。最後の 1 個は不可。削除 repo list にしか属さない repo は先頭の残存 repo list へ移る）、末尾に New list
+- **repo list バー**: 右端に編集モードトグル（編集の作用範囲がこのバー以下のリストエリアに閉じるため、ツールバーではなくここに置く）。通常モードは chip 列（クリックでアクティブ repo list を切り替え）。claude ビュー中（非編集）は chip 列の代わりにスコープ表記（"Claude terminals"）を出す — repo セクションが list ではなくプール母集団になるため、chip を出すと「切り替えても表示が変わらない / list に無い repo が見える」という表示とスコープの不一致が生じる。編集モードは縦一覧に切り替わり、行 drag で list の並び替え、行 hover の ⋮ メニューから Rename（編集ダイアログ）/ Delete（確認ダイアログ。最後の 1 個は不可。削除 repo list にしか属さない repo は先頭の残存 repo list へ移る）、末尾に New list
 - **claude ビュー連動フィルタ**: ターミナルが claude タイル表示のとき、サイドバーも Claude セッションが
   動いている repo / worktree / task 行だけに絞られる。フィルタキーはターミナルのタイル対象
   （`claudeActiveLeafIds`）から導出した dir 集合で、タイルに出る leaf とサイドバーに残る worktree が


### PR DESCRIPTION
## 概要

PR #1011 で導入した repo list について、active worktree・claude ビューと表示が食い違う 2 つのずれを解消する。

- active worktree がサイドバー外の経路で別 list の repo に切り替わったとき、アクティブ repo list をその repo を含む list へ追従させる
- claude ビュー中は repo list の chip 列をスコープ表記（bot アイコン + "Claude terminals"）に置き換える

## 背景

repo list はアクティブ list の repo だけをサイドバーに表示する機能だが、選択と表示が list を跨いでずれる経路が 2 つあった。

- claude ビュー（動いている Claude ターミナル一覧）の repo セクションは、タイルとサイドバーの一致を保つため poolDirs（全 list の union）を母集団とする。そのためアクティブ list に無い repo の worktree も選択でき、タイルのフォーカスで `selectedDir` がそこへ移る。しかしアクティブ repo list は据え置きだったため、wt ビューに戻ると active worktree がサイドバーに見えない状態が残っていた
- 同じく claude ビュー中は、chip で list を切り替えても repo セクションが変わらず（poolDirs 母集団のため）、list に無い repo も表示されている。「アクティブ list の表示機能」である chip が、list と対応しない画面で active 表示を主張し続けるのは表示とスコープの不一致で混乱を招いていた

## 変更内容

### repo list の選択追従（SidebarPane.vue / useRepoStore.ts）

- 「アクティブ list に無い repo が選択されたら、含む list（複数所属なら repoLists 先頭側）をアクティブにする」ポリシーを store のプリミティブ `activateRepoListContaining` として定義し、SSOT にする。既存の `removeRepo` の選択フォールバック内の同等インライン実装もこれに置き換え
- 既存の「アクティブ worktree のサイドバー追従」watcher（expand + scrollIntoView）からこのプリミティブを呼ぶ。全選択経路（claude ビューのタイルフォーカス / ターミナルペインのフォーカス移動 / picker 等）は `repoStore.selectedDir` に集約されるため、この watcher 1 箇所で網羅できる
- 編集モード中は既存の early return に相乗りして追従しない（編集対象が足元で変わるため）。この editMode ゲートが feature 層の概念であるため、store の `selectDir` 内での追従は却下し、watcher 側に置いた（shared → feature 依存禁止）
- store テストに 3 分岐（アクティブ list 内は no-op / 単一所属 list へ切替 / 複数所属は repoLists 先頭側）の回帰テストを追加

### claude ビューのスコープ表記（SidebarPane.vue）

- 通常モードの chip 列を、claude ビュー中のみスコープ表記に置き換える。repo list バーは 3 態（通常 chip / claude スコープ表記 / 編集ヘッダ）になる
- 表記は view mode トグルと同語彙・同アイコン（"Claude terminals" / bot）で対応づける
- 編集トグル（鉛筆）は残す。編集モードは claude フィルタを解除して list 編集に入る既存動作がそのまま有効
- chip クリックで wt ビューへ戻す案も検討したが、claude ビュー中に list 外の repo が表示されたまま chip が active 表示を主張する不一致自体は残るため、表示機能ごと隠す方を採った

### ドキュメント

- docs/workspace.md と SidebarPane の `<doc>` ブロックに、選択追従の契約と repo list バーの 3 態を追記

## 旧実装からの挙動変更・後退

- claude ビュー中に chip で list を切り替えることができなくなった。切り替えたい場合は wt ビューに戻るか編集モードに入る（claude ビュー中の切り替えは repo セクションに何の変化も起こさない操作だったため、実用上の後退は小さい）
- サイドバー外の経路で active worktree が別 list の repo に変わると、アクティブ repo list が自動で切り替わる（従来は据え置き）。ユーザーが見ていた list から表示が移ることを許容する仕様変更で、本 PR の意図そのもの
- 起動時、保存された `activeRepoListId` と active worktree の所属 list が食い違っていた場合、watcher の immediate 発火により active worktree を含む list が優先される（「終了時に見ていた list」より「active worktree の可視性」を優先）

## 確認事項

- [ ] claude ビューでタイルをフォーカスして別 list の repo の worktree を active にした後、wt ビューに戻るとその repo を含む list が表示されている
- [ ] claude ビュー中に chip 列が "Claude terminals" 表記に置き換わり、バーの高さが跳ねない
