### PR TITLE
feat(notification): notification center + persist opt-in for background must-see toasts

### DIFF
--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -48,6 +48,7 @@ import {
 import { registerAppConfigSync, registerSettingsCommand, SettingsModal } from "../settings";
 import { SidebarPane } from "../sidebar";
 import { registerThemeCommand, TerminalPane } from "../terminal";
+import NotificationCenterPanel from "./NotificationCenterPanel.vue";
 import NotificationToast from "./NotificationToast.vue";
 import ResizeHandle from "./ResizeHandle.vue";
 import { rpcWindowClose } from "./rpc";
@@ -355,6 +356,7 @@ watch(
     <FileHistoryPopover />
     <UnsavedDraftConfirmDialog />
     <NotificationToast />
+    <NotificationCenterPanel />
   </div>
 </template>
 

--- a/apps/renderer/src/features/layout/NotificationCenterItem.vue
+++ b/apps/renderer/src/features/layout/NotificationCenterItem.vue
@@ -1,0 +1,149 @@
+<doc lang="md">
+Notification center の 1 行。toast (NotificationToastItem) と同じ通知を表示するが、
+一覧の中の行として時刻・累計回数を持ち、dismiss ではなく center からの削除を emit する。
+
+## 動作
+
+- `cause` がある場合のみメッセージをクリック可能にし、詳細（cause chain）を展開する
+- 詳細パネルには Copy ボタンを併設し、message + 詳細をクリップボードへコピーする
+- `count` が 2 以上なら累計発生回数チップを出す（重複抑制で 1 項目に集約されるため）
+</doc>
+
+<script setup lang="ts">
+import { computed, ref, type FunctionalComponent, type SVGAttributes } from "vue";
+import { writeClipboardText } from "../../shared/clipboard";
+import type { Notification } from "../../shared/notification";
+import { formatCauseChain } from "./formatCause";
+import IconLucideCheck from "~icons/lucide/check";
+import IconLucideChevronDown from "~icons/lucide/chevron-down";
+import IconLucideCircleX from "~icons/lucide/circle-x";
+import IconLucideCopy from "~icons/lucide/copy";
+import IconLucideInfo from "~icons/lucide/info";
+import IconLucideTriangleAlert from "~icons/lucide/triangle-alert";
+import IconLucideX from "~icons/lucide/x";
+
+const props = defineProps<{ notification: Notification }>();
+
+defineEmits<{ remove: [] }>();
+
+type CopyState = "idle" | "copied" | "failed";
+
+const expanded = ref(false);
+const copyState = ref<CopyState>("idle");
+
+const COPY_FEEDBACK_MS = 1500;
+
+const copyLabelMap: Record<CopyState, string> = {
+  idle: "Copy",
+  copied: "Copied",
+  failed: "Failed",
+};
+
+const copyIconMap: Record<CopyState, FunctionalComponent<SVGAttributes>> = {
+  idle: IconLucideCopy,
+  copied: IconLucideCheck,
+  failed: IconLucideTriangleAlert,
+};
+
+const iconMap: Record<Notification["type"], FunctionalComponent<SVGAttributes>> = {
+  error: IconLucideCircleX,
+  warning: IconLucideTriangleAlert,
+  info: IconLucideInfo,
+};
+
+const iconColorMap: Record<Notification["type"], string> = {
+  error: "text-destructive-text",
+  warning: "text-warning-text",
+  info: "text-primary-text",
+};
+
+const hasCause = computed(() => props.notification.cause !== undefined);
+
+const detail = computed(() => formatCauseChain(props.notification.cause));
+
+/** epoch ms → HH:MM:SS。center は同日運用が主なので日付は出さない。 */
+const time = computed(() => {
+  const d = new Date(props.notification.at);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+});
+
+function toggle() {
+  if (!hasCause.value) return;
+  expanded.value = !expanded.value;
+}
+
+async function copyDetail() {
+  const text = `${props.notification.message}\n\n${detail.value}`;
+  const result = await writeClipboardText(text);
+  copyState.value = result.ok ? "copied" : "failed";
+  setTimeout(() => {
+    copyState.value = "idle";
+  }, COPY_FEEDBACK_MS);
+}
+</script>
+
+<template>
+  <div class="flex flex-col border-b border-border-subtle">
+    <div class="flex items-start gap-2 px-3 py-2">
+      <component
+        :is="iconMap[notification.type]"
+        :class="['mt-0.5 size-4 shrink-0', iconColorMap[notification.type]]"
+      />
+      <div class="min-w-0 flex-1">
+        <button
+          type="button"
+          :class="[
+            'w-full text-left text-sm break-all text-foreground',
+            hasCause ? 'cursor-pointer hover:underline' : 'cursor-default',
+          ]"
+          :aria-expanded="hasCause ? expanded : undefined"
+          :disabled="!hasCause"
+          :title="hasCause ? (expanded ? 'Hide details' : 'Show details') : undefined"
+          @click="toggle"
+        >
+          <span class="flex items-center gap-1">
+            <span :class="hasCause ? '' : 'select-text'">{{ notification.message }}</span>
+            <IconLucideChevronDown
+              v-if="hasCause"
+              class="size-3 shrink-0 text-foreground-low transition-transform"
+              :class="expanded ? 'rotate-180' : ''"
+            />
+          </span>
+        </button>
+        <div class="flex items-center gap-2 text-[11px] text-foreground-low">
+          <span class="tabular-nums">{{ time }}</span>
+          <span
+            v-if="notification.count > 1"
+            class="rounded-sm bg-element px-1 font-semibold tabular-nums"
+          >
+            ×{{ notification.count }}
+          </span>
+        </div>
+      </div>
+      <button
+        type="button"
+        class="shrink-0 cursor-pointer text-foreground-low hover:text-foreground"
+        aria-label="Remove notification"
+        @click="$emit('remove')"
+      >
+        <IconLucideX class="size-4" />
+      </button>
+    </div>
+    <div v-if="hasCause && expanded" class="border-t border-border-subtle px-3 py-2">
+      <div class="mb-2 flex justify-end">
+        <button
+          type="button"
+          class="flex cursor-pointer items-center gap-1 rounded-sm border border-border-subtle px-2 py-0.5 text-xs text-foreground hover:bg-element-hover"
+          @click="copyDetail"
+        >
+          <component :is="copyIconMap[copyState]" class="size-3" />
+          {{ copyLabelMap[copyState] }}
+        </button>
+      </div>
+      <pre
+        class="max-h-64 overflow-auto font-mono text-xs break-all whitespace-pre-wrap text-foreground select-text"
+        >{{ detail }}</pre>
+    </div>
+  </div>
+</template>

--- a/apps/renderer/src/features/layout/NotificationCenterPanel.vue
+++ b/apps/renderer/src/features/layout/NotificationCenterPanel.vue
@@ -1,0 +1,104 @@
+<doc lang="md">
+Notification center パネル。auto-dismiss で消えた toast も含む全通知の受け皿
+（VS Code の notification center と同役割）。toast は一時表示、center は永続記録という
+分業で、auto-dismiss が silent drop にならないことを構造的に保証する。
+
+## 設計判断
+
+- EventLogPanel / ServerListPanel と同じ右ドック popover 流儀 (`popover="manual"` で
+  top layer、ESC 自前閉じ)。開閉 SSOT は useNotificationCenterStore、通知データの SSOT は
+  shared/notification
+- 表示順は seq 降順（新着順）。重複抑制で集約された項目は再発生のたびに seq が進むため、
+  再発生した通知が自動的に先頭へ浮上する
+</doc>
+
+<script setup lang="ts">
+import { useEventListener } from "@vueuse/core";
+import { computed, useTemplateRef, watch } from "vue";
+import { useNotificationStore } from "../../shared/notification";
+import NotificationCenterItem from "./NotificationCenterItem.vue";
+import { useNotificationCenterStore } from "./useNotificationCenterStore";
+import IconLucideBell from "~icons/lucide/bell";
+import IconLucideTrash2 from "~icons/lucide/trash-2";
+import IconLucideX from "~icons/lucide/x";
+
+const store = useNotificationCenterStore();
+const { notifications, remove, clear } = useNotificationStore();
+
+/** 新着順。seq は発生 (再発生含む) ごとに進む単調増加値。 */
+const sorted = computed(() => [...notifications.value].sort((a, b) => b.seq - a.seq));
+
+// popover="manual" のため OS の auto dismiss が無い。ESC を自前で受けて閉じる
+// (EventLogPanel と同じく前面 modal dialog には譲る)。
+useEventListener(window, "keydown", (e: KeyboardEvent) => {
+  if (e.defaultPrevented) return;
+  if (e.code !== "Escape" || !store.isOpen) return;
+  if (document.querySelector("dialog[open]") !== null) return;
+  e.preventDefault();
+  store.close();
+});
+
+const panelRef = useTemplateRef<HTMLElement>("panel");
+// template ref が null に戻った時点 (unmount) に bindPopover(undefined) で dangling を切る。
+watch(panelRef, (el) => store.bindPopover(el ?? undefined), { immediate: true });
+</script>
+
+<template>
+  <div
+    ref="panel"
+    popover="manual"
+    class="_notification-center-popover w-[420px] flex-col border-0 border-l border-border bg-panel p-0 shadow-xl [&:popover-open]:flex"
+  >
+    <header class="flex items-center gap-2 border-b border-border px-3 py-2">
+      <IconLucideBell class="size-4 text-foreground-low" />
+      <h2 class="flex-1 text-sm font-medium text-foreground">Notifications</h2>
+      <button
+        type="button"
+        aria-label="Clear all"
+        :disabled="notifications.length === 0"
+        class="grid size-6 place-items-center rounded-sm text-foreground-low hover:bg-element-hover hover:text-foreground disabled:pointer-events-none disabled:text-foreground-muted"
+        @click="clear()"
+      >
+        <IconLucideTrash2 class="size-4" />
+      </button>
+      <button
+        type="button"
+        aria-label="Close"
+        class="grid size-6 place-items-center rounded-sm text-foreground-low hover:bg-element-hover hover:text-foreground"
+        @click="store.close()"
+      >
+        <IconLucideX class="size-4" />
+      </button>
+    </header>
+
+    <div
+      v-if="store.isOpen && sorted.length === 0"
+      class="px-3 py-8 text-center text-xs text-foreground-low"
+    >
+      No notifications
+    </div>
+
+    <div v-else-if="store.isOpen" class="min-h-0 flex-1 overflow-y-auto">
+      <NotificationCenterItem
+        v-for="n in sorted"
+        :key="n.id"
+        :notification="n"
+        @remove="remove(n.id)"
+      />
+    </div>
+  </div>
+</template>
+
+<style>
+._notification-center-popover {
+  /* タイトルバー (drag 領域) を覆わないよう、上端をその直下に置き右端に沿わせる (EventLogPanel と同流儀) */
+  inset: unset;
+  margin: 0;
+  top: var(--titlebar-height);
+  right: 0;
+  bottom: 0;
+  /* UA スタイル [popover] { height: fit-content } を打ち消し、top + bottom の伸縮を効かせる */
+  height: auto;
+  max-height: none;
+}
+</style>

--- a/apps/renderer/src/features/layout/NotificationToast.vue
+++ b/apps/renderer/src/features/layout/NotificationToast.vue
@@ -4,7 +4,7 @@ Popover API (`popover="manual"`) によるトースト通知。
 ## 動作
 
 - 通知が存在する間 popover を open にし、空になったら hide する
-- 全種別とも自動消去せず手動クローズのみ（store 側の契約）
+- error と `persist` 指定の通知は手動クローズのみ、それ以外の warning / info は自動消去（store 側で管理）
 - 複数通知は下から上へスタック表示
 </doc>
 

--- a/apps/renderer/src/features/layout/NotificationToast.vue
+++ b/apps/renderer/src/features/layout/NotificationToast.vue
@@ -3,8 +3,9 @@ Popover API (`popover="manual"`) によるトースト通知。
 
 ## 動作
 
-- 通知が存在する間 popover を open にし、空になったら hide する
+- toast 表示中の通知（store の `toasts` view）が存在する間 popover を open にし、空になったら hide する
 - error と `persist` 指定の通知は手動クローズのみ、それ以外の warning / info は自動消去（store 側で管理）
+- dismiss は toast を畳むだけで、通知自体は notification center に残る
 - 複数通知は下から上へスタック表示
 </doc>
 
@@ -14,13 +15,13 @@ import { useTemplateRef, watch } from "vue";
 import { useNotificationStore } from "../../shared/notification";
 import NotificationToastItem from "./NotificationToastItem.vue";
 
-const { notifications, dismiss } = useNotificationStore();
+const { toasts, dismiss } = useNotificationStore();
 
 const popoverRef = useTemplateRef<HTMLElement>("popover");
 
-// 通知の有無に応じて popover を開閉
+// toast の有無に応じて popover を開閉
 watch(
-  () => notifications.value.length,
+  () => toasts.value.length,
   (len) => {
     const el = popoverRef.value;
     if (!el) return;
@@ -32,10 +33,10 @@ watch(
   },
 );
 
-// popover が外部要因で閉じられた場合に全通知をクリア
+// popover が外部要因で閉じられた場合に全 toast を畳む（center には残る）
 useEventListener(popoverRef, "toggle", (e: ToggleEvent) => {
   if (e.newState === "closed") {
-    for (const n of notifications.value) {
+    for (const n of toasts.value) {
       dismiss(n.id);
     }
   }
@@ -49,7 +50,7 @@ useEventListener(popoverRef, "toggle", (e: ToggleEvent) => {
     class="_notification-toast pointer-events-none m-0 flex flex-col items-end gap-2 border-0 bg-transparent p-4 [&:popover-open]:flex"
   >
     <NotificationToastItem
-      v-for="n in notifications"
+      v-for="n in toasts"
       :key="n.id"
       :type="n.type"
       :message="n.message"

--- a/apps/renderer/src/features/layout/NotificationToast.vue
+++ b/apps/renderer/src/features/layout/NotificationToast.vue
@@ -4,7 +4,7 @@ Popover API (`popover="manual"`) によるトースト通知。
 ## 動作
 
 - 通知が存在する間 popover を open にし、空になったら hide する
-- error は手動クローズのみ、warning / info は自動消去（store 側で管理）
+- 全種別とも自動消去せず手動クローズのみ（store 側の契約）
 - 複数通知は下から上へスタック表示
 </doc>
 

--- a/apps/renderer/src/features/layout/TitleBar.vue
+++ b/apps/renderer/src/features/layout/TitleBar.vue
@@ -23,8 +23,10 @@ import { onMessage } from "../../shared/rpc";
 import { useEventLogStore } from "../event-log";
 import { useServerStore } from "../server";
 import { channelChipLabel } from "./channel";
+import { useNotificationCenterStore } from "./useNotificationCenterStore";
 import { useTitleContext } from "./useTitleContext";
 import IconLucideActivity from "~icons/lucide/activity";
+import IconLucideBell from "~icons/lucide/bell";
 import IconLucideServer from "~icons/lucide/server";
 
 /** main の enter/leave-full-screen から届く push。payload 型は購読側が SSOT（docs/rpc.md） */
@@ -36,6 +38,7 @@ const channelChip = channelChipLabel();
 const title = useTitleContext();
 const serverStore = useServerStore();
 const eventLogStore = useEventLogStore();
+const notificationCenterStore = useNotificationCenterStore();
 
 // fullscreen では macOS が信号機ボタンを消すため pad を畳む。初期値 false は
 // 「ウィンドウは非 fullscreen で生成される」前提。pull hydrate は持たない
@@ -95,6 +98,26 @@ onUnmounted(disposeFullscreen);
         @click="eventLogStore.toggle()"
       >
         <IconLucideActivity class="size-3.5" />
+      </button>
+      <button
+        type="button"
+        class="relative grid size-6 place-items-center rounded-sm hover:bg-element-hover"
+        :class="
+          notificationCenterStore.isOpen
+            ? 'text-primary-text'
+            : 'text-foreground-low hover:text-foreground'
+        "
+        title="Notifications"
+        aria-label="Notifications"
+        @click="notificationCenterStore.toggle()"
+      >
+        <IconLucideBell class="size-3.5" />
+        <!-- 未読ドット。未読に error を含むときだけ destructive で目立たせる -->
+        <span
+          v-if="notificationCenterStore.unseenCount > 0"
+          class="absolute top-0.5 right-0.5 size-1.5 rounded-full"
+          :class="notificationCenterStore.hasUnseenError ? 'bg-destructive' : 'bg-primary'"
+        ></span>
       </button>
     </div>
   </div>

--- a/apps/renderer/src/features/layout/useNotificationCenterStore.ts
+++ b/apps/renderer/src/features/layout/useNotificationCenterStore.ts
@@ -1,0 +1,61 @@
+import { acceptHMRUpdate, defineStore } from "pinia";
+import { computed, ref, watch } from "vue";
+import { useNotificationStore } from "../../shared/notification";
+
+/**
+ * Notification center パネルの開閉 + 未読管理の SSOT。EventLogPanel / ServerListPanel と
+ * 同じ右ドック popover 流儀で、開閉状態を store が所有し popover DOM へのミラーは
+ * `open()` / `close()` が担う。通知データ自体は `shared/notification` が SSOT で、
+ * 本 store は開閉と既読位置 (`lastSeenSeq`) だけを扱う。
+ *
+ * 未読は「seq が lastSeenSeq より新しい項目」。seq は重複抑制の再発生でも進むため、
+ * 既存項目への再発生も未読に戻る。パネルが開いている間は watch が既読位置を最新 seq に
+ * 追従させるので、開いた瞬間 + 開いている間の新着は即座に既読化される。
+ */
+export const useNotificationCenterStore = defineStore("notificationCenter", () => {
+  const { notifications } = useNotificationStore();
+
+  const popoverEl = ref<HTMLElement>();
+  const isOpen = ref(false);
+  const lastSeenSeq = ref(0);
+
+  const latestSeq = computed(() => notifications.value.reduce((max, n) => Math.max(max, n.seq), 0));
+  const unseen = computed(() => notifications.value.filter((n) => n.seq > lastSeenSeq.value));
+  const unseenCount = computed(() => unseen.value.length);
+  const hasUnseenError = computed(() => unseen.value.some((n) => n.type === "error"));
+
+  watch([isOpen, latestSeq], ([open, seq]) => {
+    if (open) lastSeenSeq.value = seq;
+  });
+
+  function bindPopover(el: HTMLElement | undefined): void {
+    popoverEl.value = el;
+  }
+  function open(): void {
+    if (isOpen.value) return;
+    const el = popoverEl.value;
+    if (!el) return;
+    el.showPopover();
+    isOpen.value = true;
+  }
+  function close(): void {
+    if (!isOpen.value) return;
+    const el = popoverEl.value;
+    if (!el) return;
+    el.hidePopover();
+    isOpen.value = false;
+  }
+  function toggle(): void {
+    if (isOpen.value) {
+      close();
+    } else {
+      open();
+    }
+  }
+
+  return { isOpen, unseenCount, hasUnseenError, bindPopover, open, close, toggle };
+});
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useNotificationCenterStore, import.meta.hot));
+}

--- a/apps/renderer/src/features/worktree/useRemoteFetchStore.ts
+++ b/apps/renderer/src/features/worktree/useRemoteFetchStore.ts
@@ -43,7 +43,9 @@ export function isRepoFetchDue(args: {
  * 既存規律:
  * - in-flight ロックで同 rootDir 並列発射を抑止 (`inFlight` Map で dedup)
  * - 成功時は 180s、失敗時は 30s の backoff
- * - 失敗は `notify.info` で通知 (CLAUDE.md `console.error で握り潰さない`)
+ * - 失敗は `notify.info` の persist 指定で通知 (CLAUDE.md `console.error で握り潰さない`)。
+ *   background 発火でユーザーが目撃前に自動消去されると silent drop と等価になるため、
+ *   手動クローズまで残す
  *
  * ## public API は 2 経路のみ
  *
@@ -93,13 +95,15 @@ export const useRemoteFetchStore = defineStore("remoteFetch", () => {
       const now = Date.now();
       if (!result.ok) {
         logEvent("fetch", "error", name);
-        notify.info(`Background git fetch failed for ${rootDir}`, result.error);
+        notify.info(`Background git fetch failed for ${rootDir}`, result.error, { persist: true });
         nextFetchAllowedAt.set(rootDir, now + REMOTE_FETCH_FAILURE_BACKOFF_MS);
         return false;
       }
       if (!result.value.ok) {
         logEvent("fetch", "error", name);
-        notify.info(`Background git fetch failed for ${rootDir}`, result.value.errorDetail);
+        notify.info(`Background git fetch failed for ${rootDir}`, result.value.errorDetail, {
+          persist: true,
+        });
         nextFetchAllowedAt.set(rootDir, now + REMOTE_FETCH_FAILURE_BACKOFF_MS);
         return false;
       }

--- a/apps/renderer/src/shared/notification/index.ts
+++ b/apps/renderer/src/shared/notification/index.ts
@@ -1,2 +1,3 @@
 export { useNotificationStore } from "./useNotificationStore";
+export type { Notification } from "./useNotificationStore";
 export type { NotifyPayload } from "./types";

--- a/apps/renderer/src/shared/notification/useNotificationStore.test.ts
+++ b/apps/renderer/src/shared/notification/useNotificationStore.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
-import { useNotificationStore } from "./useNotificationStore";
+import { MAX_NOTIFICATIONS, useNotificationStore } from "./useNotificationStore";
 
 const store = useNotificationStore();
 
@@ -124,6 +124,22 @@ describe("center 操作", () => {
     store.remove(second!.id);
     expect(store.notifications.value).toHaveLength(1);
     expect(store.notifications.value[0]?.id).toBe(first!.id);
+  });
+
+  test("上限超過は最終発生が最も古い項目から落ち、再発生した項目は残る", () => {
+    for (let i = 0; i < MAX_NOTIFICATIONS; i++) {
+      store.info(`msg ${i}`);
+    }
+    // msg 0 の再発生で seq が進む (配列位置は先頭のまま)
+    store.info("msg 0");
+
+    store.info("overflow trigger");
+    expect(store.notifications.value).toHaveLength(MAX_NOTIFICATIONS);
+
+    const messages = store.notifications.value.map((n) => n.message);
+    expect(messages).toContain("msg 0");
+    // 最終発生が最も古いのは msg 1 (msg 0 は再発生で保護される)
+    expect(messages).not.toContain("msg 1");
   });
 
   test("clear は全項目を削除し pending timer も解放する", () => {

--- a/apps/renderer/src/shared/notification/useNotificationStore.test.ts
+++ b/apps/renderer/src/shared/notification/useNotificationStore.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { useNotificationStore } from "./useNotificationStore";
+
+const store = useNotificationStore();
+
+// bun:test は setTimeout の fake timer を持たないため、spyOn で捕捉して同期発火させる。
+// clearTimeout が pendingTimers から消すので、「解除済み timer は発火しない」も再現される。
+const pendingTimers = new Map<number, () => void>();
+let fakeTimerId = 0;
+
+function fireAllTimers() {
+  const callbacks = [...pendingTimers.values()];
+  pendingTimers.clear();
+  for (const cb of callbacks) cb();
+}
+
+let spies: Array<{ mockRestore: () => void }> = [];
+
+beforeEach(() => {
+  pendingTimers.clear();
+  fakeTimerId = 0;
+  spies = [
+    spyOn(globalThis, "setTimeout").mockImplementation(((cb: () => void) => {
+      pendingTimers.set(++fakeTimerId, cb);
+      return fakeTimerId as unknown as ReturnType<typeof setTimeout>;
+    }) as never),
+    spyOn(globalThis, "clearTimeout").mockImplementation(((id: number) => {
+      pendingTimers.delete(id);
+    }) as never),
+  ];
+  // add() の console 出力はテストログに残る (store が module load 時に console.* を
+  // CONSOLE_BY_TYPE へ束縛するため後付け spy では黙らせられない)。観察ログなので許容する
+  store.clear();
+});
+
+afterEach(() => {
+  store.clear();
+  for (const spy of spies) spy.mockRestore();
+});
+
+describe("auto-dismiss", () => {
+  test("非 persist の info は時間経過で toast が畳まれ、center には残る", () => {
+    store.info("copied");
+    expect(store.toasts.value).toHaveLength(1);
+
+    fireAllTimers();
+    expect(store.toasts.value).toHaveLength(0);
+    expect(store.notifications.value).toHaveLength(1);
+    expect(store.notifications.value[0]?.toastVisible).toBe(false);
+  });
+
+  test("persist 指定の info は timer が張られず時間経過後も toast が残る", () => {
+    store.info("fetch failed", undefined, { persist: true });
+    expect(pendingTimers.size).toBe(0);
+
+    fireAllTimers();
+    expect(store.toasts.value).toHaveLength(1);
+  });
+
+  test("error は opt-in なしで常に persist", () => {
+    store.error("boom");
+    expect(pendingTimers.size).toBe(0);
+
+    fireAllTimers();
+    expect(store.toasts.value).toHaveLength(1);
+  });
+});
+
+describe("重複抑制と persist 昇格", () => {
+  test("表示中の非 persist toast への persist 要求は timer を解除して永続へ昇格する", () => {
+    store.info("fetch failed");
+    expect(pendingTimers.size).toBe(1);
+
+    store.info("fetch failed", undefined, { persist: true });
+    expect(pendingTimers.size).toBe(0);
+
+    fireAllTimers();
+    expect(store.toasts.value).toHaveLength(1);
+    expect(store.notifications.value[0]?.count).toBe(2);
+  });
+
+  test("persist 済み項目への非 persist 要求では降格しない", () => {
+    store.info("fetch failed", undefined, { persist: true });
+    store.info("fetch failed");
+    expect(pendingTimers.size).toBe(0);
+
+    fireAllTimers();
+    expect(store.toasts.value).toHaveLength(1);
+  });
+
+  test("再発生は toast を出し直し count / seq を進める", () => {
+    store.info("copied");
+    fireAllTimers();
+    expect(store.toasts.value).toHaveLength(0);
+    const firstSeq = store.notifications.value[0]?.seq;
+
+    store.info("copied");
+    expect(store.toasts.value).toHaveLength(1);
+    expect(store.notifications.value).toHaveLength(1);
+    expect(store.notifications.value[0]?.count).toBe(2);
+    expect(store.notifications.value[0]?.seq).toBeGreaterThan(firstSeq ?? Infinity);
+  });
+
+  test("非 persist の再発生は timer を張り直す", () => {
+    store.info("copied");
+    store.info("copied");
+    expect(pendingTimers.size).toBe(1);
+
+    fireAllTimers();
+    expect(store.toasts.value).toHaveLength(0);
+  });
+});
+
+describe("center 操作", () => {
+  test("dismiss は toast だけ畳み、remove は項目ごと削除する", () => {
+    store.info("a", undefined, { persist: true });
+    store.info("b", undefined, { persist: true });
+    const [first, second] = store.notifications.value;
+
+    store.dismiss(first!.id);
+    expect(store.toasts.value).toHaveLength(1);
+    expect(store.notifications.value).toHaveLength(2);
+
+    store.remove(second!.id);
+    expect(store.notifications.value).toHaveLength(1);
+    expect(store.notifications.value[0]?.id).toBe(first!.id);
+  });
+
+  test("clear は全項目を削除し pending timer も解放する", () => {
+    store.info("a");
+    store.info("b");
+    expect(pendingTimers.size).toBe(2);
+
+    store.clear();
+    expect(store.notifications.value).toHaveLength(0);
+    expect(pendingTimers.size).toBe(0);
+  });
+});

--- a/apps/renderer/src/shared/notification/useNotificationStore.ts
+++ b/apps/renderer/src/shared/notification/useNotificationStore.ts
@@ -1,6 +1,7 @@
 /**
  * 通知ストア。module singleton パターン。
- * トースト通知の追加・削除・タイムアウト管理を行う。
+ * トースト通知の追加・削除を行う。全種別とも自動消去せず手動クローズのみ
+ * (背景処理の失敗通知は目撃前に消えると silent drop と等価になるため)。
  *
  * `error` / `warning` / `info` は toast 表示 + console 出力、`debug` は **console.debug への
  * 集約窓口**で toast 表示なし。renderer 規約 (CLAUDE.md エラーハンドリング) で
@@ -16,12 +17,8 @@ interface Notification {
   cause?: unknown;
 }
 
-/** warning / info 通知の自動消去時間（ms）。error は手動クローズのみ */
-const AUTO_DISMISS_MS = 5000;
-
 let nextId = 0;
 const notifications = ref<Notification[]>([]);
-const timers = new Map<number, ReturnType<typeof setTimeout>>();
 
 /**
  * 最後に発火した通知イベント。`add()` のたびに (重複抑制で toast を追加しなかった場合も)
@@ -59,21 +56,10 @@ function add(type: Notification["type"], message: string, cause?: unknown) {
     return;
   }
 
-  const id = nextId++;
-  notifications.value.push({ id, type, message, cause });
-
-  if (type !== "error") {
-    const timer = setTimeout(() => dismiss(id), AUTO_DISMISS_MS);
-    timers.set(id, timer);
-  }
+  notifications.value.push({ id: nextId++, type, message, cause });
 }
 
 function dismiss(id: number) {
-  const timer = timers.get(id);
-  if (timer !== undefined) {
-    clearTimeout(timer);
-    timers.delete(id);
-  }
   notifications.value = notifications.value.filter((n) => n.id !== id);
 }
 

--- a/apps/renderer/src/shared/notification/useNotificationStore.ts
+++ b/apps/renderer/src/shared/notification/useNotificationStore.ts
@@ -36,8 +36,8 @@ export interface Notification {
 
 /** persist しない warning / info toast の自動消去時間（ms） */
 const AUTO_DISMISS_MS = 5000;
-/** center に保持する通知数の上限。超過分は古い順に落とす */
-const MAX_NOTIFICATIONS = 100;
+/** center に保持する通知数の上限。超過分は最終発生が古い順 (seq 昇順) に落とす */
+export const MAX_NOTIFICATIONS = 100;
 
 interface NotifyOptions {
   /** true でユーザーが閉じるまで toast を残す。background 発火の must-see 通知用（ヘッダコメント参照） */
@@ -117,13 +117,20 @@ function add(type: Notification["type"], message: string, cause?: unknown, opts?
     toastVisible: true,
   });
 
-  // 上限超過は古い順に落とす (toast 表示中でも落とす。100 件溜まる時点で異常系であり、
-  // 表示保護より上限保証を優先する)
+  // 上限超過は最終発生が最も古い項目 (最小 seq) から落とす (persist でも落とす。100 件
+  // 溜まる時点で異常系であり、表示保護より上限保証を優先する)。配列位置 = 初回発生順を
+  // 基準にすると、重複抑制で in-place 更新され続ける再発火中の must-see (背景 fetch 失敗等)
+  // が先頭に居座ったまま最優先で消えるため、seq (最新発生順) を基準にする
   const overflow = notifications.value.length - MAX_NOTIFICATIONS;
   if (overflow > 0) {
-    for (const dropped of notifications.value.splice(0, overflow)) {
-      clearTimer(dropped.id);
-    }
+    const dropIds = new Set(
+      [...notifications.value]
+        .sort((a, b) => a.seq - b.seq)
+        .slice(0, overflow)
+        .map((n) => n.id),
+    );
+    for (const dropId of dropIds) clearTimer(dropId);
+    notifications.value = notifications.value.filter((n) => !dropIds.has(n.id));
   }
 
   if (!persistRequested) {

--- a/apps/renderer/src/shared/notification/useNotificationStore.ts
+++ b/apps/renderer/src/shared/notification/useNotificationStore.ts
@@ -66,6 +66,11 @@ function add(type: Notification["type"], message: string, cause?: unknown, opts?
   const duplicate = notifications.value.find((n) => n.type === type && n.message === message);
   if (duplicate) {
     duplicate.cause = cause;
+    // persist は昇格のみ反映する (timer を解除して手動クローズ化)。降格はしない:
+    // 表示中の must-see を後発の非 persist 要求が短縮すると silent drop に戻るため
+    if (opts?.persist === true) {
+      clearTimer(duplicate.id);
+    }
     return;
   }
 
@@ -79,12 +84,16 @@ function add(type: Notification["type"], message: string, cause?: unknown, opts?
   }
 }
 
-function dismiss(id: number) {
+function clearTimer(id: number) {
   const timer = timers.get(id);
   if (timer !== undefined) {
     clearTimeout(timer);
     timers.delete(id);
   }
+}
+
+function dismiss(id: number) {
+  clearTimer(id);
   notifications.value = notifications.value.filter((n) => n.id !== id);
 }
 

--- a/apps/renderer/src/shared/notification/useNotificationStore.ts
+++ b/apps/renderer/src/shared/notification/useNotificationStore.ts
@@ -1,7 +1,11 @@
 /**
  * 通知ストア。module singleton パターン。
- * トースト通知の追加・削除を行う。全種別とも自動消去せず手動クローズのみ
- * (背景処理の失敗通知は目撃前に消えると silent drop と等価になるため)。
+ * トースト通知の追加・削除・タイムアウト管理を行う。
+ *
+ * 永続化 (自動消去しない) の軸は重大度 (type) ではなく「ユーザーが画面を見ているか」:
+ * ユーザー操作への応答 (Copied 等の確認) は目撃済みなので自動消去し、ユーザー操作を
+ * 伴わず background で発火する must-see 通知 (背景 fetch の失敗等) は目撃前に消えると
+ * silent drop と等価になるため `persist` opt-in で手動クローズまで残す。error は常に永続。
  *
  * `error` / `warning` / `info` は toast 表示 + console 出力、`debug` は **console.debug への
  * 集約窓口**で toast 表示なし。renderer 規約 (CLAUDE.md エラーハンドリング) で
@@ -17,8 +21,17 @@ interface Notification {
   cause?: unknown;
 }
 
+/** persist しない warning / info 通知の自動消去時間（ms） */
+const AUTO_DISMISS_MS = 5000;
+
+interface NotifyOptions {
+  /** true でユーザーが閉じるまで残す。background 発火の must-see 通知用（ヘッダコメント参照） */
+  persist?: boolean;
+}
+
 let nextId = 0;
 const notifications = ref<Notification[]>([]);
+const timers = new Map<number, ReturnType<typeof setTimeout>>();
 
 /**
  * 最後に発火した通知イベント。`add()` のたびに (重複抑制で toast を追加しなかった場合も)
@@ -44,7 +57,7 @@ const CONSOLE_BY_TYPE = {
  * 同一メッセージの重複を抑制する。既に表示中ならトーストは追加せず、cause だけ最新で上書きする。
  * cause を上書きするのは、ユーザーが Copy する詳細を最新の発生時点に揃えるため。
  */
-function add(type: Notification["type"], message: string, cause?: unknown) {
+function add(type: Notification["type"], message: string, cause?: unknown, opts?: NotifyOptions) {
   CONSOLE_BY_TYPE[type](message, ...(cause !== undefined ? [cause] : []));
 
   // 発生イベントは toast の表示有無と独立に毎回配る (重複抑制で toast を足さない場合も含む)
@@ -56,10 +69,22 @@ function add(type: Notification["type"], message: string, cause?: unknown) {
     return;
   }
 
-  notifications.value.push({ id: nextId++, type, message, cause });
+  const id = nextId++;
+  notifications.value.push({ id, type, message, cause });
+
+  const persist = type === "error" || opts?.persist === true;
+  if (!persist) {
+    const timer = setTimeout(() => dismiss(id), AUTO_DISMISS_MS);
+    timers.set(id, timer);
+  }
 }
 
 function dismiss(id: number) {
+  const timer = timers.get(id);
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    timers.delete(id);
+  }
   notifications.value = notifications.value.filter((n) => n.id !== id);
 }
 
@@ -78,8 +103,10 @@ export function useNotificationStore() {
     notifications,
     lastEvent,
     error: (message: string, cause?: unknown) => add("error", message, cause),
-    warning: (message: string, cause?: unknown) => add("warning", message, cause),
-    info: (message: string, cause?: unknown) => add("info", message, cause),
+    warning: (message: string, cause?: unknown, opts?: NotifyOptions) =>
+      add("warning", message, cause, opts),
+    info: (message: string, cause?: unknown, opts?: NotifyOptions) =>
+      add("info", message, cause, opts),
     debug,
     dismiss,
   };

--- a/apps/renderer/src/shared/notification/useNotificationStore.ts
+++ b/apps/renderer/src/shared/notification/useNotificationStore.ts
@@ -1,37 +1,55 @@
 /**
  * 通知ストア。module singleton パターン。
- * トースト通知の追加・削除・タイムアウト管理を行う。
+ * toast と notification center の共有 SSOT。通知リストは 1 本で、toast はその view
+ * (`toastVisible` な項目のみ)。auto-dismiss / 手動 dismiss は toast の表示を畳むだけで
+ * 項目は center に残り、項目の削除は center 側の `remove` / `clear` だけが行う
+ * (VS Code の toasts / notification center と同じ分業。auto-dismiss が silent drop に
+ * ならないのは center という受け皿があるため)。
  *
- * 永続化 (自動消去しない) の軸は重大度 (type) ではなく「ユーザーが画面を見ているか」:
- * ユーザー操作への応答 (Copied 等の確認) は目撃済みなので自動消去し、ユーザー操作を
- * 伴わず background で発火する must-see 通知 (背景 fetch の失敗等) は目撃前に消えると
- * silent drop と等価になるため `persist` opt-in で手動クローズまで残す。error は常に永続。
+ * toast の永続化 (自動消去しない) の軸は重大度 (type) ではなく「ユーザーが画面を見て
+ * いるか」: ユーザー操作への応答 (Copied 等の確認) は目撃済みなので自動消去し、
+ * ユーザー操作を伴わず background で発火する must-see 通知 (背景 fetch の失敗等) は
+ * `persist` opt-in で手動クローズまで残す。error は常に永続。
  *
  * `error` / `warning` / `info` は toast 表示 + console 出力、`debug` は **console.debug への
  * 集約窓口**で toast 表示なし。renderer 規約 (CLAUDE.md エラーハンドリング) で
  * 「呼び出し側で console を直書きしない (store 経由)」方針を満たすため、
  * 切り分け用 log もこの store 経由で発火する。
  */
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
-interface Notification {
+export interface Notification {
   id: number;
   type: "error" | "warning" | "info";
   message: string;
   cause?: unknown;
+  /** 最新の発生時刻 (epoch ms)。重複抑制時は最新発生で上書きする */
+  at: number;
+  /** 同一通知の累計発生回数 (重複抑制で加算) */
+  count: number;
+  /** 通知発生順の単調増加値。重複抑制時も更新され、center の未読判定 / 新着順ソートに使う */
+  seq: number;
+  persist: boolean;
+  /** toast として表示中か。false は center にのみ残る */
+  toastVisible: boolean;
 }
 
-/** persist しない warning / info 通知の自動消去時間（ms） */
+/** persist しない warning / info toast の自動消去時間（ms） */
 const AUTO_DISMISS_MS = 5000;
+/** center に保持する通知数の上限。超過分は古い順に落とす */
+const MAX_NOTIFICATIONS = 100;
 
 interface NotifyOptions {
-  /** true でユーザーが閉じるまで残す。background 発火の must-see 通知用（ヘッダコメント参照） */
+  /** true でユーザーが閉じるまで toast を残す。background 発火の must-see 通知用（ヘッダコメント参照） */
   persist?: boolean;
 }
 
 let nextId = 0;
 const notifications = ref<Notification[]>([]);
 const timers = new Map<number, ReturnType<typeof setTimeout>>();
+
+/** toast として表示中の項目だけの view (NotificationToast が購読)。 */
+const toasts = computed(() => notifications.value.filter((n) => n.toastVisible));
 
 /**
  * 最後に発火した通知イベント。`add()` のたびに (重複抑制で toast を追加しなかった場合も)
@@ -54,8 +72,11 @@ const CONSOLE_BY_TYPE = {
 } as const;
 
 /**
- * 同一メッセージの重複を抑制する。既に表示中ならトーストは追加せず、cause だけ最新で上書きする。
- * cause を上書きするのは、ユーザーが Copy する詳細を最新の発生時点に揃えるため。
+ * 同一 type + message は重複抑制で 1 項目に集約する。既存項目の cause / at / seq を最新の
+ * 発生時点に更新して count を加算し、toast を再表示する (dismiss 済みでも新しい発生は
+ * 新しい観測なので toast を出し直し、非 persist なら timer も張り直す)。
+ * persist は昇格のみ反映する: 表示中の must-see を後発の非 persist 要求が短縮すると
+ * silent drop に戻るため、降格はしない。
  */
 function add(type: Notification["type"], message: string, cause?: unknown, opts?: NotifyOptions) {
   CONSOLE_BY_TYPE[type](message, ...(cause !== undefined ? [cause] : []));
@@ -63,24 +84,53 @@ function add(type: Notification["type"], message: string, cause?: unknown, opts?
   // 発生イベントは toast の表示有無と独立に毎回配る (重複抑制で toast を足さない場合も含む)
   lastEvent.value = { type, seq: ++eventSeq };
 
+  const persistRequested = type === "error" || opts?.persist === true;
+
   const duplicate = notifications.value.find((n) => n.type === type && n.message === message);
   if (duplicate) {
     duplicate.cause = cause;
-    // persist は昇格のみ反映する (timer を解除して手動クローズ化)。降格はしない:
-    // 表示中の must-see を後発の非 persist 要求が短縮すると silent drop に戻るため
-    if (opts?.persist === true) {
-      clearTimer(duplicate.id);
+    duplicate.at = Date.now();
+    duplicate.count += 1;
+    duplicate.seq = eventSeq;
+    duplicate.persist = duplicate.persist || persistRequested;
+    duplicate.toastVisible = true;
+    clearTimer(duplicate.id);
+    if (!duplicate.persist) {
+      timers.set(
+        duplicate.id,
+        setTimeout(() => dismiss(duplicate.id), AUTO_DISMISS_MS),
+      );
     }
     return;
   }
 
   const id = nextId++;
-  notifications.value.push({ id, type, message, cause });
+  notifications.value.push({
+    id,
+    type,
+    message,
+    cause,
+    at: Date.now(),
+    count: 1,
+    seq: eventSeq,
+    persist: persistRequested,
+    toastVisible: true,
+  });
 
-  const persist = type === "error" || opts?.persist === true;
-  if (!persist) {
-    const timer = setTimeout(() => dismiss(id), AUTO_DISMISS_MS);
-    timers.set(id, timer);
+  // 上限超過は古い順に落とす (toast 表示中でも落とす。100 件溜まる時点で異常系であり、
+  // 表示保護より上限保証を優先する)
+  const overflow = notifications.value.length - MAX_NOTIFICATIONS;
+  if (overflow > 0) {
+    for (const dropped of notifications.value.splice(0, overflow)) {
+      clearTimer(dropped.id);
+    }
+  }
+
+  if (!persistRequested) {
+    timers.set(
+      id,
+      setTimeout(() => dismiss(id), AUTO_DISMISS_MS),
+    );
   }
 }
 
@@ -92,9 +142,27 @@ function clearTimer(id: number) {
   }
 }
 
+/** toast を畳む。項目は center に残る。 */
 function dismiss(id: number) {
   clearTimer(id);
+  const notification = notifications.value.find((n) => n.id === id);
+  if (!notification) return;
+  notification.toastVisible = false;
+}
+
+/** 項目を center から削除する (toast 表示中なら toast も消える)。 */
+function remove(id: number) {
+  clearTimer(id);
   notifications.value = notifications.value.filter((n) => n.id !== id);
+}
+
+/** 全項目を削除する。 */
+function clear() {
+  for (const timer of timers.values()) {
+    clearTimeout(timer);
+  }
+  timers.clear();
+  notifications.value = [];
 }
 
 /**
@@ -110,6 +178,7 @@ function debug(message: string, payload?: unknown) {
 export function useNotificationStore() {
   return {
     notifications,
+    toasts,
     lastEvent,
     error: (message: string, cause?: unknown) => add("error", message, cause),
     warning: (message: string, cause?: unknown, opts?: NotifyOptions) =>
@@ -118,5 +187,7 @@ export function useNotificationStore() {
       add("info", message, cause, opts),
     debug,
     dismiss,
+    remove,
+    clear,
   };
 }


### PR DESCRIPTION
## 概要

通知システムを「toast（一時表示）+ notification center（永続の受け皿）」の 2 層に再構成する。タイトルバー右上にトグルボタンを追加し、auto-dismiss で消えた通知も含む全通知を専用パネルで確認できるようにする。あわせて toast に `persist` opt-in を導入し、background で発火する must-see 通知（背景 git fetch の失敗）を手動クローズまで残す。

## 背景

起動時に背景 git fetch の失敗が info トーストで通知されるが、5 秒で自動消去されるため、ユーザーが画面を見ていないと読む前に消える。背景処理の失敗通知が目撃前に消えるのは、console.error だけで握りつぶす silent drop と体験上等価であり、renderer の「silent drop 禁止」規律と実質的に矛盾していた。

きっかけは upstream がタグを打ち直したことで `git fetch --all` が `would clobber existing tag` で失敗し続けたケース。30 秒 backoff で再試行のたびにトーストが出ては消えるため、ユーザーには「一瞬何か出たが読めない」状態になっていた。

toast の永続化の軸を重大度ではなく通知ごとの `persist` 明示に置くのは、`info` が「ユーザー操作の成功確認（Copied 等。操作直後で目撃済みなので自動消去すべき）」と「background の must-see 通知（見ていない可能性があるので永続化すべき）」の 2 つの意味論を担っており、同じ重大度でも望ましい永続化挙動が正反対になるため。重大度は永続化の判別軸になりえない。

auto-dismiss 機構の一律撤去は不採用。成功確認トーストまで永続化され、`Copied a.txt` / `Copied b.txt`（メッセージが異なるため重複抑制も効かない）が個別に手動 dismiss するまで積み上がる退行を持ち込む。

fetch 失敗を `error` に再分類する案も不採用。`ArcadeLayer` が error イベントで sfx + flash 演出を発火するため、offline 継続時に 30 秒ごとにエラー演出が鳴る副作用が出る。

構成は VS Code の notifications と同型（toast は severity 別 timeout の一時表示 + 呼び出し側 opt-in の `sticky`、notification center が永続の受け皿。auto-dismiss が silent drop にならないのは受け皿があるため）。gozd も center を受け皿として持つことで、auto-dismiss された通知の見落としを構造的に回収できる。

## 変更内容

### notification store（shared/notification）

- 通知リストを 1 本の SSOT に統一。toast は `toastVisible` な項目だけの computed view で、dismiss / auto-dismiss は toast を畳むだけ（項目は center に残る）。削除は center の `remove` / `clear` のみ
- `NotifyOptions.persist` を追加。`warning` / `info` が第 3 引数で受け取り、true なら auto-dismiss タイマーを掛けない。`error` は opt-in 不要で常に永続
- 重複抑制は同一 type + message を 1 項目に集約し、`count` 加算・`at` / `seq` 更新・toast 再表示・タイマー張り直しを行う。persist は昇格のみ（表示中の must-see を後発の非 persist 要求で短縮しない）
- 項目上限 100 件。超過は最終発生が最も古い項目（最小 seq）から落とす。配列位置（初回発生順）基準だと、重複抑制で in-place 更新され続ける再発火中の must-see が最優先で消えるため
- auto-dismiss / persist 昇格 / 重複抑制 / overflow eviction / center 操作の回帰テストを追加（bun:test は fake timer 未対応のため spyOn で setTimeout / clearTimeout を同期制御）

### notification center（features/layout）

- `NotificationCenterPanel`: EventLogPanel / ServerListPanel と同じ右ドック popover 流儀（`popover="manual"` + ESC 自前閉じ）。新着順（seq 降順）表示、項目ごとの削除、Clear all
- `NotificationCenterItem`: type アイコン、時刻（HH:MM:SS）、累計発生回数チップ（×N）、cause chain の展開 + Copy
- `useNotificationCenterStore`: 開閉 + 未読管理。未読は per-entry `seq` と `lastSeenSeq` の比較で、重複抑制の再発生でも未読に戻る。パネルが開いている間は既読位置が最新に追従
- TitleBar 右端に bell トグルボタンを追加（既存の Server / Event log と同列）。未読があるとドット表示、未読に error を含むときは destructive 色

### remote fetch

- 背景 fetch 失敗の `notify.info` 2 箇所（RPC reject / fetch 実行失敗）に `{ persist: true }` を指定

## 旧実装からの挙動変更・後退

- toast の X ボタン（および popover の外部クローズ）は通知の削除ではなく「toast を畳む」操作になり、通知は center に残る。完全に消すには center 側で削除する
- 重複抑制の対象が「表示中の toast」から「center の全項目」に広がる。過去に発生した同一メッセージは新規項目にならず、既存項目の count 加算 + toast 再表示になる（center 上は 1 項目に集約）
- 重複発生時に auto-dismiss タイマーを張り直すようになる（従来は初回のタイマーがそのまま進行）。再発生のたびに表示時間が 5 秒延長される

## 今回含めない点

- **別 PR で対応**: 右ドック popover（EventLogPanel / ServerListPanel / 本 PR の NotificationCenterPanel）は同一スロットを共有するが相互排他がなく、複数同時に開くと重なる。既存 2 パネルの時点からある設計課題であり、3 パネルに共通する開閉コーディネータの導入は本 PR のスコープ（通知の受け皿）から切り離す

## 確認事項

- [ ] 実画面で背景 fetch 失敗の info トーストが自動消去されず、Dismiss で閉じられること
- [ ] Copied 等のユーザー操作確認トーストが従来どおり 5 秒で自動消去されること
- [ ] bell ボタンで center が開閉し、auto-dismiss された通知が残っていること。未読ドットがパネルを開くと消えること
