### PR TITLE
fix(preview): make cmd+w close the focused surface instead of the frontmost

### DIFF
--- a/apps/renderer/src/features/layout/MainLayout.vue
+++ b/apps/renderer/src/features/layout/MainLayout.vue
@@ -48,6 +48,7 @@ import {
 import { registerAppConfigSync, registerSettingsCommand, SettingsModal } from "../settings";
 import { SidebarPane } from "../sidebar";
 import { registerThemeCommand, TerminalPane } from "../terminal";
+import { useWorktreeStore } from "../worktree";
 import NotificationCenterPanel from "./NotificationCenterPanel.vue";
 import NotificationToast from "./NotificationToast.vue";
 import ResizeHandle from "./ResizeHandle.vue";
@@ -56,6 +57,7 @@ import TitleBar from "./TitleBar.vue";
 import IconLucidePanelRightOpen from "~icons/lucide/panel-right-open";
 
 const repoStore = useRepoStore();
+const worktreeStore = useWorktreeStore();
 const previewStore = usePreviewStore();
 const previewEditStore = usePreviewEditStore();
 const contextKeys = useContextKeys();
@@ -197,6 +199,46 @@ watch(
   { immediate: true },
 );
 
+/**
+ * preview の open でフォーカスを popover へ移し、close で open 時点のフォーカス元へ戻す。
+ *
+ * cmd+w は「フォーカスのあるサーフェスを閉じる」意味論で terminalFocus により分岐する
+ * (defaultKeyBindings.json)。popover の `showPopover()` はフォーカスを移さないため、
+ * terminal リンク経由の open でフォーカスが terminal に残ると、開いた直後の cmd+w が
+ * preview でなく terminal pane を閉じてしまう。open のたびに popover へフォーカスを
+ * 引き直すことで防ぐ (VS Code の terminal link → editor focus と同じ意味論)。
+ *
+ * revealVersion を watch source に含めるのは、preview 表示中のファイル切替 (terminal
+ * リンクの再クリック等) でも同じ理由でフォーカスを引き直すため。popover 内部に
+ * フォーカスがある場合 (Monaco 編集中等) は奪わない。
+ *
+ * DOM フォーカスは view の関心なので、DOM なしでテストされる previewStore ではなく
+ * popover 要素を所有する本コンポーネントが担う。
+ */
+let previewRestoreFocusEl: HTMLElement | undefined;
+watch(
+  () => [previewStore.isOpen, worktreeStore.revealVersion] as const,
+  ([open], [wasOpen]) => {
+    const el = previewPopoverRef.value;
+    if (el === null) return;
+    if (open) {
+      const active = document.activeElement;
+      if (active instanceof HTMLElement && el.contains(active)) return;
+      previewRestoreFocusEl = active instanceof HTMLElement ? active : undefined;
+      el.focus({ preventScroll: true });
+      return;
+    }
+    if (!wasOpen) return;
+    // hidePopover の時点でフォーカスは body へ落ちているため、「popover がフォーカスを
+    // 持っていたか」は判定できない。open→close 遷移では常に復帰を試みる (xterm の
+    // hidden textarea 等。unmount 済み / 不可視なら focus() が no-op で body に留まる)
+    if (previewRestoreFocusEl?.isConnected === true) {
+      previewRestoreFocusEl.focus({ preventScroll: true });
+    }
+    previewRestoreFocusEl = undefined;
+  },
+);
+
 // floatingWindowVisible context key を undock ウィンドウ (log / preview 全種) の有無と同期
 watch(
   hasFloatingWindow,
@@ -323,11 +365,14 @@ watch(
       </div>
     </div>
 
-    <!-- Preview popover: 開閉ボタンをアンカーにして左側に展開 -->
+    <!-- Preview popover: 開閉ボタンをアンカーにして左側に展開。
+         tabindex="-1" は open 時のプログラムフォーカス移送用 (フォーカス移送 watch 参照)。
+         tab 到達不能なパネル面へのフォーカスルーティングなので focus ring は出さない -->
     <div
       ref="previewPopover"
       popover="manual"
-      class="_preview-popover overflow-hidden border-0 border-l border-border bg-background p-0 [&:popover-open]:flex"
+      tabindex="-1"
+      class="_preview-popover overflow-hidden border-0 border-l border-border bg-background p-0 outline-hidden [&:popover-open]:flex"
       :style="{ width: `${previewWidth}px` }"
     >
       <!-- 左端リサイズハンドル -->

--- a/apps/renderer/src/shared/command/defaultKeyBindings.json
+++ b/apps/renderer/src/shared/command/defaultKeyBindings.json
@@ -13,8 +13,12 @@
   { "key": "cmd+d", "command": "terminal.splitHorizontal", "when": "terminalFocus" },
   { "key": "shift+cmd+d", "command": "terminal.splitVertical", "when": "terminalFocus" },
   { "key": "cmd+w", "command": "terminal.closePane", "when": "terminalFocus" },
-  { "key": "cmd+w", "command": "floatingWindow.closeFront", "when": "floatingWindowVisible" },
-  { "key": "cmd+w", "command": "preview.close", "when": "previewVisible" },
+  {
+    "key": "cmd+w",
+    "command": "floatingWindow.closeFront",
+    "when": "floatingWindowVisible && !terminalFocus"
+  },
+  { "key": "cmd+w", "command": "preview.close", "when": "previewVisible && !terminalFocus" },
   { "key": "shift+cmd+w", "command": "window.close" },
   { "key": "alt+cmd+left", "command": "terminal.focusLeft", "when": "terminalFocus" },
   { "key": "alt+cmd+right", "command": "terminal.focusRight", "when": "terminalFocus" },

--- a/docs/preview.md
+++ b/docs/preview.md
@@ -108,6 +108,7 @@ git 変更ファイルには Original / Diff / Current の3タブを表示する
 
 - worktree 切替 (dir 変化) で自動クローズ。dir watch は `usePreviewStore` 内部に閉じ込めてあり、MainLayout や外部経路から発火を観測する必要はない。新 worktree でファイル選択を伴う dir 切替 (`gozdOpen` で別 worktree のファイルを指定した経路等) では、続けて `forceSelect` で再 open されるため最終状態は新ファイルで表示継続になる。dir watch は `flush: 'sync'` で `gozdOpen` handler の `setOpen → forceSelect` 連続呼びと順序が崩れないようにする
 - 外側クリックでは閉じない
+- Cmd+W の close チェーンは**フォーカス**で分岐する: terminal にフォーカスがあれば `terminal.closePane`、それ以外は最前面のサーフェス（preview popover > undocked window）を閉じる（`defaultKeyBindings.json` の when 条件）。この意味論を成立させるため、popover の open（表示中のファイル切替を含む）では MainLayout の watch がフォーカスを popover へ移す — `showPopover()` はフォーカスを移さないため、terminal リンク経由の open でフォーカスが terminal に残ると、開いた直後の Cmd+W が preview でなく terminal pane を閉じてしまう。close 時は open 時点のフォーカス元へ戻す（terminal リンクから開いて Cmd+W で閉じると terminal に入力が戻る）。popover 内部にフォーカスがあるとき（Monaco 編集中等）は奪わない
 - ESC キーで閉じる。ただし他の popover (BlamePopover 等) や dialog (SettingsModal 等) が前面にあるときはそれらが優先され、すべて閉じた次の ESC で preview が閉じる
 - IME 変換中の ESC（変換キャンセル）では閉じない
 - 表示中ファイルが削除されると自動クローズ。`fsChange` 再 fetch で current (作業ツリー) が notFound になったとき、content 取得層 (`usePreviewContent`) は HEAD (`gitShowFile`) の在否も確認し、**current / HEAD いずれにも無い** (= 未追跡ファイルの削除等で実体がどこにも残っていない) と確定した場合のみ `closeForMissingSelection()` を呼んで選択解除 + close する。単一ファイル削除・ディレクトリごとの削除のどちらも同じ経路で拾う


### PR DESCRIPTION
## 概要

cmd+w の close チェーンを「最前面の可視サーフェスを閉じる」から「フォーカスのあるサーフェスを閉じる」に変更する。terminal にフォーカスがあれば preview popover / undocked window が開いていても terminal pane を閉じる。

## 背景

PR #1015 で cmd+w に preview close > undocked window close > terminal closePane の優先チェーンを導入したが、when 条件が可視性 (`previewVisible` / `floatingWindowVisible`) のみで書かれていたため、terminal にフォーカスして terminal pane を閉じたいときも preview 側が閉じられてしまう。undocked window が 1 枚でも存在する間は cmd+w で terminal pane を閉じる手段がなかった (#1015 の「旧実装からの挙動変更」に明記された仕様だが、ユーザーの明示的なフォーカス操作を無視するモデルだった)。

調査で分かった前提: `terminalFocus` context key は DOM フォーカス実体 (TerminalLeaf の focusin / focusout) で正しく追跡されている一方、preview popover は `showPopover()` で表示されフォーカスを移さない (Popover API の仕様)。そのため when 条件に `!terminalFocus` を足すだけでは、terminal リンク経由で preview を開いた直後 (フォーカスが terminal に残る) の cmd+w が preview でなく terminal pane (破壊的操作) を閉じてしまい、#1015 の元の要望が壊れる。when 条件の変更とフォーカス移送は 2 点セットで初めて成立する。

## 変更内容

### cmd+w の when 条件 (defaultKeyBindings.json)

- `preview.close` / `floatingWindow.closeFront` に `&& !terminalFocus` を追加。terminal フォーカス中は `terminal.closePane` に到達する。terminal フォーカス外は従来どおり popover > undocked window の順 (top layer > plain fixed の視覚的前後関係と一致)

### preview popover のフォーカス移送 (MainLayout)

- open (表示中のファイル切替 = `revealVersion` bump を含む) でフォーカスを popover へ移し、close で open 時点のフォーカス元へ復帰する watch を追加。terminal リンクから開いて cmd+w で閉じると terminal に入力が戻る (VS Code の terminal link → editor focus と同じ意味論)
- popover 内部にフォーカスがあるとき (Monaco 編集中等) は奪わない
- popover 要素に `tabindex="-1"` を追加 (プログラムフォーカスの受け皿。tab 到達不能なパネル面へのルーティングなので focus ring は出さない)
- フォーカス処理を `usePreviewStore` でなく MainLayout に置くのは、store のテストが DOM なしの bun test で走るため `document` 参照を持ち込めないこと、MainLayout が popover 要素・`previewVisible` context key・ESC ハンドラを既に所有していることによる
- undocked window 側にはフォーカス移送を足さない。undock の全経路 (ヘッダドラッグ / ボタンクリック) はポインタ操作で、mousedown の既定動作が terminal を blur するため、undock 直後は必ず `terminalFocus=false` になり cmd+w は正しくウィンドウを閉じる

## 旧実装からの挙動変更・後退

- terminal フォーカス中の cmd+w は、preview / undocked window が開いていても terminal pane を閉じる (#1015 の「最前面の可視サーフェスを閉じる」モデルの廃止)。開いているサーフェスを cmd+w で閉じたい場合は、そのサーフェス (または terminal 以外) にフォーカスを移す必要がある
- preview open でフォーカスが popover へ移る。open 直後にキー入力を terminal へ送るには terminal のクリックが必要になる (従来は open 後もフォーカスが terminal に残った)
- preview close でフォーカスが open 時点の要素へ復帰する (従来は body に落ちた)

## 確認事項

- [ ] terminal のファイルリンクから preview を開き cmd+w → preview が閉じ、terminal に入力フォーカスが戻る
- [ ] preview を開いたまま terminal をクリックして cmd+w → preview は残り terminal pane が閉じる
- [ ] undocked window が存在する状態で terminal にフォーカスして cmd+w → terminal pane が閉じる
- [ ] Monaco で編集中 (popover 内フォーカス) にファイル切替してもフォーカスが奪われず編集を継続できる
