### PR TITLE
chore(release): bump version to 0.1.0

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gozd/electron",
   "productName": "Gozd",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "author": "miyaoka",
   "description": "Gozd — Git Orchestrated Zone for Development. Electron main process for managing parallel AI agent development.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "gozd",
-  "version": "0.0.0",
   "private": true,
   "description": "Gozd — Git Orchestrated Zone for Development. Desktop app for managing parallel AI agent development.",
   "author": "miyaoka",


### PR DESCRIPTION
初回 stable リリースの準備。merge 後に release workflow を workflow_dispatch して `v0.1.0` を発行する。

- version は semver FAQ の初期開発フェーズ推奨（0.1.0 から開始し以後 minor を刻む）に従い、0.0.1 でなく 0.1.0 とする
- あわせて root package.json の version フィールドを削除する。publish しない workspace root の version は npm 仕様上省略可で、読む消費者がいない（Joplin / Bruno の root と同じ形）。実バージョンの SSOT は apps/electron/package.json（docs/release.md）で変わらない

リリース後は canary のベースバージョンが `v0.1.1` に進む。GitHub の release 一覧は同日リリースをタグ名の文字列比較で並べるため、`v0.1.1-canary.*` が旧 `v0.0.1-canary.*` より常に上位になり、mise の `prerelease = true` + `latest` が古い canary に解決される問題が解消する。canary 採番自体の日時化は別 PR で行う。
