### PR TITLE
ci(release): generate stable notes from previous stable tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,8 @@ jobs:
           else
             # generate-notes の起点自動決定は channel を区別せず直前リリース（canary 含む）に
             # なるため、stable は前回 stable を起点に明示して canary サイクル全体を含める。
-            # 前回 stable が tag として実在しない異常系は gh release create が失敗して止まる
+            # 前回 stable は常に実在する前提。latest_stable が既定 v0.0.0 に倒れるのは
+            # stable tag がゼロの状態だけで、v0.1.0 リリース済みのため到達しない
             flags+=(--latest --notes-start-tag "${PREV_STABLE}")
           fi
           gh release create "${TAG}" "${flags[@]}" gozd-macos-arm64.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
       proceed: ${{ steps.decide.outputs.proceed }}
       tag: ${{ steps.decide.outputs.tag }}
       channel: ${{ steps.decide.outputs.channel }}
+      prev_stable: ${{ steps.decide.outputs.prev_stable }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -101,6 +102,7 @@ jobs:
             echo "proceed=true"
             echo "tag=${tag}"
             echo "channel=${channel}"
+            echo "prev_stable=${latest_stable}"
           } >> "${GITHUB_OUTPUT}"
 
   # ==============================================================
@@ -162,12 +164,16 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
+          PREV_STABLE: ${{ needs.decide.outputs.prev_stable }}
         run: |
           set -euo pipefail
           flags=(--generate-notes --target "${GITHUB_SHA}")
           if [[ "${CHANNEL}" == "canary" ]]; then
             flags+=(--prerelease)
           else
-            flags+=(--latest)
+            # generate-notes の起点自動決定は channel を区別せず直前リリース（canary 含む）に
+            # なるため、stable は前回 stable を起点に明示して canary サイクル全体を含める。
+            # 前回 stable が tag として実在しない異常系は gh release create が失敗して止まる
+            flags+=(--latest --notes-start-tag "${PREV_STABLE}")
           fi
           gh release create "${TAG}" "${flags[@]}" gozd-macos-arm64.tar.gz

--- a/docs/release.md
+++ b/docs/release.md
@@ -56,6 +56,9 @@ gozd-macos-arm64.tar.gz
   1 個だけの tar は `strip_components=1` が自動適用され `.app` バンドルが解体される
 - release notes は `--generate-notes` 自動生成。renovate / dependencies は
   `.github/release.yml` で除外する
+- ノートの範囲: canary は直前リリースとの差分（起点自動決定のまま）、stable は
+  `--notes-start-tag`（前回 stable）起点で canary サイクル全体を含める。起点の自動決定は
+  channel を区別せず直前リリースに倒れるため、stable 側だけ明示が要る
 
 ## mise インストール
 


### PR DESCRIPTION
## 概要

stable リリースの自動生成ノートの起点を「前回 stable」に明示し、canary サイクル全体の変更が stable のノートに含まれるようにする。

## 背景

v0.1.0 のリリースノートが直前 canary（v0.0.1-canary.12）との差分だけになり、canary サイクルで入った変更が stable のノートに現れなかった。

GitHub の `--generate-notes` は起点（`previous_tag_name`）を未指定だと**チャンネルを区別せず直前のリリース**に自動決定するため、prerelease を挟む運用では stable のノートが必ず直前 canary 起点になる。「リリースが 1 つも無いときだけ全履歴」というフォールバックも repo 単位であり、canary が存在する状態での stable には効かない（v0.1.0 で実際に踏み、ノートは手動で全履歴版に差し替え済み）。

prerelease 運用の repo はこの問題に `--notes-start-tag` で起点を明示して対処している（faker-js/faker の release workflow 等）。

## 変更内容

### release.yml

- decide ジョブが既に計算している `latest_stable` を `prev_stable` output として release ジョブへ渡す
- Create release の stable 分岐に `--notes-start-tag "${PREV_STABLE}"` を追加。canary 分岐は「直前リリースとの差分」が正しい姿なので起点自動決定のまま
- `--notes-start-tag` に渡す前回 stable は常に実在する前提。`latest_stable` が既定の `v0.0.0` に倒れるのは stable tag が 1 つも無い状態だけで、v0.1.0 リリース済みのため到達しない

### docs/release.md

- ノート範囲の契約（canary = 直前差分、stable = 前回 stable 起点）を追記

## 確認事項

- [ ] 次回の stable dispatch で、生成ノートの Full Changelog が `v0.1.0...v0.x.0` 形式（前回 stable 起点）になること
- [ ] 次の canary リリースのノートが引き続き「直前リリースとの差分」になっていること（起点自動決定の前提確認）
