### PR TITLE
docs(claude): add commit type rules gating release triggers

### DIFF
--- a/.claude/rules/commit.md
+++ b/.claude/rules/commit.md
@@ -1,0 +1,13 @@
+# コミット型の規律
+
+release workflow は main 上の feat / fix commit を検知して canary リリースを自動発行する
+（`.github/workflows/release.yml` の発火判定）。コミット型は変更した領域ではなく
+**配布物（`.app` の中身）に影響するか**で選ぶ。
+
+- feat / fix: 配布物に現れる変更のみ。リリース配管・CI・docs だけの変更に付けると、
+  中身の変わらない canary が発火する
+- リリース配管・workflow・CI の変更は ci を使う。release.yml 自体の修正も
+  「release 機能の fix」ではなく ci
+- scope `deps` を feat / fix で使わない（renovate 除外の前提契約。docs/release.md）
+
+迷ったら「この commit だけで canary が出たとき、`.app` のバイトが変わるか」で判定する。


### PR DESCRIPTION
## 概要

`.claude/rules/commit.md` を新設し、コミット型の選択基準を repo のルールとして固定する。

## 背景

リリース配管（release workflow / docs）だけを変更した PR に `fix(release):` を付けて merge した結果、release workflow の発火判定（feat / fix commit の検知）が反応し、アプリの中身が直前 stable と同一の canary（v0.1.1-canary.20260722132113）が発行された。

原因は発火判定ではなくコミットの型付け。Conventional Commits の標準運用では feat / fix は配布物に現れる変更に予約し、CI・リリース配管は ci を使う（semantic-release / release-please のリリーストリガーも feat / fix / breaking のみ）。この判定基準を Claude が参照するルールとして明文化する。

## 変更内容

### .claude/rules/commit.md（新設）

- 型は「変更した領域」ではなく「配布物（.app の中身）に影響するか」で選ぶ
- リリース配管・workflow・CI は ci を使う（release.yml 自体の修正も ci）
- 既存の「scope deps を feat / fix で使わない」契約（docs/release.md）も型選択の文脈で再掲
