### PR TITLE
chore(electron): bring apps/electron under lint / format coverage

### DIFF
--- a/apps/electron/buildApp.ts
+++ b/apps/electron/buildApp.ts
@@ -23,7 +23,10 @@ const productName = channel === "stable" ? "Gozd" : "Gozd Local";
 
 /** stdout を捕捉して返す（git 等の値取り用） */
 function capture(command: string, args: string[]): string {
-  const result = spawnSync(command, args, { encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] });
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+  });
   if (result.status !== 0) {
     throw new Error(`${command} ${args.join(" ")} exited with ${result.status}`);
   }
@@ -40,10 +43,21 @@ function run(command: string, args: string[]): void {
 
 // CFBundleVersion にコミット日時 + hash を注入する（About パネルのビルド識別と
 // wrapper の ~/Applications 同期の比較キー）。dirty ビルドは hash に -dirty が付く
-const commitDate = capture("git", ["show", "-s", "--format=%cd", "--date=format:%Y%m%d-%H%M%S", "HEAD"]);
+const commitDate = capture("git", [
+  "show",
+  "-s",
+  "--format=%cd",
+  "--date=format:%Y%m%d-%H%M%S",
+  "HEAD",
+]);
 const commitHash = capture("git", ["describe", "--always", "--dirty"]);
 
-const builderArgs = ["exec", "electron-builder", "--dir", `-c.buildVersion=${commitDate} ${commitHash}`];
+const builderArgs = [
+  "exec",
+  "electron-builder",
+  "--dir",
+  `-c.buildVersion=${commitDate} ${commitHash}`,
+];
 if (channel === "local") {
   // productName は Info.plist（-c.productName）と同梱 package.json（extraMetadata。実行時の
   // app.name = メニューラベル）の両方に効かせる。片方だけだと About とメニューで名前が食い違う

--- a/apps/electron/bunfig.toml
+++ b/apps/electron/bunfig.toml
@@ -1,0 +1,3 @@
+# git spawn を含むテストの env 隔離。設計理由は src/testPreload.ts 冒頭コメント
+[test]
+preload = ["./src/testPreload.ts"]

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -1,10 +1,9 @@
 {
   "name": "@gozd/electron",
-  "productName": "Gozd",
   "version": "0.1.0",
   "private": true,
-  "author": "miyaoka",
   "description": "Gozd — Git Orchestrated Zone for Development. Electron main process for managing parallel AI agent development.",
+  "author": "miyaoka",
   "type": "module",
   "main": "dist/main.cjs",
   "scripts": {
@@ -23,7 +22,6 @@
     "node-pty": "1.2.0-beta.14"
   },
   "devDependencies": {
-    "electron-builder": "26.15.7",
     "@gozd/rpc": "workspace:*",
     "@gozd/shared": "workspace:*",
     "@types/bun": "catalog:",
@@ -32,7 +30,9 @@
     "@xterm/addon-fit": "0.11.0",
     "@xterm/xterm": "6.0.0",
     "electron": "43.1.1",
+    "electron-builder": "26.15.7",
     "esbuild": "0.28.1",
     "typescript": "catalog:"
-  }
+  },
+  "productName": "Gozd"
 }

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -14,7 +14,9 @@
     "start": "electron .",
     "spike": "pnpm build && GOZD_SPIKE_TEST=1 electron .",
     "test": "bun test",
-    "typecheck": "tsgo --noEmit"
+    "typecheck": "tsgo --noEmit",
+    "lint": "oxlint --type-aware",
+    "fix": "oxlint --type-aware --fix && oxfmt ."
   },
   "dependencies": {
     "@parcel/watcher": "2.5.6",

--- a/apps/electron/src/appConfigWatcher.ts
+++ b/apps/electron/src/appConfigWatcher.ts
@@ -37,7 +37,7 @@ export function startAppConfigWatcher(push: PushFn): void {
       },
       (error) => {
         // 非同期 error（config dir の削除等）。watcher は watchSingleFile 側で畳み済み
-        console.error(`[appConfigWatcher] watcher error, hot reload stopped: ${error}`);
+        console.error(`[appConfigWatcher] watcher error, hot reload stopped: ${String(error)}`);
         disposeWatch = undefined;
       },
     ),

--- a/apps/electron/src/claude/claudeSessionLog.test.ts
+++ b/apps/electron/src/claude/claudeSessionLog.test.ts
@@ -85,7 +85,12 @@ describe("ClaudeSessionLog", () => {
     writeFileSync(join(subagentsDir, "agent-aaa.jsonl"), "sub-a\n");
     writeFileSync(
       join(subagentsDir, "agent-aaa.meta.json"),
-      JSON.stringify({ agentType: "Explore", description: "search files", toolUseId: "toolu_1", name: "scout" }),
+      JSON.stringify({
+        agentType: "Explore",
+        description: "search files",
+        toolUseId: "toolu_1",
+        name: "scout",
+      }),
     );
 
     const result = readClaudeSessionLog(SID, projects);
@@ -115,7 +120,13 @@ describe("ClaudeSessionLog", () => {
       JSON.stringify({
         workflowName: "review-changes",
         workflowProgress: [
-          { type: "workflow_agent", agentId: "w1", label: "review:bugs", phaseTitle: "Review", agentType: null },
+          {
+            type: "workflow_agent",
+            agentId: "w1",
+            label: "review:bugs",
+            phaseTitle: "Review",
+            agentType: null,
+          },
         ],
       }),
     );
@@ -201,7 +212,12 @@ describe("listReviveSessions", () => {
     const projects = makeTemp("gozd-revive-projects-");
     const wtRoot = makeTemp("gozd-revive-wtroot-");
     const outside = join(makeTemp("gozd-revive-outside-"), "20260101_120000"); // base 外・不在
-    writeSession(projects, "enc-1", "aaaaaaaa-1111-2222-3333-444444444444", `{"cwd":"${outside}"}\n`);
+    writeSession(
+      projects,
+      "enc-1",
+      "aaaaaaaa-1111-2222-3333-444444444444",
+      `{"cwd":"${outside}"}\n`,
+    );
     expect(await listReviveSessions(repo, projects, wtRoot)).toEqual([]);
   });
 
@@ -225,7 +241,9 @@ describe("listReviveSessions", () => {
     expect(valid?.title).toBe("Real session");
     expect(valid?.branch).toBe("feature/foo");
     // 0 バイトの兄弟は blank 行として出さない（cwd 分類からの救済とは別に、行生成でも skip）
-    expect(sessions.find((s) => s.sessionId === "00000000-0000-0000-0000-000000000000")).toBeUndefined();
+    expect(
+      sessions.find((s) => s.sessionId === "00000000-0000-0000-0000-000000000000"),
+    ).toBeUndefined();
   });
 
   test("非 0 バイトだが cwd を持たない破損 jsonl は行に出さない", async () => {
@@ -256,7 +274,12 @@ describe("listReviveSessions", () => {
     const wtRoot = makeTemp("gozd-revive-wtroot-");
     const cwd = await gozdCwd(repo, wtRoot, "20260101_120000");
     const sid = "aaaaaaaa-1111-2222-3333-444444444444";
-    const file = writeSession(projects, "enc-1", sid, `{"cwd":"${cwd}","gitBranch":"feature/foo"}\n`);
+    const file = writeSession(
+      projects,
+      "enc-1",
+      sid,
+      `{"cwd":"${cwd}","gitBranch":"feature/foo"}\n`,
+    );
 
     const [s] = await listReviveSessions(repo, projects, wtRoot);
     expect(s.lastActivity).toBe(statSync(file).mtimeMs);

--- a/apps/electron/src/claude/claudeSessionLog.test.ts
+++ b/apps/electron/src/claude/claudeSessionLog.test.ts
@@ -4,7 +4,7 @@
 
 import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { homedir, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolveProjectKey } from "../taskStore";
 import { listReviveSessions, readClaudeSessionLog } from "./claudeSessionLog";

--- a/apps/electron/src/claude/claudeSessionLog.ts
+++ b/apps/electron/src/claude/claudeSessionLog.ts
@@ -13,7 +13,15 @@
 
 import type { ReviveSessionInfo } from "@gozd/rpc";
 import { tryCatch } from "@gozd/shared";
-import { closeSync, existsSync, openSync, readdirSync, readFileSync, readSync, statSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  readSync,
+  statSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { basename, join, sep } from "node:path";
 import { gozdWorktreesRoot, resolveProjectKey } from "../taskStore";
@@ -98,7 +106,9 @@ function readMeta(agentFile: string): AgentMeta {
   // meta.json 不在は正常系 (古い subagent / 未生成) なので無言で空ラベルに倒す
   if (!existsSync(metaPath)) return { agentType: "", description: "", toolUseId: "", name: "" };
   // ファイルは在るのに読めない / parse 失敗は異常なので観察ログを残す
-  const parsed = tryCatch(() => JSON.parse(readFileSync(metaPath, "utf8")) as Record<string, unknown>);
+  const parsed = tryCatch(
+    () => JSON.parse(readFileSync(metaPath, "utf8")) as Record<string, unknown>,
+  );
   if (!parsed.ok || typeof parsed.value !== "object" || parsed.value === null) {
     console.error(`[ClaudeSessionLog] subagent meta decode failed: ${metaPath}`);
     return { agentType: "", description: "", toolUseId: "", name: "" };
@@ -126,7 +136,9 @@ function readMeta(agentFile: string): AgentMeta {
 function readAgentTypeFromMeta(agentFile: string): string {
   const metaPath = agentFile.replace(/\.jsonl$/, ".meta.json");
   if (!existsSync(metaPath)) return "";
-  const parsed = tryCatch(() => JSON.parse(readFileSync(metaPath, "utf8")) as Record<string, unknown>);
+  const parsed = tryCatch(
+    () => JSON.parse(readFileSync(metaPath, "utf8")) as Record<string, unknown>,
+  );
   if (!parsed.ok || typeof parsed.value !== "object" || parsed.value === null) {
     console.error(`[ClaudeSessionLog] workflow agent meta decode failed: ${metaPath}`);
     return "";
@@ -192,7 +204,9 @@ function readWorkflowProgress(
   const metaPath = join(metaDir, `${wfId}.json`);
   const agentMeta = new Map<string, WorkflowAgentMeta>();
   if (!existsSync(metaPath)) return { workflowName: "", agentMeta };
-  const parsed = tryCatch(() => JSON.parse(readFileSync(metaPath, "utf8")) as Record<string, unknown>);
+  const parsed = tryCatch(
+    () => JSON.parse(readFileSync(metaPath, "utf8")) as Record<string, unknown>,
+  );
   if (!parsed.ok || typeof parsed.value !== "object" || parsed.value === null) {
     console.error(`[ClaudeSessionLog] workflow json decode failed: ${metaPath}`);
     return { workflowName: "", agentMeta };
@@ -238,7 +252,9 @@ function readWorkflowSubagents(dir: string, metaDir: string): ClaudeSessionLogEn
       // だけ載っていない = JOIN ミス。journal / progress の追記タイミング差等で起こりうる
       // 信頼境界外データの兆候なので silent にせず観察ログを残す (ラベル無しで agent 自体は表示)
       if (progress === undefined && agentMeta.size > 0) {
-        console.error(`[ClaudeSessionLog] workflow agent missing in progress: wfId=${wfId} agentId=${agentId}`);
+        console.error(
+          `[ClaudeSessionLog] workflow agent missing in progress: wfId=${wfId} agentId=${agentId}`,
+        );
       }
       // agentType は workflowProgress 優先、空なら agent の meta.json をフォールバック
       const progressAgentType = progress?.agentType ?? "";
@@ -317,7 +333,9 @@ export function readClaudeSessionLog(
     entries.push(...readSubagents(subagentsDir));
     // workflow subagents: <subagents>/workflows/<wf_id>/agent-*.jsonl (Workflow ツール)。
     // ラベルは <sessionDir>/workflows/<wf_id>.json (兄弟) から JOIN する
-    entries.push(...readWorkflowSubagents(join(subagentsDir, "workflows"), join(sessionDir, "workflows")));
+    entries.push(
+      ...readWorkflowSubagents(join(subagentsDir, "workflows"), join(sessionDir, "workflows")),
+    );
     return { found: true, entries, watchDir: projectDir };
   }
   return { found: false, entries: [], watchDir: projectsDir };
@@ -406,10 +424,12 @@ function extractMeta(lines: string[]): SessionMeta {
     const v = result.value;
     if (typeof v.cwd === "string" && v.cwd !== "") cwd = v.cwd;
     if (typeof v.gitBranch === "string" && v.gitBranch !== "") branch = v.gitBranch;
-    if (v.type === "ai-title" && typeof v.aiTitle === "string" && v.aiTitle !== "") title = v.aiTitle;
+    if (v.type === "ai-title" && typeof v.aiTitle === "string" && v.aiTitle !== "")
+      title = v.aiTitle;
     if (typeof v.timestamp === "string" && v.timestamp !== "") timestamp = v.timestamp;
   }
-  const trimmedTitle = title.length > REVIVE_TITLE_MAX ? `${title.slice(0, REVIVE_TITLE_MAX)}…` : title;
+  const trimmedTitle =
+    title.length > REVIVE_TITLE_MAX ? `${title.slice(0, REVIVE_TITLE_MAX)}…` : title;
   return { cwd, branch, title: trimmedTitle, timestamp };
 }
 

--- a/apps/electron/src/claudeHooksSettings.ts
+++ b/apps/electron/src/claudeHooksSettings.ts
@@ -31,9 +31,15 @@ export function claudeHooksSettings(): Record<string, unknown> {
       UserPromptSubmit: [{ hooks: [{ type: "command", command: ncCommand("running") }] }],
       Stop: [{ hooks: [{ type: "command", command: cliCommand("done") }] }],
       StopFailure: [{ hooks: [{ type: "command", command: cliCommand("stop-failure") }] }],
-      PermissionRequest: [{ matcher: "*", hooks: [{ type: "command", command: cliCommand("needs-input") }] }],
-      PostToolUse: [{ matcher: "*", hooks: [{ type: "command", command: ncCommand("tool-done") }] }],
-      PostToolUseFailure: [{ matcher: "*", hooks: [{ type: "command", command: ncCommand("tool-failure") }] }],
+      PermissionRequest: [
+        { matcher: "*", hooks: [{ type: "command", command: cliCommand("needs-input") }] },
+      ],
+      PostToolUse: [
+        { matcher: "*", hooks: [{ type: "command", command: ncCommand("tool-done") }] },
+      ],
+      PostToolUseFailure: [
+        { matcher: "*", hooks: [{ type: "command", command: ncCommand("tool-failure") }] },
+      ],
       // 子エージェント（subagent / teammate）のライフサイクル。teammate は idle 化しても
       // Stop の background_tasks に status "running" のまま残るため、稼働中/idle の判定は
       // この 3 hook を情報源に renderer 側の台帳で行う（orca の roster と同じ構成）。

--- a/apps/electron/src/cli.ts
+++ b/apps/electron/src/cli.ts
@@ -15,7 +15,12 @@ import type { ClientMessage } from "@gozd/rpc";
 import { tryCatch } from "@gozd/shared";
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { buildHookMessage, parseStdinJson, resolveSocketPath, writeLaunchRequest } from "./cli/cliOps";
+import {
+  buildHookMessage,
+  parseStdinJson,
+  resolveSocketPath,
+  writeLaunchRequest,
+} from "./cli/cliOps";
 import { sendClientMessage } from "./cli/socketClient";
 
 const USAGE = `gozd - Git Orchestrated Zone for Development

--- a/apps/electron/src/cli/cliOps.test.ts
+++ b/apps/electron/src/cli/cliOps.test.ts
@@ -132,7 +132,9 @@ describe("buildHookMessage", () => {
     expect(mixed.hasTeammateTask).toBe(true);
 
     // teammate なし → hasTeammateTask は立たない
-    expect(buildHookMessage("done", { background_tasks: [{ type: "subagent" }] }, {}).hasTeammateTask).toBe(false);
+    expect(
+      buildHookMessage("done", { background_tasks: [{ type: "subagent" }] }, {}).hasTeammateTask,
+    ).toBe(false);
     expect(buildHookMessage("done", {}, {}).hasTeammateTask).toBe(false);
   });
 

--- a/apps/electron/src/cli/cliOps.ts
+++ b/apps/electron/src/cli/cliOps.ts
@@ -66,14 +66,17 @@ export function buildHookMessage(
   // Stop (done) フックの pending work シグナル。teammate 型を除く background_tasks /
   // session_crons のいずれかが残っていれば true（旧バージョンのキー欠落は count 0 =
   // pending なし）。teammate の稼働判定は renderer が subagent lifecycle hook の台帳で行う
-  const backgroundTasks = Array.isArray(stdinJson.background_tasks) ? stdinJson.background_tasks : [];
+  const backgroundTasks = Array.isArray(stdinJson.background_tasks)
+    ? stdinJson.background_tasks
+    : [];
   const nonTeammateCount = backgroundTasks.filter((task) => !isTeammateTask(task)).length;
   const cronCount = Array.isArray(stdinJson.session_crons) ? stdinJson.session_crons.length : 0;
 
   return {
     event,
     ptyId,
-    lastAssistantMessage: typeof stdinJson.last_assistant_message === "string" ? stdinJson.last_assistant_message : "",
+    lastAssistantMessage:
+      typeof stdinJson.last_assistant_message === "string" ? stdinJson.last_assistant_message : "",
     toolName: typeof stdinJson.tool_name === "string" ? stdinJson.tool_name : "",
     toolInput: toolInputText,
     sessionId: typeof stdinJson.session_id === "string" ? stdinJson.session_id : "",

--- a/apps/electron/src/commandResolver.test.ts
+++ b/apps/electron/src/commandResolver.test.ts
@@ -25,7 +25,10 @@ function makeFakeShell(name: string, body: string): string {
  * countFile 指定時は呼び出しごとに 1 行追記する（キャッシュ検証用） */
 function makeStandardFakeShell(name: string, countFile?: string): string {
   const count = countFile === undefined ? "" : `echo x >> "${countFile}"`;
-  return makeFakeShell(name, `${count}\nPATH="${workDir}:$PATH"; export PATH\nexec /bin/sh -c "$4"`);
+  return makeFakeShell(
+    name,
+    `${count}\nPATH="${workDir}:$PATH"; export PATH\nexec /bin/sh -c "$4"`,
+  );
 }
 
 function makeTargetCommand(name: string): string {
@@ -36,7 +39,9 @@ function makeTargetCommand(name: string): string {
 }
 
 function countInvocations(countFile: string): number {
-  return readFileSync(countFile, "utf8").split("\n").filter((line) => line !== "").length;
+  return readFileSync(countFile, "utf8")
+    .split("\n")
+    .filter((line) => line !== "").length;
 }
 
 describe("createCommandResolver (fake shell)", () => {

--- a/apps/electron/src/commandResolver.ts
+++ b/apps/electron/src/commandResolver.ts
@@ -112,7 +112,11 @@ function stderrTail(chunks: Buffer[]): string {
 /** `<shell> -i -l -c 'command -v <name>'` を新 session で起動して絶対パスを得る。
  * 戻り値 undefined = `command -v` が空（コマンド未インストール）。
  * spawn 失敗 / hang / 非 0 exit / marker 抽出失敗は CommandResolveError で reject する */
-function lookupViaLoginShell(name: string, shell: string, timeoutMs: number): Promise<string | undefined> {
+function lookupViaLoginShell(
+  name: string,
+  shell: string,
+  timeoutMs: number,
+): Promise<string | undefined> {
   const token = randomUUID();
   const begin = `GOZD_BEGIN_${token}`;
   const end = `GOZD_END_${token}`;
@@ -130,7 +134,9 @@ function lookupViaLoginShell(name: string, shell: string, timeoutMs: number): Pr
     let timedOut = false;
     let settled = false;
 
-    const settle = (result: { ok: true; value: string | undefined } | { ok: false; error: Error }) => {
+    const settle = (
+      result: { ok: true; value: string | undefined } | { ok: false; error: Error },
+    ) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
@@ -170,7 +176,8 @@ function lookupViaLoginShell(name: string, shell: string, timeoutMs: number): Pr
         return;
       }
       if (code !== 0) {
-        const reason = code !== null ? `shell exited with code ${code}` : `shell killed by signal ${signal}`;
+        const reason =
+          code !== null ? `shell exited with code ${code}` : `shell killed by signal ${signal}`;
         settle({
           ok: false,
           error: new CommandResolveError(
@@ -244,7 +251,9 @@ export function createCommandResolver({
 
   async function resolve(name: string): Promise<string | undefined> {
     if (!VALID_COMMAND_NAME.test(name)) {
-      throw new CommandResolveError(`CLI resolver: invalid command name '${name}' (must match [A-Za-z0-9_-]+)`);
+      throw new CommandResolveError(
+        `CLI resolver: invalid command name '${name}' (must match [A-Za-z0-9_-]+)`,
+      );
     }
     const cached = cache.get(name);
     if (cached !== undefined) return cached;
@@ -259,7 +268,9 @@ export function createCommandResolver({
     inflight.delete(name);
     if (!result.ok) {
       // 失敗時にユーザーには launchFailed 相当としか見えないため、サブ原因を stderr に残す
-      console.error(`[commandResolver] resolve failed name=${name} shell=${shell}: ${result.error.message}`);
+      console.error(
+        `[commandResolver] resolve failed name=${name} shell=${shell}: ${result.error.message}`,
+      );
       throw result.error;
     }
     if (result.value === undefined) {
@@ -305,7 +316,9 @@ export async function withResolvedCommand<T>(
   const first = await tryCatch(run(await resolveRequired(name)));
   if (first.ok) return first.value;
   if (!isEnoent(first.error)) throw first.error;
-  console.error(`[commandResolver] cached path for '${name}' hit ENOENT, invalidating and re-resolving`);
+  console.error(
+    `[commandResolver] cached path for '${name}' hit ENOENT, invalidating and re-resolving`,
+  );
   commandResolver.invalidate(name);
   return run(await resolveRequired(name));
 }

--- a/apps/electron/src/fs/absFileWatcher.ts
+++ b/apps/electron/src/fs/absFileWatcher.ts
@@ -116,7 +116,7 @@ export function watchAbsFile(path: string, push: PushFn): void {
     },
     (error) => {
       // 非同期 error は entry ごと破棄する（refCount は無視して即死。以後の unwatch は no-op で安全）
-      console.error(`[absFileWatcher] watcher error, watch dropped: ${path}: ${error}`);
+      console.error(`[absFileWatcher] watcher error, watch dropped: ${path}: ${String(error)}`);
       entries.delete(path);
     },
   );

--- a/apps/electron/src/fs/fsOps.test.ts
+++ b/apps/electron/src/fs/fsOps.test.ts
@@ -3,7 +3,7 @@
 
 import { tryCatch } from "@gozd/shared";
 import { afterEach, describe, expect, test } from "bun:test";
-import { execFileSync } from "node:child_process";
+import { runFixtureGit } from "../testGitFixture";
 import {
   chmodSync,
   mkdirSync,
@@ -134,7 +134,7 @@ describe("FSOps", () => {
 
   test("git repo 内では .gitignore に一致する entry の isIgnored=true", async () => {
     const dir = makeTempDir();
-    execFileSync("git", ["init"], { cwd: dir, stdio: "ignore" });
+    runFixtureGit(["init"], dir);
     writeFileSync(join(dir, ".gitignore"), "dist/\n*.log\n");
     mkdirSync(join(dir, "dist"));
     writeFileSync(join(dir, "app.log"), "");

--- a/apps/electron/src/fs/fsOps.ts
+++ b/apps/electron/src/fs/fsOps.ts
@@ -16,7 +16,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, isAbsolute, join } from "node:path";
+import { dirname, isAbsolute } from "node:path";
 import { checkIgnore } from "../git/gitOps";
 import { toWireBytes } from "../wireBytes";
 import { resolveContained } from "./pathContainment";

--- a/apps/electron/src/fs/fsWatchRegistry.test.ts
+++ b/apps/electron/src/fs/fsWatchRegistry.test.ts
@@ -7,7 +7,7 @@
 
 import { subscribe as parcelSubscribe } from "@parcel/watcher";
 import { afterEach, describe, expect, test } from "bun:test";
-import { execFileSync } from "node:child_process";
+import { runFixtureGit } from "../testGitFixture";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -46,17 +46,13 @@ async function waitUntil(predicate: () => boolean, label: string): Promise<void>
   throw new Error(`waitUntil timeout: ${label}`);
 }
 
-function runGitCmd(args: string[], cwd: string): void {
-  execFileSync("git", args, { cwd, stdio: "ignore" });
-}
-
 function initGitRepo(dir: string): void {
-  runGitCmd(["init", "-b", "main"], dir);
-  runGitCmd(["config", "user.email", "test@example.com"], dir);
-  runGitCmd(["config", "user.name", "test"], dir);
+  runFixtureGit(["init", "-b", "main"], dir);
+  runFixtureGit(["config", "user.email", "test@example.com"], dir);
+  runFixtureGit(["config", "user.name", "test"], dir);
   writeFileSync(join(dir, "init.txt"), "init\n");
-  runGitCmd(["add", "."], dir);
-  runGitCmd(["commit", "-m", "init"], dir);
+  runFixtureGit(["add", "."], dir);
+  runFixtureGit(["commit", "-m", "init"], dir);
 }
 
 interface Recorded {
@@ -127,8 +123,8 @@ describe("FSWatchRegistry (integration)", () => {
 
     await registry.watch(dir);
     writeFileSync(join(dir, "a.txt"), "a\n");
-    runGitCmd(["add", "."], dir);
-    runGitCmd(["commit", "-m", "second"], dir);
+    runFixtureGit(["add", "."], dir);
+    runFixtureGit(["commit", "-m", "second"], dir);
 
     // commit は refs/heads を動かす → branchChange 候補 → heads digest 変化で発火
     await waitUntil(() => recorded.branchDirs.length > 0, "branchChange");
@@ -143,9 +139,9 @@ describe("FSWatchRegistry (integration)", () => {
     const { registry, recorded } = createRecordingRegistry();
     cleanups.push(() => registry.unwatchAll());
 
-    runGitCmd(["branch", "other"], dir);
+    runFixtureGit(["branch", "other"], dir);
     await registry.watch(dir);
-    runGitCmd(["switch", "other"], dir);
+    runFixtureGit(["switch", "other"], dir);
 
     // `.git/HEAD` の symbolic-ref 先変化 → head 候補 → digest の head 変化 → worktreeChange
     await waitUntil(() => recorded.worktreeDirs.length > 0, "worktreeChange");

--- a/apps/electron/src/fs/fsWatchRegistry.ts
+++ b/apps/electron/src/fs/fsWatchRegistry.ts
@@ -317,7 +317,7 @@ export function createFsWatchRegistry(handlers: FsWatchHandlers, options: FsWatc
     for (const sub of entry.subscriptions) {
       // unsubscribe は async だが完了を待つ必要はない。失敗だけ観察可能にする
       sub.unsubscribe().catch((error: unknown) => {
-        console.error(`[FSWatchRegistry] unsubscribe failed for ${dir}: ${error}`);
+        console.error(`[FSWatchRegistry] unsubscribe failed for ${dir}: ${String(error)}`);
       });
     }
     // dedup キャッシュも掃除する。再 watch 後の最初の status を無条件 push させ、dir 削除後の

--- a/apps/electron/src/git/gitBlame.test.ts
+++ b/apps/electron/src/git/gitBlame.test.ts
@@ -1,7 +1,7 @@
 // gitBlame の統合テスト。実 git repo で blame porcelain parse と blame-anchored log の契約を固定する。
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { execFileSync } from "node:child_process";
+import { runFixtureGit } from "../testGitFixture";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -17,19 +17,16 @@ describe("gitBlame (integration)", () => {
   function makeRepo(): string {
     const dir = mkdtempSync(join(tmpdir(), "gozd-blame-test-"));
     tempDirs.push(dir);
-    execFileSync("git", ["init", "-b", "main"], { cwd: dir, stdio: "ignore" });
-    execFileSync("git", ["config", "user.email", "alice@example.com"], {
-      cwd: dir,
-      stdio: "ignore",
-    });
-    execFileSync("git", ["config", "user.name", "alice"], { cwd: dir, stdio: "ignore" });
+    runFixtureGit(["init", "-b", "main"], dir);
+    runFixtureGit(["config", "user.email", "alice@example.com"], dir);
+    runFixtureGit(["config", "user.name", "alice"], dir);
     return dir;
   }
 
   function commit(dir: string, message: string): string {
-    execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
-    execFileSync("git", ["commit", "-m", message], { cwd: dir, stdio: "ignore" });
-    return execFileSync("git", ["rev-parse", "HEAD"], { cwd: dir, encoding: "utf8" }).trim();
+    runFixtureGit(["add", "."], dir);
+    runFixtureGit(["commit", "-m", message], dir);
+    return runFixtureGit(["rev-parse", "HEAD"], dir);
   }
 
   test("blameLine: コミット済み行の author / summary / hash を返す", async () => {

--- a/apps/electron/src/git/gitBlame.test.ts
+++ b/apps/electron/src/git/gitBlame.test.ts
@@ -18,7 +18,10 @@ describe("gitBlame (integration)", () => {
     const dir = mkdtempSync(join(tmpdir(), "gozd-blame-test-"));
     tempDirs.push(dir);
     execFileSync("git", ["init", "-b", "main"], { cwd: dir, stdio: "ignore" });
-    execFileSync("git", ["config", "user.email", "alice@example.com"], { cwd: dir, stdio: "ignore" });
+    execFileSync("git", ["config", "user.email", "alice@example.com"], {
+      cwd: dir,
+      stdio: "ignore",
+    });
     execFileSync("git", ["config", "user.name", "alice"], { cwd: dir, stdio: "ignore" });
     return dir;
   }

--- a/apps/electron/src/git/gitBlame.ts
+++ b/apps/electron/src/git/gitBlame.ts
@@ -7,7 +7,7 @@ import { statSync } from "node:fs";
 import { join } from "node:path";
 import { LOG_FORMAT, parseLogRecords, type CommitInfo } from "./gitLog";
 import { GitCommandError, runGit } from "./gitRunner";
-import { validateRev } from "./gitValidate";
+import { isAllZeroHex, validateRev } from "./gitValidate";
 
 /** blame 対象ファイルのサイズ上限。これを超えると blame は秒オーダーでブロックするため
  * 早期に reject する。閾値は GitHub の blame UI のハード上限と同等の目安 */
@@ -94,7 +94,7 @@ export async function blameLine(params: {
   if (hash === "") {
     throw new Error("git blame: missing porcelain header");
   }
-  const notCommitted = [...hash].every((char) => char === "0");
+  const notCommitted = isAllZeroHex(hash);
   return {
     hash,
     shortHash: hash.slice(0, 7),

--- a/apps/electron/src/git/gitBranch.ts
+++ b/apps/electron/src/git/gitBranch.ts
@@ -78,7 +78,9 @@ export async function allBranchRefs(dir: string): Promise<string[]> {
  *     caller（handleGitDefaultBranch）が空文字に倒す
  */
 export async function resolveStartPoint(dir: string): Promise<string> {
-  const remote = await tryCatch(runGit(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], dir));
+  const remote = await tryCatch(
+    runGit(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], dir),
+  );
   if (remote.ok) {
     const text = remote.value.trim();
     if (text !== "") return text;

--- a/apps/electron/src/git/gitDiff.ts
+++ b/apps/electron/src/git/gitDiff.ts
@@ -58,12 +58,21 @@ export async function diffHunks(original: string, current: string): Promise<Diff
     // exit 0（差分なし）/ 1（差分あり）はどちらも成功
     const output = await runGitAllowExit1(
       [
-        "-c", "diff.algorithm=myers",
-        "-c", "diff.renames=false",
-        "-c", "core.autocrlf=false",
-        "-c", "core.eol=lf",
-        "diff", "--no-index", "--no-color", "-U3",
-        "--", aPath, bPath,
+        "-c",
+        "diff.algorithm=myers",
+        "-c",
+        "diff.renames=false",
+        "-c",
+        "core.autocrlf=false",
+        "-c",
+        "core.eol=lf",
+        "diff",
+        "--no-index",
+        "--no-color",
+        "-U3",
+        "--",
+        aPath,
+        bPath,
       ],
       tmpDir,
     );

--- a/apps/electron/src/git/gitLog.test.ts
+++ b/apps/electron/src/git/gitLog.test.ts
@@ -36,7 +36,16 @@ describe("parseLogRecords", () => {
   const record = (fields: string[]) => `${fields.join("\x1f")}\x1e`;
 
   test("8 field record を CommitInfo に変換する", () => {
-    const text = record(["abc123", "abc", "p1 p2", "alice", "1700000000", "subject", "body", "HEAD -> main"]);
+    const text = record([
+      "abc123",
+      "abc",
+      "p1 p2",
+      "alice",
+      "1700000000",
+      "subject",
+      "body",
+      "HEAD -> main",
+    ]);
     expect(parseLogRecords(text)).toEqual([
       {
         hash: "abc123",

--- a/apps/electron/src/git/gitLog.test.ts
+++ b/apps/electron/src/git/gitLog.test.ts
@@ -2,7 +2,7 @@
 // parseRefs / parseLogRecords の契約は Swift 版 GitOps+Log.swift の parser と対。
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { execFileSync } from "node:child_process";
+import { runFixtureGit } from "../testGitFixture";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -112,22 +112,18 @@ describe("log (integration)", () => {
     for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
   });
 
-  function runGitCmd(args: string[], cwd: string): void {
-    execFileSync("git", args, { cwd, stdio: "ignore" });
-  }
-
   test("origin 未設定 repo でも HEAD walk で commit 列と branchHead を返す", async () => {
     const dir = mkdtempSync(join(tmpdir(), "gozd-gitlog-test-"));
     tempDirs.push(dir);
-    runGitCmd(["init", "-b", "main"], dir);
-    runGitCmd(["config", "user.email", "t@example.com"], dir);
-    runGitCmd(["config", "user.name", "t"], dir);
+    runFixtureGit(["init", "-b", "main"], dir);
+    runFixtureGit(["config", "user.email", "t@example.com"], dir);
+    runFixtureGit(["config", "user.name", "t"], dir);
     writeFileSync(join(dir, "a.txt"), "a\n");
-    runGitCmd(["add", "."], dir);
-    runGitCmd(["commit", "-m", "first"], dir);
+    runFixtureGit(["add", "."], dir);
+    runFixtureGit(["commit", "-m", "first"], dir);
     writeFileSync(join(dir, "b.txt"), "b\n");
-    runGitCmd(["add", "."], dir);
-    runGitCmd(["commit", "-m", "second"], dir);
+    runFixtureGit(["add", "."], dir);
+    runFixtureGit(["commit", "-m", "second"], dir);
 
     const result = await log({
       dir,
@@ -146,19 +142,19 @@ describe("log (integration)", () => {
   test('branchScope "all" は HEAD 非到達の別ブランチ commit も walk する', async () => {
     const dir = mkdtempSync(join(tmpdir(), "gozd-gitlog-all-"));
     tempDirs.push(dir);
-    runGitCmd(["init", "-b", "main"], dir);
-    runGitCmd(["config", "user.email", "t@example.com"], dir);
-    runGitCmd(["config", "user.name", "t"], dir);
+    runFixtureGit(["init", "-b", "main"], dir);
+    runFixtureGit(["config", "user.email", "t@example.com"], dir);
+    runFixtureGit(["config", "user.name", "t"], dir);
     writeFileSync(join(dir, "a.txt"), "a\n");
-    runGitCmd(["add", "."], dir);
-    runGitCmd(["commit", "-m", "base"], dir);
+    runFixtureGit(["add", "."], dir);
+    runFixtureGit(["commit", "-m", "base"], dir);
     // main から分岐した別ブランチに、main へマージされない独立 commit を積む
-    runGitCmd(["checkout", "-b", "feature"], dir);
+    runFixtureGit(["checkout", "-b", "feature"], dir);
     writeFileSync(join(dir, "f.txt"), "f\n");
-    runGitCmd(["add", "."], dir);
-    runGitCmd(["commit", "-m", "feature-only"], dir);
+    runFixtureGit(["add", "."], dir);
+    runFixtureGit(["commit", "-m", "feature-only"], dir);
     // HEAD を main に戻す。feature-only は HEAD 系統から到達不可になる
-    runGitCmd(["checkout", "main"], dir);
+    runFixtureGit(["checkout", "main"], dir);
 
     const common = { dir, maxCount: 50, firstParentOnly: false, sortMode: "topo" as const };
     const defaultScope = await log({ ...common, branchScope: "default" });
@@ -173,19 +169,19 @@ describe("log (integration)", () => {
   test('branchScope "all" で HEAD が maxCount 窓外に押し出されても rescue で末尾 append する', async () => {
     const dir = mkdtempSync(join(tmpdir(), "gozd-gitlog-all-rescue-"));
     tempDirs.push(dir);
-    runGitCmd(["init", "-b", "main"], dir);
-    runGitCmd(["config", "user.email", "t@example.com"], dir);
-    runGitCmd(["config", "user.name", "t"], dir);
+    runFixtureGit(["init", "-b", "main"], dir);
+    runFixtureGit(["config", "user.email", "t@example.com"], dir);
+    runFixtureGit(["config", "user.name", "t"], dir);
     // main（= HEAD）を古い commit にする
     writeFileSync(join(dir, "a.txt"), "a\n");
-    runGitCmd(["add", "."], dir);
-    runGitCmd(["commit", "-m", "old-head"], dir);
+    runFixtureGit(["add", "."], dir);
+    runFixtureGit(["commit", "-m", "old-head"], dir);
     // main から分岐した feature に、より新しい独立 commit を積む
-    runGitCmd(["checkout", "-b", "feature"], dir);
+    runFixtureGit(["checkout", "-b", "feature"], dir);
     writeFileSync(join(dir, "f.txt"), "f\n");
-    runGitCmd(["add", "."], dir);
-    runGitCmd(["commit", "-m", "newer-feature"], dir);
-    runGitCmd(["checkout", "main"], dir);
+    runFixtureGit(["add", "."], dir);
+    runFixtureGit(["commit", "-m", "newer-feature"], dir);
+    runFixtureGit(["checkout", "main"], dir);
 
     // maxCount=1 の all walk は topo 先頭の feature tip だけを返し HEAD(main) を窓外に落とす。
     // rescue が HEAD-only walk を末尾 append し、境界先頭に truncatedAbove を立てる。
@@ -207,7 +203,7 @@ describe("log (integration)", () => {
   test("unborn branch（commit 無し）は空 commits で正常応答する", async () => {
     const dir = mkdtempSync(join(tmpdir(), "gozd-gitlog-unborn-"));
     tempDirs.push(dir);
-    runGitCmd(["init", "-b", "main"], dir);
+    runFixtureGit(["init", "-b", "main"], dir);
 
     const result = await log({
       dir,

--- a/apps/electron/src/git/gitLog.ts
+++ b/apps/electron/src/git/gitLog.ts
@@ -124,7 +124,10 @@ export async function log(params: LogParams): Promise<LogResult> {
   return { commits: merged, defaultBranch, branchHead };
 }
 
-function fallbackEmpty(result: { ok: true; value: string } | { ok: false; error: unknown }, note: string): string {
+function fallbackEmpty(
+  result: { ok: true; value: string } | { ok: false; error: unknown },
+  note: string,
+): string {
   if (result.ok) return result.value;
   console.error(`[GitOps] ${note}`);
   return "";
@@ -292,7 +295,9 @@ export async function mergeBase(dir: string, hash1: string, hash2: string): Prom
     validateRev(hash2);
   });
   if (!valid.ok) {
-    console.error(`[GitOps] mergeBase: invalid rev: hash1='${hash1}' hash2='${hash2}': ${valid.error}`);
+    console.error(
+      `[GitOps] mergeBase: invalid rev: hash1='${hash1}' hash2='${hash2}': ${valid.error}`,
+    );
     return "";
   }
   const result = await tryCatch(runGit(["merge-base", hash1, hash2], dir));

--- a/apps/electron/src/git/gitLsFiles.test.ts
+++ b/apps/electron/src/git/gitLsFiles.test.ts
@@ -1,10 +1,10 @@
 // subtractDeleted の pure test + 実 git repo での lsFiles 統合テスト。
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { execFileSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { runFixtureGit } from "../testGitFixture";
 import { lsFiles, subtractDeleted } from "./gitLsFiles";
 
 describe("subtractDeleted", () => {
@@ -28,24 +28,20 @@ describe("lsFiles (integration)", () => {
     for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
   });
 
-  function runGitCmd(args: string[], cwd: string): void {
-    execFileSync("git", args, { cwd, stdio: "ignore" });
-  }
-
   test("tracked + untracked を列挙し、gitignore と working tree 削除済みを除外する", async () => {
     const dir = mkdtempSync(join(tmpdir(), "gozd-lsfiles-test-"));
     tempDirs.push(dir);
-    runGitCmd(["init", "-b", "main"], dir);
-    runGitCmd(["config", "user.email", "t@example.com"], dir);
-    runGitCmd(["config", "user.name", "t"], dir);
+    runFixtureGit(["init", "-b", "main"], dir);
+    runFixtureGit(["config", "user.email", "t@example.com"], dir);
+    runFixtureGit(["config", "user.name", "t"], dir);
 
     // tracked
     mkdirSync(join(dir, "src"));
     writeFileSync(join(dir, "src", "tracked.ts"), "a\n");
     writeFileSync(join(dir, "removed.ts"), "b\n");
     writeFileSync(join(dir, ".gitignore"), "ignored.log\n");
-    runGitCmd(["add", "."], dir);
-    runGitCmd(["commit", "-m", "first"], dir);
+    runFixtureGit(["add", "."], dir);
+    runFixtureGit(["commit", "-m", "first"], dir);
 
     // untracked / ignored / working tree 削除
     writeFileSync(join(dir, "untracked.ts"), "c\n");
@@ -63,20 +59,20 @@ describe("lsFiles (integration)", () => {
   test("merge コンフリクト中も unmerged パスを 1 件に畳む", async () => {
     const dir = mkdtempSync(join(tmpdir(), "gozd-lsfiles-conflict-"));
     tempDirs.push(dir);
-    runGitCmd(["init", "-b", "main"], dir);
-    runGitCmd(["config", "user.email", "t@example.com"], dir);
-    runGitCmd(["config", "user.name", "t"], dir);
+    runFixtureGit(["init", "-b", "main"], dir);
+    runFixtureGit(["config", "user.email", "t@example.com"], dir);
+    runFixtureGit(["config", "user.name", "t"], dir);
     writeFileSync(join(dir, "conflict.txt"), "base\n");
-    runGitCmd(["add", "."], dir);
-    runGitCmd(["commit", "-m", "base"], dir);
-    runGitCmd(["checkout", "-b", "topic"], dir);
+    runFixtureGit(["add", "."], dir);
+    runFixtureGit(["commit", "-m", "base"], dir);
+    runFixtureGit(["checkout", "-b", "topic"], dir);
     writeFileSync(join(dir, "conflict.txt"), "topic\n");
-    runGitCmd(["commit", "-am", "topic"], dir);
-    runGitCmd(["checkout", "main"], dir);
+    runFixtureGit(["commit", "-am", "topic"], dir);
+    runFixtureGit(["checkout", "main"], dir);
     writeFileSync(join(dir, "conflict.txt"), "main\n");
-    runGitCmd(["commit", "-am", "main"], dir);
+    runFixtureGit(["commit", "-am", "main"], dir);
     // コンフリクトで merge は exit 1 になる（期待挙動なので失敗を握りつぶす）
-    expect(() => runGitCmd(["merge", "topic"], dir)).toThrow();
+    expect(() => runFixtureGit(["merge", "topic"], dir)).toThrow();
 
     const files = await lsFiles(dir);
     expect(files.filter((path) => path === "conflict.txt").length).toBe(1);
@@ -85,7 +81,7 @@ describe("lsFiles (integration)", () => {
   test("commit 無し repo でも untracked を列挙する", async () => {
     const dir = mkdtempSync(join(tmpdir(), "gozd-lsfiles-unborn-"));
     tempDirs.push(dir);
-    runGitCmd(["init", "-b", "main"], dir);
+    runFixtureGit(["init", "-b", "main"], dir);
     writeFileSync(join(dir, "a.ts"), "a\n");
 
     expect(await lsFiles(dir)).toEqual(["a.ts"]);

--- a/apps/electron/src/git/gitTree.test.ts
+++ b/apps/electron/src/git/gitTree.test.ts
@@ -1,7 +1,7 @@
 // gitTree の pure parser test + 実 git repo での統合テスト。
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { execFileSync } from "node:child_process";
+import { runFixtureGit } from "../testGitFixture";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -61,16 +61,16 @@ describe("gitTree (integration)", () => {
   function makeRepo(): string {
     const dir = mkdtempSync(join(tmpdir(), "gozd-gittree-test-"));
     tempDirs.push(dir);
-    execFileSync("git", ["init", "-b", "main"], { cwd: dir, stdio: "ignore" });
-    execFileSync("git", ["config", "user.email", "t@example.com"], { cwd: dir, stdio: "ignore" });
-    execFileSync("git", ["config", "user.name", "t"], { cwd: dir, stdio: "ignore" });
+    runFixtureGit(["init", "-b", "main"], dir);
+    runFixtureGit(["config", "user.email", "t@example.com"], dir);
+    runFixtureGit(["config", "user.name", "t"], dir);
     return dir;
   }
 
   function commit(dir: string, message: string): string {
-    execFileSync("git", ["add", "."], { cwd: dir, stdio: "ignore" });
-    execFileSync("git", ["commit", "-m", message], { cwd: dir, stdio: "ignore" });
-    return execFileSync("git", ["rev-parse", "HEAD"], { cwd: dir, encoding: "utf8" }).trim();
+    runFixtureGit(["add", "."], dir);
+    runFixtureGit(["commit", "-m", message], dir);
+    return runFixtureGit(["rev-parse", "HEAD"], dir);
   }
 
   test("fileReadResultFromGit: HEAD の blob を読み、未追跡 path は notFound", async () => {

--- a/apps/electron/src/git/gitTree.ts
+++ b/apps/electron/src/git/gitTree.ts
@@ -171,7 +171,12 @@ export async function prDiffFiles(dir: string, baseHash: string): Promise<FileCh
  */
 async function isRootCommit(dir: string, hash: string): Promise<boolean> {
   const stdout = await runGit(["rev-list", "--parents", "-n", "1", hash], dir);
-  return stdout.trim().split(" ").filter((token) => token !== "").length === 1;
+  return (
+    stdout
+      .trim()
+      .split(" ")
+      .filter((token) => token !== "").length === 1
+  );
 }
 
 /**

--- a/apps/electron/src/git/gitValidate.ts
+++ b/apps/electron/src/git/gitValidate.ts
@@ -34,7 +34,7 @@ export function validateRev(rev: string): void {
  * `validateRev` は hex 文字列を通すため、「コミット指定が必須」な RPC 入口で別途明示的に弾く */
 export function isAllZeroHex(s: string): boolean {
   if (s === "") return false;
-  return [...s].every((char) => char === "0");
+  return /^0+$/.test(s);
 }
 
 /**

--- a/apps/electron/src/git/github.ts
+++ b/apps/electron/src/git/github.ts
@@ -216,7 +216,18 @@ async function resolveGitHubRepoOrError(
 // `-F` は型推論で number/bool を渡しうるため、string にしたい owner/repo/query は `-f` を使う。
 // limit のみ Int として渡したいので `-F` で渡す
 function graphqlArgs(owner: string, repo: string, query: string): string[] {
-  return ["api", "graphql", "-f", `owner=${owner}`, "-f", `repo=${repo}`, "-F", "limit=100", "-f", `query=${query}`];
+  return [
+    "api",
+    "graphql",
+    "-f",
+    `owner=${owner}`,
+    "-f",
+    `repo=${repo}`,
+    "-F",
+    "limit=100",
+    "-f",
+    `query=${query}`,
+  ];
 }
 
 /** gh を実行し、non-zero exit を stderr 内容で GhError 4 種に分類して返す。
@@ -231,7 +242,10 @@ async function runGhCategorized(args: string[], cwd: string): Promise<GhResult<s
     const error = result.error as Error & { code?: number | string; stderr?: string };
     if (typeof error.code === "number") {
       const stderr = error.stderr ?? "";
-      return { ok: false, error: { kind: classifyGhStderr(stderr), detail: truncateDetail(stderr) } };
+      return {
+        ok: false,
+        error: { kind: classifyGhStderr(stderr), detail: truncateDetail(stderr) },
+      };
     }
     throw result.error;
   });
@@ -337,9 +351,7 @@ function nodesAt(rawJson: string, key: "pullRequests" | "issues"): unknown[] | u
  * それ以外は undefined。`.git` 拡張子は剥がす。
  * `https://host/owner/repo` / `ssh://user@host/owner/repo` / scp 形式 `git@host:owner/repo` に対応
  */
-export function parseGitHubOwnerRepo(
-  url: string,
-): { owner: string; repo: string } | undefined {
+export function parseGitHubOwnerRepo(url: string): { owner: string; repo: string } | undefined {
   let host: string;
   let path: string;
 

--- a/apps/electron/src/git/porcelain.test.ts
+++ b/apps/electron/src/git/porcelain.test.ts
@@ -65,9 +65,11 @@ describe("parsePorcelainV2WithBranch", () => {
 
   test("rename エントリは新パスを statuses に、旧パスを renameOldPaths に入れる", () => {
     const text =
-      ["1 .M N... 100644 100644 100644 aaa bbb other.txt", "2 R. N... 100644 100644 100644 aaa bbb R100 new.txt", "old.txt"].join(
-        NUL,
-      ) + NUL;
+      [
+        "1 .M N... 100644 100644 100644 aaa bbb other.txt",
+        "2 R. N... 100644 100644 100644 aaa bbb R100 new.txt",
+        "old.txt",
+      ].join(NUL) + NUL;
     const result = parsePorcelainV2WithBranch(text);
     expect(result.statuses["new.txt"]).toBe("R.");
     expect(result.renameOldPaths).toEqual({ "new.txt": "old.txt" });

--- a/apps/electron/src/git/worktreeOps.test.ts
+++ b/apps/electron/src/git/worktreeOps.test.ts
@@ -2,7 +2,7 @@
 // main repo / worktree を模した 2 つの temp dir を直接操作して検証する。
 
 import { afterEach, describe, expect, test } from "bun:test";
-import { execFileSync } from "node:child_process";
+import { runFixtureGit } from "../testGitFixture";
 import {
   existsSync,
   lstatSync,
@@ -100,7 +100,7 @@ describe("resolveReviveBranch", () => {
   const tempDirs: string[] = [];
 
   function git(args: string[], cwd: string): void {
-    execFileSync("git", args, { cwd, stdio: "ignore" });
+    runFixtureGit(args, cwd);
   }
 
   /** origin 無しの初期 commit 1 個 repo（default branch = main）。 */

--- a/apps/electron/src/git/worktreeOps.ts
+++ b/apps/electron/src/git/worktreeOps.ts
@@ -109,7 +109,9 @@ async function isBranchCheckedOut(dir: string, branch: string): Promise<boolean>
 
 /** ローカルに branch が存在するか。`git rev-parse --verify --quiet refs/heads/<branch>` 相当。 */
 async function localBranchExists(dir: string, branch: string): Promise<boolean> {
-  const result = await tryCatch(runGit(["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`], dir));
+  const result = await tryCatch(
+    runGit(["rev-parse", "--verify", "--quiet", `refs/heads/${branch}`], dir),
+  );
   return result.ok;
 }
 

--- a/apps/electron/src/git/worktreeOps.ts
+++ b/apps/electron/src/git/worktreeOps.ts
@@ -151,11 +151,6 @@ export async function removeWorktree(dir: string, path: string, force: boolean):
   await runGit(args, dir);
 }
 
-/**
- * `~/.local/share/gozd/worktrees/<projectKey>/<leaf>` の絶対パスを返し、親ディレクトリを作成する。
- * `leaf` は 1 path component のみ許可。`/`, `.`, `..`, 制御文字を含むものは拒否する
- * （base 配下からの逸脱や、ファイル API への橋渡しでの予期しない扱いを防ぐ）
- */
 /** C0 制御文字（< 0x20）と DEL（0x7f）を含むか。for-of は code point 単位で走査する */
 function hasControlChar(s: string): boolean {
   for (const char of s) {
@@ -165,6 +160,11 @@ function hasControlChar(s: string): boolean {
   return false;
 }
 
+/**
+ * `~/.local/share/gozd/worktrees/<projectKey>/<leaf>` の絶対パスを返し、親ディレクトリを作成する。
+ * `leaf` は 1 path component のみ許可。`/`, `.`, `..`, 制御文字を含むものは拒否する
+ * （base 配下からの逸脱や、ファイル API への橋渡しでの予期しない扱いを防ぐ）
+ */
 async function ensureWorktreePath(projectDir: string, leaf: string): Promise<string> {
   const invalid =
     leaf === "" || leaf.includes("/") || leaf === "." || leaf === ".." || hasControlChar(leaf);

--- a/apps/electron/src/git/worktreeOps.ts
+++ b/apps/electron/src/git/worktreeOps.ts
@@ -156,16 +156,22 @@ export async function removeWorktree(dir: string, path: string, force: boolean):
  * `leaf` は 1 path component のみ許可。`/`, `.`, `..`, 制御文字を含むものは拒否する
  * （base 配下からの逸脱や、ファイル API への橋渡しでの予期しない扱いを防ぐ）
  */
+/** C0 制御文字（< 0x20）と DEL（0x7f）を含むか。for-of は code point 単位で走査する */
+function hasControlChar(s: string): boolean {
+  for (const char of s) {
+    const code = char.codePointAt(0) ?? 0;
+    if (code < 0x20 || code === 0x7f) return true;
+  }
+  return false;
+}
+
 async function ensureWorktreePath(projectDir: string, leaf: string): Promise<string> {
   const invalid =
     leaf === "" ||
     leaf.includes("/") ||
     leaf === "." ||
     leaf === ".." ||
-    [...leaf].some((char) => {
-      const code = char.codePointAt(0) ?? 0;
-      return code < 0x20 || code === 0x7f;
-    });
+    hasControlChar(leaf);
   if (invalid) {
     throw new Error(`invalid worktree leaf name: ${leaf}`);
   }

--- a/apps/electron/src/git/worktreeOps.ts
+++ b/apps/electron/src/git/worktreeOps.ts
@@ -167,11 +167,7 @@ function hasControlChar(s: string): boolean {
 
 async function ensureWorktreePath(projectDir: string, leaf: string): Promise<string> {
   const invalid =
-    leaf === "" ||
-    leaf.includes("/") ||
-    leaf === "." ||
-    leaf === ".." ||
-    hasControlChar(leaf);
+    leaf === "" || leaf.includes("/") || leaf === "." || leaf === ".." || hasControlChar(leaf);
   if (invalid) {
     throw new Error(`invalid worktree leaf name: ${leaf}`);
   }

--- a/apps/electron/src/launchRequest.ts
+++ b/apps/electron/src/launchRequest.ts
@@ -31,7 +31,9 @@ export function consumeLaunchRequest(launchDir: string): string | undefined {
   const parsed = tryCatch(() => JSON.parse(readFileSync(first.path, "utf8")) as unknown);
   rmSync(first.path, { force: true });
   if (!parsed.ok) {
-    console.error(`[launchRequest] parse failed, request discarded: ${first.path}: ${parsed.error}`);
+    console.error(
+      `[launchRequest] parse failed, request discarded: ${first.path}: ${parsed.error}`,
+    );
     return undefined;
   }
   if (parsed.value === null || typeof parsed.value !== "object") {

--- a/apps/electron/src/main.ts
+++ b/apps/electron/src/main.ts
@@ -5,13 +5,26 @@ import { join } from "node:path";
 import { startAppConfigWatcher, stopAppConfigWatcher } from "./appConfigWatcher";
 import { registerChildWindow } from "./childWindows";
 import { writeClaudeHooksSettings } from "./claudeHooksSettings";
-import { bundledRendererIndex, channel, claudeSettingsPath, isPackaged, launchRequestDir, socketPath } from "./gozdEnv";
+import {
+  bundledRendererIndex,
+  channel,
+  claudeSettingsPath,
+  isPackaged,
+  launchRequestDir,
+  socketPath,
+} from "./gozdEnv";
 import { GOZD_CHANNEL_ARG_PREFIX, SPIKE_TEST_ARG } from "./ipc";
 import { consumeLaunchRequest } from "./launchRequest";
 import { installAppMenu } from "./menu";
 import { buildGozdOpenPayload } from "./openTarget";
 import { createRpcDispatcher, type PushFn } from "./rpcDispatcher";
-import { killAllPtys, routes, startPortScanner, stopPortScanner, unwatchAllFsWatches } from "./routes";
+import {
+  killAllPtys,
+  routes,
+  startPortScanner,
+  stopPortScanner,
+  unwatchAllFsWatches,
+} from "./routes";
 import { createSocketMessageHandler } from "./socketMessages";
 import { startSocketServer, type SocketServerHandle } from "./socketServer";
 import { runSpikeResolverDiag } from "./spikeDiag";
@@ -243,7 +256,9 @@ app.whenReady().then(() => {
   // 当てる。dev / production をアイコンで識別する運用（Swift 期の Gozd-Dev.app 相当）
   if (!isPackaged) {
     const devIconResult = tryCatch(() =>
-      app.dock?.setIcon(join(__dirname, "..", "resources", "icon.dev.iconset", "icon_512x512@2x.png")),
+      app.dock?.setIcon(
+        join(__dirname, "..", "resources", "icon.dev.iconset", "icon_512x512@2x.png"),
+      ),
     );
     if (!devIconResult.ok) {
       console.error(`[main] failed to set dev dock icon: ${devIconResult.error}`);

--- a/apps/electron/src/main.ts
+++ b/apps/electron/src/main.ts
@@ -241,7 +241,7 @@ if (isTestMode) {
 
 let socketServer: SocketServerHandle | undefined;
 
-app.whenReady().then(() => {
+void app.whenReady().then(() => {
   installAppMenu();
 
   // spike 診断: 実 Electron main が使う git / credential helper を stdout に残す。
@@ -272,7 +272,7 @@ app.whenReady().then(() => {
   try {
     writeClaudeHooksSettings(claudeSettingsPath);
   } catch (error) {
-    console.error(`[main] failed to write claude hooks settings: ${error}`);
+    console.error(`[main] failed to write claude hooks settings: ${String(error)}`);
   }
 
   // CLI / Claude hooks からの NDJSON を受け付けるソケット server。push は window の

--- a/apps/electron/src/portScanner.test.ts
+++ b/apps/electron/src/portScanner.test.ts
@@ -45,7 +45,13 @@ describe("portScanner", () => {
     const h = makeHarness();
     // shell(10) → npm(20) → node(30, LISTEN)
     h.setOwners(new Map([[10, { ptyId: 7, worktreePath: "/wt/a" }]]));
-    h.setParents(new Map([[30, 20], [20, 10], [10, 1]]));
+    h.setParents(
+      new Map([
+        [30, 20],
+        [20, 10],
+        [10, 1],
+      ]),
+    );
     h.setListens([{ pid: 30, name: "node", ports: [3000] }]);
     await h.scanner.scanOnce();
     expect(h.pushes).toHaveLength(1);
@@ -62,7 +68,12 @@ describe("portScanner", () => {
   test("PTY 消滅後は orphaned として worktree を記憶し続ける", async () => {
     const h = makeHarness();
     h.setOwners(new Map([[10, { ptyId: 7, worktreePath: "/wt/a" }]]));
-    h.setParents(new Map([[30, 10], [10, 1]]));
+    h.setParents(
+      new Map([
+        [30, 10],
+        [10, 1],
+      ]),
+    );
     h.setListens([{ pid: 30, name: "node", ports: [3000] }]);
     await h.scanner.scanOnce();
 
@@ -71,7 +82,11 @@ describe("portScanner", () => {
     h.setParents(new Map([[30, 1]]));
     await h.scanner.scanOnce();
     expect(h.pushes).toHaveLength(2);
-    expect(h.pushes[1]?.[0]).toMatchObject({ attribution: "orphaned", worktreePath: "/wt/a", ptyId: 0 });
+    expect(h.pushes[1]?.[0]).toMatchObject({
+      attribution: "orphaned",
+      worktreePath: "/wt/a",
+      ptyId: 0,
+    });
   });
 
   test("gozd 外プロセスは external", async () => {
@@ -111,7 +126,13 @@ describe("portScanner", () => {
 
   test("port 昇順 → pid 昇順で安定ソートする", async () => {
     const h = makeHarness();
-    h.setParents(new Map([[1, 1], [2, 1], [3, 1]]));
+    h.setParents(
+      new Map([
+        [1, 1],
+        [2, 1],
+        [3, 1],
+      ]),
+    );
     h.setListens([
       { pid: 3, name: "c", ports: [9000] },
       { pid: 2, name: "b", ports: [3000] },
@@ -124,7 +145,12 @@ describe("portScanner", () => {
   test("消滅した pid の orphaned 記憶は掃除される", async () => {
     const h = makeHarness();
     h.setOwners(new Map([[10, { ptyId: 7, worktreePath: "/wt/a" }]]));
-    h.setParents(new Map([[30, 10], [10, 1]]));
+    h.setParents(
+      new Map([
+        [30, 10],
+        [10, 1],
+      ]),
+    );
     h.setListens([{ pid: 30, name: "node", ports: [3000] }]);
     await h.scanner.scanOnce();
 

--- a/apps/electron/src/pty/ptyClient.test.ts
+++ b/apps/electron/src/pty/ptyClient.test.ts
@@ -112,7 +112,12 @@ describe("ptyClient", () => {
   test("exit message は signal 優先で onExit に渡る", async () => {
     const ctx = setup();
     const { proc } = await establish(ctx, 1);
-    proc.emit("message", { type: "exit", id: 1, exitCode: 0, signal: 15 } satisfies PtyToHostMessage);
+    proc.emit("message", {
+      type: "exit",
+      id: 1,
+      exitCode: 0,
+      signal: 15,
+    } satisfies PtyToHostMessage);
     expect(ctx.exits).toEqual([[1, 0, 15]]);
   });
 

--- a/apps/electron/src/pty/ptyClient.ts
+++ b/apps/electron/src/pty/ptyClient.ts
@@ -65,7 +65,10 @@ export function createPtyClient(deps: PtyClientDeps): PtyClient {
   // 生存中の pty id 集合。host crash 時にまとめて exited 通知する対象
   const live = new Set<number>();
   // spawn ack 待ち。spawned / spawnError を id で相関する
-  const pending = new Map<number, { resolve: (pid: number) => void; reject: (error: Error) => void }>();
+  const pending = new Map<
+    number,
+    { resolve: (pid: number) => void; reject: (error: Error) => void }
+  >();
 
   function onHostMessage(message: PtyToHostMessage): void {
     switch (message.type) {

--- a/apps/electron/src/pty/ptyFlowControl.test.ts
+++ b/apps/electron/src/pty/ptyFlowControl.test.ts
@@ -2,11 +2,7 @@
 // edge-triggered（閾値を跨いだ瞬間に 1 度だけ発火）であることを呼び出し回数で検証する。
 
 import { describe, expect, test } from "bun:test";
-import {
-  createFlowController,
-  HIGH_WATERMARK_CHARS,
-  LOW_WATERMARK_CHARS,
-} from "./ptyFlowControl";
+import { createFlowController, HIGH_WATERMARK_CHARS, LOW_WATERMARK_CHARS } from "./ptyFlowControl";
 
 function setup() {
   const calls: string[] = [];

--- a/apps/electron/src/ptySessions.ts
+++ b/apps/electron/src/ptySessions.ts
@@ -15,7 +15,11 @@ const expectedResumeSidById = new Map<number, string>();
 // spawn 成功 ptyId は単調増加で再利用されないため、集合に残しても偽陽性は出ない
 const explicitlyRemovedPtyIds = new Set<number>();
 
-export function registerSpawn(ptyId: number, worktreePath: string, expectedResumeSid: string): void {
+export function registerSpawn(
+  ptyId: number,
+  worktreePath: string,
+  expectedResumeSid: string,
+): void {
   if (worktreePath !== "") worktreePathById.set(ptyId, worktreePath);
   if (expectedResumeSid !== "") expectedResumeSidById.set(ptyId, expectedResumeSid);
 }
@@ -28,7 +32,9 @@ export function unregisterExit(ptyId: number): void {
   const stale = expectedResumeSidById.get(ptyId);
   if (stale !== undefined) {
     expectedResumeSidById.delete(ptyId);
-    console.error(`[PtySessions] exit: dropped expected resume sid=${stale} without removeByPty for pty=${ptyId}`);
+    console.error(
+      `[PtySessions] exit: dropped expected resume sid=${stale} without removeByPty for pty=${ptyId}`,
+    );
   }
 }
 

--- a/apps/electron/src/rawJson.ts
+++ b/apps/electron/src/rawJson.ts
@@ -81,7 +81,9 @@ export function strictDictArray(value: unknown, label: string): RawDict[] {
 // 落とすと UI 状態が永続的にずれるため message ごと破棄せずフィールド単位で継続する。
 
 function logLenientFallback(label: string, expected: string, value: unknown): void {
-  console.error(`[rawJson] ${label}: expected ${expected}, got ${describeValue(value)}; using default`);
+  console.error(
+    `[rawJson] ${label}: expected ${expected}, got ${describeValue(value)}; using default`,
+  );
 }
 
 export function lenientString(value: unknown, label: string, fallback = ""): string {

--- a/apps/electron/src/routes.ts
+++ b/apps/electron/src/routes.ts
@@ -190,7 +190,14 @@ import {
   saveProjectConfig,
 } from "./projectConfigStore";
 import { createPortScanner, listProcParents, type PtyOwner } from "./portScanner";
-import { clearAssociations, consumeExpectedResumeSid, registerSpawn, sessionIdFor, unregisterExit, worktreePathFor } from "./ptySessions";
+import {
+  clearAssociations,
+  consumeExpectedResumeSid,
+  registerSpawn,
+  sessionIdFor,
+  unregisterExit,
+  worktreePathFor,
+} from "./ptySessions";
 import type { PushFn, RpcContext, RpcHandler } from "./rpcDispatcher";
 import { listListenProcesses } from "./serverList";
 import {
@@ -317,57 +324,57 @@ async function handlePtySpawn(body: unknown, ctx: RpcContext): Promise<unknown> 
   }
   ptyPids.set(id, spawned.value);
 
-  return ({ ptyId: id }) satisfies PtySpawnResponse;
+  return { ptyId: id } satisfies PtySpawnResponse;
 }
 
 function handlePtyWrite(body: unknown): unknown {
   const req = body as PtyWriteRequest;
   ptyClient.write(req.ptyId, req.data);
-  return ({}) satisfies PtyWriteResponse;
+  return {} satisfies PtyWriteResponse;
 }
 
 function handlePtyResize(body: unknown): unknown {
   const req = body as PtyResizeRequest;
   ptyClient.resize(req.ptyId, req.cols, req.rows);
-  return ({}) satisfies PtyResizeResponse;
+  return {} satisfies PtyResizeResponse;
 }
 
 function handlePtyKill(body: unknown): unknown {
   const req = body as PtyKillRequest;
   // host が kill + ptmx close し、onExit 経由で ptyExit が push される（状態掃除もそこで走る）
   ptyClient.kill(req.ptyId);
-  return ({}) satisfies PtyKillResponse;
+  return {} satisfies PtyKillResponse;
 }
 
 function handleEcho(body: unknown): unknown {
   const req = body as EchoRequest;
-  return ({ text: req.text }) satisfies EchoResponse;
+  return { text: req.text } satisfies EchoResponse;
 }
 
 function handleAppConfigLoad(): unknown {
-  return ({ config: loadAppConfig() }) satisfies LoadAppConfigResponse;
+  return { config: loadAppConfig() } satisfies LoadAppConfigResponse;
 }
 
 function handleAppConfigSave(body: unknown): unknown {
   const req = body as SaveAppConfigRequest;
   if (req.config === undefined) throw new Error("appConfig/save: config is required");
   saveAppConfig(req.config);
-  return ({}) satisfies SaveAppConfigResponse;
+  return {} satisfies SaveAppConfigResponse;
 }
 
 function handleAppConfigEnsureFile(): unknown {
-  return ({ path: ensureAppConfigFile() }) satisfies EnsureAppConfigFileResponse;
+  return { path: ensureAppConfigFile() } satisfies EnsureAppConfigFileResponse;
 }
 
 function handleAppStateLoad(): unknown {
-  return ({ state: loadAppState() }) satisfies LoadAppStateResponse;
+  return { state: loadAppState() } satisfies LoadAppStateResponse;
 }
 
 function handleAppStateSave(body: unknown): unknown {
   const req = body as SaveAppStateRequest;
   if (req.state === undefined) throw new Error("appState/save: state is required");
   saveAppState(req.state);
-  return ({}) satisfies SaveAppStateResponse;
+  return {} satisfies SaveAppStateResponse;
 }
 
 function handleServerList(): unknown {
@@ -404,12 +411,12 @@ async function handleGitWorktreeList(body: unknown): Promise<unknown> {
       };
     }),
   );
-  return ({ worktrees: entries }) satisfies GitWorktreeListResponse;
+  return { worktrees: entries } satisfies GitWorktreeListResponse;
 }
 
 async function handleTaskList(body: unknown): Promise<unknown> {
   const req = body as TaskListRequest;
-  return ({ tasks: await taskStore.list(req.dir) }) satisfies TaskListResponse;
+  return { tasks: await taskStore.list(req.dir) } satisfies TaskListResponse;
 }
 
 async function handleTaskAdd(body: unknown): Promise<unknown> {
@@ -420,25 +427,25 @@ async function handleTaskAdd(body: unknown): Promise<unknown> {
     worktreeDir: req.worktreeDir,
     ghRef: req.ghRef,
   });
-  return ({ task }) satisfies TaskAddResponse;
+  return { task } satisfies TaskAddResponse;
 }
 
 async function handleTaskSetTerminalTitle(body: unknown): Promise<unknown> {
   const req = body as TaskSetTerminalTitleRequest;
   const task = await taskStore.setTerminalTitle(req.dir, req.id, req.terminalTitle);
-  return ({ task }) satisfies TaskSetTerminalTitleResponse;
+  return { task } satisfies TaskSetTerminalTitleResponse;
 }
 
 async function handleTaskSetUserTitle(body: unknown): Promise<unknown> {
   const req = body as TaskSetUserTitleRequest;
   const task = await taskStore.setUserTitle(req.dir, req.id, req.userTitle);
-  return ({ task }) satisfies TaskSetUserTitleResponse;
+  return { task } satisfies TaskSetUserTitleResponse;
 }
 
 async function handleTaskRemove(body: unknown): Promise<unknown> {
   const req = body as TaskRemoveRequest;
   await taskStore.remove(req.dir, req.id);
-  return ({}) satisfies TaskRemoveResponse;
+  return {} satisfies TaskRemoveResponse;
 }
 
 async function handleTaskRemoveByWorktree(body: unknown): Promise<unknown> {
@@ -447,32 +454,32 @@ async function handleTaskRemoveByWorktree(body: unknown): Promise<unknown> {
   // 残したまま単独発火する経路。main worktree は git worktree remove 不可のため、
   // 滞留 task の一掃にはこの経路が唯一の手段になる（Claude セッションの JSONL は消さない）
   await taskStore.removeByWorktree(req.dir, req.worktreeDir);
-  return ({}) satisfies TaskRemoveByWorktreeResponse;
+  return {} satisfies TaskRemoveByWorktreeResponse;
 }
 
 async function handleGitGithubIdentity(body: unknown): Promise<unknown> {
   const req = body as GitGithubIdentityRequest;
   const identity = await repoOwnerName(req.dir);
   if (identity.kind === "ok") {
-    return ({ owner: identity.owner, repo: identity.repo }) satisfies GitGithubIdentityResponse;
+    return { owner: identity.owner, repo: identity.repo } satisfies GitGithubIdentityResponse;
   }
   // remote 未設定 / 非 github.com host。UI には出ないが観察可能にする
   // （raw URL は credential 漏出防止のため stderr にも載せない）
   console.error(`[handleGitGithubIdentity] ${identity.kind} for dir=${req.dir}`);
-  return ({ owner: "", repo: "" }) satisfies GitGithubIdentityResponse;
+  return { owner: "", repo: "" } satisfies GitGithubIdentityResponse;
 }
 
 async function handleGitFetchRemotes(body: unknown): Promise<unknown> {
   const req = body as GitFetchRemotesRequest;
   const result = await tryCatch(fetchRemotes(req.dir));
-  if (result.ok) return ({ ok: true, errorDetail: "" }) satisfies GitFetchRemotesResponse;
+  if (result.ok) return { ok: true, errorDetail: "" } satisfies GitFetchRemotesResponse;
   // offline / 認証失敗 / remote 未設定 etc. は呼び出し側で握り潰す。
   // stderr 冒頭のみを debug 用に積む (UI には出さない)
   const detail =
     result.error instanceof GitCommandError
       ? result.error.stderr.slice(0, 512)
       : String(result.error);
-  return ({ ok: false, errorDetail: detail }) satisfies GitFetchRemotesResponse;
+  return { ok: false, errorDetail: detail } satisfies GitFetchRemotesResponse;
 }
 
 // fs watch の push は「最後に /fs/watch を呼んだ window」の sender に配送する。
@@ -554,35 +561,35 @@ async function handleFsReadDir(body: unknown): Promise<unknown> {
 
 function handleFsReadFileAbsolute(body: unknown): unknown {
   const req = body as FsReadFileAbsoluteRequest;
-  return ({ result: readFileAbsolute(req.absolutePath) }) satisfies FsReadFileAbsoluteResponse;
+  return { result: readFileAbsolute(req.absolutePath) } satisfies FsReadFileAbsoluteResponse;
 }
 
 function handleFsWriteFile(body: unknown): unknown {
   const req = body as FsWriteFileRequest;
   writeFile(req.dir, req.path, req.content);
-  return ({}) satisfies FsWriteFileResponse;
+  return {} satisfies FsWriteFileResponse;
 }
 
 function handleFsWriteFileAbsolute(body: unknown): unknown {
   const req = body as FsWriteFileAbsoluteRequest;
   writeFileAbsolute(req.absolutePath, req.content);
-  return ({}) satisfies FsWriteFileAbsoluteResponse;
+  return {} satisfies FsWriteFileAbsoluteResponse;
 }
 
 function handleFsStat(body: unknown): unknown {
   const req = body as FsStatRequest;
-  return (stat(req.dir, req.path)) satisfies FsStatResponse;
+  return stat(req.dir, req.path) satisfies FsStatResponse;
 }
 
 async function handleGitStatus(body: unknown): Promise<unknown> {
   const req = body as GitStatusRequest;
   const status = await gitStatusFull(req.dir);
-  return ({
+  return {
     entries: status.statuses,
     renameOldPaths: status.renameOldPaths,
     latestMtime: status.latestMtime,
     upstream: status.hasUpstream ? { ahead: status.ahead, behind: status.behind } : undefined,
-  }) satisfies GitStatusResponse;
+  } satisfies GitStatusResponse;
 }
 
 async function handleFsWatch(body: unknown, ctx: RpcContext): Promise<unknown> {
@@ -590,29 +597,29 @@ async function handleFsWatch(body: unknown, ctx: RpcContext): Promise<unknown> {
   if (req.dir === "") throw new Error("fs/watch: dir is required");
   fsPush = ctx.push;
   await fsWatchRegistry.watch(req.dir);
-  return ({}) satisfies FsWatchResponse;
+  return {} satisfies FsWatchResponse;
 }
 
 function handleFsUnwatch(body: unknown): unknown {
   const req = body as FsUnwatchRequest;
   fsWatchRegistry.unwatch(req.dir);
-  return ({}) satisfies FsUnwatchResponse;
+  return {} satisfies FsUnwatchResponse;
 }
 
 function handleFsWatchFileAbsolute(body: unknown, ctx: RpcContext): unknown {
   const req = body as FsWatchFileAbsoluteRequest;
   watchAbsFile(req.absolutePath, ctx.push);
-  return ({}) satisfies FsWatchFileAbsoluteResponse;
+  return {} satisfies FsWatchFileAbsoluteResponse;
 }
 
 function handleFsUnwatchFileAbsolute(body: unknown): unknown {
   const req = body as FsUnwatchFileAbsoluteRequest;
   unwatchAbsFile(req.absolutePath);
-  return ({}) satisfies FsUnwatchFileAbsoluteResponse;
+  return {} satisfies FsUnwatchFileAbsoluteResponse;
 }
 
 function handleFsUnwatchAll(): unknown {
-  return ({ unwatchedCount: fsWatchRegistry.unwatchAll() }) satisfies FsUnwatchAllResponse;
+  return { unwatchedCount: fsWatchRegistry.unwatchAll() } satisfies FsUnwatchAllResponse;
 }
 
 async function handleGitLog(body: unknown): Promise<unknown> {
@@ -624,23 +631,25 @@ async function handleGitLog(body: unknown): Promise<unknown> {
     branchScope: req.branchScope,
     sortMode: req.sortMode,
   });
-  return (result) satisfies GitLogResponse;
+  return result satisfies GitLogResponse;
 }
 
 async function handleGitMergeBase(body: unknown): Promise<unknown> {
   const req = body as GitMergeBaseRequest;
-  return ({ mergeBaseOid: await mergeBase(req.dir, req.hash1, req.hash2) }) satisfies GitMergeBaseResponse;
+  return {
+    mergeBaseOid: await mergeBase(req.dir, req.hash1, req.hash2),
+  } satisfies GitMergeBaseResponse;
 }
 
 async function handleGitRevReachable(body: unknown): Promise<unknown> {
   const req = body as GitRevReachableRequest;
-  return ({ reachable: await revReachable(req.dir, req.hash) }) satisfies GitRevReachableResponse;
+  return { reachable: await revReachable(req.dir, req.hash) } satisfies GitRevReachableResponse;
 }
 
 async function handleGitResetMixed(body: unknown): Promise<unknown> {
   const req = body as GitResetMixedRequest;
   await resetMixed(req.dir, req.hash);
-  return ({}) satisfies GitResetMixedResponse;
+  return {} satisfies GitResetMixedResponse;
 }
 
 async function handleGitDefaultBranch(body: unknown): Promise<unknown> {
@@ -649,13 +658,18 @@ async function handleGitDefaultBranch(body: unknown): Promise<unknown> {
   // spawn 失敗（git CLI 解決失敗）は throw して renderer に通知する
   const result = await tryCatch(resolveStartPoint(req.dir));
   if (!result.ok && !(result.error instanceof GitCommandError)) throw result.error;
-  return ({ branch: result.ok ? result.value : "" }) satisfies GitDefaultBranchResponse;
+  return { branch: result.ok ? result.value : "" } satisfies GitDefaultBranchResponse;
 }
 
 async function handleGitBlameLine(body: unknown): Promise<unknown> {
   const req = body as GitBlameLineRequest;
-  const commit = await blameLine({ dir: req.dir, relPath: req.relPath, rev: req.rev, line: req.line });
-  return ({ commit }) satisfies GitBlameLineResponse;
+  const commit = await blameLine({
+    dir: req.dir,
+    relPath: req.relPath,
+    rev: req.rev,
+    line: req.line,
+  });
+  return { commit } satisfies GitBlameLineResponse;
 }
 
 async function handleGitLogLine(body: unknown): Promise<unknown> {
@@ -667,7 +681,7 @@ async function handleGitLogLine(body: unknown): Promise<unknown> {
     line: req.line,
     maxCount: req.maxCount,
   });
-  return ({ commits }) satisfies GitLogLineResponse;
+  return { commits } satisfies GitLogLineResponse;
 }
 
 async function handleGitLogFile(body: unknown): Promise<unknown> {
@@ -678,7 +692,7 @@ async function handleGitLogFile(body: unknown): Promise<unknown> {
     rev: req.rev,
     maxCount: req.maxCount,
   });
-  return ({ commits }) satisfies GitLogFileResponse;
+  return { commits } satisfies GitLogFileResponse;
 }
 
 async function handleGitDiffHunks(body: unknown): Promise<unknown> {
@@ -690,16 +704,16 @@ async function handleGitDiffHunks(body: unknown): Promise<unknown> {
 
 function handleGitDiffExpandLines(body: unknown): unknown {
   const req = body as GitDiffExpandLinesRequest;
-  return ({
+  return {
     lines: expandDiffLines(req.original, req.current, req.oldStart, req.newStart, req.lines),
-  }) satisfies GitDiffExpandLinesResponse;
+  } satisfies GitDiffExpandLinesResponse;
 }
 
 async function handleGitShowFile(body: unknown): Promise<unknown> {
   const req = body as GitShowFileRequest;
-  return ({
+  return {
     result: await fileReadResultFromGit(req.dir, "HEAD", req.relPath),
-  }) satisfies GitShowFileResponse;
+  } satisfies GitShowFileResponse;
 }
 
 async function handleGitShowCommitFile(body: unknown): Promise<unknown> {
@@ -723,12 +737,12 @@ async function handleGitShowCommitFile(body: unknown): Promise<unknown> {
     treeFileOID(req.dir, fromHash, req.relPath),
     treeFileOID(req.dir, req.hash, req.relPath),
   ]);
-  return ({
+  return {
     from,
     to,
     // 両 OID が解決でき、かつ一致した場合のみ true
     unchanged: fromOID !== undefined && toOID !== undefined && fromOID === toOID,
-  }) satisfies GitShowCommitFileResponse;
+  } satisfies GitShowCommitFileResponse;
 }
 
 function toFileChangeProto(change: FileChangeInfo): {
@@ -747,32 +761,32 @@ async function handleGitCommitFiles(body: unknown): Promise<unknown> {
     rangeHashes: req.rangeHashes,
     includeWorkingTree: req.includeWorkingTree,
   });
-  return ({ changes: changes.map(toFileChangeProto) }) satisfies GitCommitFilesResponse;
+  return { changes: changes.map(toFileChangeProto) } satisfies GitCommitFilesResponse;
 }
 
 async function handleGitPrDiffFiles(body: unknown): Promise<unknown> {
   const req = body as GitPrDiffFilesRequest;
   const changes = await prDiffFiles(req.dir, req.baseHash);
-  return ({ changes: changes.map(toFileChangeProto) }) satisfies GitPrDiffFilesResponse;
+  return { changes: changes.map(toFileChangeProto) } satisfies GitPrDiffFilesResponse;
 }
 
 async function handleGitReadBlob(body: unknown): Promise<unknown> {
   const req = body as GitReadBlobRequest;
   // rev は `git show <rev>:<path>` に渡るため option 注入を弾く validateRev を入口で通す
   validateRev(req.hash);
-  return ({
+  return {
     result: await fileReadResultFromGit(req.dir, req.hash, req.relPath),
-  }) satisfies GitReadBlobResponse;
+  } satisfies GitReadBlobResponse;
 }
 
 async function handleGitLsTree(body: unknown): Promise<unknown> {
   const req = body as GitLsTreeRequest;
-  return ({ entries: await lsTree(req.dir, req.hash, req.path) }) satisfies GitLsTreeResponse;
+  return { entries: await lsTree(req.dir, req.hash, req.path) } satisfies GitLsTreeResponse;
 }
 
 async function handleGitLsFiles(body: unknown): Promise<unknown> {
   const req = body as GitLsFilesRequest;
-  return ({ files: await lsFiles(req.dir) }) satisfies GitLsFilesResponse;
+  return { files: await lsFiles(req.dir) } satisfies GitLsFilesResponse;
 }
 
 async function handleGitPrList(body: unknown): Promise<unknown> {
@@ -786,7 +800,12 @@ async function handleGitPrList(body: unknown): Promise<unknown> {
       errorDetail: result.error.detail,
     } satisfies GitPrListResponse;
   }
-  return { ok: true, prs: result.value, errorKind: "ok", errorDetail: "" } satisfies GitPrListResponse;
+  return {
+    ok: true,
+    prs: result.value,
+    errorKind: "ok",
+    errorDetail: "",
+  } satisfies GitPrListResponse;
 }
 
 async function handleGitIssueList(body: unknown): Promise<unknown> {
@@ -819,7 +838,12 @@ async function handleGitViewer(body: unknown): Promise<unknown> {
       errorDetail: result.error.detail,
     } satisfies GitViewerResponse;
   }
-  return { ok: true, login: result.value, errorKind: "ok", errorDetail: "" } satisfies GitViewerResponse;
+  return {
+    ok: true,
+    login: result.value,
+    errorKind: "ok",
+    errorDetail: "",
+  } satisfies GitViewerResponse;
 }
 
 async function handleCreateWorktree(body: unknown): Promise<unknown> {
@@ -835,7 +859,7 @@ async function handleCreateWorktree(body: unknown): Promise<unknown> {
     startPoint: req.startPoint,
     symlinks: projectConfig.worktreeSymlinks,
   });
-  return ({
+  return {
     worktree: {
       path: info.path,
       head: info.head,
@@ -849,7 +873,7 @@ async function handleCreateWorktree(body: unknown): Promise<unknown> {
     },
     dir: info.path,
     setupScript: projectConfig.setupScript,
-  }) satisfies CreateWorktreeResponse;
+  } satisfies CreateWorktreeResponse;
 }
 
 async function handleWorktreeRemove(body: unknown, ctx: RpcContext): Promise<unknown> {
@@ -870,24 +894,24 @@ async function handleWorktreeRemove(body: unknown, ctx: RpcContext): Promise<unk
       dir: req.dir,
     });
   }
-  return ({}) satisfies GitWorktreeRemoveResponse;
+  return {} satisfies GitWorktreeRemoveResponse;
 }
 
 async function handleProjectConfigLoad(body: unknown): Promise<unknown> {
   const req = body as ProjectConfigLoadRequest;
-  return ({ config: await loadProjectConfig(req.dir) }) satisfies ProjectConfigLoadResponse;
+  return { config: await loadProjectConfig(req.dir) } satisfies ProjectConfigLoadResponse;
 }
 
 async function handleProjectConfigSave(body: unknown): Promise<unknown> {
   const req = body as ProjectConfigSaveRequest;
   if (req.config === undefined) throw new Error("projectConfig/save: config is required");
   await saveProjectConfig(req.dir, req.config);
-  return ({}) satisfies ProjectConfigSaveResponse;
+  return {} satisfies ProjectConfigSaveResponse;
 }
 
 async function handleProjectConfigEnsureFile(body: unknown): Promise<unknown> {
   const req = body as ProjectConfigEnsureFileRequest;
-  return ({ path: await ensureProjectConfigFile(req.dir) }) satisfies ProjectConfigEnsureFileResponse;
+  return { path: await ensureProjectConfigFile(req.dir) } satisfies ProjectConfigEnsureFileResponse;
 }
 
 // `openExternal` で許可する URL scheme の allowlist。OSC 8 リンクや WebLinksAddon 経由で
@@ -903,7 +927,7 @@ async function handleOpenExternal(body: unknown): Promise<unknown> {
     throw new Error(`scheme not allowed: ${parsed.value.protocol}`);
   }
   await shell.openExternal(req.url);
-  return ({}) satisfies OpenExternalResponse;
+  return {} satisfies OpenExternalResponse;
 }
 
 async function handleOpenFile(body: unknown): Promise<unknown> {
@@ -922,7 +946,7 @@ async function handleOpenFile(body: unknown): Promise<unknown> {
   if (errorMessage !== "") {
     throw new Error(`failed to open: ${errorMessage}`);
   }
-  return ({}) satisfies OpenFileResponse;
+  return {} satisfies OpenFileResponse;
 }
 
 async function handlePickAndOpen(_body: unknown, ctx: RpcContext): Promise<unknown> {
@@ -938,13 +962,13 @@ async function handlePickAndOpen(_body: unknown, ctx: RpcContext): Promise<unkno
     const payload = await buildGozdOpenPayload(pickedPath);
     if (payload !== undefined) ctx.push("gozdOpen", payload);
   }
-  return ({}) satisfies PickAndOpenResponse;
+  return {} satisfies PickAndOpenResponse;
 }
 
 function handleWindowClose(): unknown {
   // シングルウィンドウ運用ではアプリ終了相当（Swift 版 NSApplication.terminate と同じ）
   app.quit();
-  return ({}) satisfies WindowCloseResponse;
+  return {} satisfies WindowCloseResponse;
 }
 
 function handleWindowSetTitleContext(body: unknown): unknown {
@@ -957,7 +981,7 @@ function handleWindowSetTitleContext(body: unknown): unknown {
     if (isChildWindow(window)) continue;
     window.setTitle(req.title === "" ? "gozd" : req.title);
   }
-  return ({}) satisfies WindowSetTitleContextResponse;
+  return {} satisfies WindowSetTitleContextResponse;
 }
 
 async function handleClaudeSessionRemoveByPty(body: unknown, ctx: RpcContext): Promise<unknown> {
@@ -1021,22 +1045,22 @@ async function handleClaudeSessionRemoveByPty(body: unknown, ctx: RpcContext): P
   // else: live も expected もない素 PTY pane の close。正常経路でログ価値が薄い
 
   clearAssociations(req.ptyId);
-  return ({ removedSessionId }) satisfies ClaudeSessionRemoveByPtyResponse;
+  return { removedSessionId } satisfies ClaudeSessionRemoveByPtyResponse;
 }
 
 function handleClaudeSessionReadLog(body: unknown): unknown {
   const req = body as ClaudeSessionLogRequest;
   const result = readClaudeSessionLog(req.sessionId);
-  return ({
+  return {
     found: result.found,
     watchDir: result.watchDir,
     entries: result.entries,
-  }) satisfies ClaudeSessionLogResponse;
+  } satisfies ClaudeSessionLogResponse;
 }
 
 async function handleReviveSessionList(body: unknown): Promise<unknown> {
   const req = body as ReviveSessionListRequest;
-  return ({ sessions: await listReviveSessions(req.dir) }) satisfies ReviveSessionListResponse;
+  return { sessions: await listReviveSessions(req.dir) } satisfies ReviveSessionListResponse;
 }
 
 async function handleReviveSession(body: unknown): Promise<unknown> {
@@ -1065,7 +1089,7 @@ async function handleReviveSession(body: unknown): Promise<unknown> {
   if (task === undefined) {
     throw new Error(`revive: task not created for session ${req.sessionId} at ${info.path}`);
   }
-  return ({
+  return {
     worktree: {
       path: info.path,
       head: info.head,
@@ -1080,21 +1104,21 @@ async function handleReviveSession(body: unknown): Promise<unknown> {
     dir: info.path,
     task,
     setupScript: projectConfig.setupScript,
-  }) satisfies ReviveSessionResponse;
+  } satisfies ReviveSessionResponse;
 }
 
 function handleClipboardCopyFiles(body: unknown): unknown {
   const req = body as ClipboardCopyFilesRequest;
   writeFilesToClipboard(req.paths);
-  return ({}) satisfies ClipboardCopyFilesResponse;
+  return {} satisfies ClipboardCopyFilesResponse;
 }
 
 async function handleVoicevoxLaunch(): Promise<unknown> {
-  return ({ ok: await voicevoxLaunch() }) satisfies VoicevoxLaunchResponse;
+  return { ok: await voicevoxLaunch() } satisfies VoicevoxLaunchResponse;
 }
 
 async function handleVoicevoxCheckEngine(): Promise<unknown> {
-  return ({ ok: await checkEngine() }) satisfies VoicevoxCheckEngineResponse;
+  return { ok: await checkEngine() } satisfies VoicevoxCheckEngineResponse;
 }
 
 async function handleVoicevoxListSpeakers(): Promise<unknown> {
@@ -1102,9 +1126,11 @@ async function handleVoicevoxListSpeakers(): Promise<unknown> {
   // engine 起動失敗 / network 失敗は空 list にフォールバックしつつ、silent drop 禁止規律
   // として stderr に観察ログを残す（listSpeakers 内部でも要因別にログ済み）
   if (speakers === undefined) {
-    console.error("[handleVoicevoxListSpeakers] listSpeakers returned undefined; responding with empty list");
+    console.error(
+      "[handleVoicevoxListSpeakers] listSpeakers returned undefined; responding with empty list",
+    );
   }
-  return ({ speakers: speakers ?? [] }) satisfies VoicevoxListSpeakersResponse;
+  return { speakers: speakers ?? [] } satisfies VoicevoxListSpeakersResponse;
 }
 
 async function handleVoicevoxSpeak(body: unknown): Promise<unknown> {

--- a/apps/electron/src/rpcDispatcher.ts
+++ b/apps/electron/src/rpcDispatcher.ts
@@ -12,7 +12,8 @@ export interface RpcContext {
   push: PushFn;
 }
 
-export type RpcHandler = (body: unknown, ctx: RpcContext) => Promise<unknown> | unknown;
+// 戻り値は sync / async 両対応。unknown は Promise<unknown> を包含するため union にしない
+export type RpcHandler = (body: unknown, ctx: RpcContext) => unknown;
 
 /** 移行中の観測用: 未実装パスは初回のみ stderr に出す（移行チェックリストとして機能する） */
 const loggedUnimplemented = new Set<string>();

--- a/apps/electron/src/socketMessages.test.ts
+++ b/apps/electron/src/socketMessages.test.ts
@@ -75,7 +75,9 @@ describe("socketMessages", () => {
   test("未登録 ptyId の session-start は skip されつつ hook push 自体は届く", async () => {
     const pushed: Array<{ type: string; payload: unknown }> = [];
     const handle = createSocketMessageHandler((type, payload) => pushed.push({ type, payload }));
-    handle('{"hook":{"event":"session-start","ptyId":999999,"sessionId":"00000000-0000-0000-0000-000000000001"}}');
+    handle(
+      '{"hook":{"event":"session-start","ptyId":999999,"sessionId":"00000000-0000-0000-0000-000000000001"}}',
+    );
     await waitFor(() => pushed.length === 1);
     expect(pushed[0]?.type).toBe("hook");
     const payload = pushed[0]?.payload as { sessionId: string };

--- a/apps/electron/src/socketMessages.ts
+++ b/apps/electron/src/socketMessages.ts
@@ -29,7 +29,11 @@ function notifyTaskStoreError(push: PushFn, message: string, error: unknown, dir
 
 /** session-start / session-end hook を task store に反映する。
  * 各 taskStore 呼び出しは個別 tryCatch で notify に倒すため、本関数自身は throw しない */
-async function applyClaudeSessionHook(hook: HookMessage, worktreePath: string, push: PushFn): Promise<void> {
+async function applyClaudeSessionHook(
+  hook: HookMessage,
+  worktreePath: string,
+  push: PushFn,
+): Promise<void> {
   if (hook.sessionId === "") return;
   if (worktreePath === "") {
     // worktreePath 空には 2 つの異なる経路がある。観察ログで区別する:
@@ -41,7 +45,9 @@ async function applyClaudeSessionHook(hook: HookMessage, worktreePath: string, p
         `[applyClaudeSessionHook] late ${hook.event} for pty=${hook.ptyId} session=${hook.sessionId} after removeByPty; skipping`,
       );
     } else {
-      console.error(`[applyClaudeSessionHook] ${hook.event} for unknown pty=${hook.ptyId}; skipping`);
+      console.error(
+        `[applyClaudeSessionHook] ${hook.event} for unknown pty=${hook.ptyId}; skipping`,
+      );
     }
     return;
   }
@@ -55,7 +61,12 @@ async function applyClaudeSessionHook(hook: HookMessage, worktreePath: string, p
     if (previous !== "" && previous !== hook.sessionId) {
       const detached = await tryCatch(taskStore.detachSession(worktreePath, previous));
       if (!detached.ok) {
-        notifyTaskStoreError(push, "Failed to detach previous session from task", detached.error, worktreePath);
+        notifyTaskStoreError(
+          push,
+          "Failed to detach previous session from task",
+          detached.error,
+          worktreePath,
+        );
       }
     }
     // expected resume sid を必ず消費する。これで removeByPty 経路の
@@ -79,7 +90,9 @@ async function applyClaudeSessionHook(hook: HookMessage, worktreePath: string, p
     // 永続化（attachSession）を先に成功させてから registry のマッピングを更新する。
     // 逆順だと attach が失敗した場合 registry だけ新 sessionId に進み、次回 cleanup
     // （removeByPty）の根拠を失う
-    const attached = await tryCatch(taskStore.attachSession(worktreePath, hook.sessionId, worktreePath));
+    const attached = await tryCatch(
+      taskStore.attachSession(worktreePath, hook.sessionId, worktreePath),
+    );
     if (attached.ok) {
       setSessionId(hook.ptyId, hook.sessionId);
     } else {
@@ -96,7 +109,6 @@ async function applyClaudeSessionHook(hook: HookMessage, worktreePath: string, p
   }
   clearSessionId(hook.ptyId);
 }
-
 
 /** NDJSON 1 行を ClientMessage に正規化する。nc 直送経路の hook は event / ptyId しか
  * JSON に載せないため default 充填が必須（充填しないと hook push payload に undefined が
@@ -123,7 +135,9 @@ function parseClientMessage(line: string): ClientMessage {
     };
   }
   if (dict.open !== undefined) {
-    msg.open = { targetPath: lenientString(lenientDict(dict.open, "open").targetPath, "open.targetPath") };
+    msg.open = {
+      targetPath: lenientString(lenientDict(dict.open, "open").targetPath, "open.targetPath"),
+    };
   }
   return msg;
 }
@@ -131,7 +145,9 @@ function parseClientMessage(line: string): ClientMessage {
 async function handleSocketMessage(line: string, push: PushFn): Promise<void> {
   const parsed = tryCatch(() => parseClientMessage(line));
   if (!parsed.ok) {
-    console.error(`[SocketServer] failed to decode ClientMessage: ${parsed.error}: ${line.slice(0, 200)}`);
+    console.error(
+      `[SocketServer] failed to decode ClientMessage: ${parsed.error}: ${line.slice(0, 200)}`,
+    );
     return;
   }
   const msg = parsed.value;
@@ -175,7 +191,9 @@ export function createSocketMessageHandler(push: PushFn): (line: string) => void
         // 全メッセージが onRejected 不在の .then で素通しされて恒久 drop になる
         // （unhandledRejection になるだけで [SocketServer] の観察ログも出ない）。
         // キューを生かし続け、失敗行だけを観察ログに倒す
-        console.error(`[SocketServer] handler rejected, chain kept alive: ${error}: ${line.slice(0, 200)}`);
+        console.error(
+          `[SocketServer] handler rejected, chain kept alive: ${error}: ${line.slice(0, 200)}`,
+        );
       });
   };
 }

--- a/apps/electron/src/socketMessages.ts
+++ b/apps/electron/src/socketMessages.ts
@@ -23,7 +23,7 @@ import type { PushFn } from "./rpcDispatcher";
 import { taskStore } from "./taskStore";
 
 function notifyTaskStoreError(push: PushFn, message: string, error: unknown, dir: string): void {
-  console.error(`[TaskStore] ${message}: ${error}`);
+  console.error(`[TaskStore] ${message}: ${String(error)}`);
   push("notify", { type: "error", source: "task-store", message, detail: String(error), dir });
 }
 

--- a/apps/electron/src/socketServer.test.ts
+++ b/apps/electron/src/socketServer.test.ts
@@ -36,7 +36,10 @@ describe("SocketServer", () => {
   const cleanups: Array<() => void> = [];
   const tempDirs: string[] = [];
 
-  function makeServer(onMessage: (line: string) => void): { handle: SocketServerHandle; path: string } {
+  function makeServer(onMessage: (line: string) => void): {
+    handle: SocketServerHandle;
+    path: string;
+  } {
     const dir = mkdtempSync(join(tmpdir(), "gozd-socket-test-"));
     tempDirs.push(dir);
     const path = join(dir, "test.sock");
@@ -69,7 +72,11 @@ describe("SocketServer", () => {
   test("複数接続から並行受信できる", async () => {
     const received: string[] = [];
     const { path } = makeServer((line) => received.push(line));
-    await Promise.all([sendLines(path, '{"from":"a"}\n'), sendLines(path, '{"from":"b"}\n'), sendLines(path, '{"from":"c"}\n')]);
+    await Promise.all([
+      sendLines(path, '{"from":"a"}\n'),
+      sendLines(path, '{"from":"b"}\n'),
+      sendLines(path, '{"from":"c"}\n'),
+    ]);
     await waitFor(() => received.length === 3);
     expect(received.toSorted()).toEqual(['{"from":"a"}', '{"from":"b"}', '{"from":"c"}']);
   });

--- a/apps/electron/src/spikeDiag.ts
+++ b/apps/electron/src/spikeDiag.ts
@@ -94,7 +94,9 @@ async function diagFetch(dir: string): Promise<void> {
 export async function runSpikeResolverDiag(): Promise<void> {
   log(`process.env.PATH = ${process.env.PATH ?? "(unset)"}`);
   const shell = tryCatch(() => userInfo().shell);
-  log(`login shell: userInfo.shell=${shell.ok ? shell.value : "?"} env.SHELL=${process.env.SHELL ?? "(unset)"}`);
+  log(
+    `login shell: userInfo.shell=${shell.ok ? shell.value : "?"} env.SHELL=${process.env.SHELL ?? "(unset)"}`,
+  );
 
   await diagGit();
 

--- a/apps/electron/src/stores.test.ts
+++ b/apps/electron/src/stores.test.ts
@@ -3,7 +3,12 @@ import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { RawJsonTypeError } from "./rawJson";
-import { loadAppConfigFrom, loadAppStateFrom, normalizeAppConfig, normalizeAppState } from "./stores";
+import {
+  loadAppConfigFrom,
+  loadAppStateFrom,
+  normalizeAppConfig,
+  normalizeAppState,
+} from "./stores";
 
 function makeTempDir(): string {
   return mkdtempSync(join(tmpdir(), "gozd-stores-test-"));
@@ -36,9 +41,9 @@ describe("normalizeAppState (strict)", () => {
     expect(() => normalizeAppState({ sidebarRepos: [{ collapsed: "yes" }] })).toThrow(
       RawJsonTypeError,
     );
-    expect(() =>
-      normalizeAppState({ sidebarRepos: [{ worktrees: [{ isMain: 1 }] }] }),
-    ).toThrow(RawJsonTypeError);
+    expect(() => normalizeAppState({ sidebarRepos: [{ worktrees: [{ isMain: 1 }] }] })).toThrow(
+      RawJsonTypeError,
+    );
     expect(() => normalizeAppState({ activeRepoListId: 5 })).toThrow(RawJsonTypeError);
     expect(() => normalizeAppState({ activeDir: 5 })).toThrow(RawJsonTypeError);
   });

--- a/apps/electron/src/stores.ts
+++ b/apps/electron/src/stores.ts
@@ -56,7 +56,9 @@ function asBooleanMap(raw: unknown, label: string): Record<string, boolean> {
     if (typeof value === "boolean") {
       result[key] = value;
     } else {
-      console.error(`[normalizeAppConfig] ${label}.${key}: expected boolean, got ${typeof value}; dropping`);
+      console.error(
+        `[normalizeAppConfig] ${label}.${key}: expected boolean, got ${typeof value}; dropping`,
+      );
     }
   }
   return result;
@@ -206,7 +208,9 @@ export function loadAppState(): AppState {
 function saveAppStateTo(path: string, state: AppState): void {
   // merge 元の既存ファイル読み込み失敗は新規化に倒す（load 経路と対照的に、save の
   // merge 元は救済不要）
-  const existing = tryCatch(() => JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>);
+  const existing = tryCatch(
+    () => JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>,
+  );
   const merged: Record<string, unknown> =
     existing.ok && typeof existing.value === "object" && existing.value !== null
       ? existing.value

--- a/apps/electron/src/taskStore.test.ts
+++ b/apps/electron/src/taskStore.test.ts
@@ -59,10 +59,20 @@ describe("TaskStore", () => {
 
   test("add: 同 worktreeDir + 同 ghRef の既存 task は再活性化される (PR/issue 再選択)", async () => {
     const { store, dir } = setup();
-    const first = await store.add({ dir, ghTitle: "old title", worktreeDir: "/wt/a", ghRef: ghRefForPr(42) });
+    const first = await store.add({
+      dir,
+      ghTitle: "old title",
+      worktreeDir: "/wt/a",
+      ghRef: ghRefForPr(42),
+    });
     // closed 状態を作る（detachSession は sessionId 起点なので直接ファイルを書き換えない
     // 代わりに、再 add で closedByUser=false へ戻る挙動を上書きタイトルとセットで検証）
-    const second = await store.add({ dir, ghTitle: "new title", worktreeDir: "/wt/a", ghRef: ghRefForPr(42) });
+    const second = await store.add({
+      dir,
+      ghTitle: "new title",
+      worktreeDir: "/wt/a",
+      ghRef: ghRefForPr(42),
+    });
     expect(second.id).toBe(first.id);
     expect(second.ghTitle).toBe("new title");
     expect(second.closedByUser).toBe(false);
@@ -79,8 +89,18 @@ describe("TaskStore", () => {
 
   test("add: 別 worktree の同 ghRef は別 task として扱う", async () => {
     const { store, dir } = setup();
-    const first = await store.add({ dir, ghTitle: "t", worktreeDir: "/wt/a", ghRef: ghRefForPr(42) });
-    const second = await store.add({ dir, ghTitle: "t", worktreeDir: "/wt/b", ghRef: ghRefForPr(42) });
+    const first = await store.add({
+      dir,
+      ghTitle: "t",
+      worktreeDir: "/wt/a",
+      ghRef: ghRefForPr(42),
+    });
+    const second = await store.add({
+      dir,
+      ghTitle: "t",
+      worktreeDir: "/wt/b",
+      ghRef: ghRefForPr(42),
+    });
     expect(second.id).not.toBe(first.id);
     expect((await store.list(dir)).length).toBe(2);
   });
@@ -111,7 +131,9 @@ describe("TaskStore", () => {
 
   test("detachSession: ghRef 無し task も残し、sessionID 保持 + closed_by_user=true", async () => {
     const { store, dir, configDir } = setup();
-    await writeTasksFile(configDir, dir, [makeTask({ id: "1", worktreeDir: "/wt/a", sessionId: "sid-1" })]);
+    await writeTasksFile(configDir, dir, [
+      makeTask({ id: "1", worktreeDir: "/wt/a", sessionId: "sid-1" }),
+    ]);
     await store.detachSession(dir, "sid-1");
     const [task] = await store.list(dir);
     expect(task?.sessionId).toBe("sid-1");
@@ -132,7 +154,9 @@ describe("TaskStore", () => {
 
   test("detachSession: sessionId 不一致なら no-op (silent return)", async () => {
     const { store, dir, configDir } = setup();
-    await writeTasksFile(configDir, dir, [makeTask({ id: "1", worktreeDir: "/wt/a", sessionId: "sid-1" })]);
+    await writeTasksFile(configDir, dir, [
+      makeTask({ id: "1", worktreeDir: "/wt/a", sessionId: "sid-1" }),
+    ]);
     await store.detachSession(dir, "sid-unknown");
     const [task] = await store.list(dir);
     expect(task?.closedByUser).toBe(false);
@@ -155,7 +179,13 @@ describe("TaskStore", () => {
   test("attachSession: 既に同 sessionID の task があれば closed=false に戻して no-op (resume 復帰)", async () => {
     const { store, dir, configDir } = setup();
     await writeTasksFile(configDir, dir, [
-      makeTask({ id: "1", worktreeDir: "/wt/a", sessionId: "sid-1", closedByUser: true, ghTitle: "keep" }),
+      makeTask({
+        id: "1",
+        worktreeDir: "/wt/a",
+        sessionId: "sid-1",
+        closedByUser: true,
+        ghTitle: "keep",
+      }),
     ]);
     await store.attachSession(dir, "sid-1", "/wt/a");
     const tasks = await store.list(dir);
@@ -168,7 +198,12 @@ describe("TaskStore", () => {
     const { store, dir, configDir } = setup();
     await writeTasksFile(configDir, dir, [
       makeTask({ id: "old", worktreeDir: "/wt/a", createdAt: "2026-07-01T00:00:00Z" }),
-      makeTask({ id: "new", worktreeDir: "/wt/a", createdAt: "2026-07-02T00:00:00Z", closedByUser: true }),
+      makeTask({
+        id: "new",
+        worktreeDir: "/wt/a",
+        createdAt: "2026-07-02T00:00:00Z",
+        closedByUser: true,
+      }),
     ]);
     await store.attachSession(dir, "sid-new", "/wt/a");
     const tasks = await store.list(dir);
@@ -240,7 +275,13 @@ describe("TaskStore", () => {
   test("attachSession: ghRef 有り closed task も奪わず、素 claude (新 sid) は別 task を作る", async () => {
     const { store, dir, configDir } = setup();
     await writeTasksFile(configDir, dir, [
-      makeTask({ id: "1", worktreeDir: "/wt/a", sessionId: "sid-kept", closedByUser: true, ghRef: ghRefForPr(9) }),
+      makeTask({
+        id: "1",
+        worktreeDir: "/wt/a",
+        sessionId: "sid-kept",
+        closedByUser: true,
+        ghRef: ghRefForPr(9),
+      }),
     ]);
     await store.attachSession(dir, "sid-new", "/wt/a");
     const tasks = await store.list(dir);
@@ -252,7 +293,9 @@ describe("TaskStore", () => {
 
   test("clearDeadSession(markClosedByUser=true): sessionID 空 + closed_by_user=true (terminal close 経路)", async () => {
     const { store, dir, configDir } = setup();
-    await writeTasksFile(configDir, dir, [makeTask({ id: "1", worktreeDir: "/wt/a", sessionId: "sid-1" })]);
+    await writeTasksFile(configDir, dir, [
+      makeTask({ id: "1", worktreeDir: "/wt/a", sessionId: "sid-1" }),
+    ]);
     await store.clearDeadSession(dir, "sid-1", true);
     const [task] = await store.list(dir);
     expect(task?.sessionId).toBe("");
@@ -261,7 +304,9 @@ describe("TaskStore", () => {
 
   test("clearDeadSession(markClosedByUser=false): closed_by_user 据え置き (session-start fallback)", async () => {
     const { store, dir, configDir } = setup();
-    await writeTasksFile(configDir, dir, [makeTask({ id: "1", worktreeDir: "/wt/a", sessionId: "sid-1" })]);
+    await writeTasksFile(configDir, dir, [
+      makeTask({ id: "1", worktreeDir: "/wt/a", sessionId: "sid-1" }),
+    ]);
     await store.clearDeadSession(dir, "sid-1", false);
     const [task] = await store.list(dir);
     expect(task?.sessionId).toBe("");

--- a/apps/electron/src/taskStore.ts
+++ b/apps/electron/src/taskStore.ts
@@ -18,7 +18,14 @@
 import type { GhRef, Task, TaskList } from "@gozd/rpc";
 import { tryCatch } from "@gozd/shared";
 import { createHash, randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, realpathSync, renameSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join } from "node:path";
 import { runGit } from "./git/gitRunner";
@@ -97,7 +104,9 @@ function normalizeGhRef(raw: unknown, label: string): GhRef | undefined {
   const dict = asDict(raw);
   const kind = strictString(dict.kind, `${label}.kind`);
   if (kind !== "GH_REF_KIND_PR" && kind !== "GH_REF_KIND_ISSUE") {
-    console.error(`[TaskStore] normalizeGhRef: unknown kind ${JSON.stringify(kind)}; dropping ghRef`);
+    console.error(
+      `[TaskStore] normalizeGhRef: unknown kind ${JSON.stringify(kind)}; dropping ghRef`,
+    );
     return undefined;
   }
   return { kind, number: strictNumber(dict.number, `${label}.number`) };
@@ -184,7 +193,9 @@ export function createTaskStore(configDir: string) {
     if (ghRef !== undefined) {
       const existing = fileList.tasks.find(
         (task) =>
-          task.worktreeDir === worktreeDir && task.ghRef !== undefined && sameGhRef(task.ghRef, ghRef),
+          task.worktreeDir === worktreeDir &&
+          task.ghRef !== undefined &&
+          sameGhRef(task.ghRef, ghRef),
       );
       if (existing !== undefined) {
         existing.ghTitle = ghTitle;
@@ -258,7 +269,9 @@ export function createTaskStore(configDir: string) {
       }
       return;
     }
-    const candidates = fileList.tasks.filter((t) => t.worktreeDir === worktreeDir && t.sessionId === "");
+    const candidates = fileList.tasks.filter(
+      (t) => t.worktreeDir === worktreeDir && t.sessionId === "",
+    );
     const [pick] = candidates.toSorted((a, b) => {
       if (a.createdAt !== b.createdAt) return a.createdAt < b.createdAt ? 1 : -1;
       return a.id < b.id ? 1 : -1;
@@ -287,7 +300,11 @@ export function createTaskStore(configDir: string) {
    * markClosedByUser=true（removeByPty 経路: pane close + SessionStart 不達）は
    * closedByUser も立てる。false（session-start fallback 経路）は据え置き —
    * 直後の attachSession が候補ピックで同一 task に転移する */
-  async function clearDeadSession(dir: string, sessionId: string, markClosedByUser: boolean): Promise<void> {
+  async function clearDeadSession(
+    dir: string,
+    sessionId: string,
+    markClosedByUser: boolean,
+  ): Promise<void> {
     const fileList = await loadFile(dir);
     const task = fileList.tasks.find((t) => t.sessionId === sessionId);
     if (task === undefined) return;

--- a/apps/electron/src/taskStore.ts
+++ b/apps/electron/src/taskStore.ts
@@ -345,7 +345,5 @@ export function createTaskStore(configDir: string) {
   };
 }
 
-type TaskStore = ReturnType<typeof createTaskStore>;
-
 /** production 用の単一インスタンス（`~/.config/gozd/`）。routes.ts はこれを使う */
 export const taskStore = createTaskStore(defaultConfigDir);

--- a/apps/electron/src/testGitFixture.ts
+++ b/apps/electron/src/testGitFixture.ts
@@ -1,0 +1,31 @@
+// テスト fixture 用の git 実行ヘルパー。テストコードで素の execFileSync("git", ...) を
+// 書かず、必ずこれを経由する。
+//
+// env を明示指定するのは、git hook（lefthook の pre-commit ジョブ等）配下では git が
+// GIT_DIR / GIT_INDEX_FILE（linked worktree では絶対パス）を注入し、GIT_DIR が cwd より
+// 優先されるため、env 未指定の git spawn が fixture でなく実リポジトリを書き換えるため
+// （2026-07-22 の ref / config 汚染事故）。
+// preload（testPreload.ts）の process.env 除去で足りないのは、Bun の sync spawn
+// （execFileSync）が JS レベルの process.env mutation を子に伝えないため（Bun 1.3.14 実測。
+// async spawn と env 明示指定は反映される）。
+
+import { execFileSync } from "node:child_process";
+import { devNull } from "node:os";
+
+function fixtureGitEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value === undefined || key.startsWith("GIT_")) continue;
+    env[key] = value;
+  }
+  // ユーザー / システム gitconfig からの隔離（git t/test-lib.sh と同じ規律）。
+  // commit.gpgsign / init.defaultBranch 等のユーザー設定をテストに混入させない
+  env.GIT_CONFIG_GLOBAL = devNull;
+  env.GIT_CONFIG_NOSYSTEM = "1";
+  return env;
+}
+
+/** fixture 操作用に git を実行し、trim 済み stdout を返す */
+export function runFixtureGit(args: string[], cwd: string): string {
+  return execFileSync("git", args, { cwd, env: fixtureGitEnv(), encoding: "utf8" }).trim();
+}

--- a/apps/electron/src/testGitFixture.ts
+++ b/apps/electron/src/testGitFixture.ts
@@ -1,5 +1,5 @@
-// テスト fixture 用の git 実行ヘルパー。テストコードで素の execFileSync("git", ...) を
-// 書かず、必ずこれを経由する。
+// テスト fixture 用の git 実行ヘルパーと、git env 隔離ポリシーの SSOT。
+// テストコードで素の execFileSync("git", ...) を書かず、必ず runFixtureGit を経由する。
 //
 // env を明示指定するのは、git hook（lefthook の pre-commit ジョブ等）配下では git が
 // GIT_DIR / GIT_INDEX_FILE（linked worktree では絶対パス）を注入し、GIT_DIR が cwd より
@@ -12,16 +12,25 @@
 import { execFileSync } from "node:child_process";
 import { devNull } from "node:os";
 
+/** git spawn から剥がす環境変数の prefix。git が hook に注入する repo-local 変数を包含する */
+export const GIT_ENV_PREFIX = "GIT_";
+
+/**
+ * ユーザー / システム gitconfig からの隔離（git t/test-lib.sh と同じ規律）。
+ * commit.gpgsign / init.defaultBranch 等のユーザー設定をテストに混入させない
+ */
+export const GIT_CONFIG_ISOLATION = {
+  GIT_CONFIG_GLOBAL: devNull,
+  GIT_CONFIG_NOSYSTEM: "1",
+} as const;
+
 function fixtureGitEnv(): Record<string, string> {
   const env: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {
-    if (value === undefined || key.startsWith("GIT_")) continue;
+    if (value === undefined || key.startsWith(GIT_ENV_PREFIX)) continue;
     env[key] = value;
   }
-  // ユーザー / システム gitconfig からの隔離（git t/test-lib.sh と同じ規律）。
-  // commit.gpgsign / init.defaultBranch 等のユーザー設定をテストに混入させない
-  env.GIT_CONFIG_GLOBAL = devNull;
-  env.GIT_CONFIG_NOSYSTEM = "1";
+  Object.assign(env, GIT_CONFIG_ISOLATION);
   return env;
 }
 

--- a/apps/electron/src/testPreload.ts
+++ b/apps/electron/src/testPreload.ts
@@ -1,5 +1,6 @@
 // bun test の preload（bunfig.toml [test].preload）。テストプロセスの process.env から
 // GIT_* を除去し、テスト対象実装が spawn する git を ambient な git 環境から隔離する。
+// 隔離ポリシー（剥がす prefix / config 隔離ペア）の SSOT は testGitFixture.ts。
 //
 // git hook（lefthook の pre-commit ジョブ等）配下では git が GIT_DIR / GIT_INDEX_FILE を
 // 注入し、linked worktree ではどちらも絶対パスになる。GIT_DIR は cwd より優先されるため、
@@ -13,12 +14,10 @@
 // git 実行は testGitFixture.ts の runFixtureGit（env 明示指定）を必ず使う。この二層で
 // 「テスト対象」「fixture」双方の git spawn が隔離される。
 
-import { devNull } from "node:os";
+import { GIT_CONFIG_ISOLATION, GIT_ENV_PREFIX } from "./testGitFixture";
 
 for (const key of Object.keys(process.env)) {
-  if (key.startsWith("GIT_")) delete process.env[key];
+  if (key.startsWith(GIT_ENV_PREFIX)) delete process.env[key];
 }
 
-// ユーザー / システム gitconfig からの隔離（git t/test-lib.sh と同じ規律）
-process.env.GIT_CONFIG_GLOBAL = devNull;
-process.env.GIT_CONFIG_NOSYSTEM = "1";
+Object.assign(process.env, GIT_CONFIG_ISOLATION);

--- a/apps/electron/src/testPreload.ts
+++ b/apps/electron/src/testPreload.ts
@@ -1,0 +1,24 @@
+// bun test の preload（bunfig.toml [test].preload）。テストプロセスの process.env から
+// GIT_* を除去し、テスト対象実装が spawn する git を ambient な git 環境から隔離する。
+//
+// git hook（lefthook の pre-commit ジョブ等）配下では git が GIT_DIR / GIT_INDEX_FILE を
+// 注入し、linked worktree ではどちらも絶対パスになる。GIT_DIR は cwd より優先されるため、
+// 継承 env のままの git spawn は fixture でなく実リポジトリを書き換える
+// （2026-07-22 の ref / config 汚染事故）。git 自身も別 repo へ子 git を起こす際は
+// prepare_other_repo_env（run-command.c）で repo-local env を全消しするのが規範。
+//
+// この preload が守るのは「process.env を列挙して env を明示構築する」spawn 経路
+// （gitRunner の gozdGitEnv 等）と async spawn。Bun の sync spawn（execFileSync）は
+// JS レベルの process.env mutation を子に伝えないため（Bun 1.3.14 実測）、fixture の
+// git 実行は testGitFixture.ts の runFixtureGit（env 明示指定）を必ず使う。この二層で
+// 「テスト対象」「fixture」双方の git spawn が隔離される。
+
+import { devNull } from "node:os";
+
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith("GIT_")) delete process.env[key];
+}
+
+// ユーザー / システム gitconfig からの隔離（git t/test-lib.sh と同じ規律）
+process.env.GIT_CONFIG_GLOBAL = devNull;
+process.env.GIT_CONFIG_NOSYSTEM = "1";

--- a/apps/electron/src/voicevox.ts
+++ b/apps/electron/src/voicevox.ts
@@ -79,13 +79,21 @@ export async function listSpeakers(): Promise<VoicevoxSpeaker[] | undefined> {
   const speakers: VoicevoxSpeaker[] = [];
   for (const entry of root as Record<string, unknown>[]) {
     if (typeof entry.name !== "string" || !Array.isArray(entry.styles)) {
-      console.error(`[VoicevoxOps.listSpeakers] skipping malformed speaker entry: ${JSON.stringify(entry)}`);
+      console.error(
+        `[VoicevoxOps.listSpeakers] skipping malformed speaker entry: ${JSON.stringify(entry)}`,
+      );
       continue;
     }
     const styles: VoicevoxSpeakerStyle[] = [];
     for (const style of entry.styles as Record<string, unknown>[]) {
-      if (typeof style.name !== "string" || typeof style.id !== "number" || !Number.isInteger(style.id)) {
-        console.error(`[VoicevoxOps.listSpeakers] skipping malformed style entry: ${JSON.stringify(style)}`);
+      if (
+        typeof style.name !== "string" ||
+        typeof style.id !== "number" ||
+        !Number.isInteger(style.id)
+      ) {
+        console.error(
+          `[VoicevoxOps.listSpeakers] skipping malformed style entry: ${JSON.stringify(style)}`,
+        );
         continue;
       }
       styles.push({ name: style.name, id: style.id });
@@ -105,7 +113,10 @@ async function resolveVoicevoxAppPath(): Promise<string | undefined> {
     const [first = ""] = found.value.stdout.split("\n");
     if (first !== "") return first;
   }
-  const candidates = [join("/Applications", "VOICEVOX.app"), join(homedir(), "Applications", "VOICEVOX.app")];
+  const candidates = [
+    join("/Applications", "VOICEVOX.app"),
+    join(homedir(), "Applications", "VOICEVOX.app"),
+  ];
   return candidates.find((path) => existsSync(path));
 }
 
@@ -135,13 +146,17 @@ export async function launch(): Promise<boolean> {
   // （戻り値 true は「engine listen 済み」ではなく「後続は polling で listen を待つ責任」の意味。
   // caller (renderer の doActivate) は launch ok=true の後に waitForEngine を回す前提）
   if (spawnedEngine !== undefined && spawnedEngine.exitCode === null) {
-    console.error("[VoicevoxOps.launch] concurrent spawn in-flight; skipping (caller must poll /version)");
+    console.error(
+      "[VoicevoxOps.launch] concurrent spawn in-flight; skipping (caller must poll /version)",
+    );
     return true;
   }
 
   // stdout / stderr は親 (gozd) を継承。engine がモデルロード失敗等で起動できない
   // ケースのログを gozd の stderr に流して観察可能性を保つ
-  const spawnResult = tryCatch(() => spawn(enginePath, [], { stdio: ["ignore", "inherit", "inherit"] }));
+  const spawnResult = tryCatch(() =>
+    spawn(enginePath, [], { stdio: ["ignore", "inherit", "inherit"] }),
+  );
   if (!spawnResult.ok) {
     console.error(`[VoicevoxOps.launch] failed to spawn engine: ${spawnResult.error}`);
     return false;
@@ -162,7 +177,10 @@ export async function launch(): Promise<boolean> {
   return true;
 }
 
-async function audioQuery(text: string, speakerId: number): Promise<Record<string, unknown> | undefined> {
+async function audioQuery(
+  text: string,
+  speakerId: number,
+): Promise<Record<string, unknown> | undefined> {
   const params = new URLSearchParams({ text, speaker: String(speakerId) });
   const result = await tryCatch(
     fetch(`${BASE_URL}/audio_query?${params}`, {
@@ -175,7 +193,9 @@ async function audioQuery(text: string, speakerId: number): Promise<Record<strin
     return undefined;
   }
   if (!result.value.ok) {
-    console.error(`[VoicevoxOps.audioQuery] non-200 status: ${result.value.status} (speaker=${speakerId})`);
+    console.error(
+      `[VoicevoxOps.audioQuery] non-200 status: ${result.value.status} (speaker=${speakerId})`,
+    );
     return undefined;
   }
   const json = await tryCatch(result.value.json() as Promise<Record<string, unknown>>);
@@ -186,7 +206,10 @@ async function audioQuery(text: string, speakerId: number): Promise<Record<strin
   return json.value;
 }
 
-async function synthesize(audioQueryBody: Record<string, unknown>, speakerId: number): Promise<Uint8Array | undefined> {
+async function synthesize(
+  audioQueryBody: Record<string, unknown>,
+  speakerId: number,
+): Promise<Uint8Array | undefined> {
   const params = new URLSearchParams({ speaker: String(speakerId) });
   const result = await tryCatch(
     fetch(`${BASE_URL}/synthesis?${params}`, {
@@ -201,7 +224,9 @@ async function synthesize(audioQueryBody: Record<string, unknown>, speakerId: nu
     return undefined;
   }
   if (!result.value.ok) {
-    console.error(`[VoicevoxOps.synthesize] non-200 status: ${result.value.status} (speaker=${speakerId})`);
+    console.error(
+      `[VoicevoxOps.synthesize] non-200 status: ${result.value.status} (speaker=${speakerId})`,
+    );
     return undefined;
   }
   const buf = await tryCatch(result.value.arrayBuffer());

--- a/apps/electron/src/windowState.test.ts
+++ b/apps/electron/src/windowState.test.ts
@@ -63,7 +63,10 @@ describe("windowStateStore", () => {
   test("save は既存ファイルを丸ごと置き換える（bounds 以外の未知キーは保持しない）", () => {
     const dir = makeStateDir();
     const path = join(dir, "electron-window.json");
-    writeFileSync(path, JSON.stringify({ bounds: { x: 0, y: 0, width: 1, height: 1 }, junk: true }));
+    writeFileSync(
+      path,
+      JSON.stringify({ bounds: { x: 0, y: 0, width: 1, height: 1 }, junk: true }),
+    );
     const store = createWindowStateStore(dir);
     store.saveBounds({ x: 10, y: 20, width: 800, height: 600 });
     const written = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;

--- a/apps/electron/src/windowState.ts
+++ b/apps/electron/src/windowState.ts
@@ -62,6 +62,4 @@ export function createWindowStateStore(stateDir: string) {
   return { loadBounds, saveBounds };
 }
 
-export const windowStateStore = createWindowStateStore(
-  join(homedir(), ".local", "state", "gozd"),
-);
+export const windowStateStore = createWindowStateStore(join(homedir(), ".local", "state", "gozd"));

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -24,6 +24,10 @@ pre-commit:
             root: "apps/renderer/"
             glob: "**/*.{ts,vue}"
             run: pnpm run typecheck
+          - name: typecheck-electron
+            root: "apps/electron/"
+            glob: "**/*.ts"
+            run: pnpm run typecheck
           - name: test-shared
             root: "packages/shared/"
             glob: "**/*.ts"
@@ -34,6 +38,10 @@ pre-commit:
             run: bun test
           - name: test-renderer
             root: "apps/renderer/"
+            glob: "**/*.ts"
+            run: bun test
+          - name: test-electron
+            root: "apps/electron/"
             glob: "**/*.ts"
             run: bun test
 
@@ -58,6 +66,11 @@ pre-commit:
             stage_fixed: true
           - name: oxlint-claude-session-log
             root: "packages/claude-session-log/"
+            glob: "**/*.ts"
+            run: pnpm exec oxlint --type-aware --fix {staged_files} && pnpm exec oxfmt {staged_files}
+            stage_fixed: true
+          - name: oxlint-electron
+            root: "apps/electron/"
             glob: "**/*.ts"
             run: pnpm exec oxlint --type-aware --fix {staged_files} && pnpm exec oxfmt {staged_files}
             stage_fixed: true


### PR DESCRIPTION
## 概要

apps/electron を lint / format の被覆に入れる。scripts 追加、蓄積していた警告とフォーマット漂流の一括解消、pre-commit ジョブの追加をまとめて行う。あわせて、pre-commit でテストが走るようになったことで顕在化した「テストの git spawn が hook 注入の環境変数を継承して実リポジトリを書き換える」問題を隔離で解消する。

## 背景

エディタで eslint(no-unused-vars) 警告が表示されるのに commit しても消えない、という観察から調査した結果、apps/electron だけがツールチェーンの被覆から漏れていた。

- package.json に lint / fix script が無く、`lint:all` / `fix:all`（`pnpm -r --if-present`）の巡回対象外
- lefthook の pre-commit にも electron の typecheck / test / lint fix ジョブが無く、unused import 等が commit を素通り
- oxlint の warning は exit 0 のため CI も落ちず、警告 13 件とフォーマット漂流（39 ファイル）が蓄積していた

なお knip が消さないのは責務どおり（knip はモジュール境界の unused export / file / dependency が対象で、ファイル内で閉じた unused import / 非 export 型は linter の領分）。

### pre-commit テスト導入で顕在化した git spawn の env 汚染

本 PR の `test-electron` ジョブ追加により、git spawn を含む統合テストが初めて git hook 配下で実行され、fixture 用の git 操作（init / config / commit / checkout）が gozd 実リポジトリの ref / config に適用される事故が起きた（復旧済み。origin への push は無し）。調査で確認した因果:

- git は hook の子プロセスに `GIT_DIR` / `GIT_INDEX_FILE` 等を注入する。通常 repo では `GIT_INDEX_FILE=.git/index`（相対）のみで実害が出にくいが、**linked worktree では両方が絶対パス**になり、`GIT_DIR` は cwd より優先されるため、env 未指定の `execFileSync("git", { cwd: fixtureDir })` は fixture でなく実リポジトリに適用される（使い捨て repo での再現検証で確認）
- lefthook は job に環境を素通しする設計（`exec_unix.go` が `os.Environ()` を継承。lefthook 自身は別 repo へ git を打つ際 `WithoutEnvs("GIT_DIR", "GIT_INDEX_FILE")` で自衛しており、除去は spawn する側の責務）
- 「実 git を temp dir に spawn するテスト」自体は git 本体のテストスイートも採る標準手法で、git は `t/test-lib.sh` で GIT_\* を allowlist 以外全 unset + `GIT_CONFIG_NOSYSTEM` 等の隔離を必ず行う。本 PR のテストにはこの隔離が無かった

## 変更内容

### apps/electron/package.json

- 他パッケージ（shared / claude-session-log）と同じ規約で `lint` / `fix` を追加

### フォーマット catch-up（style commit）

- `oxlint --fix` + `oxfmt .` を全体適用（39 ファイル）。fix script の導入で CI の fix:all が electron を含むようになるため、漂流の一括解消が前提になる
- oxfmt の package.json 整形で標準フィールドが規約順になり、非標準フィールド `productName`（electron-builder / Electron が読む独自フィールド）は末尾へ移動。全消費者はキー名でアクセスするため位置は無関係

### 警告 13 件の解消（refactor commit）

- unused import 2 件・未使用の非 export 型 alias 1 件を削除
- `${error}`（unknown 型）のテンプレート埋め込み 5 件を `String(error)` に明示化
- `app.whenReady().then(...)` の floating promise に `void` を付与
- `RpcHandler` の戻り値 `Promise<unknown> | unknown` を `unknown` に縮約（unknown が Promise を包含し union が冗長）。sync / async 両対応の意図はコメントで保持
- 文字列 spread 3 件を解消: gitBlame の全ゼロ hash 判定は gitValidate の `isAllZeroHex` を参照（SSOT 化）、isAllZeroHex 自体は正規表現化、worktree leaf の制御文字判定は `hasControlChar` ヘルパー（for-of は spread と同じ code point 走査）に切り出し

### lefthook.yml

- `typecheck-electron` / `test-electron` / `oxlint-electron`（fix + oxfmt、stage_fixed）を追加

### テストの git spawn 隔離（test commit）

二層で隔離する。片方だけでは不足することを検証で確認済み:

- `bunfig.toml` + `src/testPreload.ts` — bun test の preload で `process.env` から `GIT_*` を除去し、`GIT_CONFIG_GLOBAL=/dev/null` + `GIT_CONFIG_NOSYSTEM=1` を設定。「process.env を列挙して env を明示構築する」テスト対象実装（`gitRunner` の `gozdGitEnv` 等）の spawn 経路を隔離する
- `src/testGitFixture.ts` の `runFixtureGit` — GIT_\* を除去した env を明示指定して git を実行する fixture 共通ヘルパー。テスト 7 ファイルの素の `execFileSync("git", ...)` をすべて置き換え
- preload 単独で足りないのは Bun の仕様による: Bun 1.3.14 の sync spawn（`execFileSync`）は JS レベルの `process.env` mutation を子プロセスに伝えない（async spawn と env 明示指定は反映される。実測で確認）
- 検証: linked worktree の pre-commit が注入する env を模した状態で全テスト 290 件が pass し、外部 repo が無変更であることを確認（修正前の同条件では 27 fail + 汚染再現）

## 旧実装からの挙動変更・後退

- アプリ挙動の変更なし（refactor はいずれも同値変換。typecheck / lint / テスト 290 件で確認済み）
- テスト実行環境のみ変更: ユーザーのグローバル / システム gitconfig（`commit.gpgsign` / `init.defaultBranch` 等）がテスト結果に影響しなくなる（隔離の意図どおり）
