### PR TITLE
ci: move fix:all from per-PR gate to a daily bot PR

### DIFF
--- a/.github/workflows/code_validation.yml
+++ b/.github/workflows/code_validation.yml
@@ -42,9 +42,10 @@ jobs:
             diff_command: pnpm --filter '...[origin/${{ github.base_ref }}]' --if-present --no-bail --aggregate-output --reporter=append-only lint
             full_command: pnpm run lint:all
 
-          # fix（oxlint --fix / eslint --fix + oxfmt）はここで gate しない。
-          # 自動修正可能な違反は PR を止めずに daily-fix workflow が日次で返済する
+          # fix（oxlint --fix / eslint --fix + oxfmt）は matrix に持たない。自動修正できる
+          # 違反で PR を止めず、daily-fix workflow が日次の全件実行で返済する
           # （.github/workflows/daily-fix.yml）
+
           - name: test
             diff_command: pnpm --filter '...[origin/${{ github.base_ref }}]' --if-present --no-bail --aggregate-output --reporter=append-only test
             full_command: pnpm run test:all

--- a/.github/workflows/code_validation.yml
+++ b/.github/workflows/code_validation.yml
@@ -42,13 +42,9 @@ jobs:
             diff_command: pnpm --filter '...[origin/${{ github.base_ref }}]' --if-present --no-bail --aggregate-output --reporter=append-only lint
             full_command: pnpm run lint:all
 
-          # fix（oxlint --fix / eslint --fix + oxfmt）を実行し、working tree に
-          # 差分が出たら fail する。フォーマット崩れ・自動修正可能な lint 違反が
-          # commit されていないことを保証する
-          - name: fix
-            diff_command: pnpm --filter '...[origin/${{ github.base_ref }}]' --if-present --no-bail --aggregate-output --reporter=append-only fix && git diff --exit-code
-            full_command: pnpm run fix:all && git diff --exit-code
-
+          # fix（oxlint --fix / eslint --fix + oxfmt）はここで gate しない。
+          # 自動修正可能な違反は PR を止めずに daily-fix workflow が日次で返済する
+          # （.github/workflows/daily-fix.yml）
           - name: test
             diff_command: pnpm --filter '...[origin/${{ github.base_ref }}]' --if-present --no-bail --aggregate-output --reporter=append-only test
             full_command: pnpm run test:all

--- a/.github/workflows/code_validation.yml
+++ b/.github/workflows/code_validation.yml
@@ -30,6 +30,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # ルートの集約スクリプトは 6 種あるが、matrix は fix を除いた 5 本。自動修正できる
+          # 違反で PR を止めず、daily-fix workflow が日次の全件実行で返済する
+          # （.github/workflows/daily-fix.yml）
+          #
           # diff_command に --include-workspace-root は要らない: 正のフィルタ（`--filter`）を
           # 与えると pnpm は root project を除外しないため、root 直下ファイルの変更でも root は
           # 選択される。逆に full_command 側の `pnpm -r`（*:all）はフィルタが無く root が
@@ -41,10 +45,6 @@ jobs:
           - name: lint
             diff_command: pnpm --filter '...[origin/${{ github.base_ref }}]' --if-present --no-bail --aggregate-output --reporter=append-only lint
             full_command: pnpm run lint:all
-
-          # fix（oxlint --fix / eslint --fix + oxfmt）は matrix に持たない。自動修正できる
-          # 違反で PR を止めず、daily-fix workflow が日次の全件実行で返済する
-          # （.github/workflows/daily-fix.yml）
 
           - name: test
             diff_command: pnpm --filter '...[origin/${{ github.base_ref }}]' --if-present --no-bail --aggregate-output --reporter=append-only test

--- a/.github/workflows/daily-fix.yml
+++ b/.github/workflows/daily-fix.yml
@@ -1,0 +1,122 @@
+# 日次 fix PR + auto merge
+#
+# 目的: 「任意の時点で fix:all を実行したとき、生じる diff は 100% 自分の変更に起因する」
+# という不変条件を維持する。日次で全件検査し、ドリフトがあれば bot が PR を作成して
+# CI green で auto merge する。差分がなければ何もしない（空振り＝不変条件成立の日次の証明）。
+#
+# 設計上の判断:
+# - PR ごとの gate（code_validation の fix job）を置かず日次の全件検査にする。gate は
+#   「ドリフトを入れさせない」が、--no-verify / GitHub Web UI 編集 / lint 設定変更時の
+#   一括適用漏れといった経路を塞げない。経路に依存しない全件検査を維持装置にする。
+# - main push をトリガーにしない（schedule + workflow_dispatch のみ）。fix PR のマージ自体が
+#   main push であり、main push トリガーだと自己再帰ループになる。また main push は release
+#   workflow を発火させる重いイベントで、整形コミットがそれを増産してしまう。
+# - コミット・固定ブランチ管理・PR 作成/更新・差分ゼロ時の自動 close は
+#   peter-evans/create-pull-request に委ねる。git push や上書き判定を自前で実装しない
+#   （自作の認証・分岐がセキュリティ穴の温床になるため）。bot/daily-fix は bot 所有ブランチとし
+#   人間は直接編集しない（CI 失敗時は auto merge が待つだけ）。
+# - トークンは GitHub App の installation token を使う。PAT は使わない（人間の identity に
+#   紐づき、無期限で、失効も手動になるため）。GITHUB_TOKEN も使えない: それで作成した PR は
+#   pull_request イベントが発火せず code_validation が走らない。main の ruleset は all-green を
+#   required status check にしており bypass actor がゼロのため、CI が走らない PR は auto merge
+#   どころか手動マージも不可能な塩漬け PR になる。App token は job 終了時に自動失効する。
+# - App token に Contents / Pull requests に加えて Workflows の write を与える。最小権限に
+#   絞りたいところだが、oxfmt の対象には .github/workflows/*.yml も含まれる（root の fix
+#   スクリプトが repo 直下を走るため）。GitHub API 経由で workflow ファイルを含む tree を作るには
+#   workflows 権限が必須で、無いと yml がドリフトした日に create-a-tree が 403 になり
+#   bot が恒久停止する。
+# - commit は sign-commits で GitHub API 経由の verified commit にする。git push を使わないため
+#   トークンは URL にも .git/config にも残らず、checkout も persist-credentials: false で
+#   fix:all へ露出させない。
+# - fix:all は 1 回だけ実行する（複数回は回さない）。linter → formatter の相互作用で 1 パスでは
+#   固定点に達しないファイルは、その日の差分をマージし翌日の run で次のパスへ、と日次で
+#   自然収束させる。
+name: daily-fix
+
+on:
+  schedule:
+    # 毎日 18:23 UTC（= 03:23 JST）。開発の少ない時間帯かつ毎正時を避ける
+    # （GitHub の cron は毎正時に集中し遅延しやすい）
+    - cron: "23 18 * * *"
+  workflow_dispatch:
+
+# 同時実行を防ぐ（前回の run が走っている間は待つ）。cancel はしない:
+# PR 作成途中の cancel は固定ブランチだけ進んだ中途半端な状態を作るため
+concurrency:
+  group: daily-fix
+  cancel-in-progress: false
+
+# checkout の clone（GITHUB_TOKEN）に contents: read のみ。
+# コミット・PR 操作・auto merge は App token で行うため、ここでは書き込み権限を付与しない
+permissions:
+  contents: read
+
+jobs:
+  daily-fix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # PR を pull_request イベント発火可能なトークンで作るため App token を取得する。
+      # 権限は create-pull-request が使う範囲（commit = contents、PR = pull-requests、
+      # workflow ファイルを含む tree = workflows）に絞る
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.GOZD_BOT_APP_ID }}
+          private-key: ${{ secrets.GOZD_BOT_PRIVATE_KEY }}
+          # App が他リポジトリにもインストールされた場合に、過剰な write 権限のトークンが
+          # fix:all の走る job 内に存在するのを防ぐ
+          owner: ${{ github.repository_owner }}
+          repositories: gozd
+          permission-contents: write
+          permission-pull-requests: write
+          permission-workflows: write
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: main
+          # create-pull-request は既存ブランチとの差分算出に履歴を必要とする
+          # （shallow だと既存 PR ブランチの更新で破綻しうる）
+          fetch-depth: 0
+          # create-pull-request は token: input の App token で commit / PR 操作を行い、
+          # checkout の永続クレデンシャルを使わない。トークンを fix:all へ露出させないため
+          # 永続化しない
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-environment
+
+      # fix:all 自体の失敗（lint 設定エラー・formatter クラッシュ等）は握りつぶさない。
+      # 握りつぶすと「整形が走っていないのにドリフト無し＝不変条件成立」と誤報告する
+      # サイレント故障になるため、失敗時はそのまま job を fail させて可観測にする
+      - name: Run fix:all
+        run: pnpm run fix:all
+
+      # 整形差分があれば固定ブランチ bot/daily-fix へ verified commit して PR を作成/更新する。
+      # 差分が無ければ PR を作らず、既存 PR が不要になれば自動 close + ブランチ削除される。
+      # add-paths で絞らないのは fix:all の対象が repo 全域に及ぶため。job 内で生成される
+      # 未追跡ファイル（資格情報等）は存在しない前提で、増えたら .gitignore 側で塞ぐ
+      - name: Create or update fix PR
+        id: cpr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          base: main
+          branch: bot/daily-fix
+          sign-commits: true
+          delete-branch: true
+          # type は style。release workflow の canary 発火判定（feat / fix）に掛けないため
+          # （配布物の中身は変わらない）
+          commit-message: "style: repay lint and format drift found by fix:all"
+          title: "style: repay lint and format drift found by fix:all"
+          body: Automated PR from the daily `daily-fix` workflow. It runs `fix:all` across the whole repo and repays the lint / format drift it finds.
+
+      # PR が作成/更新/既存のいずれかで存在するとき auto merge を有効にする
+      # （差分ゼロで close された場合・PR が無い場合は何もしない）
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-number != '' && steps.cpr.outputs.pull-request-operation != 'closed'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # ${{ }} を run: に直接展開せず env 経由で渡す（テンプレートインジェクション面を作らない）
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+        run: gh pr merge --auto --merge --delete-branch "$PR_NUMBER"

--- a/.github/workflows/daily-fix.yml
+++ b/.github/workflows/daily-fix.yml
@@ -1,56 +1,24 @@
-# 日次 fix PR + auto merge
+# 日次で fix:all を全件実行し、ドリフトがあれば bot PR を作って auto merge する。
+# 差分ゼロなら何もしない（空振り＝その日に整形ドリフトが無いことの証明）。
 #
-# 目的: 「任意の時点で fix:all を実行したとき、生じる diff は 100% 自分の変更に起因する」
-# という不変条件を維持する。日次で全件検査し、ドリフトがあれば bot が PR を作成して
-# CI green で auto merge する。差分がなければ何もしない（空振り＝不変条件成立の日次の証明）。
-#
-# 設計上の判断:
-# - main push をトリガーにしない（schedule + workflow_dispatch のみ）。fix PR のマージ自体が
-#   main push であり、main push トリガーだと自己再帰ループになる。また main push は release
-#   workflow を発火させる重いイベントで、整形コミットがそれを増産してしまう。
-# - コミット・固定ブランチ管理・PR 作成/更新・差分ゼロ時の自動 close は
-#   peter-evans/create-pull-request に委ねる。git push や上書き判定を自前で実装しない
-#   （自作の認証・分岐がセキュリティ穴の温床になるため）。bot/daily-fix は bot 所有ブランチとし
-#   人間は直接編集しない（CI 失敗時は auto merge が待つだけ）。
-# - トークンは GitHub App の installation token を使う。PAT は使わない（人間の identity に
-#   紐づき、無期限で、失効も手動になるため）。GITHUB_TOKEN も使えない: それで作成した PR は
-#   pull_request イベントが発火せず code_validation が走らない。main の ruleset は all-green を
-#   required status check にしており bypass actor がゼロのため、CI が走らない PR は auto merge
-#   どころか手動マージも不可能な塩漬け PR になる。App token は job 終了時に自動失効する。
-# - App token の生成は fix:all の後に置く。install と fix:all は third-party コード
-#   （postinstall script、oxlint / oxfmt / eslint と各 plugin）を実行するため、その間 job 内に
-#   write 権限のトークンを存在させない。repositories による scope 絞りは blast radius を
-#   狭めるだけで存在自体は防げないので、順序で解く。
-# - App token に Contents / Pull requests に加えて Workflows の write を与える。最小権限に
-#   絞りたいところだが、oxfmt の対象には .github/workflows/*.yml も含まれる（root の fix
-#   スクリプトが repo 直下を走るため）。GitHub API 経由で workflow ファイルを含む tree を作るには
-#   workflows 権限が必須で、無いと yml がドリフトした日に create-a-tree が 403 になり
-#   bot が恒久停止する。
-# - トークンを fix:all へ露出させない担保は step 順序と checkout の persist-credentials: false。
-#   sign-commits は担保にならない: create-pull-request は HTTPS remote に対し configureToken を
-#   無条件で呼び、差分ゼロ時のブランチ削除（git push --delete）のために .git/config へ
-#   extraheader を書き込む（実行後に自身で除去する）。
-# - fix:all は 1 回だけ実行する。各 package の fix は lint --fix → oxfmt の順で formatter が
-#   最後に走るため 1 パスで固定点に達する。収束を待つループは、観測されたことのない非収束の
-#   ために実行時間と fail 経路を増やすだけになる。仮に将来 A→B→A の振動が生じても、
-#   同じファイルの bot PR が毎日出続ける形で観測できるので silent には壊れない。
+# - main push を trigger にしない。fix PR のマージ自体が main push であり自己再帰する
+# - App token を使う。GITHUB_TOKEN で作った PR は pull_request が発火せず code_validation が
+#   走らないため、required status check の all-green が永久に付かず手動マージもできなくなる
+# - App token の生成は fix:all の後。install と fix:all は third-party コードを実行するため、
+#   その間 job 内に write 権限のトークンを置かない（scope 絞りでは存在自体を防げない）
 name: daily-fix
 
 on:
   schedule:
-    # 毎日 18:23 UTC（= 03:23 JST）。開発の少ない時間帯かつ毎正時を避ける
-    # （GitHub の cron は毎正時に集中し遅延しやすい）
+    # 03:23 JST。毎正時は GitHub の cron が混んで遅延しやすいので避ける
     - cron: "23 18 * * *"
   workflow_dispatch:
 
-# 同時実行を防ぐ（前回の run が走っている間は待つ）。cancel はしない:
-# PR 作成途中の cancel は固定ブランチだけ進んだ中途半端な状態を作るため
+# cancel はしない: PR 作成途中の cancel は固定ブランチだけ進んだ状態を残す
 concurrency:
   group: daily-fix
   cancel-in-progress: false
 
-# checkout の clone（GITHUB_TOKEN）に contents: read のみ。
-# コミット・PR 操作・auto merge は App token で行うため、ここでは書き込み権限を付与しない
 permissions:
   contents: read
 
@@ -62,24 +30,20 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
-          # create-pull-request は既存ブランチとの差分算出に履歴を必要とする
-          # （shallow だと既存 PR ブランチの更新で破綻しうる）
+          # create-pull-request が既存ブランチとの差分算出に全履歴を要求する
           fetch-depth: 0
           persist-credentials: false
 
       - uses: ./.github/actions/setup-environment
 
-      # fix:all 自体の失敗（lint 設定エラー・formatter クラッシュ等）は握りつぶさない。
-      # 握りつぶすと「整形が走っていないのにドリフト無し＝不変条件成立」と誤報告する
-      # サイレント故障になるため、失敗時はそのまま job を fail させて可観測にする
+      # 各 package の fix は lint --fix → oxfmt の順で formatter が最後に走るため 1 パスで
+      # 固定点に達する。収束を待つループは不要
       - name: Run fix:all
         run: pnpm run fix:all
 
-      # PR を pull_request イベント発火可能なトークンで作るため App token を取得する。
-      # 権限は create-pull-request が使う範囲（commit = contents、PR = pull-requests、
-      # workflow ファイルを含む tree = workflows）に絞る。owner / repositories は指定しない:
-      # 両方未指定なら action が GITHUB_REPOSITORY から現 repo 1 個に scope するため、
-      # repo 名をハードコードせずに同じ結果が得られる
+      # workflows は oxfmt の対象に .github/workflows/*.yml が含まれるため必須。無いと yml が
+      # ドリフトした日に create-a-tree が 403 になり bot が恒久停止する。
+      # owner / repositories は指定しない（両方未指定なら action が現 repo 1 個に scope する）
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
@@ -90,11 +54,8 @@ jobs:
           permission-pull-requests: write
           permission-workflows: write
 
-      # 整形差分があれば固定ブランチ bot/daily-fix へ verified commit して PR を作成/更新する。
-      # 差分が無ければ PR を作らず、既存 PR が不要になれば自動 close + ブランチ削除される。
       # add-paths で絞らないのは fix:all の対象が repo 全域に及ぶため。裏を返せば working tree に
-      # 現れたものは何でも commit されて auto merge で無審査に main へ入る経路であり、
-      # job 内で生成される未追跡ファイルは .gitignore 側で塞ぐ必要がある
+      # 現れたものは何でも commit されて auto merge で無審査に main へ入る
       - name: Create or update fix PR
         id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
@@ -104,20 +65,16 @@ jobs:
           branch: bot/daily-fix
           sign-commits: true
           delete-branch: true
-          # type は style。release workflow の canary 発火判定（feat / fix）に掛けないため
-          # （配布物の中身は変わらない）
+          # style は release workflow の canary 発火判定（feat / fix）に掛からない
           commit-message: "style: repay lint and format drift found by fix:all"
           title: "style: repay lint and format drift found by fix:all"
           body: Automated PR from the daily `daily-fix` workflow. It runs `fix:all` across the whole repo and repays the lint / format drift it finds.
 
-      # PR が作成/更新/既存のいずれかで存在するとき auto merge を有効にする
-      # （差分ゼロで close された場合・PR が無い場合は何もしない）。
       # --delete-branch は付けない: gh の deleteRemoteBranch は autoMerge 経路で早期 return する
-      # no-op であり、実際の削除は repo 設定の delete_branch_on_merge が担う
+      # no-op であり、削除は repo 設定の delete_branch_on_merge が担う
       - name: Enable auto-merge
         if: steps.cpr.outputs.pull-request-number != '' && steps.cpr.outputs.pull-request-operation != 'closed'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          # ${{ }} を run: に直接展開せず env 経由で渡す（テンプレートインジェクション面を作らない）
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
         run: gh pr merge --auto --merge "$PR_NUMBER"

--- a/.github/workflows/daily-fix.yml
+++ b/.github/workflows/daily-fix.yml
@@ -30,10 +30,10 @@
 #   sign-commits は担保にならない: create-pull-request は HTTPS remote に対し configureToken を
 #   無条件で呼び、差分ゼロ時のブランチ削除（git push --delete）のために .git/config へ
 #   extraheader を書き込む（実行後に自身で除去する）。
-# - fix:all は固定点に達するまで回す。linter → formatter の相互作用で 1 パスでは収束しない
-#   ファイルがあり、非固定点の tree を merge すると「merge 直後の main で fix:all が diff を
-#   出す」状態になって不変条件を bot 自身が破る。上限内に収束しない場合は lint / formatter
-#   設定側の欠陥なので、日を跨いで隠さず fail させる。
+# - fix:all は 1 回だけ実行する。各 package の fix は lint --fix → oxfmt の順で formatter が
+#   最後に走るため 1 パスで固定点に達する。収束を待つループは、観測されたことのない非収束の
+#   ために実行時間と fail 経路を増やすだけになる。仮に将来 A→B→A の振動が生じても、
+#   同じファイルの bot PR が毎日出続ける形で観測できるので silent には壊れない。
 name: daily-fix
 
 on:
@@ -72,21 +72,8 @@ jobs:
       # fix:all 自体の失敗（lint 設定エラー・formatter クラッシュ等）は握りつぶさない。
       # 握りつぶすと「整形が走っていないのにドリフト無し＝不変条件成立」と誤報告する
       # サイレント故障になるため、失敗時はそのまま job を fail させて可観測にする
-      - name: Run fix:all until fixpoint
-        run: |
-          set -euo pipefail
-          prev=""
-          for _ in 1 2 3; do
-            pnpm run fix:all
-            git add -A
-            cur="$(git write-tree)"
-            if [[ "${cur}" == "${prev}" ]]; then
-              exit 0
-            fi
-            prev="${cur}"
-          done
-          echo "::error::fix:all did not reach a fixpoint in 3 passes"
-          exit 1
+      - name: Run fix:all
+        run: pnpm run fix:all
 
       # PR を pull_request イベント発火可能なトークンで作るため App token を取得する。
       # 権限は create-pull-request が使う範囲（commit = contents、PR = pull-requests、

--- a/.github/workflows/daily-fix.yml
+++ b/.github/workflows/daily-fix.yml
@@ -5,9 +5,6 @@
 # CI green で auto merge する。差分がなければ何もしない（空振り＝不変条件成立の日次の証明）。
 #
 # 設計上の判断:
-# - PR ごとの gate（code_validation の fix job）を置かず日次の全件検査にする。gate は
-#   「ドリフトを入れさせない」が、--no-verify / GitHub Web UI 編集 / lint 設定変更時の
-#   一括適用漏れといった経路を塞げない。経路に依存しない全件検査を維持装置にする。
 # - main push をトリガーにしない（schedule + workflow_dispatch のみ）。fix PR のマージ自体が
 #   main push であり、main push トリガーだと自己再帰ループになる。また main push は release
 #   workflow を発火させる重いイベントで、整形コミットがそれを増産してしまう。
@@ -20,17 +17,23 @@
 #   pull_request イベントが発火せず code_validation が走らない。main の ruleset は all-green を
 #   required status check にしており bypass actor がゼロのため、CI が走らない PR は auto merge
 #   どころか手動マージも不可能な塩漬け PR になる。App token は job 終了時に自動失効する。
+# - App token の生成は fix:all の後に置く。install と fix:all は third-party コード
+#   （postinstall script、oxlint / oxfmt / eslint と各 plugin）を実行するため、その間 job 内に
+#   write 権限のトークンを存在させない。repositories による scope 絞りは blast radius を
+#   狭めるだけで存在自体は防げないので、順序で解く。
 # - App token に Contents / Pull requests に加えて Workflows の write を与える。最小権限に
 #   絞りたいところだが、oxfmt の対象には .github/workflows/*.yml も含まれる（root の fix
 #   スクリプトが repo 直下を走るため）。GitHub API 経由で workflow ファイルを含む tree を作るには
 #   workflows 権限が必須で、無いと yml がドリフトした日に create-a-tree が 403 になり
 #   bot が恒久停止する。
-# - commit は sign-commits で GitHub API 経由の verified commit にする。git push を使わないため
-#   トークンは URL にも .git/config にも残らず、checkout も persist-credentials: false で
-#   fix:all へ露出させない。
-# - fix:all は 1 回だけ実行する（複数回は回さない）。linter → formatter の相互作用で 1 パスでは
-#   固定点に達しないファイルは、その日の差分をマージし翌日の run で次のパスへ、と日次で
-#   自然収束させる。
+# - トークンを fix:all へ露出させない担保は step 順序と checkout の persist-credentials: false。
+#   sign-commits は担保にならない: create-pull-request は HTTPS remote に対し configureToken を
+#   無条件で呼び、差分ゼロ時のブランチ削除（git push --delete）のために .git/config へ
+#   extraheader を書き込む（実行後に自身で除去する）。
+# - fix:all は固定点に達するまで回す。linter → formatter の相互作用で 1 パスでは収束しない
+#   ファイルがあり、非固定点の tree を merge すると「merge 直後の main で fix:all が diff を
+#   出す」状態になって不変条件を bot 自身が破る。上限内に収束しない場合は lint / formatter
+#   設定側の欠陥なので、日を跨いで隠さず fail させる。
 name: daily-fix
 
 on:
@@ -56,32 +59,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      # PR を pull_request イベント発火可能なトークンで作るため App token を取得する。
-      # 権限は create-pull-request が使う範囲（commit = contents、PR = pull-requests、
-      # workflow ファイルを含む tree = workflows）に絞る
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.GOZD_BOT_APP_ID }}
-          private-key: ${{ secrets.GOZD_BOT_PRIVATE_KEY }}
-          # App が他リポジトリにもインストールされた場合に、過剰な write 権限のトークンが
-          # fix:all の走る job 内に存在するのを防ぐ
-          owner: ${{ github.repository_owner }}
-          repositories: gozd
-          permission-contents: write
-          permission-pull-requests: write
-          permission-workflows: write
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: main
           # create-pull-request は既存ブランチとの差分算出に履歴を必要とする
           # （shallow だと既存 PR ブランチの更新で破綻しうる）
           fetch-depth: 0
-          # create-pull-request は token: input の App token で commit / PR 操作を行い、
-          # checkout の永続クレデンシャルを使わない。トークンを fix:all へ露出させないため
-          # 永続化しない
           persist-credentials: false
 
       - uses: ./.github/actions/setup-environment
@@ -89,13 +72,42 @@ jobs:
       # fix:all 自体の失敗（lint 設定エラー・formatter クラッシュ等）は握りつぶさない。
       # 握りつぶすと「整形が走っていないのにドリフト無し＝不変条件成立」と誤報告する
       # サイレント故障になるため、失敗時はそのまま job を fail させて可観測にする
-      - name: Run fix:all
-        run: pnpm run fix:all
+      - name: Run fix:all until fixpoint
+        run: |
+          set -euo pipefail
+          prev=""
+          for _ in 1 2 3; do
+            pnpm run fix:all
+            git add -A
+            cur="$(git write-tree)"
+            if [[ "${cur}" == "${prev}" ]]; then
+              exit 0
+            fi
+            prev="${cur}"
+          done
+          echo "::error::fix:all did not reach a fixpoint in 3 passes"
+          exit 1
+
+      # PR を pull_request イベント発火可能なトークンで作るため App token を取得する。
+      # 権限は create-pull-request が使う範囲（commit = contents、PR = pull-requests、
+      # workflow ファイルを含む tree = workflows）に絞る。owner / repositories は指定しない:
+      # 両方未指定なら action が GITHUB_REPOSITORY から現 repo 1 個に scope するため、
+      # repo 名をハードコードせずに同じ結果が得られる
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.GOZD_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.GOZD_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-workflows: write
 
       # 整形差分があれば固定ブランチ bot/daily-fix へ verified commit して PR を作成/更新する。
       # 差分が無ければ PR を作らず、既存 PR が不要になれば自動 close + ブランチ削除される。
-      # add-paths で絞らないのは fix:all の対象が repo 全域に及ぶため。job 内で生成される
-      # 未追跡ファイル（資格情報等）は存在しない前提で、増えたら .gitignore 側で塞ぐ
+      # add-paths で絞らないのは fix:all の対象が repo 全域に及ぶため。裏を返せば working tree に
+      # 現れたものは何でも commit されて auto merge で無審査に main へ入る経路であり、
+      # job 内で生成される未追跡ファイルは .gitignore 側で塞ぐ必要がある
       - name: Create or update fix PR
         id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
@@ -112,11 +124,13 @@ jobs:
           body: Automated PR from the daily `daily-fix` workflow. It runs `fix:all` across the whole repo and repays the lint / format drift it finds.
 
       # PR が作成/更新/既存のいずれかで存在するとき auto merge を有効にする
-      # （差分ゼロで close された場合・PR が無い場合は何もしない）
+      # （差分ゼロで close された場合・PR が無い場合は何もしない）。
+      # --delete-branch は付けない: gh の deleteRemoteBranch は autoMerge 経路で早期 return する
+      # no-op であり、実際の削除は repo 設定の delete_branch_on_merge が担う
       - name: Enable auto-merge
         if: steps.cpr.outputs.pull-request-number != '' && steps.cpr.outputs.pull-request-operation != 'closed'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           # ${{ }} を run: に直接展開せず env 経由で渡す（テンプレートインジェクション面を作らない）
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
-        run: gh pr merge --auto --merge --delete-branch "$PR_NUMBER"
+        run: gh pr merge --auto --merge "$PR_NUMBER"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ import { useTerminalStore } from "../terminal/useTerminalStore";
 - `pnpm --filter @gozd/electron build:app` — `.app` バンドルを生成（無指定は local channel の
   `apps/electron/out/mac-arm64/Gozd Local.app`。stable identity は release CI のみ。docs/release.md）
 
-全チェックはルートの `pnpm run typecheck:all` / `pnpm run lint:all` / `pnpm run test:all` / `pnpm run build:all` / `pnpm run knip` で行う（CI の `code_validation.yml` matrix 6 本から `fix` を除いた 5 種。`fix` は commit 時の hook が担うため手動実行は不要で、CI の fix job は未 fix のまま commit されていないかの gate）。pnpm 11 は `pnpm run` 実行時に node_modules を自動インストールするため、事前の手動 install は不要。
+全チェックはルートの `pnpm run typecheck:all` / `pnpm run lint:all` / `pnpm run test:all` / `pnpm run build:all` / `pnpm run knip` で行う（CI の `code_validation.yml` matrix 5 本と同一）。`fix` は commit 時の hook が担うため手動実行は不要で、PR の gate にも入れない。取りこぼした整形差分は `daily-fix.yml` が日次で `fix:all` を全件実行し、bot PR + auto merge で返済する。pnpm 11 は `pnpm run` 実行時に node_modules を自動インストールするため、事前の手動 install は不要。
 
 - import の整理（未使用 import の削除、並び替え）は commit 時に lint が自動実行する。手動で整理しない
 


### PR DESCRIPTION
## 概要

`fix:all` の実行を PR ごとの CI gate から日次実行に移す。

- `.github/workflows/daily-fix.yml` を追加。schedule（03:23 JST）+ `workflow_dispatch` で `fix:all` を全件実行し、差分があれば固定ブランチ `bot/daily-fix` に verified commit して PR を作成/更新、`all-green` で auto merge する
- `code_validation.yml` の matrix から `fix` を削除（6 本 → 5 本）

## 背景

自動修正できる違反で PR を止めたくない、というのが動機。`fix:all` は commit 時の lefthook が担っており、CI での再検査は「hook を通らなかった場合の保険」として PR の merge を塞いでいた。

代わりに、日次で `fix:all` を全件実行してドリフトを返済する維持装置を置く。守る不変条件は「任意の時点で `fix:all` を実行したとき、生じる diff は 100% 自分の変更に起因する」。差分ゼロの空振りが、その日に不変条件が成立していることの証明になる。

設計は studio-design/studio-front pr15908 を参考にした。

### 撤去する gate が実際に担っていたもの

main の ruleset は `pull_request` rule + bypass actor ゼロで、`--no-verify` コミットも GitHub Web UI での編集も必ず PR を経由する。したがって旧 fix job はそれらを捕捉できており、run 30064937247（2026-07-24）は `apps/renderer/src/shared/notification/index.ts` のドリフトを実際に止めている。

gate に原理的な穴があるとすれば「lint / format 設定の変更が、差分フィルタで選ばれない package のコードに効く」ケースだけで、これは PR 単位の gate では届かず日次の全件検査でしか埋まらない領域。ただし gate が不完全であることは gate を消す理由にはならないため、撤去は後退を伴う判断として「旧実装からの後退」に列挙する。

### 調査で判明した gozd 固有の制約

**トークンは GitHub App の installation token でなければならない。**

`GITHUB_TOKEN` で作成した PR は `pull_request` イベントを発火させないため `code_validation` が走らない。main の ruleset は `all-green` を required status check にしており bypass actor がゼロなので、CI が走らない PR は auto merge どころか手動マージも不可能な塩漬け PR になる。PAT は人間の identity に紐づき無期限で失効も手動になるため採用しない。App の installation token は job 終了時に自動失効する。

**App token に `workflows: write` が必要。**

退行注入で検証したところ、ルートの `fix` スクリプト（`oxfmt '!apps/**' '!packages/**'`）は `.github/workflows/*.yml` も整形対象に含み、シングルクォートをダブルクォートに書き換えた。GitHub API 経由で workflow ファイルを含む tree を作るには `workflows` 権限が要り、無いと yml がドリフトした日に create-a-tree が 403 になって bot が恒久停止する。参考にした studio-front はこれをマージ後に踏み、`workflows` 権限を持たない最小権限設計のまま「残課題」として残している（studio-design/studio-front pr15973）。gozd の lefthook は glob に yml を持たず commit 時の canonical 化も効かないため、確実に踏む経路として先に塞いだ。

**`fix:all` は 1 パスで固定点に達する。**

各 package の `fix` は `oxlint --type-aware --fix && oxfmt .`（renderer は `eslint . --fix -c eslint.config.fix.ts && oxfmt .`）で、1 パス内で formatter が最後に走る。2 パス目が変化するのは oxfmt の出力が新たな lint 違反を生む場合に限られるが、fix 専用に有効化されるルールは `import-x/order`（import の順序）と `better-tailwindcss/enforce-canonical-classes`（class 文字列の中身）の 2 つで、oxfmt はどちらも変えない。退行注入（3 ファイルにクォート置換・セミコロン除去・未使用 import 追加）後に `fix:all` を 3 回連続実行し、tree hash が 3 回とも一致することを実測した。

**事前の一括クリーンアップは不要。**

現時点で `fix:all` は exit 0 かつ working tree に差分ゼロ。初回 schedule が巨大 PR になる懸念はない。

## 変更内容

### daily-fix workflow の追加

- trigger は schedule + `workflow_dispatch` のみ。main push を trigger にすると fix PR のマージ自身が再帰し、`release.yml` も増産する
- コミット・固定ブランチ管理・PR 作成/更新・差分ゼロ時の自動 close は `peter-evans/create-pull-request` に委譲する（git push や上書き判定を自前実装しない）
- **App token の生成は `fix:all` の後**に置く。install と `fix:all` は third-party コード（postinstall script、oxlint / oxfmt / eslint と各 plugin）を実行するため、その間 job 内に write 権限のトークンを存在させない
- `fix:all` の失敗は握りつぶさない。握りつぶすと「整形が走っていないのにドリフト無し = 不変条件成立」と誤報告するサイレント故障になる
- App token の権限は `contents` / `pull-requests` / `workflows` の write に限定する。`owner` / `repositories` は指定しない（両方未指定なら action が `GITHUB_REPOSITORY` から現 repo 1 個に scope するため、repo 名のハードコードが不要）
- `client-id` を使う（`app-id` は v3 で deprecated）
- commit / PR タイトルの type は `style`。`release.yml` の canary 発火判定（`^(feat|fix)`）に掛けないため（配布物の中身は変わらない）

### code_validation からの fix job 削除

matrix が 5 本になる。ルートの集約スクリプトは 6 種あるため、`fix` だけ意図的に持たないことを matrix の先頭にコメントで残す。

### CLAUDE.md

matrix 本数と `fix` の位置づけ（PR の gate に入れず daily-fix が返済する）を更新。

## 旧実装からの後退

- **自動修正可能な lint 違反・整形崩れが main に入るようになる**。旧実装では PR の `fix` job が working tree の差分を検知して fail させていたため、未整形のコードはマージできなかった。本 PR 以降は最大 1 日ドリフトが main に滞留し、翌日の bot PR で返済される
- **PR 単位でのドリフトの帰属が失われる**。旧実装ではどの PR がドリフトを持ち込んだか CI の失敗で即座に分かったが、日次返済ではドリフトが誰の変更由来か bot PR からは追えない
- **`fix:all` が working tree に出したものは無審査で main に入る**。`add-paths` を指定していないため、job 内で生成された未追跡ファイルがあれば commit されて auto merge される。現状は生成物がすべて `dist/` 配下（gitignore 済み）であることを確認済みだが、この経路自体は残る

## 今回含めない点

- **今回は対応しない**: lefthook の glob（`**/*.{css,md}` / `*.ts` / renderer の `{ts,vue,css,md}`）は各 package の `fix` script が整形する対象集合の手書き複製で、yml が抜けているのもその帰結。ドリフトの発生源はここにあるが、本 PR は返済機構の導入に絞る

## 確認事項

- [ ] マージ後に `gh workflow run daily-fix.yml` を実行し、App token の生成が成功すること（現在ドリフトゼロのため PR は作られず空振り成功が期待挙動）
- [ ] コミット経路（create-a-tree + `workflows: write`）は空振り実行では検証できない。意図的に整形ドリフトを main に入れて bot が返済 PR を出せるか確認するかは要判断
