### PR TITLE
feat(filer): resolve symlink entries to their real entity

### DIFF
--- a/apps/electron/src/fs/fsOps.test.ts
+++ b/apps/electron/src/fs/fsOps.test.ts
@@ -209,13 +209,12 @@ describe("FSOps", () => {
     const dir = makeTempDir();
     mkdirSync(join(dir, "locked", "sub"), { recursive: true });
     chmodSync(join(dir, "locked"), 0o000);
-    try {
-      // 他の rejects と違い await するのは finally との順序のため（await が無いと assertion の
-      // 決着前に chmod 復帰が走る）。復帰しないと子を持つこの dir は afterEach の rmSync ごと落ちる
-      await expect(readDir(dir, "locked/sub")).rejects.toThrow(/EACCES/);
-    } finally {
-      chmodSync(join(dir, "locked"), 0o755);
-    }
+    // 他の rejects と違い Result で受けるのは、assert 前に権限を戻す必要があるため。子を持つこの
+    // dir を 000 のまま残すと afterEach の rmSync ごと落ちる
+    const failed = await tryCatch(readDir(dir, "locked/sub"));
+    chmodSync(join(dir, "locked"), 0o755);
+    expect(failed.ok).toBe(false);
+    expect(String(failed.ok ? "" : failed.error)).toMatch(/EACCES/);
   });
 
   test("dir 範囲外は拒否される", async () => {

--- a/apps/electron/src/fs/fsOps.test.ts
+++ b/apps/electron/src/fs/fsOps.test.ts
@@ -10,6 +10,7 @@ import {
   mkdtempSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -67,9 +68,93 @@ describe("FSOps", () => {
     expect(result.notFound).toBe(false);
     expect(result.entries).toEqual([
       { name: "file.txt", type: "file", isIgnored: false },
-      { name: "link", type: "symlink", isIgnored: false },
+      {
+        name: "link",
+        type: "symlink",
+        realTarget: {
+          type: "file",
+          absPath: join(realpathSync(dir), "file.txt"),
+          relPath: "file.txt",
+        },
+        isIgnored: false,
+      },
       { name: "subdir", type: "directory", isIgnored: false },
     ]);
+  });
+
+  test("ディレクトリへの symlink は realTarget.type: 'directory' を併記する", async () => {
+    const dir = makeTempDir();
+    mkdirSync(join(dir, "subdir"));
+    symlinkSync(join(dir, "subdir"), join(dir, "dirlink"));
+    const result = await readDir(dir, "");
+    expect(result.entries[0]?.realTarget).toEqual({
+      type: "directory",
+      absPath: join(realpathSync(dir), "subdir"),
+      relPath: "subdir",
+    });
+  });
+
+  test("dir 外を指す symlink は realTarget.relPath 不在で返る", async () => {
+    const dir = makeTempDir();
+    const outside = makeTempDir();
+    writeFileSync(join(outside, "outer.txt"), "x");
+    symlinkSync(join(outside, "outer.txt"), join(dir, "outlink"));
+    const result = await readDir(dir, "");
+    expect(result.entries[0]?.realTarget).toEqual({
+      type: "file",
+      absPath: join(realpathSync(outside), "outer.txt"),
+      relPath: undefined,
+    });
+  });
+
+  test("辿れない symlink は realTarget 不在で返る", async () => {
+    const dir = makeTempDir();
+    symlinkSync(join(dir, "missing.txt"), join(dir, "dangling"));
+    symlinkSync(join(dir, "loop"), join(dir, "loop"));
+    const result = await readDir(dir, "");
+    expect(result.entries).toEqual([
+      { name: "dangling", type: "symlink", realTarget: undefined, isIgnored: false },
+      { name: "loop", type: "symlink", realTarget: undefined, isIgnored: false },
+    ]);
+  });
+
+  test("symlink 配下はリンク越しに列挙でき、entry 自身が link でなくても realTarget を持つ", async () => {
+    const dir = makeTempDir();
+    mkdirSync(join(dir, "subdir", "nested"), { recursive: true });
+    writeFileSync(join(dir, "subdir", "inner.txt"), "x");
+    symlinkSync(join(dir, "subdir"), join(dir, "dirlink"));
+    const result = await readDir(dir, "dirlink");
+    expect(result.notFound).toBe(false);
+    expect(result.entries).toEqual([
+      {
+        name: "inner.txt",
+        type: "file",
+        realTarget: {
+          type: "file",
+          absPath: join(realpathSync(dir), "subdir", "inner.txt"),
+          relPath: join("subdir", "inner.txt"),
+        },
+        isIgnored: false,
+      },
+      {
+        name: "nested",
+        type: "directory",
+        realTarget: {
+          type: "directory",
+          absPath: join(realpathSync(dir), "subdir", "nested"),
+          relPath: join("subdir", "nested"),
+        },
+        isIgnored: false,
+      },
+    ]);
+  });
+
+  test("link を経由しない列挙は realTarget を持たない（実体とツリー上のパスが一致）", async () => {
+    const dir = makeTempDir();
+    mkdirSync(join(dir, "subdir"));
+    writeFileSync(join(dir, "subdir", "inner.txt"), "x");
+    const result = await readDir(dir, "subdir");
+    expect(result.entries).toEqual([{ name: "inner.txt", type: "file", isIgnored: false }]);
   });
 
   test("空ディレクトリは空配列", async () => {

--- a/apps/electron/src/fs/fsOps.test.ts
+++ b/apps/electron/src/fs/fsOps.test.ts
@@ -232,6 +232,52 @@ describe("FSOps", () => {
     expect(byName.get(".gitignore")).toBe(false);
   });
 
+  test("symlink 越しの列挙でも実体側の path で gitignore 判定する", async () => {
+    const dir = makeTempDir();
+    runFixtureGit(["init"], dir);
+    writeFileSync(join(dir, ".gitignore"), "*.log\n");
+    mkdirSync(join(dir, "real"));
+    writeFileSync(join(dir, "real", "app.log"), "");
+    writeFileSync(join(dir, "real", "keep.ts"), "");
+    symlinkSync(join(dir, "real"), join(dir, "link"));
+    // link 越しの pathspec を渡すと git が fatal になり全 entry の判定が落ちる。実体側の
+    // 相対パスで問い合わせることで、link 経由で見ても ignored が付く
+    const result = await readDir(dir, "link");
+    const byName = new Map(result.entries.map((entry) => [entry.name, entry.isIgnored]));
+    expect(byName.get("app.log")).toBe(true);
+    expect(byName.get("keep.ts")).toBe(false);
+  });
+
+  test("実体が dir 外の symlink 越し列挙は gitignore を問い合わせない", async () => {
+    const dir = makeTempDir();
+    const outside = makeTempDir();
+    runFixtureGit(["init"], dir);
+    writeFileSync(join(dir, ".gitignore"), "*.log\n");
+    writeFileSync(join(outside, "outer.log"), "");
+    symlinkSync(outside, join(dir, "link"));
+    const result = await readDir(dir, "link");
+    expect(result.entries).toEqual([
+      {
+        name: "outer.log",
+        type: "file",
+        realTarget: {
+          type: "file",
+          absPath: join(realpathSync(outside), "outer.log"),
+          relPath: undefined,
+        },
+        isIgnored: false,
+      },
+    ]);
+  });
+
+  test("末尾スラッシュ付き path でも link 越し判定が誤爆しない", async () => {
+    const dir = makeTempDir();
+    mkdirSync(join(dir, "subdir"));
+    writeFileSync(join(dir, "subdir", "inner.txt"), "x");
+    const result = await readDir(dir, "subdir/");
+    expect(result.entries).toEqual([{ name: "inner.txt", type: "file", isIgnored: false }]);
+  });
+
   test("writeFileAbsolute は絶対パスに書き込め、tmp ファイルを残さない", () => {
     const dir = makeTempDir();
     const path = join(dir, "config.json");

--- a/apps/electron/src/fs/fsOps.test.ts
+++ b/apps/electron/src/fs/fsOps.test.ts
@@ -248,26 +248,41 @@ describe("FSOps", () => {
     expect(byName.get("keep.ts")).toBe(false);
   });
 
-  test("実体が dir 外の symlink 越し列挙は gitignore を問い合わせない", async () => {
+  test("dir 外を指す entry が混ざっても、同じ列挙内の ignored 判定は壊れない", async () => {
+    // dir 外の pathspec を batch に混ぜると git が fatal して batch 全体が落ちる。dir 外は
+    // 問い合わせから外す決定が効いていれば、同居する worktree 内 entry の判定だけが残る
     const dir = makeTempDir();
     const outside = makeTempDir();
     runFixtureGit(["init"], dir);
     writeFileSync(join(dir, ".gitignore"), "*.log\n");
-    writeFileSync(join(outside, "outer.log"), "");
-    symlinkSync(outside, join(dir, "link"));
+    mkdirSync(join(dir, "real"));
+    writeFileSync(join(dir, "real", "app.log"), "");
+    writeFileSync(join(outside, "outer.txt"), "");
+    symlinkSync(join(outside, "outer.txt"), join(dir, "real", "outlink"));
+    symlinkSync(join(dir, "real"), join(dir, "link"));
     const result = await readDir(dir, "link");
-    expect(result.entries).toEqual([
-      {
-        name: "outer.log",
-        type: "file",
-        realTarget: {
-          type: "file",
-          absPath: join(realpathSync(outside), "outer.log"),
-          relPath: undefined,
-        },
-        isIgnored: false,
-      },
-    ]);
+    const byName = new Map(result.entries.map((entry) => [entry.name, entry.isIgnored]));
+    expect(byName.get("app.log")).toBe(true);
+    expect(byName.get("outlink")).toBe(false);
+    expect(result.entries.find((entry) => entry.name === "outlink")?.realTarget).toEqual({
+      type: "file",
+      absPath: join(realpathSync(outside), "outer.txt"),
+      relPath: undefined,
+    });
+  });
+
+  test("link 越し列挙の symlink 行は、リンク先ではなく行自身の path で ignored 判定する", async () => {
+    const dir = makeTempDir();
+    runFixtureGit(["init"], dir);
+    // リンク先 (logs/) は ignored、リンク自身 (real/data) は ignored ではない
+    writeFileSync(join(dir, ".gitignore"), "/logs\n");
+    mkdirSync(join(dir, "logs"));
+    mkdirSync(join(dir, "real"));
+    symlinkSync(join(dir, "logs"), join(dir, "real", "data"));
+    symlinkSync(join(dir, "real"), join(dir, "link"));
+    const result = await readDir(dir, "link");
+    expect(result.entries[0]?.name).toBe("data");
+    expect(result.entries[0]?.isIgnored).toBe(false);
   });
 
   test("末尾スラッシュ付き path でも link 越し判定が誤爆しない", async () => {

--- a/apps/electron/src/fs/fsOps.test.ts
+++ b/apps/electron/src/fs/fsOps.test.ts
@@ -248,9 +248,9 @@ describe("FSOps", () => {
     expect(byName.get("keep.ts")).toBe(false);
   });
 
-  test("dir 外を指す entry が混ざっても、同じ列挙内の ignored 判定は壊れない", async () => {
-    // dir 外の pathspec を batch に混ぜると git が fatal して batch 全体が落ちる。dir 外は
-    // 問い合わせから外す決定が効いていれば、同居する worktree 内 entry の判定だけが残る
+  test("dir 外を指す link が同居しても、他の行の ignored 判定と realTarget は保たれる", async () => {
+    // 判定対象は行自身なので、行の実体が dir 外でも pathspec は worktree 内（列挙対象 + 行名）に
+    // なる。pathspec の worktree 内 / 外は列挙単位で揃うため、外を指す行の同居で batch が落ちない
     const dir = makeTempDir();
     const outside = makeTempDir();
     runFixtureGit(["init"], dir);

--- a/apps/electron/src/fs/fsOps.test.ts
+++ b/apps/electron/src/fs/fsOps.test.ts
@@ -195,6 +195,29 @@ describe("FSOps", () => {
     chmodSync(join(dir, "locked"), 0o755);
   });
 
+  test("循環 symlink のディレクトリはエラーではなく notFound を返す", async () => {
+    // 辿れない link は削除ノードと同じ扱い。ここで throw に倒すと、壊れた link 1 本で
+    // 親の fsChange のたびにエラートーストが出続ける
+    const dir = makeTempDir();
+    symlinkSync(join(dir, "loop"), join(dir, "loop"));
+    const result = await readDir(dir, "loop");
+    expect(result.notFound).toBe(true);
+  });
+
+  test("親ディレクトリの権限で recheck が失敗する場合も notFound ではなく throw する", async () => {
+    // recheck 自身の失敗を notFound に倒すと、権限の問題が「削除された」として UI に出る
+    const dir = makeTempDir();
+    mkdirSync(join(dir, "locked", "sub"), { recursive: true });
+    chmodSync(join(dir, "locked"), 0o000);
+    try {
+      // 他の rejects と違い await するのは finally との順序のため（await が無いと assertion の
+      // 決着前に chmod 復帰が走る）。復帰しないと子を持つこの dir は afterEach の rmSync ごと落ちる
+      await expect(readDir(dir, "locked/sub")).rejects.toThrow(/EACCES/);
+    } finally {
+      chmodSync(join(dir, "locked"), 0o755);
+    }
+  });
+
   test("dir 範囲外は拒否される", async () => {
     const dir = makeTempDir();
     expect(readDir(dir, "../..")).rejects.toThrow(/outsideDir/);

--- a/apps/electron/src/fs/fsOps.ts
+++ b/apps/electron/src/fs/fsOps.ts
@@ -251,7 +251,7 @@ function logUnresolvedLink(
 ): void {
   if (isUntraversable(error)) return;
   console.error(
-    `[resolveRealTarget] resolve failed path=${linkPath} resolved=${resolvedPath ?? "(unresolved)"} error=${error}`,
+    `[resolveRealTarget] resolve failed path=${linkPath} resolved=${resolvedPath ?? "(unresolved)"} error=${String(error)}`,
   );
 }
 

--- a/apps/electron/src/fs/fsOps.ts
+++ b/apps/electron/src/fs/fsOps.ts
@@ -5,18 +5,19 @@
 // - 不在 / ディレクトリは throw ではなく正常応答（notFound / isDirectory）で返す。
 //   renderer は削除ノードとして扱い、エラートーストを出さない規律
 
-import type { FileReadResult } from "@gozd/rpc";
+import type { FileReadResult, FsReadDirRealTarget } from "@gozd/rpc";
 import { tryCatch } from "@gozd/shared";
 import {
   lstatSync,
   mkdirSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   renameSync,
   statSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, isAbsolute } from "node:path";
+import { dirname, isAbsolute, join, sep } from "node:path";
 import { checkIgnore } from "../git/gitOps";
 import { toWireBytes } from "../wireBytes";
 import { resolveContained } from "./pathContainment";
@@ -24,6 +25,8 @@ import { resolveContained } from "./pathContainment";
 interface FsEntry {
   name: string;
   type: string;
+  /** 実体の在り処（FsReadDirRealTarget の契約） */
+  realTarget?: FsReadDirRealTarget;
   isIgnored: boolean;
 }
 
@@ -121,9 +124,31 @@ export async function readDir(dir: string, path: string): Promise<FsReadDirResul
   // `.git` (directory / gitlink file 両方) はツリーから完全一致で除外する（docs/filer.md）。
   // gitignore 経路とは独立。checkIgnore に渡す前に落とし、無駄な git 呼び出しも省く
   const dirents = listed.value.filter((entry) => entry.name !== ".git");
+  // 実体の在り処を判定する基準。dir / 列挙対象それぞれの realpath を 1 回だけ引く。
+  // - dirRealPath: relPath（dir 相対）の算出基準
+  // - listRealPath: 列挙対象自身が symlink 越しか（!== dir + path）と、entry の実体パスの基準
+  const dirRealPath = realpathSync(dir);
+  const listRealPath = realpathSync(target);
   const typed = dirents.map((entry) => {
-    const type = entry.isSymbolicLink() ? "symlink" : entry.isDirectory() ? "directory" : "file";
-    return { name: entry.name, type };
+    // symlink は lstat 由来の種別 ("symlink") を保ったまま、辿った結果を realTarget に載せる。
+    // これが無いと renderer は dir symlink を leaf に潰すしかない。
+    // 辿れない dangling / 循環 (ELOOP) は realTarget 不在で「実体なし」を表現する。
+    if (entry.isSymbolicLink()) {
+      return {
+        name: entry.name,
+        type: "symlink",
+        realTarget: resolveRealTarget(join(listRealPath, entry.name), dirRealPath),
+      };
+    }
+    const type = entry.isDirectory() ? "directory" : "file";
+    // 列挙対象が symlink 越し（`.claude/skills/x` が link で、その配下を見ている等）なら、
+    // entry 自身が link でなくても実体はツリー上のパスとは別の場所にある。
+    if (listRealPath === join(dirRealPath, path)) return { name: entry.name, type };
+    return {
+      name: entry.name,
+      type,
+      realTarget: resolveRealTarget(join(listRealPath, entry.name), dirRealPath),
+    };
   });
   // gitignore 判定は dir（worktree root）からの相対パスで行う
   const prefix = path === "" ? "" : path.endsWith("/") ? path : `${path}/`;
@@ -135,6 +160,30 @@ export async function readDir(dir: string, path: string): Promise<FsReadDirResul
     .map((entry) => ({ ...entry, isIgnored: ignored.has(prefix + entry.name) }))
     .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
   return { entries, notFound: false };
+}
+
+/**
+ * 実体の在り処を返す。辿れない（dangling / 循環）場合は undefined。
+ *
+ * `relPath` の包含判定は realpath 同士で行う。`dirRealPath` を使わず入力の dir で比較すると、
+ * dir 自身が symlink 経由のパス（macOS の `$TMPDIR` 等）のときに「実体は dir 配下なのに外部扱い」
+ * になり、renderer が worktree 相対で開ける実体を absolute へ倒してしまう。
+ */
+function resolveRealTarget(
+  entryPath: string,
+  dirRealPath: string,
+): FsReadDirRealTarget | undefined {
+  const resolved = tryCatch(() => realpathSync(entryPath));
+  if (!resolved.ok) return undefined;
+  const absPath = resolved.value;
+  const followed = tryCatch(() => statSync(absPath));
+  if (!followed.ok) return undefined;
+  const prefix = dirRealPath.endsWith(sep) ? dirRealPath : `${dirRealPath}${sep}`;
+  return {
+    type: followed.value.isDirectory() ? "directory" : "file",
+    absPath,
+    relPath: absPath.startsWith(prefix) ? absPath.slice(prefix.length) : undefined,
+  };
 }
 
 /** 共通の file 読み取り処理。directory / not-found / binary 検出を一括で扱う */

--- a/apps/electron/src/fs/fsOps.ts
+++ b/apps/electron/src/fs/fsOps.ts
@@ -5,7 +5,7 @@
 // - 不在 / ディレクトリは throw ではなく正常応答（notFound / isDirectory）で返す。
 //   renderer は削除ノードとして扱い、エラートーストを出さない規律
 
-import type { FileReadResult, FsReadDirRealTarget } from "@gozd/rpc";
+import type { FileReadResult, FsReadDirEntry, FsReadDirRealTarget } from "@gozd/rpc";
 import { tryCatch } from "@gozd/shared";
 import type { Dirent } from "node:fs";
 import {
@@ -25,7 +25,7 @@ import { resolveContained } from "./pathContainment";
 
 interface FsEntry {
   name: string;
-  type: string;
+  type: FsReadDirEntry["type"];
   /** 実体の在り処（FsReadDirRealTarget の契約） */
   realTarget?: FsReadDirRealTarget;
   isIgnored: boolean;
@@ -113,18 +113,7 @@ export function stat(dir: string, path: string): FsStatResult {
 export async function readDir(dir: string, path: string): Promise<FsReadDirResult> {
   const target = resolveSafe(dir, path);
   const listed = tryCatch(() => readdirSync(target, { withFileTypes: true }));
-  if (!listed.ok) {
-    // 列挙に失敗。対象がディレクトリとして存在するか「失敗後」に再確認する。
-    // 不在 (ENOENT) / ディレクトリでなくなった (ENOTDIR: 削除後に同名ファイルへ置換) なら
-    // 削除済みノードとして notFound を返す。事前チェックではなく失敗後 recheck にすることで、
-    // 存在チェックと列挙の隙に削除される TOCTOU race を避ける。存在するディレクトリでの失敗
-    // (permission 等) は真の読み取りエラーなので rethrow して 500 にする
-    const recheck = tryCatch(() => statSync(target));
-    if (!recheck.ok || !recheck.value.isDirectory()) {
-      return { entries: [], notFound: true };
-    }
-    throw listed.error;
-  }
+  if (!listed.ok) return recheckMissingDir(target, listed.error);
   // 入力 path の表記揺れ（`""` / `"."` / 末尾スラッシュ）を以降へ持ち込まないよう、resolve 済みの
   // target から導出した正規化相対パスだけを使う。同一関数内に入力表記依存の判定を作らないための契約
   const relDir = relative(dir, target);
@@ -134,19 +123,30 @@ export async function readDir(dir: string, path: string): Promise<FsReadDirResul
   // 実体の在り処を判定する基準。dir / 列挙対象それぞれの realpath を 1 回だけ引く。
   // - dirRealPath: relPath（dir 相対）の算出基準
   // - listRealPath: 列挙対象自身が symlink 越しかの判定と、entry の実体パスの基準
-  const dirRealPath = realpathSync(dir);
-  const listRealPath = realpathSync(target);
+  //
+  // 列挙成功後でも対象は消え得る（branch 切替 / worktree remove / build 出力の掃除は正常系の
+  // event クラス）。readdir 失敗と同じ recheck に合流させ、消えていれば notFound で返す
+  const realPaths = tryCatch(() => ({
+    dirReal: realpathSync(dir),
+    listReal: realpathSync(target),
+  }));
+  if (!realPaths.ok) return recheckMissingDir(target, realPaths.error);
+  const { dirReal: dirRealPath, listReal: listRealPath } = realPaths.value;
   // 列挙対象自身が symlink 越しか（`.claude/skills/x` が link で、その配下を見ている等）。
   // 真なら entry 自身が link でなくても実体はツリー上のパスとは別の場所にある
   const listCrossesLink = listRealPath !== join(dirRealPath, relDir);
   const prefix = relDir === "" ? "" : `${relDir}${sep}`;
   const listing = dirents.map((entry) => {
     const built = buildEntry(entry, listRealPath, dirRealPath, listCrossesLink);
-    // gitignore 判定に渡す pathspec。link 越しの列挙では実体側の dir 相対パスを使う。
-    // link 越しのパスを渡すと git が `pathspec ... is beyond a symbolic link` で fatal になり、
-    // その列挙の全 entry の判定を落とす（checkIgnore は失敗を空集合に倒す契約）。
-    // 実体が dir 外なら当該 repo の gitignore の管轄外なので問い合わせ自体を落とす
-    const ignoreSpec = listCrossesLink ? built.realTarget?.relPath : prefix + entry.name;
+    // gitignore 判定に渡す pathspec は常に **entry 自身**を指す（判定対象は行そのもので、
+    // symlink 行ではリンク先ではなく link 自身が git の管理対象）。link 越しの列挙では
+    // entry 自身の canonical path を使う: link 越しのパスを渡すと git が
+    // `pathspec ... is beyond a symbolic link` で fatal になり、その列挙の全 entry の判定を
+    // 落とす（checkIgnore は失敗を空集合に倒す契約）。dir 外は当該 repo の gitignore の
+    // 管轄外なので問い合わせ自体を落とす
+    const ignoreSpec = listCrossesLink
+      ? relPathWithin(join(listRealPath, entry.name), dirRealPath)
+      : prefix + entry.name;
     return { built, ignoreSpec };
   });
   const ignored = await checkIgnore(
@@ -160,6 +160,23 @@ export async function readDir(dir: string, path: string): Promise<FsReadDirResul
     }))
     .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
   return { entries, notFound: false };
+}
+
+/**
+ * 列挙経路の失敗を「削除済みノード」と「真の読み取りエラー」に振り分ける判定の SSOT。
+ *
+ * 対象がディレクトリとして存在するかを **失敗後に** 再確認する。不在 (ENOENT) / ディレクトリで
+ * なくなった (ENOTDIR: 削除後に同名ファイルへ置換) なら削除済みノードとして notFound を返す。
+ * 事前チェックではなく失敗後 recheck にすることで、存在チェックと操作の隙に削除される TOCTOU race
+ * を避ける。存在するディレクトリでの失敗 (permission 等) は真の読み取りエラーなので rethrow して
+ * 500 にする。
+ */
+function recheckMissingDir(target: string, error: unknown): FsReadDirResult {
+  const recheck = tryCatch(() => statSync(target));
+  if (!recheck.ok || !recheck.value.isDirectory()) {
+    return { entries: [], notFound: true };
+  }
+  throw error;
 }
 
 /**
@@ -217,12 +234,17 @@ function toRealTarget(
   isDirectory: boolean,
   dirRealPath: string,
 ): FsReadDirRealTarget {
-  const prefix = dirRealPath.endsWith(sep) ? dirRealPath : `${dirRealPath}${sep}`;
   return {
     type: isDirectory ? "directory" : "file",
     absPath,
-    relPath: absPath.startsWith(prefix) ? absPath.slice(prefix.length) : undefined,
+    relPath: relPathWithin(absPath, dirRealPath),
   };
+}
+
+/** realpath 済みの絶対パスが dir 配下なら dir 相対パスを返す。dir 外なら undefined */
+function relPathWithin(absPath: string, dirRealPath: string): string | undefined {
+  const prefix = dirRealPath.endsWith(sep) ? dirRealPath : `${dirRealPath}${sep}`;
+  return absPath.startsWith(prefix) ? absPath.slice(prefix.length) : undefined;
 }
 
 /** 共通の file 読み取り処理。directory / not-found / binary 検出を一括で扱う */

--- a/apps/electron/src/fs/fsOps.ts
+++ b/apps/electron/src/fs/fsOps.ts
@@ -165,26 +165,33 @@ export async function readDir(dir: string, path: string): Promise<FsReadDirResul
 /**
  * 列挙経路の失敗を「削除済みノード」と「真の読み取りエラー」に振り分ける判定の SSOT。
  *
- * 対象がディレクトリとして存在するかを **失敗後に** 再確認する。不在 (ENOENT) / ディレクトリで
- * なくなった (ENOTDIR: 削除後に同名ファイルへ置換) なら削除済みノードとして notFound を返す。
- * 事前チェックではなく失敗後 recheck にすることで、存在チェックと操作の隙に削除される TOCTOU race
- * を避ける。存在するディレクトリでの失敗 (permission 等) は真の読み取りエラーなので rethrow して
- * 500 にする。
+ * 対象がディレクトリとして存在するかを **失敗後に** 再確認する。事前チェックではなく失敗後 recheck に
+ * することで、存在チェックと操作の隙に削除される TOCTOU race を避ける。分岐は 3 つ:
+ *
+ * - 再確認が成功してディレクトリでない: 同名ファイルへ置換された削除済みノードとして notFound
+ * - 再確認が成功してディレクトリのまま: 真の読み取りエラー (permission 等) なので rethrow して 500
+ * - 再確認自体が失敗: 辿れない系 (削除 / 循環 / 非ディレクトリ化) なら notFound、それ以外
+ *   (permission 等) は rethrow。notFound に倒すと権限の問題が「削除された」として UI に出て原因が消える
  */
 function recheckMissingDir(target: string, error: unknown): FsReadDirResult {
   const recheck = tryCatch(() => statSync(target));
-  if (!recheck.ok || !recheck.value.isDirectory()) {
+  if (recheck.ok) {
+    if (recheck.value.isDirectory()) throw error;
     return { entries: [], notFound: true };
   }
-  throw error;
+  // recheck 自身の失敗も分類する。辿れない系 (削除 / 循環 / 非ディレクトリ化) 以外
+  // (permission 等) を notFound に倒すと、権限の問題が「削除された」として UI に出て
+  // 元の error も消える
+  if (!isUntraversable(recheck.error)) throw error;
+  return { entries: [], notFound: true };
 }
 
 /**
  * dirent 1 件を entry（name / type / realTarget）に組み立てる。
  *
  * symlink は lstat 由来の種別 ("symlink") を保ったまま、辿った結果を realTarget に載せる。
- * これが無いと renderer は dir symlink を leaf に潰すしかない。辿れない dangling / 循環 (ELOOP) は
- * realTarget 不在で「実体なし」を表現する。
+ * これが無いと renderer は dir symlink を leaf に潰すしかない。辿れない link は realTarget 不在で
+ * 「実体なし」を表現する（分類は resolveRealTarget）。
  *
  * 非 symlink の entry は `listRealPath` が canonical であることから実体パスが確定するため、
  * realpath / stat を引き直さない（entry 数ぶんの syscall を避けるだけでなく、readdir と stat の
@@ -213,13 +220,49 @@ function buildEntry(
   };
 }
 
-/** symlink を辿って実体の在り処を返す。辿れない（dangling / 循環）場合は undefined */
+/**
+ * symlink を辿って実体の在り処を返す。辿れない場合は undefined。
+ *
+ * dangling (ENOENT) / 循環 (ELOOP) / 中間成分が非ディレクトリ (ENOTDIR) は symlink の正常な
+ * 壊れ方で、renderer も `realTarget` 不在を「実体なし」として表示に使うため無音で返す。それ以外
+ * (permission 等) は「実体なし」と区別が付かないまま握り潰されると link 行が壊れて見える原因を
+ * 追えなくなるので観察ログを残す。
+ */
 function resolveRealTarget(linkPath: string, dirRealPath: string): FsReadDirRealTarget | undefined {
   const resolved = tryCatch(() => realpathSync(linkPath));
-  if (!resolved.ok) return undefined;
+  if (!resolved.ok) {
+    logUnresolvedLink(linkPath, undefined, resolved.error);
+    return undefined;
+  }
   const followed = tryCatch(() => statSync(resolved.value));
-  if (!followed.ok) return undefined;
+  if (!followed.ok) {
+    logUnresolvedLink(linkPath, resolved.value, followed.error);
+    return undefined;
+  }
   return toRealTarget(resolved.value, followed.value.isDirectory(), dirRealPath);
+}
+
+/** 実体を解決できなかった失敗のうち、symlink の正常な壊れ方でないものだけ観察ログに残す。
+ * 発生源の行を特定できるよう link 自身の path を常に出す */
+function logUnresolvedLink(
+  linkPath: string,
+  resolvedPath: string | undefined,
+  error: unknown,
+): void {
+  if (isUntraversable(error)) return;
+  console.error(
+    `[resolveRealTarget] resolve failed path=${linkPath} resolved=${resolvedPath ?? "(unresolved)"} error=${error}`,
+  );
+}
+
+/**
+ * path を辿れない系の失敗か。UI は「実体なし」/「削除ノード」で表現できるので、無音で扱ってよい
+ * 集合の SSOT にする（readDir の recheck と link 解決で集合が割れると、同じ壊れた link が経路に
+ * よってトーストと無音に分かれる）。非 Error が throw されても壊れない。
+ */
+function isUntraversable(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return code === "ENOENT" || code === "ELOOP" || code === "ENOTDIR";
 }
 
 /**

--- a/apps/electron/src/fs/fsOps.ts
+++ b/apps/electron/src/fs/fsOps.ts
@@ -7,6 +7,7 @@
 
 import type { FileReadResult, FsReadDirRealTarget } from "@gozd/rpc";
 import { tryCatch } from "@gozd/shared";
+import type { Dirent } from "node:fs";
 import {
   lstatSync,
   mkdirSync,
@@ -17,7 +18,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { dirname, isAbsolute, join, sep } from "node:path";
+import { dirname, isAbsolute, join, relative, sep } from "node:path";
 import { checkIgnore } from "../git/gitOps";
 import { toWireBytes } from "../wireBytes";
 import { resolveContained } from "./pathContainment";
@@ -29,6 +30,9 @@ interface FsEntry {
   realTarget?: FsReadDirRealTarget;
   isIgnored: boolean;
 }
+
+/** gitignore 判定前の entry。`isIgnored` は checkIgnore の結果を突き合わせて後から載せる */
+type FsEntryDraft = Omit<FsEntry, "isIgnored">;
 
 export interface FsReadDirResult {
   entries: FsEntry[];
@@ -121,66 +125,101 @@ export async function readDir(dir: string, path: string): Promise<FsReadDirResul
     }
     throw listed.error;
   }
+  // 入力 path の表記揺れ（`""` / `"."` / 末尾スラッシュ）を以降へ持ち込まないよう、resolve 済みの
+  // target から導出した正規化相対パスだけを使う。同一関数内に入力表記依存の判定を作らないための契約
+  const relDir = relative(dir, target);
   // `.git` (directory / gitlink file 両方) はツリーから完全一致で除外する（docs/filer.md）。
   // gitignore 経路とは独立。checkIgnore に渡す前に落とし、無駄な git 呼び出しも省く
   const dirents = listed.value.filter((entry) => entry.name !== ".git");
   // 実体の在り処を判定する基準。dir / 列挙対象それぞれの realpath を 1 回だけ引く。
   // - dirRealPath: relPath（dir 相対）の算出基準
-  // - listRealPath: 列挙対象自身が symlink 越しか（!== dir + path）と、entry の実体パスの基準
+  // - listRealPath: 列挙対象自身が symlink 越しかの判定と、entry の実体パスの基準
   const dirRealPath = realpathSync(dir);
   const listRealPath = realpathSync(target);
-  const typed = dirents.map((entry) => {
-    // symlink は lstat 由来の種別 ("symlink") を保ったまま、辿った結果を realTarget に載せる。
-    // これが無いと renderer は dir symlink を leaf に潰すしかない。
-    // 辿れない dangling / 循環 (ELOOP) は realTarget 不在で「実体なし」を表現する。
-    if (entry.isSymbolicLink()) {
-      return {
-        name: entry.name,
-        type: "symlink",
-        realTarget: resolveRealTarget(join(listRealPath, entry.name), dirRealPath),
-      };
-    }
-    const type = entry.isDirectory() ? "directory" : "file";
-    // 列挙対象が symlink 越し（`.claude/skills/x` が link で、その配下を見ている等）なら、
-    // entry 自身が link でなくても実体はツリー上のパスとは別の場所にある。
-    if (listRealPath === join(dirRealPath, path)) return { name: entry.name, type };
-    return {
-      name: entry.name,
-      type,
-      realTarget: resolveRealTarget(join(listRealPath, entry.name), dirRealPath),
-    };
+  // 列挙対象自身が symlink 越しか（`.claude/skills/x` が link で、その配下を見ている等）。
+  // 真なら entry 自身が link でなくても実体はツリー上のパスとは別の場所にある
+  const listCrossesLink = listRealPath !== join(dirRealPath, relDir);
+  const prefix = relDir === "" ? "" : `${relDir}${sep}`;
+  const listing = dirents.map((entry) => {
+    const built = buildEntry(entry, listRealPath, dirRealPath, listCrossesLink);
+    // gitignore 判定に渡す pathspec。link 越しの列挙では実体側の dir 相対パスを使う。
+    // link 越しのパスを渡すと git が `pathspec ... is beyond a symbolic link` で fatal になり、
+    // その列挙の全 entry の判定を落とす（checkIgnore は失敗を空集合に倒す契約）。
+    // 実体が dir 外なら当該 repo の gitignore の管轄外なので問い合わせ自体を落とす
+    const ignoreSpec = listCrossesLink ? built.realTarget?.relPath : prefix + entry.name;
+    return { built, ignoreSpec };
   });
-  // gitignore 判定は dir（worktree root）からの相対パスで行う
-  const prefix = path === "" ? "" : path.endsWith("/") ? path : `${path}/`;
   const ignored = await checkIgnore(
     dir,
-    typed.map((entry) => prefix + entry.name),
+    listing.flatMap(({ ignoreSpec }) => (ignoreSpec === undefined ? [] : [ignoreSpec])),
   );
-  const entries = typed
-    .map((entry) => ({ ...entry, isIgnored: ignored.has(prefix + entry.name) }))
+  const entries = listing
+    .map(({ built, ignoreSpec }) => ({
+      ...built,
+      isIgnored: ignoreSpec !== undefined && ignored.has(ignoreSpec),
+    }))
     .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
   return { entries, notFound: false };
 }
 
 /**
- * 実体の在り処を返す。辿れない（dangling / 循環）場合は undefined。
+ * dirent 1 件を entry（name / type / realTarget）に組み立てる。
+ *
+ * symlink は lstat 由来の種別 ("symlink") を保ったまま、辿った結果を realTarget に載せる。
+ * これが無いと renderer は dir symlink を leaf に潰すしかない。辿れない dangling / 循環 (ELOOP) は
+ * realTarget 不在で「実体なし」を表現する。
+ *
+ * 非 symlink の entry は `listRealPath` が canonical であることから実体パスが確定するため、
+ * realpath / stat を引き直さない（entry 数ぶんの syscall を避けるだけでなく、readdir と stat の
+ * 隙に entry が消えて realTarget だけ静かに落ちる失敗経路も作らない）。
+ */
+function buildEntry(
+  entry: Dirent,
+  listRealPath: string,
+  dirRealPath: string,
+  listCrossesLink: boolean,
+): FsEntryDraft {
+  if (entry.isSymbolicLink()) {
+    return {
+      name: entry.name,
+      type: "symlink",
+      realTarget: resolveRealTarget(join(listRealPath, entry.name), dirRealPath),
+    };
+  }
+  const isDirectory = entry.isDirectory();
+  const type = isDirectory ? "directory" : "file";
+  if (!listCrossesLink) return { name: entry.name, type };
+  return {
+    name: entry.name,
+    type,
+    realTarget: toRealTarget(join(listRealPath, entry.name), isDirectory, dirRealPath),
+  };
+}
+
+/** symlink を辿って実体の在り処を返す。辿れない（dangling / 循環）場合は undefined */
+function resolveRealTarget(linkPath: string, dirRealPath: string): FsReadDirRealTarget | undefined {
+  const resolved = tryCatch(() => realpathSync(linkPath));
+  if (!resolved.ok) return undefined;
+  const followed = tryCatch(() => statSync(resolved.value));
+  if (!followed.ok) return undefined;
+  return toRealTarget(resolved.value, followed.value.isDirectory(), dirRealPath);
+}
+
+/**
+ * 解決済みの実体パスから realTarget を組み立てる。
  *
  * `relPath` の包含判定は realpath 同士で行う。`dirRealPath` を使わず入力の dir で比較すると、
  * dir 自身が symlink 経由のパス（macOS の `$TMPDIR` 等）のときに「実体は dir 配下なのに外部扱い」
  * になり、renderer が worktree 相対で開ける実体を absolute へ倒してしまう。
  */
-function resolveRealTarget(
-  entryPath: string,
+function toRealTarget(
+  absPath: string,
+  isDirectory: boolean,
   dirRealPath: string,
-): FsReadDirRealTarget | undefined {
-  const resolved = tryCatch(() => realpathSync(entryPath));
-  if (!resolved.ok) return undefined;
-  const absPath = resolved.value;
-  const followed = tryCatch(() => statSync(absPath));
-  if (!followed.ok) return undefined;
+): FsReadDirRealTarget {
   const prefix = dirRealPath.endsWith(sep) ? dirRealPath : `${dirRealPath}${sep}`;
   return {
-    type: followed.value.isDirectory() ? "directory" : "file",
+    type: isDirectory ? "directory" : "file",
     absPath,
     relPath: absPath.startsWith(prefix) ? absPath.slice(prefix.length) : undefined,
   };

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -423,8 +423,8 @@ watch(
  */
 async function handleReveal() {
   const request = worktreeStore.revealRequest;
-  const targetPath = request?.relPath;
-  if (request === undefined || targetPath === undefined) return;
+  if (request === undefined) return;
+  const targetPath = request.relPath;
   const isLatestRequest = () => worktreeStore.revealRequest?.seq === request.seq;
   // 自身がターゲットの場合、展開してスクロールインビュー
   if (targetPath === props.path) {

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -17,21 +17,16 @@
 - `submodule`: 常に no-op。gitlink object (`160000`) は `gitShowCommitFile` で内容を取得できないため
   preview に流すとエラーになる。視覚的にも opacity を落として「click できない」ことを示す
 
-## symlink（`isSymlink`）
+## symlink
 
-- working tree の symlink は `kind` が実体側（`file` / `directory`）に解決済みで届くため、click は
-  実体に対する経路（file は preview、directory は展開）に自動で乗る
-- 表現は 2 軸に分ける。**バッジ**（アイコン右下の矢印）は `isSymlink` = link 自身の行だけ。**名前の色**
-  （info）は `isLinked` = link 自身 + link 越しに列挙された行で、link ディレクトリの下層まで色が続く。
-  右クリックで実体向け項目が出る集合と色が付く集合を揃えることで、「色が付いている = ツリー上の
-  パスと実体が違う」が一貫して読める
-- 色の優先順位は git change > link > ignored。link は gitignore 対象が大半（worktree symlink 等）
-  なので ignored の gray より上に置く。git change に色を譲る行でも、link であることはバッジが示し続ける
-- 右クリックの既存項目 (Open / Copy file / Copy path) は link path そのものを対象にする。実体側へ
-  読み替えると Copy path が「見えている path」と別物を返すため
-- 実体を対象にする操作は右クリックの専用項目に分離する。対象 (`realTarget`) は symlink 自身だけでなく
-  「symlink 越しに列挙された行」も持つ (link 配下のファイルも実体は別の場所にある)。payload には
-  事実として `realTarget` をそのまま載せ、どの項目を出せるかの判定は menu 側 (FileContextMenu) が持つ
+表示 2 軸（バッジ / 名前の色）と色の優先順位、右クリック項目の切り分けは
+[docs/filer.md](../../../../../docs/filer.md#symlink-の表示) が SSOT。本 component 固有の点だけ:
+
+- バッジは行の hover / 選択色に追従せず自前の面を持つ。実体の種別でアイコン自体が決まる
+  （dir symlink はフォルダアイコン）ため、link であることは重ね表示でしか表現できず、背景に
+  溶けると矢印が読めない
+- 右クリック payload には事実として `realTarget` をそのまま載せ、どの項目を出せるかの判定は
+  menu 側 (FileContextMenu) が持つ。項目を足すたびに払い出し側を触らないための責務分割
 
 ## snapshot mode (snapshotHash プロパティが真値のとき)
 
@@ -118,7 +113,7 @@ const props = defineProps<{
   kind: FileEntryKind;
   /** symlink 経由の entry か（kind とは独立。link バッジの表示 SSOT） */
   isSymlink?: boolean;
-  /** 実体の在り処。右クリック menu の "Open target" 対象 */
+  /** 実体の在り処。右クリック menu の実体向け項目の対象 */
   realTarget?: FileRealTarget;
   /** working tree モード由来の gitignore フラグ。snapshot mode では undefined */
   isIgnored?: boolean;
@@ -205,11 +200,11 @@ const effectiveGitChange = computed<GitChangeKind | undefined>(() => {
 });
 
 /**
- * リンクが絡む行。link 自身 (`isSymlink`) と、link 越しに列挙された行 (`realTarget`) の両方を含む。
- * 名前の色はこの軸で付ける: 右クリックで実体向け項目が出る行と色が付く行を同じ集合に揃えることで、
- * 「色が付いている = ツリー上のパスと実体が違う」が一貫して読める（link 配下も色が続く）。
+ * 実体がツリー上のパスと別の場所にある行。名前の色はこの軸で付ける: 右クリックで実体向け項目が出る
+ * 集合と一致するため「色が付いている = 実体へのアクションがある」が一貫して読める（link 配下も色が
+ * 続く）。実体を持たない dangling / 循環はバッジと tooltip (broken symlink) だけで表し色は付けない。
  */
-const isLinked = computed(() => props.isSymlink === true || props.realTarget !== undefined);
+const isLinked = computed(() => props.realTarget !== undefined);
 
 // 優先順位は git change > link > ignored。link 色を ignored の下に置くと、gitignore 対象が
 // 大半を占める実運用 (worktree symlink 等) でほぼ発火しないため ignored より上に置く。
@@ -441,7 +436,7 @@ async function handleReveal() {
   if (!isDescendantOf(targetPath, props.path)) return;
   // 自身の配下に target がある場合、自分は展開するだけ（target そのものへの scroll は
   // 子の watch が処理する）。子は v-for で children を読み込むとマウントされ、
-  // immediate watch が現在の revealVersion で発火する
+  // immediate watch が現在の revealRequest で発火する
   if (!expanded.value) {
     expanded.value = true;
     if (children.value === undefined) {

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -454,7 +454,8 @@ async function handleReveal() {
 
 // watch source は request object そのもの。`revealRequest?.relPath` に変えてはならない
 // (同一パスの再要求は relPath が不変なので発火せず、同じファイルを再選択したときの
-// 展開 + スクロールが無音で落ちる)。発火は要求ごとに新しい object を立てる identity に依存する
+// 展開 + スクロールが無音で落ちる)。発火は要求ごとに新しい object を立てる identity に依存する。
+// store 側 `revealRequest` の docstring と対の再掲で、発火機構を変えるときは両方を同時に更新する
 watch(
   () => worktreeStore.revealRequest,
   () => {

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -11,10 +11,27 @@
 
 - `directory`: 展開 / 折りたたみ
 - `file`: `select` emit
-- `symlink`: working tree モード (`snapshotHash` undefined) では `select` emit で実 file に resolve。
+- `symlink`: 実体を持たない symlink のみこの kind に来る（working tree の dangling / 循環、
+  snapshot tree の symlink blob）。working tree では `select` emit（preview が not found を出す）、
   snapshot mode では blob 内容が target path 文字列でしかないため click を no-op に倒す
 - `submodule`: 常に no-op。gitlink object (`160000`) は `gitShowCommitFile` で内容を取得できないため
   preview に流すとエラーになる。視覚的にも opacity を落として「click できない」ことを示す
+
+## symlink（`isSymlink`）
+
+- working tree の symlink は `kind` が実体側（`file` / `directory`）に解決済みで届くため、click は
+  実体に対する経路（file は preview、directory は展開）に自動で乗る
+- 表現は 2 軸に分ける。**バッジ**（アイコン右下の矢印）は `isSymlink` = link 自身の行だけ。**名前の色**
+  （info）は `isLinked` = link 自身 + link 越しに列挙された行で、link ディレクトリの下層まで色が続く。
+  右クリックで実体向け項目が出る集合と色が付く集合を揃えることで、「色が付いている = ツリー上の
+  パスと実体が違う」が一貫して読める
+- 色の優先順位は git change > link > ignored。link は gitignore 対象が大半（worktree symlink 等）
+  なので ignored の gray より上に置く。git change に色を譲る行でも、link であることはバッジが示し続ける
+- 右クリックの既存項目 (Open / Copy file / Copy path) は link path そのものを対象にする。実体側へ
+  読み替えると Copy path が「見えている path」と別物を返すため
+- 実体を対象にする操作は右クリックの専用項目に分離する。対象 (`realTarget`) は symlink 自身だけでなく
+  「symlink 越しに列挙された行」も持つ (link 配下のファイルも実体は別の場所にある)。payload には
+  事実として `realTarget` をそのまま載せ、どの項目を出せるかの判定は menu 側 (FileContextMenu) が持つ
 
 ## snapshot mode (snapshotHash プロパティが真値のとき)
 
@@ -50,7 +67,8 @@
 - filer event store の fsChange を watch して自分の path 該当時に再読み込み (snapshot mode では skip)
 - filer event store の gitStatusChange を watch して展開中なら children を再構築 (snapshot mode では skip)
 - snapshotHash 変化を watch して展開中なら children を再 load (cache invalidate)
-- worktreeStore.revealVersion を watch して selectedRelPath が自分または配下なら展開＋スクロール
+- worktreeStore.revealRequest を watch して対象パスが自分または配下なら展開＋スクロール。要求元は
+  selection 由来 (select\*Path) と選択を動かさない tree reveal (revealRelPath) の 2 経路
 - 親→子の命令呼び出し（defineExpose）は使わず、各ノードが自律的にイベントを処理する設計
 </doc>
 
@@ -76,12 +94,13 @@ import {
   toFileEntries,
   toFileEntriesFromGitTree,
 } from "./filerUtils";
-import type { FileEntry, FileEntryKind } from "./filerUtils";
+import type { FileEntry, FileEntryKind, FileRealTarget } from "./filerUtils";
 import { rpcFsReadDir, rpcGitLsTree } from "./rpc";
 import { getFileIconUrl, getFolderIconUrl } from "./useFileIcon";
 import { useFilerEventStore } from "./useFilerEventStore";
 import IconLucideChevronDown from "~icons/lucide/chevron-down";
 import IconLucideChevronRight from "~icons/lucide/chevron-right";
+import IconLucideCornerUpRight from "~icons/lucide/corner-up-right";
 
 const GIT_CHANGE_COLOR_MAP: Record<GitChangeKind, string> = {
   modified: "text-warning-text",
@@ -95,7 +114,12 @@ const props = defineProps<{
   name: string;
   /** worktree からの相対パス。worktree 直下（不可視ルート）は `""` */
   path: string;
+  /** 実体としての種別。working tree の symlink は解決済みの実体側 kind が届く */
   kind: FileEntryKind;
+  /** symlink 経由の entry か（kind とは独立。link バッジの表示 SSOT） */
+  isSymlink?: boolean;
+  /** 実体の在り処。右クリック menu の "Open target" 対象 */
+  realTarget?: FileRealTarget;
   /** working tree モード由来の gitignore フラグ。snapshot mode では undefined */
   isIgnored?: boolean;
   /** ファイル自身の git 変更種別 */
@@ -180,8 +204,20 @@ const effectiveGitChange = computed<GitChangeKind | undefined>(() => {
   return resolveFileGitChange(props.path, props.gitStatuses);
 });
 
+/**
+ * リンクが絡む行。link 自身 (`isSymlink`) と、link 越しに列挙された行 (`realTarget`) の両方を含む。
+ * 名前の色はこの軸で付ける: 右クリックで実体向け項目が出る行と色が付く行を同じ集合に揃えることで、
+ * 「色が付いている = ツリー上のパスと実体が違う」が一貫して読める（link 配下も色が続く）。
+ */
+const isLinked = computed(() => props.isSymlink === true || props.realTarget !== undefined);
+
+// 優先順位は git change > link > ignored。link 色を ignored の下に置くと、gitignore 対象が
+// 大半を占める実運用 (worktree symlink 等) でほぼ発火しないため ignored より上に置く。
+// git change は「今この行に起きている変化」で link より緊急度が高く、色を譲っても
+// link であることはバッジが示し続ける。
 const textColorClass = computed(() => {
   if (effectiveGitChange.value) return GIT_CHANGE_COLOR_MAP[effectiveGitChange.value];
+  if (isLinked.value) return "text-info";
   if (props.isIgnored === true) return "text-foreground-low";
   if (props.selectedRelPath === props.path) return "text-foreground";
   return "text-foreground";
@@ -196,6 +232,18 @@ const rowSelectedClass = computed(() => (isSnapshot.value ? "bg-element-hover" :
 
 /** 削除ファイルかどうか (snapshot mode では発生しない) */
 const isDeleted = computed(() => !isSnapshot.value && props.gitChange === "deleted");
+
+/**
+ * hover tooltip。symlink バッジは「link であること」しか伝えられないため、実体を解決できない
+ * ケース (kind === "symlink") だけ文言で区別する。working tree では dangling / 循環、
+ * snapshot tree では blob が target path 文字列でしかないことを指す。
+ */
+const rowTitle = computed(() => {
+  if (props.kind === "submodule") return "submodule (not previewable)";
+  if (props.kind === "symlink") return isSnapshot.value ? "symlink" : "broken symlink";
+  if (props.isSymlink === true) return "symlink";
+  return undefined;
+});
 
 /** material-icon-theme のアイコン URL */
 const iconUrl = computed(() => {
@@ -364,17 +412,18 @@ watch(
 );
 
 /**
- * revealVersion 変化で worktreeStore.selectedRelPath を見て、自分が target または target の祖先なら処理。
- * 祖先の場合は展開するだけ。子は v-for でマウント後に自分の revealVersion watch (immediate)
+ * reveal 要求 (worktreeStore.revealRequest) の対象が自分または自分の配下なら処理する。
+ * 祖先の場合は展開するだけ。子は v-for でマウント後に自分の revealRequest watch (immediate)
  * で target を処理する再帰チェーン。
  *
  * ルートノード（path === ""）は `isDescendantOf` で worktree 内の任意 target の祖先扱い。
  *
- * absolute 選択中 (worktree 外) は selectedRelPath が undefined になり reveal は no-op。
- * ツリーが持っていないパスをマッチさせる経路を型レベルで排除する。
+ * 要求元は selection 由来 (select*Path) と選択を動かさない tree reveal (revealRelPath) の
+ * 2 経路で、どちらも request の relPath が対象。absolute 選択中 (worktree 外) は request が
+ * undefined に落ち、ツリーが持っていないパスをマッチさせる経路を構造的に排除する。
  */
 async function handleReveal() {
-  const targetPath = worktreeStore.selectedRelPath;
+  const targetPath = worktreeStore.revealRequest?.relPath;
   if (targetPath === undefined) return;
   // 自身がターゲットの場合、展開してスクロールインビュー
   if (targetPath === props.path) {
@@ -402,7 +451,7 @@ async function handleReveal() {
 }
 
 watch(
-  () => worktreeStore.revealVersion,
+  () => worktreeStore.revealRequest,
   () => {
     void handleReveal();
   },
@@ -433,6 +482,7 @@ function onContextMenu(event: MouseEvent) {
   emit("contextMenu", {
     anchorEl: event.currentTarget,
     relPath: props.path,
+    realTarget: props.realTarget,
     x: event.clientX,
     y: event.clientY,
   });
@@ -454,7 +504,7 @@ function onContextMenu(event: MouseEvent) {
         isInertLeaf ? 'cursor-not-allowed text-foreground-muted' : '',
       ]"
       :style="{ paddingLeft: `${depth * 16 + 4}px` }"
-      :title="kind === 'submodule' ? 'submodule (not previewable)' : undefined"
+      :title="rowTitle"
       @click="toggle"
       @contextmenu="onContextMenu"
     >
@@ -467,12 +517,16 @@ function onContextMenu(event: MouseEvent) {
       <!-- ファイル用のスペーサー -->
       <span v-else class="size-4 shrink-0" />
 
-      <img
-        :src="iconUrl"
-        class="size-4 shrink-0"
-        :class="isIgnored === true ? 'grayscale' : ''"
-        alt=""
-      />
+      <span class="relative flex size-4 shrink-0">
+        <img :src="iconUrl" class="size-4" :class="isIgnored === true ? 'grayscale' : ''" alt="" />
+        <!-- symlink バッジ。実体の種別でアイコン自体が決まる（dir symlink はフォルダアイコン）
+             ため、「実体への転送」は重ね表示でしか表現できない。Finder の alias バッジと同じく
+             行の hover / 選択色には追従せず自前の面を持つ（背景に溶けると矢印が読めない） -->
+        <IconLucideCornerUpRight
+          v-if="isSymlink === true"
+          class="absolute -right-0.5 -bottom-0.5 size-3 rounded-full bg-background text-info"
+        />
+      </span>
       <span class="truncate">{{ name }}</span>
     </button>
 
@@ -491,6 +545,8 @@ function onContextMenu(event: MouseEvent) {
         :name="child.name"
         :path="joinPath(path, child.name)"
         :kind="child.kind"
+        :is-symlink="child.isSymlink"
+        :real-target="child.realTarget"
         :is-ignored="child.isIgnored"
         :git-change="child.gitChange"
         :git-statuses="gitStatuses"

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -416,10 +416,16 @@ watch(
  * 要求元は selection 由来 (select*Path) と選択を動かさない tree reveal (revealRelPath) の
  * 2 経路で、どちらも request の relPath が対象。absolute 選択中 (worktree 外) は request が
  * undefined に落ち、ツリーが持っていないパスをマッチさせる経路を構造的に排除する。
+ *
+ * `loadChildren` の await を挟むため、`seq` で世代保護する (loadChildren 自身の `loadSeq` と同じ
+ * 規律)。await 中に来た新しい要求が load 不要で先に完走すると、古い要求の scrollIntoView が
+ * 後から上書きしてしまう。
  */
 async function handleReveal() {
-  const targetPath = worktreeStore.revealRequest?.relPath;
-  if (targetPath === undefined) return;
+  const request = worktreeStore.revealRequest;
+  const targetPath = request?.relPath;
+  if (request === undefined || targetPath === undefined) return;
+  const isLatestRequest = () => worktreeStore.revealRequest?.seq === request.seq;
   // 自身がターゲットの場合、展開してスクロールインビュー
   if (targetPath === props.path) {
     if (isDirectory.value && !expanded.value) {
@@ -428,6 +434,7 @@ async function handleReveal() {
         await loadChildren();
       }
     }
+    if (!isLatestRequest()) return;
     buttonRef.value?.scrollIntoView({ block: "nearest" });
     return;
   }

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -452,6 +452,9 @@ async function handleReveal() {
   }
 }
 
+// watch source は request object そのもの。`revealRequest?.relPath` に変えてはならない
+// (同一パスの再要求は relPath が不変なので発火せず、同じファイルを再選択したときの
+// 展開 + スクロールが無音で落ちる)。発火は要求ごとに新しい object を立てる identity に依存する
 watch(
   () => worktreeStore.revealRequest,
   () => {

--- a/apps/renderer/src/features/filer/filerUtils.test.ts
+++ b/apps/renderer/src/features/filer/filerUtils.test.ts
@@ -158,9 +158,86 @@ describe("toFileEntries", () => {
     expect(result[0]?.kind).toBe("file");
   });
 
-  test("type === 'symlink' は kind: 'symlink' になる", () => {
+  test("realTarget 不在の symlink (dangling) は kind: 'symlink' のまま残る", () => {
     const result = toFileEntries([{ name: "link", type: "symlink", isIgnored: false }]);
     expect(result[0]?.kind).toBe("symlink");
+    expect(result[0]?.isSymlink).toBe(true);
+    expect(result[0]?.realTarget).toBeUndefined();
+  });
+
+  test("ディレクトリへの symlink は kind: 'directory' に解決され実体も directory になる", () => {
+    const result = toFileEntries([
+      {
+        name: "link",
+        type: "symlink",
+        realTarget: { type: "directory", absPath: "/wt/docs", relPath: "docs" },
+        isIgnored: false,
+      },
+    ]);
+    expect(result[0]?.kind).toBe("directory");
+    expect(result[0]?.isSymlink).toBe(true);
+    expect(result[0]?.realTarget).toEqual({
+      absPath: "/wt/docs",
+      relPath: "docs",
+      isDirectory: true,
+    });
+  });
+
+  test("ファイルへの symlink は kind: 'file' に解決され実体パスを保持する", () => {
+    const result = toFileEntries([
+      {
+        name: "link",
+        type: "symlink",
+        realTarget: { type: "file", absPath: "/wt/README.md", relPath: "README.md" },
+        isIgnored: false,
+      },
+    ]);
+    expect(result[0]?.kind).toBe("file");
+    expect(result[0]?.isSymlink).toBe(true);
+    expect(result[0]?.realTarget).toEqual({
+      absPath: "/wt/README.md",
+      relPath: "README.md",
+      isDirectory: false,
+    });
+  });
+
+  test("worktree 外を指す symlink は realTarget.relPath が undefined のまま伝搬する", () => {
+    const result = toFileEntries([
+      {
+        name: "link",
+        type: "symlink",
+        realTarget: { type: "file", absPath: "/other/main/.env.local" },
+        isIgnored: false,
+      },
+    ]);
+    expect(result[0]?.realTarget).toEqual({
+      absPath: "/other/main/.env.local",
+      relPath: undefined,
+      isDirectory: false,
+    });
+  });
+
+  test("symlink 越しに列挙された通常 entry は isSymlink: false でも realTarget を持つ", () => {
+    const result = toFileEntries([
+      {
+        name: "SKILL.md",
+        type: "file",
+        realTarget: {
+          type: "file",
+          absPath: "/wt/.agents/skills/review/SKILL.md",
+          relPath: ".agents/skills/review/SKILL.md",
+        },
+        isIgnored: false,
+      },
+    ]);
+    expect(result[0]?.isSymlink).toBe(false);
+    expect(result[0]?.realTarget?.relPath).toBe(".agents/skills/review/SKILL.md");
+  });
+
+  test("実体がツリー上のパスと一致する entry は isSymlink: false / realTarget なし", () => {
+    const result = toFileEntries([{ name: "a.txt", type: "file", isIgnored: false }]);
+    expect(result[0]?.isSymlink).toBe(false);
+    expect(result[0]?.realTarget).toBeUndefined();
   });
 
   test("type === 'other' は kind: 'file' に倒れる", () => {
@@ -185,9 +262,10 @@ describe("toFileEntriesFromGitTree", () => {
     expect(result[0]?.kind).toBe("file");
   });
 
-  test("type === 'symlink' は kind: 'symlink' になる (snapshot tree でも保持)", () => {
+  test("type === 'symlink' は kind: 'symlink' になり isSymlink が立つ (snapshot tree でも保持)", () => {
     const result = toFileEntriesFromGitTree([{ name: "link", type: "symlink" }]);
     expect(result[0]?.kind).toBe("symlink");
+    expect(result[0]?.isSymlink).toBe(true);
   });
 
   test("type === 'submodule' は kind: 'submodule' になる", () => {

--- a/apps/renderer/src/features/filer/filerUtils.test.ts
+++ b/apps/renderer/src/features/filer/filerUtils.test.ts
@@ -240,11 +240,6 @@ describe("toFileEntries", () => {
     expect(result[0]?.realTarget).toBeUndefined();
   });
 
-  test("type === 'other' は kind: 'file' に倒れる", () => {
-    const result = toFileEntries([{ name: "fifo", type: "other", isIgnored: false }]);
-    expect(result[0]?.kind).toBe("file");
-  });
-
   test("空配列を処理できる", () => {
     expect(toFileEntries([])).toEqual([]);
   });

--- a/apps/renderer/src/features/filer/filerUtils.ts
+++ b/apps/renderer/src/features/filer/filerUtils.ts
@@ -55,8 +55,6 @@ interface FileEntry {
  *
  * - symlink は `realTarget.type`（main が辿った先の種別）に倒し、dir symlink が leaf に潰れるのを防ぐ
  * - 辿れない symlink（dangling / 循環）は実体が無いので `symlink` のまま残す
- * - 非 symlink の未知 type（fifo / socket 等）は file 扱いにする。ツリーは表示と click 経路しか
- *   持たないため、file 以外の葉として区別する意味が無い
  */
 function fsEntryToKind(entry: FsReadDirEntry): FileEntryKind {
   if (entry.type === "symlink") {

--- a/apps/renderer/src/features/filer/filerUtils.ts
+++ b/apps/renderer/src/features/filer/filerUtils.ts
@@ -20,8 +20,9 @@ type FileEntryKind = "file" | "directory" | "symlink" | "submodule";
  *
  * - `relPath`: 実体が worktree 配下にあるときだけ定義される。worktree 外を指す場合は
  *   undefined で、「絶対パスでしか開けない」制約がそのまま型に出る
- * - `isDirectory`: 実体を開く経路が preview（file）か tree reveal（directory）かを決める。
- *   行の `kind` とは別に持つ（`kind` は行の振る舞い、こちらは移動先の性質）
+ * - `isDirectory`: 実体を開く経路が preview（file）か tree reveal（directory）かを決める。値は
+ *   行の `kind` と常に同値だが、この型は右クリック payload に載って menu だけで消費されるため、
+ *   menu に `kind`（ツリー表示用の 4 値）まで持ち込まずに済ませるための投影として持つ
  */
 interface FileRealTarget {
   absPath: string;
@@ -49,29 +50,20 @@ interface FileEntry {
   gitChange?: GitChangeKind;
 }
 
-/** FsReadDir 由来の type 文字列を FileEntryKind に写像する */
-function fsTypeToKind(type: string): FileEntryKind {
-  switch (type) {
-    case "directory":
-      return "directory";
-    case "symlink":
-      return "symlink";
-    case "file":
-      return "file";
-    default:
-      return "file";
-  }
-}
-
 /**
- * FsReadDir 由来の entry を、**実体の種別**として FileEntryKind に写像する。symlink は
- * `realTarget.type`（main が辿った先の種別）に倒し、dir symlink が leaf に潰れるのを防ぐ。
- * 辿れない symlink（dangling / 循環）は実体が無いので `symlink` のまま残す。
+ * FsReadDir 由来の entry を、**実体の種別**として FileEntryKind に写像する。
+ *
+ * - symlink は `realTarget.type`（main が辿った先の種別）に倒し、dir symlink が leaf に潰れるのを防ぐ
+ * - 辿れない symlink（dangling / 循環）は実体が無いので `symlink` のまま残す
+ * - 非 symlink の未知 type（fifo / socket 等）は file 扱いにする。ツリーは表示と click 経路しか
+ *   持たないため、file 以外の葉として区別する意味が無い
  */
 function fsEntryToKind(entry: FsReadDirEntry): FileEntryKind {
-  if (entry.type !== "symlink") return fsTypeToKind(entry.type);
-  if (entry.realTarget === undefined) return "symlink";
-  return fsTypeToKind(entry.realTarget.type);
+  if (entry.type === "symlink") {
+    if (entry.realTarget === undefined) return "symlink";
+    return entry.realTarget.type === "directory" ? "directory" : "file";
+  }
+  return entry.type === "directory" ? "directory" : "file";
 }
 
 /** git ls-tree 由来の type 文字列を FileEntryKind に写像する */

--- a/apps/renderer/src/features/filer/filerUtils.ts
+++ b/apps/renderer/src/features/filer/filerUtils.ts
@@ -2,21 +2,43 @@ import type { FsReadDirEntry, GitTreeEntry } from "@gozd/rpc";
 import type { GitChangeKind } from "../worktree";
 
 /**
- * ファイラーノードの種類。`isDirectory: boolean` だけでは submodule / symlink が file 扱いに
- * 潰れてしまい、snapshot mode で submodule をクリックして `gitShowCommitFile` を呼ぶような
- * 経路差を構造的に区別できないため独立した SSOT として持つ。
+ * ファイラーノードの種類。**実体としてどう振る舞うか**の SSOT で、`isDirectory: boolean` では
+ * submodule / 実体を解決できない symlink が file 扱いに潰れてしまうため独立して持つ。
  *
- * - `file` / `directory`: working / snapshot どちらでも表示・展開・選択の通常経路
- * - `symlink`: working tree では実 file へ resolve できるため select 可。snapshot tree では
- *   blob 内容が target path 文字列なので click を no-op に倒す (FileTreeItem 側で判定)
+ * - `file` / `directory`: working / snapshot どちらでも表示・展開・選択の通常経路。working tree の
+ *   symlink は辿った先の種別でこの 2 つに解決される（dir symlink を leaf に潰さないため）
+ * - `symlink`: 実体を持たない symlink。working tree では dangling / 循環、snapshot tree では
+ *   blob 内容が target path 文字列でしかない（後者は click を no-op に倒す。FileTreeItem 側で判定）
  * - `submodule`: gitlink object (`160000`)。git show <hash>:<path> では内容を返せないため
  *   常に no-op
  */
 type FileEntryKind = "file" | "directory" | "symlink" | "submodule";
 
+/**
+ * entry の実体の在り処。ツリー上のパスと実体が食い違うときだけ持つ（symlink 自身と、
+ * symlink 越しに列挙された entry の 2 経路）。
+ *
+ * - `relPath`: 実体が worktree 配下にあるときだけ定義される。worktree 外を指す場合は
+ *   undefined で、「絶対パスでしか開けない」制約がそのまま型に出る
+ * - `isDirectory`: 実体を開く経路が preview（file）か tree reveal（directory）かを決める。
+ *   行の `kind` とは別に持つ（`kind` は行の振る舞い、こちらは移動先の性質）
+ */
+interface FileRealTarget {
+  absPath: string;
+  relPath?: string;
+  isDirectory: boolean;
+}
+
 interface FileEntry {
   name: string;
   kind: FileEntryKind;
+  /**
+   * symlink 経由の entry か。`kind` は実体側の種別に解決されるため、「link であること自体」は
+   * この flag だけが保持する（実体表示 + link バッジの重ね合わせを両立させる分離）。
+   */
+  isSymlink?: boolean;
+  /** 実体の在り処。ツリー上のパスと一致する / 実体を解決できない場合は undefined */
+  realTarget?: FileRealTarget;
   /**
    * gitignore に該当するか。working tree mode 由来のみ意味があり、snapshot mode では
    * 概念自体が存在しないため undefined になる。`isIgnored === true` のときだけ "ignored" の
@@ -39,6 +61,17 @@ function fsTypeToKind(type: string): FileEntryKind {
     default:
       return "file";
   }
+}
+
+/**
+ * FsReadDir 由来の entry を、**実体の種別**として FileEntryKind に写像する。symlink は
+ * `realTarget.type`（main が辿った先の種別）に倒し、dir symlink が leaf に潰れるのを防ぐ。
+ * 辿れない symlink（dangling / 循環）は実体が無いので `symlink` のまま残す。
+ */
+function fsEntryToKind(entry: FsReadDirEntry): FileEntryKind {
+  if (entry.type !== "symlink") return fsTypeToKind(entry.type);
+  if (entry.realTarget === undefined) return "symlink";
+  return fsTypeToKind(entry.realTarget.type);
 }
 
 /** git ls-tree 由来の type 文字列を FileEntryKind に写像する */
@@ -95,7 +128,16 @@ function getDeletedEntries(dirPath: string, gitStatuses: Record<string, string>)
 function toFileEntries(entries: FsReadDirEntry[]): FileEntry[] {
   return entries.map((e) => ({
     name: e.name,
-    kind: fsTypeToKind(e.type),
+    kind: fsEntryToKind(e),
+    isSymlink: e.type === "symlink",
+    realTarget:
+      e.realTarget === undefined
+        ? undefined
+        : {
+            absPath: e.realTarget.absPath,
+            relPath: e.realTarget.relPath,
+            isDirectory: e.realTarget.type === "directory",
+          },
     isIgnored: e.isIgnored,
   }));
 }
@@ -108,6 +150,7 @@ function toFileEntriesFromGitTree(entries: GitTreeEntry[]): FileEntry[] {
   return entries.map((e) => ({
     name: e.name,
     kind: gitTreeTypeToKind(e.type),
+    isSymlink: e.type === "symlink",
   }));
 }
 
@@ -173,4 +216,4 @@ export {
   toFileEntries,
   toFileEntriesFromGitTree,
 };
-export type { FileEntry, FileEntryKind };
+export type { FileEntry, FileEntryKind, FileRealTarget };

--- a/apps/renderer/src/features/filer/index.ts
+++ b/apps/renderer/src/features/filer/index.ts
@@ -1,5 +1,6 @@
 export { default as FileActionMenuItems } from "./FileActionMenuItems.vue";
 export { default as FilerPane } from "./FilerPane.vue";
+export type { FileRealTarget } from "./filerUtils";
 export { registerFilerCommands } from "./registerFilerCommands";
 export { relDirOf } from "./relDirOf";
 export {

--- a/apps/renderer/src/features/navigator/FileContextMenu.vue
+++ b/apps/renderer/src/features/navigator/FileContextMenu.vue
@@ -53,24 +53,28 @@ watch(
 );
 
 /**
- * 実体へ移動できるか = 実体が worktree 配下にあるか (`relPath` が定義されている)。worktree 外の実体は
- * filer のツリーに対応ノードが無いため「移動」が成立しない。移動と path コピーは排他で、
- * 開ける実体は移動項目、開けない実体は `Copy real path` だけを出す。
+ * 実体を選択できるか = 実体が worktree 配下にあるか (`relPath` が定義されている)。worktree 外の実体は
+ * filer のツリーに対応ノードが無いため選択が成立しない。選択と path コピーは排他で、
+ * 選択できる実体は選択項目、できない実体は `Copy original path` だけを出す。
  */
-const canGoToTarget = computed(() => realTarget.value?.relPath !== undefined);
+const canSelectOriginal = computed(() => realTarget.value?.relPath !== undefined);
 
-/** 移動先が file / directory のどちらかを label で明示する (行の見た目からは実体の種別が分からない) */
-const goToTargetLabel = computed(() =>
-  realTarget.value?.isDirectory === true ? "Go to real folder" : "Go to real file",
+/**
+ * 動詞は `Select` = filer のクリック操作の再現。file 行の click は選択 → preview を開き、folder 行の
+ * click は展開なので、kind 別の意味差が filer 側に既にあり、実装 (file は preview 差し替え / folder は
+ * ツリーだけ移動) とそのまま対応する。surface 名を書き足す必要が無い。
+ */
+const selectOriginalLabel = computed(() =>
+  realTarget.value?.isDirectory === true ? "Select original folder" : "Select original file",
 );
 
 // 各 handler は context を同期 snapshot してから close する (close 後に context が undefined へ
 // 倒れても、実行中のアクションは snapshot 済みの値で完走する。FileActionMenuItems と同じ規律)
 
-function handleGoToTarget() {
+function handleSelectOriginal() {
   const target = realTarget.value;
   close();
-  // worktree 外の実体は移動項目自体を出さない (canGoToTarget) ため relPath は定義済み
+  // worktree 外の実体は選択項目自体を出さない (canSelectOriginal) ため relPath は定義済み
   if (target?.relPath === undefined) return;
   // ディレクトリ実体は preview に流せないのでツリーだけ移動する
   if (target.isDirectory) {
@@ -80,13 +84,13 @@ function handleGoToTarget() {
   previewStore.forceSelect({ kind: "worktreeRelative", relPath: target.relPath });
 }
 
-async function handleCopyRealPath() {
+async function handleCopyOriginalPath() {
   const target = realTarget.value;
   close();
   if (target === undefined) return;
   const result = await writeClipboardText(target.absPath);
   if (!result.ok) {
-    notify.error("Failed to copy real path", result.error);
+    notify.error("Failed to copy original path", result.error);
   }
 }
 
@@ -137,24 +141,24 @@ const itemProps = computed(() => {
     :style="popoverStyle"
   >
     <button
-      v-if="canGoToTarget"
+      v-if="canSelectOriginal"
       type="button"
       class="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-panel"
       :title="realTarget?.absPath"
-      @click="handleGoToTarget"
+      @click="handleSelectOriginal"
     >
       <IconLucideCornerUpRight class="size-4 shrink-0" />
-      {{ goToTargetLabel }}
+      {{ selectOriginalLabel }}
     </button>
     <button
-      v-if="realTarget && !canGoToTarget"
+      v-if="realTarget && !canSelectOriginal"
       type="button"
       class="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-panel"
       :title="realTarget.absPath"
-      @click="handleCopyRealPath"
+      @click="handleCopyOriginalPath"
     >
       <IconLucideClipboardCopy class="size-4 shrink-0" />
-      Copy real path
+      Copy original path
     </button>
     <FileActionMenuItems v-if="itemProps" v-bind="itemProps" @close="close()" />
   </Popover>

--- a/apps/renderer/src/features/navigator/FileContextMenu.vue
+++ b/apps/renderer/src/features/navigator/FileContextMenu.vue
@@ -9,29 +9,21 @@ FileActionMenuItems の doc を参照 (openable prop に反転して渡す)。
 
 ## 実体向けの項目 (実体がツリー上のパスと違う行のみ)
 
-共通の `FileActionMenuItems` には入れない: 共有先の preview ヘッダ ⋮ メニューは実体情報を持たず、
-これらは filer の symlink 経路に固有だから (共有するのは「どの入口でも同じ意味を持つ項目」に限る)。
+項目の一覧と可視条件は [docs/filer.md](../../../../../docs/filer.md#実体を対象にする右クリック項目) が
+SSOT。本 component 固有の点だけ:
 
-**移動と path コピーは排他**。判定軸は「filer で開けるか」= 実体が worktree 配下か (`relPath` の
-有無) の 1 本だけで、開ける実体は移動項目、開けない実体は `Copy real path` を出す。両方出すと
-「どちらを使うべきか」の判断をユーザーに預けることになるため、実体の在り処で 1 つに定める。
-
-- 左クリックと右クリックの対象は分けたままにする。行の click は見えているパスで振る舞い、実体への
-  移動は本項目という明示操作でだけ起きる (symlink は 1 つの実体に複数の名前がある構造で、UI が暗黙に
-  実体へ正規化すると「どの名前で開いたか」が復元できなくなる)
-- 移動先の label は実体の種別で file / folder を出し分ける。行の見た目 (link 自身の名前とアイコン)
-  からは実体がファイルかディレクトリか判別できないため
-- 実体が file: `worktreeRelative` で preview に出す (ツリー reveal と git 連動が効く)。navigation
-  意味の経路なので `requestSelect` ではなく `forceSelect` を使う (同一 path でもトグル close させない。
-  [docs/preview.md](../../../../../docs/preview.md) の決定表)
-- 実体が directory: preview はディレクトリを表示できないので `worktreeStore.revealRelPath` で
-  **ツリーだけ**実体へ移動する (selection は動かさないので開いている preview は保たれる)
-- worktree 外の実体は `Copy real path` のみ。既存の `Copy path` は link path を返し続けるので、
-  両者は別の値を返す別項目として並ぶ
+- 共通の `FileActionMenuItems` には入れない。共有先の preview ヘッダ ⋮ メニューは実体情報を持たず、
+  これらは filer の symlink 経路に固有 (共有するのは「どの入口でも同じ意味を持つ項目」に限る)
+- file 実体は navigation 意味の経路なので `requestSelect` ではなく `forceSelect` を使う (同一 path でも
+  トグル close させない。[docs/preview.md](../../../../../docs/preview.md) の決定表)
+- directory 実体は preview がディレクトリを表示できないため `worktreeStore.revealRelPath` で
+  **ツリーだけ**移動する (selection は動かさないので開いている preview は保たれる)
+- 実体向け項目は context の `dir` snapshot ではなく現在の store 基準で解決するため、dir 切替では
+  menu を閉じる (詳細は `watch` 直上のコメント)
 </doc>
 
 <script setup lang="ts">
-import { computed, type CSSProperties } from "vue";
+import { computed, watch, type CSSProperties } from "vue";
 import { writeClipboardText } from "../../shared/clipboard";
 import { useNotificationStore } from "../../shared/notification";
 import { FileActionMenuItems } from "../filer";
@@ -48,6 +40,17 @@ const notify = useNotificationStore();
 
 /** 実体がツリー上のパスと違う行でだけ定義される。実体向け項目の可視判定と対象を兼ねる */
 const realTarget = computed(() => context.value?.realTarget);
+
+// dir 切替で menu を閉じる。context の `dir` は右クリック時点の snapshot で、実体向け項目は
+// worktree 相対パスを **現在の** dir 基準で解決する (`revealRelPath` / `forceSelect`)。menu が dir
+// 切替を生き延びると worktree A で算出した relPath が worktree B に適用され、同名パスが実在する
+// 並列 worktree では「別 worktree の同名ファイルが静かに開く」。menu を閉じることで、
+// dir 切替時に selection クリア / preview close / ツリー再マウントが走る既存の規律に揃える
+// (handler ごとに dir 一致を比較する形は項目追加のたびに判定が分散するため採らない)
+watch(
+  () => worktreeStore.dir,
+  () => close(),
+);
 
 /**
  * 実体へ移動できるか = 実体が worktree 配下にあるか (`relPath` が定義されている)。worktree 外の実体は

--- a/apps/renderer/src/features/navigator/FileContextMenu.vue
+++ b/apps/renderer/src/features/navigator/FileContextMenu.vue
@@ -6,15 +6,86 @@ context の組み立てと snapshot semantics、defer / disconnect ガード等�
 
 Open / Copy file は snapshot mode (context.isSnapshot) では出さない。可視判定の理由は
 FileActionMenuItems の doc を参照 (openable prop に反転して渡す)。
+
+## 実体向けの項目 (実体がツリー上のパスと違う行のみ)
+
+共通の `FileActionMenuItems` には入れない: 共有先の preview ヘッダ ⋮ メニューは実体情報を持たず、
+これらは filer の symlink 経路に固有だから (共有するのは「どの入口でも同じ意味を持つ項目」に限る)。
+
+**移動と path コピーは排他**。判定軸は「filer で開けるか」= 実体が worktree 配下か (`relPath` の
+有無) の 1 本だけで、開ける実体は移動項目、開けない実体は `Copy real path` を出す。両方出すと
+「どちらを使うべきか」の判断をユーザーに預けることになるため、実体の在り処で 1 つに定める。
+
+- 左クリックと右クリックの対象は分けたままにする。行の click は見えているパスで振る舞い、実体への
+  移動は本項目という明示操作でだけ起きる (symlink は 1 つの実体に複数の名前がある構造で、UI が暗黙に
+  実体へ正規化すると「どの名前で開いたか」が復元できなくなる)
+- 移動先の label は実体の種別で file / folder を出し分ける。行の見た目 (link 自身の名前とアイコン)
+  からは実体がファイルかディレクトリか判別できないため
+- 実体が file: `worktreeRelative` で preview に出す (ツリー reveal と git 連動が効く)。navigation
+  意味の経路なので `requestSelect` ではなく `forceSelect` を使う (同一 path でもトグル close させない。
+  [docs/preview.md](../../../../../docs/preview.md) の決定表)
+- 実体が directory: preview はディレクトリを表示できないので `worktreeStore.revealRelPath` で
+  **ツリーだけ**実体へ移動する (selection は動かさないので開いている preview は保たれる)
+- worktree 外の実体は `Copy real path` のみ。既存の `Copy path` は link path を返し続けるので、
+  両者は別の値を返す別項目として並ぶ
 </doc>
 
 <script setup lang="ts">
 import { computed, type CSSProperties } from "vue";
+import { writeClipboardText } from "../../shared/clipboard";
+import { useNotificationStore } from "../../shared/notification";
 import { FileActionMenuItems } from "../filer";
-import { joinAbsRel } from "../worktree";
+import { usePreviewStore } from "../preview";
+import { joinAbsRel, useWorktreeStore } from "../worktree";
 import { useFileContextMenu } from "./useFileContextMenu";
+import IconLucideClipboardCopy from "~icons/lucide/clipboard-copy";
+import IconLucideCornerUpRight from "~icons/lucide/corner-up-right";
 
 const { Popover, context, close } = useFileContextMenu();
+const previewStore = usePreviewStore();
+const worktreeStore = useWorktreeStore();
+const notify = useNotificationStore();
+
+/** 実体がツリー上のパスと違う行でだけ定義される。実体向け項目の可視判定と対象を兼ねる */
+const realTarget = computed(() => context.value?.realTarget);
+
+/**
+ * 実体へ移動できるか = 実体が worktree 配下にあるか (`relPath` が定義されている)。worktree 外の実体は
+ * filer のツリーに対応ノードが無いため「移動」が成立しない。移動と path コピーは排他で、
+ * 開ける実体は移動項目、開けない実体は `Copy real path` だけを出す。
+ */
+const canGoToTarget = computed(() => realTarget.value?.relPath !== undefined);
+
+/** 移動先が file / directory のどちらかを label で明示する (行の見た目からは実体の種別が分からない) */
+const goToTargetLabel = computed(() =>
+  realTarget.value?.isDirectory === true ? "Go to real folder" : "Go to real file",
+);
+
+// 各 handler は context を同期 snapshot してから close する (close 後に context が undefined へ
+// 倒れても、実行中のアクションは snapshot 済みの値で完走する。FileActionMenuItems と同じ規律)
+
+function handleGoToTarget() {
+  const target = realTarget.value;
+  close();
+  // worktree 外の実体は移動項目自体を出さない (canGoToTarget) ため relPath は定義済み
+  if (target?.relPath === undefined) return;
+  // ディレクトリ実体は preview に流せないのでツリーだけ移動する
+  if (target.isDirectory) {
+    worktreeStore.revealRelPath(target.relPath);
+    return;
+  }
+  previewStore.forceSelect({ kind: "worktreeRelative", relPath: target.relPath });
+}
+
+async function handleCopyRealPath() {
+  const target = realTarget.value;
+  close();
+  if (target === undefined) return;
+  const result = await writeClipboardText(target.absPath);
+  if (!result.ok) {
+    notify.error("Failed to copy real path", result.error);
+  }
+}
 
 /**
  * 右クリック座標 (context.x/y) に置く不可視の 0 サイズ anchor。popover に left/top を直書きすると
@@ -62,6 +133,26 @@ const itemProps = computed(() => {
     class="m-0 min-w-36 rounded-lg border border-border bg-background py-1 text-sm text-foreground shadow-lg"
     :style="popoverStyle"
   >
+    <button
+      v-if="canGoToTarget"
+      type="button"
+      class="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-panel"
+      :title="realTarget?.absPath"
+      @click="handleGoToTarget"
+    >
+      <IconLucideCornerUpRight class="size-4 shrink-0" />
+      {{ goToTargetLabel }}
+    </button>
+    <button
+      v-if="realTarget && !canGoToTarget"
+      type="button"
+      class="flex w-full items-center gap-2 px-3 py-1.5 text-left hover:bg-panel"
+      :title="realTarget.absPath"
+      @click="handleCopyRealPath"
+    >
+      <IconLucideClipboardCopy class="size-4 shrink-0" />
+      Copy real path
+    </button>
     <FileActionMenuItems v-if="itemProps" v-bind="itemProps" @close="close()" />
   </Popover>
 </template>

--- a/apps/renderer/src/features/navigator/NavigatorPane.vue
+++ b/apps/renderer/src/features/navigator/NavigatorPane.vue
@@ -6,7 +6,7 @@ Filer（上）と Changes（下）を垂直分割で表示するコンテナ。
 - Filer が flex-1 で残りスペースを取り、Changes が固定高さ
 - ResizeHandle で上下の比率をリサイズ可能
 - git リポジトリでない場合は Filer のみ表示
-- FilerPane の reveal は worktreeStore.revealVersion を内部で購読しているため props 経由不要
+- FilerPane の reveal は worktreeStore.revealRequest を内部で購読しているため props 経由不要
 - FilerPane / ChangesPane の `select` emit はどちらも user-initiated select として `previewStore.requestSelect` を呼ぶ。同一パス再選択でのトグル close / summary 抜けの意思決定は preview store 側に集約されている（[docs/preview.md](../../../../../docs/preview.md) の決定表を参照）
 - Filer ヘッダーの状態表示は `headerStatus` 1 つの computed に集約する。snapshot mode（`gitGraphStore.selectedHash` が `UNCOMMITTED_HASH` 以外）では選択中コミットの日時（`formatCompactTime` の狭幅向け compact 表示、tooltip に `formatAbsoluteTime` の絶対時刻）、working tree mode では固定テキスト `"(now)"` を同じ span で描画する。working tree mode を時刻でなく固定ラベルにするのは、"Now" ボタン（FilerPane がツリー右上に float 表示。設計意図はそちらの doc 参照）を押した遷移先が何であるかを明示するため（変更ファイルの mtime を出すと「今」であることが伝わりにくい）
 
@@ -184,6 +184,7 @@ useEventListener(
     openFileContextMenu(pending.payload.anchorEl, {
       dir: pending.dir,
       relPath: pending.payload.relPath,
+      realTarget: pending.payload.realTarget,
       commitHash: pending.hash,
       isSnapshot: pending.isSnapshot,
       x: pending.payload.x,

--- a/apps/renderer/src/features/navigator/useFileContextMenu.ts
+++ b/apps/renderer/src/features/navigator/useFileContextMenu.ts
@@ -55,9 +55,10 @@ export type FileContextMenuPayload = {
   /** worktree 相対パス */
   relPath: string;
   /**
-   * 実体がツリー上のパスと食い違う行のとき、その実体の在り処 ("Open target" 項目の対象)。
+   * 実体がツリー上のパスと食い違う行のとき、その実体の在り処 (実体向け項目の対象)。
    * 既存項目 (Open / Copy file / Copy path) は relPath 側で動き続けるため両者は独立に共存する。
-   * 実体が一致する行 / 移動先を提示できない行 (dangling / worktree 外の dir 実体) では undefined。
+   * undefined になるのは実体がツリー上のパスと一致する行と、実体を解決できない行 (dangling / 循環)。
+   * worktree 外の実体では定義され (`relPath` だけ undefined)、どの項目を出すかは menu 側が決める。
    */
   realTarget?: FileRealTarget;
   /** contextmenu イベント時のマウス座標 (`position: fixed; left/top` 用) */

--- a/apps/renderer/src/features/navigator/useFileContextMenu.ts
+++ b/apps/renderer/src/features/navigator/useFileContextMenu.ts
@@ -37,6 +37,7 @@
  * 仕様を変える際は両者を必ず同時に更新する責務がある。
  */
 import { usePopover } from "../../shared/popover";
+import type { FileRealTarget } from "../filer";
 
 /**
  * 子 pane (FilerPane / ChangesPane / TreeItem) が contextmenu event で navigator まで bubble
@@ -53,6 +54,12 @@ export type FileContextMenuPayload = {
   anchorEl: HTMLElement;
   /** worktree 相対パス */
   relPath: string;
+  /**
+   * 実体がツリー上のパスと食い違う行のとき、その実体の在り処 ("Open target" 項目の対象)。
+   * 既存項目 (Open / Copy file / Copy path) は relPath 側で動き続けるため両者は独立に共存する。
+   * 実体が一致する行 / 移動先を提示できない行 (dangling / worktree 外の dir 実体) では undefined。
+   */
+  realTarget?: FileRealTarget;
   /** contextmenu イベント時のマウス座標 (`position: fixed; left/top` 用) */
   x: number;
   y: number;
@@ -63,6 +70,8 @@ type FileContextMenuContext = {
   dir: string;
   /** worktree 相対パス */
   relPath: string;
+  /** 実体の在り処 (FileContextMenuPayload の同名フィールドを引き継ぐ) */
+  realTarget?: FileRealTarget;
   /** 右クリック時に snapshot した commit hash。working tree なら undefined */
   commitHash?: string;
   /**

--- a/apps/renderer/src/features/preview/CodePreview.vue
+++ b/apps/renderer/src/features/preview/CodePreview.vue
@@ -43,7 +43,7 @@ const props = withDefaults(
     /** スクロール・ハイライト対象の行番号（1-based） */
     lineNumber?: number;
     /** 同一パス・同一行番号でもスクロールを再発火させるためのカウンタ */
-    revealVersion: number;
+    selectPathVersion: number;
     wordWrap: boolean;
     /**
      * 行番号を blame ボタンとして扱うか。false なら gutter click を無視し、
@@ -270,7 +270,7 @@ watch(
 
 /** selectPath のたびにスクロールを再発火（同一パス・同一行番号でも対応） */
 watch(
-  () => props.revealVersion,
+  () => props.selectPathVersion,
   () => {
     if (props.lineNumber !== undefined) {
       revealLine(props.lineNumber);

--- a/apps/renderer/src/features/preview/PreviewContent.vue
+++ b/apps/renderer/src/features/preview/PreviewContent.vue
@@ -8,7 +8,7 @@
 保証する (view の切り離しで UI が縮小・分岐しないための境界)。
 
 - 編集 / blame / 行番号 reveal は capability props (editable / blameEnabled / lineNumber /
-  revealVersion)。対応する文脈を持たない呼び出し側 (undocked window) は default の
+  selectPathVersion)。対応する文脈を持たない呼び出し側 (undocked window) は default の
   無効値のまま使う
 - フォント設定 (previewConfig) の適用もここに含める (本体と undocked でフォントが
   食い違わないように)。root は overflow-auto のみ持ち、サイズ決定 (size-full /
@@ -54,7 +54,7 @@ withDefaults(
     /** スクロール・ハイライト対象の行番号 (1-based) */
     lineNumber?: number | undefined;
     /** 同一パス・同一行番号でもスクロールを再発火させるためのカウンタ */
-    revealVersion?: number;
+    selectPathVersion?: number;
     blameEnabled?: boolean;
     editable?: boolean;
   }>(),
@@ -65,7 +65,7 @@ withDefaults(
     isNotFound: false,
     error: undefined,
     lineNumber: undefined,
-    revealVersion: 0,
+    selectPathVersion: 0,
     blameEnabled: false,
     editable: false,
   },
@@ -145,7 +145,7 @@ const emit = defineEmits<{
       :content="codeContent"
       :file-path="filePath"
       :line-number="lineNumber"
-      :reveal-version="revealVersion"
+      :select-path-version="selectPathVersion"
       :word-wrap="wordWrap"
       :blame-enabled="blameEnabled"
       :editable="editable"

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -63,7 +63,7 @@ const emit = defineEmits<{
 
 const worktreeStore = useWorktreeStore();
 const repoStore = useRepoStore();
-const { selection, selectedDisplayPath, selectedLineNumber, revealVersion } =
+const { selection, selectedDisplayPath, selectedLineNumber, selectPathVersion } =
   storeToRefs(worktreeStore);
 const summaryStore = useChangesSummaryStore();
 const previewStore = usePreviewStore();
@@ -344,11 +344,11 @@ onMounted(() => {
 /**
  * 個別ファイル選択時のみ summary モードを抜ける。
  * git-graph の commit 切替 (selectedHash / compareHash の変化) では summary は維持する。
- * `revealVersion` は select*Path() 専用のバージョンカウンタなので、これを trigger に使うことで
+ * `selectPathVersion` は select*Path() 専用のバージョンカウンタなので、これを trigger に使うことで
  * 「ユーザーがファイル行を実際にクリックした」経路のみで disable が走る。
  */
 watch(
-  () => [selectedDisplayPath.value, revealVersion.value] as const,
+  () => [selectedDisplayPath.value, selectPathVersion.value] as const,
   ([path]) => {
     if (path !== undefined) {
       summaryStore.disable();
@@ -483,7 +483,7 @@ function onCodeScrolled() {
             :is-not-found="isNotFound"
             :error="displayError"
             :line-number="selectedLineNumber"
-            :reveal-version="revealVersion"
+            :reveal-version="selectPathVersion"
             :blame-enabled="blameEnabled"
             :editable="isEditable"
             @code-line-click="onCodeLineClick"

--- a/apps/renderer/src/features/preview/PreviewPane.vue
+++ b/apps/renderer/src/features/preview/PreviewPane.vue
@@ -483,7 +483,7 @@ function onCodeScrolled() {
             :is-not-found="isNotFound"
             :error="displayError"
             :line-number="selectedLineNumber"
-            :reveal-version="selectPathVersion"
+            :select-path-version="selectPathVersion"
             :blame-enabled="blameEnabled"
             :editable="isEditable"
             @code-line-click="onCodeLineClick"

--- a/apps/renderer/src/features/preview/usePreviewContent.ts
+++ b/apps/renderer/src/features/preview/usePreviewContent.ts
@@ -577,7 +577,7 @@ export function usePreviewContent(
    * **deps はプリミティブで揃える**: selection オブジェクトを deps にすると、`selectRelPath` /
    * `selectAbsPath` が毎回新 object literal を作るため、同一パス再クリックでも identity 変化で
    * watch が発火し refetch が連打される。path 文字列 + kind + commit selection を deps にすることで
-   * 「実際に refetch が必要な軸」だけで発火させる (= 同一パス再クリックは revealVersion 経路で
+   * 「実際に refetch が必要な軸」だけで発火させる (= 同一パス再クリックは selectPathVersion 経路で
    * scroll / reveal のみ走らせ content fetch は走らせない)。
    */
   watch(

--- a/apps/renderer/src/features/worktree/useWorktreeStore.test.ts
+++ b/apps/renderer/src/features/worktree/useWorktreeStore.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { createPinia, setActivePinia } from "pinia";
+import { useRepoStore } from "../../shared/repo";
+import { useWorktreeStore } from "./useWorktreeStore";
+
+/**
+ * ツリー reveal 要求と selection の分離を検証する。
+ *
+ * reveal は「発火が要求 object の identity に依存する」「selection を動かす経路と動かさない経路が
+ * 併存する」という 2 点が実装から読み取りにくく、片方だけ壊れても型・lint では落ちない。
+ */
+const DIR = "/repo";
+const OTHER_DIR = "/other-repo";
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  useRepoStore().selectDir(DIR);
+});
+
+describe("useWorktreeStore の reveal 要求", () => {
+  test("selectRelPath は selection と reveal 要求の両方を出す", () => {
+    const wt = useWorktreeStore();
+    wt.selectRelPath("src/a.ts");
+    expect(wt.selectedRelPath).toBe("src/a.ts");
+    expect(wt.revealRequest?.relPath).toBe("src/a.ts");
+  });
+
+  test("同一パスの再要求でも新しい object になる（購読側は identity で発火する）", () => {
+    const wt = useWorktreeStore();
+    wt.selectRelPath("src/a.ts");
+    const first = wt.revealRequest;
+    wt.selectRelPath("src/a.ts");
+    expect(wt.revealRequest).not.toBe(first);
+    expect(wt.revealRequest?.relPath).toBe("src/a.ts");
+    expect(wt.revealRequest?.seq).toBeGreaterThan(first?.seq ?? 0);
+  });
+
+  test("revealRelPath は selection を動かさずツリーだけ移動させる", () => {
+    const wt = useWorktreeStore();
+    wt.selectRelPath("src/a.ts");
+    wt.revealRelPath("docs");
+    expect(wt.revealRequest?.relPath).toBe("docs");
+    // selection が dir に動くと preview がディレクトリ表示に落ちるため、動かさないことが契約
+    expect(wt.selectedRelPath).toBe("src/a.ts");
+  });
+
+  test("selectAbsPath は reveal 要求を落とす（worktree 外はツリーに対応ノードが無い）", () => {
+    const wt = useWorktreeStore();
+    wt.selectRelPath("src/a.ts");
+    wt.selectAbsPath("/elsewhere/b.ts");
+    expect(wt.revealRequest).toBeUndefined();
+    expect(wt.selectedRelPath).toBeUndefined();
+  });
+
+  test("clearSelectedPath は reveal 要求も落とす", () => {
+    const wt = useWorktreeStore();
+    wt.selectRelPath("src/a.ts");
+    wt.clearSelectedPath();
+    expect(wt.revealRequest).toBeUndefined();
+    expect(wt.selection).toBeUndefined();
+  });
+
+  test("dir 切替は selection と reveal 要求を落とす", () => {
+    const wt = useWorktreeStore();
+    wt.selectRelPath("src/a.ts");
+    useRepoStore().selectDir(OTHER_DIR);
+    expect(wt.revealRequest).toBeUndefined();
+    expect(wt.selection).toBeUndefined();
+  });
+
+  test("selectPathVersion は select*Path でだけ進み、tree reveal では進まない", () => {
+    const wt = useWorktreeStore();
+    wt.selectRelPath("src/a.ts");
+    const afterSelect = wt.selectPathVersion;
+    wt.revealRelPath("docs");
+    expect(wt.selectPathVersion).toBe(afterSelect);
+    wt.selectRelPath("src/b.ts");
+    expect(wt.selectPathVersion).toBeGreaterThan(afterSelect);
+  });
+});

--- a/apps/renderer/src/features/worktree/useWorktreeStore.test.ts
+++ b/apps/renderer/src/features/worktree/useWorktreeStore.test.ts
@@ -35,6 +35,15 @@ describe("useWorktreeStore の reveal 要求", () => {
     expect(wt.revealRequest?.seq).toBeGreaterThan(first?.seq ?? 0);
   });
 
+  test("正規化前の綴りでも selection と reveal 対象が揃う", () => {
+    // terminal のファイルパスリンクは matched token をそのまま渡すため `./` 付きが入る。
+    // 片方だけ正規化すると reveal 対象がツリーの path と一致せず、reveal だけ無音で落ちる
+    const wt = useWorktreeStore();
+    wt.selectRelPath("./src/a.ts");
+    expect(wt.selectedRelPath).toBe("src/a.ts");
+    expect(wt.revealRequest?.relPath).toBe("src/a.ts");
+  });
+
   test("revealRelPath は selection を動かさずツリーだけ移動させる", () => {
     const wt = useWorktreeStore();
     wt.selectRelPath("src/a.ts");

--- a/apps/renderer/src/features/worktree/useWorktreeStore.ts
+++ b/apps/renderer/src/features/worktree/useWorktreeStore.ts
@@ -25,10 +25,31 @@ export const useWorktreeStore = defineStore("worktree", () => {
    * 同一パスでも reveal を発火させるためのバージョンカウンタ。
    * **invariant**: `revealVersion` の bump は必ず `selection.value` の同期更新と
    * セットで行う（= 必ず `selectRelPath()` / `selectAbsPath()` 経由で更新する）。
-   * 購読側（FilerPane の watch）は `revealVersion` を trigger にして `selectedRelPath`
-   * を直接読むため、両者が同 tick で一致していないと古いパスで reveal が走る。
+   * preview 側（PreviewPane）は「select* が起きた」signal としてこれを購読するため、
+   * 選択を動かさない tree reveal（`revealRelPath()`）では bump しない。
    */
   const revealVersion = ref(0);
+
+  /**
+   * ツリー reveal（展開 + スクロール）の要求。**selection とは別概念**として持つ。
+   * symlink の実体がディレクトリのとき「ツリーだけ実体へ移動する」経路が要り、そこで
+   * selection を動かすと preview がディレクトリ表示（"Directory" プレースホルダ）に落ちる。
+   *
+   * `seq` は同一パスの再要求を発火させるためのカウンタ。購読側（FileTreeItem）は本 ref だけを
+   * watch し、対象パスも request から読む（selection を別途読まないので「trigger と対象パスが
+   * 同 tick で食い違う」経路が構造的に存在しない）。
+   */
+  const revealRequest = ref<{ relPath: string; seq: number }>();
+  let revealSeq = 0;
+
+  function requestReveal(relPath: string | undefined) {
+    if (relPath === undefined) {
+      revealRequest.value = undefined;
+      return;
+    }
+    revealSeq++;
+    revealRequest.value = { relPath: normalizeRelative(relPath), seq: revealSeq };
+  }
 
   /** setOpen 呼び出しごとにインクリメント。観測側（terminal 等）が「wt 選択イベント」として購読する */
   const selectionVersion = ref(0);
@@ -76,6 +97,7 @@ export const useWorktreeStore = defineStore("worktree", () => {
     dir,
     () => {
       selection.value = undefined;
+      revealRequest.value = undefined;
     },
     { flush: "sync" },
   );
@@ -101,7 +123,18 @@ export const useWorktreeStore = defineStore("worktree", () => {
       relPath: normalizeRelative(relPath),
       lineNumber,
     };
+    requestReveal(relPath);
     revealVersion.value++;
+  }
+
+  /**
+   * selection を動かさずにツリーだけ対象パスへ reveal する。symlink の実体（ディレクトリ）へ
+   * 移動する経路で使う。preview は selection を SSOT にしているため、開いているファイルの
+   * 表示は保たれる。
+   */
+  function revealRelPath(relPath: string) {
+    if (!dir.value) return;
+    requestReveal(relPath);
   }
 
   // absolute は dir 文脈を必要としない (読みは fsReadFileAbsolute 単独、filer reveal は
@@ -113,6 +146,8 @@ export const useWorktreeStore = defineStore("worktree", () => {
       absPath: normalizeAbsolute(absPath),
       lineNumber,
     };
+    // worktree 外の選択はツリーに対応するノードが無いので reveal 要求を落とす
+    requestReveal(undefined);
     revealVersion.value++;
   }
 
@@ -141,9 +176,11 @@ export const useWorktreeStore = defineStore("worktree", () => {
     selectedLineNumber,
     selectedGitChange,
     revealVersion,
+    revealRequest,
     selectionVersion,
     setOpen,
     selectRelPath,
+    revealRelPath,
     selectAbsPath,
     selectFromTarget,
     clearSelectedPath,

--- a/apps/renderer/src/features/worktree/useWorktreeStore.ts
+++ b/apps/renderer/src/features/worktree/useWorktreeStore.ts
@@ -37,8 +37,9 @@ export const useWorktreeStore = defineStore("worktree", () => {
    *
    * 購読側（FileTreeItem）は本 ref だけを watch し、対象パスも request から読む（selection を
    * 別途読まないので「trigger と対象パスが同 tick で食い違う」経路が構造的に存在しない）。
-   * 同一パスの再要求が発火するのは要求ごとに新しい object を立てるためで、`seq` はその要求を
-   * ログ / デバッグで識別するための連番（発火の仕組みそのものではない）。
+   * 同一パスの再要求が発火するのは要求ごとに新しい object を立てるためで、`seq` は購読側が
+   * await を挟んだ後に「自分が処理していた要求が最新か」を判定する世代番号（FileTreeItem の
+   * `handleReveal` が消費する）。
    */
   const revealRequest = ref<{ relPath: string; seq: number }>();
   let revealSeq = 0;

--- a/apps/renderer/src/features/worktree/useWorktreeStore.ts
+++ b/apps/renderer/src/features/worktree/useWorktreeStore.ts
@@ -22,22 +22,23 @@ export const useWorktreeStore = defineStore("worktree", () => {
   const selection = ref<Selection>();
 
   /**
-   * 同一パスでも reveal を発火させるためのバージョンカウンタ。
-   * **invariant**: `revealVersion` の bump は必ず `selection.value` の同期更新と
-   * セットで行う（= 必ず `selectRelPath()` / `selectAbsPath()` 経由で更新する）。
-   * preview 側（PreviewPane）は「select* が起きた」signal としてこれを購読するため、
-   * 選択を動かさない tree reveal（`revealRelPath()`）では bump しない。
+   * `select*Path()` のたびに進むカウンタ。同一パスの再選択も観測できる signal で、preview が
+   * 「選択し直された」ことを検出して行スクロールをやり直すために購読する。
+   * **invariant**: bump は必ず `selection.value` の同期更新とセットで行う（= 必ず
+   * `selectRelPath()` / `selectAbsPath()` 経由）。選択を動かさない tree reveal
+   * （`revealRelPath()`）では bump しない。
    */
-  const revealVersion = ref(0);
+  const selectPathVersion = ref(0);
 
   /**
    * ツリー reveal（展開 + スクロール）の要求。**selection とは別概念**として持つ。
    * symlink の実体がディレクトリのとき「ツリーだけ実体へ移動する」経路が要り、そこで
    * selection を動かすと preview がディレクトリ表示（"Directory" プレースホルダ）に落ちる。
    *
-   * `seq` は同一パスの再要求を発火させるためのカウンタ。購読側（FileTreeItem）は本 ref だけを
-   * watch し、対象パスも request から読む（selection を別途読まないので「trigger と対象パスが
-   * 同 tick で食い違う」経路が構造的に存在しない）。
+   * 購読側（FileTreeItem）は本 ref だけを watch し、対象パスも request から読む（selection を
+   * 別途読まないので「trigger と対象パスが同 tick で食い違う」経路が構造的に存在しない）。
+   * 同一パスの再要求が発火するのは要求ごとに新しい object を立てるためで、`seq` はその要求を
+   * ログ / デバッグで識別するための連番（発火の仕組みそのものではない）。
    */
   const revealRequest = ref<{ relPath: string; seq: number }>();
   let revealSeq = 0;
@@ -124,7 +125,7 @@ export const useWorktreeStore = defineStore("worktree", () => {
       lineNumber,
     };
     requestReveal(relPath);
-    revealVersion.value++;
+    selectPathVersion.value++;
   }
 
   /**
@@ -148,7 +149,7 @@ export const useWorktreeStore = defineStore("worktree", () => {
     };
     // worktree 外の選択はツリーに対応するノードが無いので reveal 要求を落とす
     requestReveal(undefined);
-    revealVersion.value++;
+    selectPathVersion.value++;
   }
 
   /**
@@ -164,8 +165,11 @@ export const useWorktreeStore = defineStore("worktree", () => {
     }
   }
 
+  // reveal 要求も落とす。selection が無いのに要求だけ残ると、後から mount された FileTreeItem が
+  // immediate watch で stale な path を掘り出し、消えたパスに向けてツリーが自動展開される
   function clearSelectedPath() {
     selection.value = undefined;
+    requestReveal(undefined);
   }
 
   return {
@@ -175,7 +179,7 @@ export const useWorktreeStore = defineStore("worktree", () => {
     selectedDisplayPath,
     selectedLineNumber,
     selectedGitChange,
-    revealVersion,
+    selectPathVersion,
     revealRequest,
     selectionVersion,
     setOpen,

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -146,7 +146,7 @@ export const useRepoStore = defineStore("repo", () => {
   /**
    * shared 層内で `selectedDir.value =` を直書きする正当な経路は以下に限定する。
    * 新たな書き換え経路を増やす前に、`worktreeStore.setOpen` 側の副作用一覧
-   * （selectionVersion bump / 必要なら selection / revealVersion の同期更新）と整合
+   * （selectionVersion bump / 必要なら selection / selectPathVersion の同期更新）と整合
    * するか確認すること（feature 層側の責務に踏み込む変更が必要な可能性）。
    * - `selectDir()`: 通常の選択（feature 層の setOpen 経由含む）
    * - `removeRepo()`: repo まるごと削除時の fallback

--- a/docs/filer.md
+++ b/docs/filer.md
@@ -56,7 +56,7 @@ watch 同期 layer 側は mutex + coalesce で並列実行を 1 本に集約し�
 
 - reveal 要求の SSOT は `worktreeStore.revealRequest`（対象 relPath + 連番）。各ツリー子ノードはこれを watch し、自身の path が target の祖先か判定して自動展開 + 子の load を行う
 - 最終ノードに到達したら `scrollIntoView({ block: "nearest" })` で表示
-- 同じパスを再度 reveal するケースを取り扱うため、要求ごとに連番を進めて「再 reveal イベント」を発火させる
+- 同じパスを再度 reveal するケースを取り扱うため、要求ごとに新しい要求オブジェクトを立てて購読側の watch を発火させる。要求に添える連番は、購読側が子 load の await を挟んだ後に「自分が処理している要求が最新か」を判定する世代番号
 - 要求元は 2 経路: ファイル選択（`select*Path`。selection と同時に reveal を要求する）と、selection を動かさない tree reveal（`revealRelPath`。symlink の実体がディレクトリのときに使う）。後者を selection 経由にすると preview がディレクトリ表示（"Directory" プレースホルダ）に落ちるため、reveal 対象と selection は別 state として持つ
 
 dir 切替と reveal 要求が同 tick で起きた場合の順序保証（dir 変化 → ルート初期化 → 子マウント後の reveal 処理）は、ルートペインの dir watch を同期 flush に固定することで構造的に成立させている。
@@ -119,11 +119,13 @@ working tree の symlink は「link であること」と「実体としてど�
   link であることはバッジが示し続ける
 - symlink 配下は FSEvents がリンクを辿らないため `fsChange` が届かない。リンク先の変更はツリーを
   折りたたみ → 再展開したときに反映される
-- symlink 越しの列挙では gitignore 判定の pathspec を**実体側の dir 相対パス**（`realTarget.relPath`）に
-  差し替える。link 越しのパスをそのまま渡すと `git check-ignore` が
-  `pathspec ... is beyond a symbolic link` で fatal になり、その列挙の全 entry の判定を落とす
-  （`checkIgnore` は失敗を空集合として扱う契約なので無音で ignored が消える）。実体が worktree 外の
-  entry は当該 repo の gitignore の管轄外なので問い合わせ自体を落とす
+- gitignore 判定の pathspec は常に **entry 自身**を指す。symlink 越しの列挙では entry 自身の
+  canonical path（列挙対象の realpath + entry 名）の worktree 相対を渡す。ツリー上のパス（link 越し）を
+  そのまま渡すと `git check-ignore` が `pathspec ... is beyond a symbolic link` で fatal になり、その
+  列挙の全 entry の判定を落とす（`checkIgnore` は失敗を空集合として扱う契約なので無音で ignored が
+  消える）。symlink 行にリンク先の path を渡すのも誤りで、git の管理対象は link blob 自身なので
+  リンク先の ignored を行が引き継いでしまう。列挙対象自身が worktree 外にある場合（外部を指す
+  dir link の配下）は当該 repo の gitignore の管轄外なので問い合わせを落とす
 
 ### 実体を対象にする右クリック項目
 

--- a/docs/filer.md
+++ b/docs/filer.md
@@ -92,7 +92,7 @@ working tree の symlink は「link であること」と「実体としてど�
 - main の `readDir` は entry 自身の種別（`type`、lstat 由来）に加えて、**実体の在り処**を
   `realTarget`（`type` / `absPath` / `dir` 配下なら `relPath`）として併記する。載るのは実体が
   entry のパスと食い違うときだけで、該当経路は symlink 自身と「symlink 越しに列挙された entry」
-  （親ディレクトリが link）の 2 つ。辿れない dangling / 循環（ELOOP）は `realTarget` 不在で
+  （親ディレクトリが link）の 2 つ。辿れない link（dangling / 循環 / 中間成分が非ディレクトリ）は `realTarget` 不在で
   「実体なし」を表す
 - `relPath` の包含判定は realpath 同士で行う。worktree dir 自身が symlink 経由のパスでも
   「実体は worktree 配下なのに外部扱い」にならない

--- a/docs/filer.md
+++ b/docs/filer.md
@@ -136,16 +136,17 @@ working tree の symlink は「link であること」と「実体としてど�
 
 対象は link 自身の行に限らない。`realTarget` を持つ行すべて（link 配下のファイルを含む）で出る。
 
-移動と path コピーは**排他**で、判定軸は「filer で開けるか」= 実体が worktree 配下か（`relPath` の有無）の 1 本だけ。
+選択と path コピーは**排他**で、判定軸は「filer で開けるか」= 実体が worktree 配下か（`relPath` の有無）の 1 本だけ。
 
 | 項目                                        | 条件                           | 動作                                                                                |
 | ------------------------------------------- | ------------------------------ | ----------------------------------------------------------------------------------- |
-| `Go to real file`                           | 実体が worktree 内の file      | worktree 相対で preview に出す（ツリー reveal と git 連動が効く）                   |
-| `Go to real folder`                         | 実体が worktree 内の directory | selection を動かさない tree reveal でツリーだけ実体へ移動する                       |
-| `Copy real path`                            | 実体が worktree 外             | 実体の絶対パスを clipboard に書く（ツリーに開く先が無いため移動しない）             |
+| `Select original file`                      | 実体が worktree 内の file      | worktree 相対で preview に出す（ツリー reveal と git 連動が効く）                   |
+| `Select original folder`                    | 実体が worktree 内の directory | selection を動かさない tree reveal でツリーだけ実体へ移動する（preview は保たれる） |
+| `Copy original path`                        | 実体が worktree 外             | 実体の絶対パスを clipboard に書く（ツリーに選択先が無いため移動しない）             |
 | Open in default app / Copy file / Copy path | 既存の共通項目                 | link path そのものを対象にする（実体へ読み替えると「見えている path」と別物を返す） |
 
-- 移動項目の label は実体の種別で file / folder を出し分ける。行の見た目（link 自身の名前とアイコン）からは実体がファイルかディレクトリか判別できないため
+- 動詞 `Select` は filer のクリック操作の再現を指す。file 行の click は選択 → preview を開き、folder 行の click は展開なので、kind 別の意味差は filer 側に既にあり、実装（file は preview 差し替え / folder はツリーだけ移動）とそのまま対応する
+- `original` は「link を経由しない元の場所」。link 経由の行はバッジと色が「実体は別の場所にある」ことを示しているため、この語は行という文脈の中で一意に読める（`man ln` も リンク先を "the original copy" と呼ぶ）
 - 両方を同時に出さないのは、「どちらを使うべきか」の判断をユーザーに預けないため。実体の在り処で 1 つに定まる
 
 ## 削除ファイルの表示

--- a/docs/filer.md
+++ b/docs/filer.md
@@ -102,13 +102,14 @@ working tree の symlink は「link であること」と「実体としてど�
 - 実体の種別でアイコン自体が決まる（dir symlink はフォルダアイコン + chevron）ため、link が絡むことは
   バッジと名前の色で示す。表現は 2 軸に分ける
 
-  | 表現                     | 対象                                                     | 意味                       |
-  | ------------------------ | -------------------------------------------------------- | -------------------------- |
-  | アイコン右下の矢印バッジ | link 自身の行（`isSymlink`）                             | この行が symlink である    |
-  | 名前の色（info）         | link 自身 + link 越しに列挙された行（`realTarget` あり） | ツリー上のパスと実体が違う |
+  | 表現                     | 対象                         | 意味                    |
+  | ------------------------ | ---------------------------- | ----------------------- |
+  | アイコン右下の矢印バッジ | link 自身の行（`isSymlink`） | この行が symlink である |
+  | 名前の色（info）         | `realTarget` を持つ行        | 実体が別の場所にある    |
 
   色が link ディレクトリの下層まで続くのは、実体向けの右クリック項目が出る集合と揃えるため（色が
-  付いている行では必ず実体へのアクションが出る）
+  付いている行では必ず実体へのアクションが出る）。実体を解決できない dangling / 循環と、snapshot
+  tree の symlink は `realTarget` を持たないため、バッジ（+ tooltip の `broken symlink`）だけで表す
 
 - バッジは行の hover / 選択色に追従せず自前の面を持つ（Finder の alias バッジと同じ扱い。背景に
   溶けると矢印が読めない）
@@ -117,10 +118,11 @@ working tree の symlink は「link であること」と「実体としてど�
   link であることはバッジが示し続ける
 - symlink 配下は FSEvents がリンクを辿らないため `fsChange` が届かない。リンク先の変更はツリーを
   折りたたみ → 再展開したときに反映される
-- symlink 越しの列挙では gitignore 判定が付かない。`git check-ignore` が
-  `pathspec ... is beyond a symbolic link` で fatal になり、その列挙の全 entry が
-  `isIgnored: false` に倒れる（`checkIgnore` は失敗を空集合として扱う契約）。link 配下では
-  ignored の色落ちが起きない
+- symlink 越しの列挙では gitignore 判定の pathspec を**実体側の dir 相対パス**（`realTarget.relPath`）に
+  差し替える。link 越しのパスをそのまま渡すと `git check-ignore` が
+  `pathspec ... is beyond a symbolic link` で fatal になり、その列挙の全 entry の判定を落とす
+  （`checkIgnore` は失敗を空集合として扱う契約なので無音で ignored が消える）。実体が worktree 外の
+  entry は当該 repo の gitignore の管轄外なので問い合わせ自体を落とす
 
 ### 実体を対象にする右クリック項目
 

--- a/docs/filer.md
+++ b/docs/filer.md
@@ -129,7 +129,7 @@ working tree の symlink は「link であること」と「実体としてど�
 
 ### 実体を対象にする右クリック項目
 
-左クリックは見えているパスで振る舞い、実体への移動は右クリックの明示操作でだけ起きる。symlink は
+左クリックは見えているパスで振る舞い、実体を対象にする操作は右クリックの明示操作でだけ起きる。symlink は
 1 つの実体に複数の名前がある構造で、UI が暗黙に実体へ正規化すると「どの名前で開いたか」が復元
 できなくなるため、gesture で対象を分ける（Finder の「元を表示」/ VS Code の
 [microsoft/vscode#57873](https://github.com/microsoft/vscode/issues/57873) と同じ切り分け）。
@@ -147,6 +147,7 @@ working tree の symlink は「link であること」と「実体としてど�
 
 - 動詞 `Select` は filer のクリック操作の再現を指す。file 行の click は選択 → preview を開き、folder 行の click は展開なので、kind 別の意味差は filer 側に既にあり、実装（file は preview 差し替え / folder はツリーだけ移動）とそのまま対応する
 - `original` は「link を経由しない元の場所」。link 経由の行はバッジと色が「実体は別の場所にある」ことを示しているため、この語は行という文脈の中で一意に読める（`man ln` も リンク先を "the original copy" と呼ぶ）
+- filer では folder の click は選択ではなく展開で、`selectedRelPath` は file 選択でしか設定されない（folder にハイライトが付かないのも同じ理由）。したがって `Select original folder` も selection を動かさず、ツリーの展開 + スクロールだけを行う。ここを `selectRelPath` に倒すと preview がディレクトリ表示に落ちる
 - 両方を同時に出さないのは、「どちらを使うべきか」の判断をユーザーに預けないため。実体の在り処で 1 つに定まる
 
 ## 削除ファイルの表示

--- a/docs/filer.md
+++ b/docs/filer.md
@@ -52,13 +52,14 @@ watch 同期 layer 側は mutex + coalesce で並列実行を 1 本に集約し�
 
 ## ツリー自動展開（reveal）
 
-ファイル選択時に、対象パスまでツリーを自動展開してスクロールインビューする。
+対象パスまでツリーを自動展開してスクロールインビューする。
 
-- イベントバスが reveal target を伝搬し、各ツリー子ノードは自身の path が target の祖先か判定して自動展開 + 子の load を行う
+- reveal 要求の SSOT は `worktreeStore.revealRequest`（対象 relPath + 連番）。各ツリー子ノードはこれを watch し、自身の path が target の祖先か判定して自動展開 + 子の load を行う
 - 最終ノードに到達したら `scrollIntoView({ block: "nearest" })` で表示
-- 同じファイルを再度 reveal するケースを取り扱うため、`worktreeStore.revealVersion` を bump することで「再 reveal イベント」を発火させる
+- 同じパスを再度 reveal するケースを取り扱うため、要求ごとに連番を進めて「再 reveal イベント」を発火させる
+- 要求元は 2 経路: ファイル選択（`select*Path`。selection と同時に reveal を要求する）と、selection を動かさない tree reveal（`revealRelPath`。symlink の実体がディレクトリのときに使う）。後者を selection 経由にすると preview がディレクトリ表示（"Directory" プレースホルダ）に落ちるため、reveal 対象と selection は別 state として持つ
 
-dir 切替と revealVersion 更新が同 tick で起きた場合の順序保証（dir 変化 → ルート初期化 → 子マウント後の reveal 処理）は、ルートペインの dir watch を同期 flush に固定することで構造的に成立させている。
+dir 切替と reveal 要求が同 tick で起きた場合の順序保証（dir 変化 → ルート初期化 → 子マウント後の reveal 処理）は、ルートペインの dir watch を同期 flush に固定することで構造的に成立させている。
 
 ## git status の色分け
 
@@ -82,6 +83,65 @@ dir 切替と revealVersion 更新が同 tick で起きた場合の順序保証�
 - 完全一致のため `.gitignore` / `.gitkeep` / `.gitattributes` などの近傍名は影響を受けず表示される
 - `.gitignore` 経路とは独立。`.gitignore` 対象 entry は `isIgnored=true` を立てて表示したまま色を落とす（除外しない）
 - working tree モード (`fs` 経路) / snapshot モード (`git ls-tree` 経路) のいずれでも `.git` は出ない。後者は git の commit tree object に `.git` が含まれない性質により自然に揃う
+
+## symlink の表示
+
+working tree の symlink は「link であること」と「実体としてどう振る舞うか」を分けて持つ。実体側の
+種別で振る舞いを決めるため、ディレクトリへの symlink は leaf に潰れず展開できる。
+
+- main の `readDir` は entry 自身の種別（`type`、lstat 由来）に加えて、**実体の在り処**を
+  `realTarget`（`type` / `absPath` / `dir` 配下なら `relPath`）として併記する。載るのは実体が
+  entry のパスと食い違うときだけで、該当経路は symlink 自身と「symlink 越しに列挙された entry」
+  （親ディレクトリが link）の 2 つ。辿れない dangling / 循環（ELOOP）は `realTarget` 不在で
+  「実体なし」を表す
+- `relPath` の包含判定は realpath 同士で行う。worktree dir 自身が symlink 経由のパスでも
+  「実体は worktree 配下なのに外部扱い」にならない
+- renderer は `realTarget.type` を `FileEntry.kind` に写像し、link であること自体は `isSymlink` が
+  保持する。したがって click 経路は実体に対する経路（file なら preview、directory なら展開）に
+  そのまま乗り、`kind === "symlink"` は実体を解決できないケースだけに縮む
+- 実体の種別でアイコン自体が決まる（dir symlink はフォルダアイコン + chevron）ため、link が絡むことは
+  バッジと名前の色で示す。表現は 2 軸に分ける
+
+  | 表現                     | 対象                                                     | 意味                       |
+  | ------------------------ | -------------------------------------------------------- | -------------------------- |
+  | アイコン右下の矢印バッジ | link 自身の行（`isSymlink`）                             | この行が symlink である    |
+  | 名前の色（info）         | link 自身 + link 越しに列挙された行（`realTarget` あり） | ツリー上のパスと実体が違う |
+
+  色が link ディレクトリの下層まで続くのは、実体向けの右クリック項目が出る集合と揃えるため（色が
+  付いている行では必ず実体へのアクションが出る）
+
+- バッジは行の hover / 選択色に追従せず自前の面を持つ（Finder の alias バッジと同じ扱い。背景に
+  溶けると矢印が読めない）
+- 名前の色の優先順位は git change > link > ignored。link は gitignore 対象であることが多いため
+  ignored の gray より上に置く（下に置くと実運用でほぼ発火しない）。git change に色を譲る行でも
+  link であることはバッジが示し続ける
+- symlink 配下は FSEvents がリンクを辿らないため `fsChange` が届かない。リンク先の変更はツリーを
+  折りたたみ → 再展開したときに反映される
+- symlink 越しの列挙では gitignore 判定が付かない。`git check-ignore` が
+  `pathspec ... is beyond a symbolic link` で fatal になり、その列挙の全 entry が
+  `isIgnored: false` に倒れる（`checkIgnore` は失敗を空集合として扱う契約）。link 配下では
+  ignored の色落ちが起きない
+
+### 実体を対象にする右クリック項目
+
+左クリックは見えているパスで振る舞い、実体への移動は右クリックの明示操作でだけ起きる。symlink は
+1 つの実体に複数の名前がある構造で、UI が暗黙に実体へ正規化すると「どの名前で開いたか」が復元
+できなくなるため、gesture で対象を分ける（Finder の「元を表示」/ VS Code の
+[microsoft/vscode#57873](https://github.com/microsoft/vscode/issues/57873) と同じ切り分け）。
+
+対象は link 自身の行に限らない。`realTarget` を持つ行すべて（link 配下のファイルを含む）で出る。
+
+移動と path コピーは**排他**で、判定軸は「filer で開けるか」= 実体が worktree 配下か（`relPath` の有無）の 1 本だけ。
+
+| 項目                                        | 条件                           | 動作                                                                                |
+| ------------------------------------------- | ------------------------------ | ----------------------------------------------------------------------------------- |
+| `Go to real file`                           | 実体が worktree 内の file      | worktree 相対で preview に出す（ツリー reveal と git 連動が効く）                   |
+| `Go to real folder`                         | 実体が worktree 内の directory | selection を動かさない tree reveal でツリーだけ実体へ移動する                       |
+| `Copy real path`                            | 実体が worktree 外             | 実体の絶対パスを clipboard に書く（ツリーに開く先が無いため移動しない）             |
+| Open in default app / Copy file / Copy path | 既存の共通項目                 | link path そのものを対象にする（実体へ読み替えると「見えている path」と別物を返す） |
+
+- 移動項目の label は実体の種別で file / folder を出し分ける。行の見た目（link 自身の名前とアイコン）からは実体がファイルかディレクトリか判別できないため
+- 両方を同時に出さないのは、「どちらを使うべきか」の判断をユーザーに預けないため。実体の在り処で 1 つに定まる
 
 ## 削除ファイルの表示
 
@@ -129,8 +189,9 @@ git-graph で UNCOMMITTED_HASH 以外の commit が選択されている間、fi
 
 - `directory`: 展開 / 折りたたみ
 - `file`: `select` emit
-- `symlink`: working tree モードでは `select` emit (実 file へ resolve される)。snapshot mode では
-  blob 内容が target path 文字列でしかないため click を no-op に倒す
+- `symlink`: 実体を持たない symlink だけがこの kind に来る（working tree の dangling / 循環、
+  snapshot tree の symlink blob）。working tree では `select` emit（preview が not found を出す）、
+  snapshot mode では blob 内容が target path 文字列でしかないため click を no-op に倒す
 - `submodule`: 常に no-op。gitlink object (`160000`) は `gitShowCommitFile` で内容を取得できず
   preview に流すとエラーになるため。UI 上は `cursor-not-allowed` + opacity 低下 + tooltip で
   「click できない」ことを示す

--- a/docs/filer.md
+++ b/docs/filer.md
@@ -147,7 +147,7 @@ working tree の symlink は「link であること」と「実体としてど�
 
 - 動詞 `Select` は filer のクリック操作の再現を指す。file 行の click は選択 → preview を開き、folder 行の click は展開なので、kind 別の意味差は filer 側に既にあり、実装（file は preview 差し替え / folder はツリーだけ移動）とそのまま対応する
 - `original` は「link を経由しない元の場所」。link 経由の行はバッジと色が「実体は別の場所にある」ことを示しているため、この語は行という文脈の中で一意に読める（`man ln` も リンク先を "the original copy" と呼ぶ）
-- filer の click では folder 行は選択を発生させず展開だけを行う（`select` emit は file 行のみ）。したがって `Select original folder` も selection を動かさず、ツリーの展開 + スクロールだけを行う。ここを `selectRelPath` に倒すと preview がディレクトリ表示に落ちる（markdown link がディレクトリを指したときに起きる状態と同じ。`resolveMarkdownLink` は stat せず字句解決するため selection にディレクトリが入り得る）
+- filer の click では folder 行は選択を発生させず展開だけを行う。したがって `Select original folder` も selection を動かさず、ツリーの展開 + スクロールだけを行う。ここを `selectRelPath` に倒すと preview がディレクトリ表示に落ちる（markdown link がディレクトリを指したときに起きる状態と同じ。`resolveMarkdownLink` は stat せず字句解決するため selection にディレクトリが入り得る）
 - 両方を同時に出さないのは、「どちらを使うべきか」の判断をユーザーに預けないため。実体の在り処で 1 つに定まる
 
 ## 削除ファイルの表示

--- a/docs/filer.md
+++ b/docs/filer.md
@@ -147,7 +147,7 @@ working tree の symlink は「link であること」と「実体としてど�
 
 - 動詞 `Select` は filer のクリック操作の再現を指す。file 行の click は選択 → preview を開き、folder 行の click は展開なので、kind 別の意味差は filer 側に既にあり、実装（file は preview 差し替え / folder はツリーだけ移動）とそのまま対応する
 - `original` は「link を経由しない元の場所」。link 経由の行はバッジと色が「実体は別の場所にある」ことを示しているため、この語は行という文脈の中で一意に読める（`man ln` も リンク先を "the original copy" と呼ぶ）
-- filer では folder の click は選択ではなく展開で、`selectedRelPath` は file 選択でしか設定されない（folder にハイライトが付かないのも同じ理由）。したがって `Select original folder` も selection を動かさず、ツリーの展開 + スクロールだけを行う。ここを `selectRelPath` に倒すと preview がディレクトリ表示に落ちる
+- filer の click では folder 行は選択を発生させず展開だけを行う（`select` emit は file 行のみ）。したがって `Select original folder` も selection を動かさず、ツリーの展開 + スクロールだけを行う。ここを `selectRelPath` に倒すと preview がディレクトリ表示に落ちる（markdown link がディレクトリを指したときに起きる状態と同じ。`resolveMarkdownLink` は stat せず字句解決するため selection にディレクトリが入り得る）
 - 両方を同時に出さないのは、「どちらを使うべきか」の判断をユーザーに預けないため。実体の在り処で 1 つに定まる
 
 ## 削除ファイルの表示

--- a/docs/filer.md
+++ b/docs/filer.md
@@ -108,8 +108,9 @@ working tree の symlink は「link であること」と「実体としてど�
   | 名前の色（info）         | `realTarget` を持つ行        | 実体が別の場所にある    |
 
   色が link ディレクトリの下層まで続くのは、実体向けの右クリック項目が出る集合と揃えるため（色が
-  付いている行では必ず実体へのアクションが出る）。実体を解決できない dangling / 循環と、snapshot
-  tree の symlink は `realTarget` を持たないため、バッジ（+ tooltip の `broken symlink`）だけで表す
+  付いている行では必ず実体へのアクションが出る）。`realTarget` を持たない行はバッジと tooltip だけで
+  表す: working tree の dangling / 循環は `broken symlink`、snapshot tree の symlink は実体の有無を
+  語れないため `symlink`
 
 - バッジは行の hover / 選択色に追従せず自前の面を持つ（Finder の alias バッジと同じ扱い。背景に
   溶けると矢印が読めない）

--- a/packages/rpc/src/fs.ts
+++ b/packages/rpc/src/fs.ts
@@ -26,8 +26,8 @@ export interface FsReadDirRequest {
 /** entry の実体の在り処。entry 自身の情報（name / type）と実体の情報を分けて持つことで、
  * renderer は「symlink であること」と「実体としてどう振る舞うか」を独立に決められる。 */
 export interface FsReadDirRealTarget {
-  /** 実体の種別（"file" / "directory"） */
-  type: string;
+  /** 実体の種別。symlink chain を辿った先なので symlink は現れない */
+  type: "file" | "directory";
   /** 実体の絶対パス（realpath。chain 全体を解決済み） */
   absPath: string;
   /** 実体が readDir の `dir` 配下にある場合の dir 相対パス。dir 外を指すなら未設定。

--- a/packages/rpc/src/fs.ts
+++ b/packages/rpc/src/fs.ts
@@ -15,9 +15,6 @@ export interface FsReadFileRequest {
 export type FsReadFileResponse = FileReadResult;
 
 // ディレクトリエントリ列挙。
-//
-// type は "file" / "directory" / "symlink" / "other" の文字列。renderer 側の
-// リテラル判定をそのまま書けるよう enum 化しない。
 export interface FsReadDirRequest {
   dir: string;
   path: string;
@@ -37,7 +34,8 @@ export interface FsReadDirRealTarget {
 
 export interface FsReadDirEntry {
   name: string;
-  type: string;
+  /** entry 自身の種別（lstat 由来。link は辿らず "symlink"） */
+  type: "file" | "directory" | "symlink";
   /** 実体の在り処が entry のパス（`dir` + `path` + `name`）と食い違うときだけ設定する。
    * 該当するのは symlink 自身と、symlink 越しに列挙された entry（親 dir が link）の 2 経路。
    * 辿れない dangling / 循環（ELOOP）は未設定で「実体なし」を表す。 */

--- a/packages/rpc/src/fs.ts
+++ b/packages/rpc/src/fs.ts
@@ -23,9 +23,25 @@ export interface FsReadDirRequest {
   path: string;
 }
 
+/** entry の実体の在り処。entry 自身の情報（name / type）と実体の情報を分けて持つことで、
+ * renderer は「symlink であること」と「実体としてどう振る舞うか」を独立に決められる。 */
+export interface FsReadDirRealTarget {
+  /** 実体の種別（"file" / "directory"） */
+  type: string;
+  /** 実体の絶対パス（realpath。chain 全体を解決済み） */
+  absPath: string;
+  /** 実体が readDir の `dir` 配下にある場合の dir 相対パス。dir 外を指すなら未設定。
+   * 判定は realpath 同士で行うため、dir 自身が symlink 経由のパスでも取り違えない。 */
+  relPath?: string;
+}
+
 export interface FsReadDirEntry {
   name: string;
   type: string;
+  /** 実体の在り処が entry のパス（`dir` + `path` + `name`）と食い違うときだけ設定する。
+   * 該当するのは symlink 自身と、symlink 越しに列挙された entry（親 dir が link）の 2 経路。
+   * 辿れない dangling / 循環（ELOOP）は未設定で「実体なし」を表す。 */
+  realTarget?: FsReadDirRealTarget;
   /** gitignore で無視されているか。dir が git repo でない場合は常に false。 */
   isIgnored: boolean;
 }

--- a/packages/rpc/src/fs.ts
+++ b/packages/rpc/src/fs.ts
@@ -38,7 +38,7 @@ export interface FsReadDirEntry {
   type: "file" | "directory" | "symlink";
   /** 実体の在り処が entry のパス（`dir` + `path` + `name`）と食い違うときだけ設定する。
    * 該当するのは symlink 自身と、symlink 越しに列挙された entry（親 dir が link）の 2 経路。
-   * 辿れない dangling / 循環（ELOOP）は未設定で「実体なし」を表す。 */
+   * 辿れない link（dangling / 循環 / 中間成分が非ディレクトリ）は未設定で「実体なし」を表す。 */
   realTarget?: FsReadDirRealTarget;
   /** gitignore で無視されているか。dir が git repo でない場合は常に false。 */
   isIgnored: boolean;

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -55,6 +55,7 @@ export type {
 export type { EchoRequest, EchoResponse } from "./echo";
 export type {
   FsReadDirEntry,
+  FsReadDirRealTarget,
   FsReadDirRequest,
   FsReadDirResponse,
   FsReadFileAbsoluteRequest,


### PR DESCRIPTION
## 概要

filer が symlink を symlink として扱えるようにする。

- ディレクトリへの symlink が leaf に潰れず、フォルダとして展開できる
- link であること（アイコン右下の矢印バッジ）と、実体が別の場所にあること（名前の色）を表示で分ける
- 右クリックに実体向けの項目を足す。実体が worktree 内なら実体の行を選択、外なら実体パスのコピー

## 背景

ディレクトリへの symlink がツリー上でファイル扱いになり、クリックすると preview が "Directory" プレースホルダを出すだけだった。原因は main の `readDir` が lstat 由来の `type: "symlink"` しか返しておらず、**link 自身の種別と実体の種別が 1 フィールドに潰れていた**こと。renderer は `kind !== "directory"` を leaf として扱うため、dir symlink は構造的に file へ倒れるしかなかった。

`realTarget` が載る軸は「実体の在り処がツリー上のパスと食い違うか」で、symlink 自身の行に限らない。dir link 自身（preview に流せない）と link 配下の通常ファイル（entry 自身は link でない）の双方が実体情報を必要とするため、`.claude/skills/studio-review/SKILL.md` のように link 越しに列挙された行も実体を持つ。

左クリックで実体へ選択を移す案は検討して却下した（詳細は下記）。

## 変更内容

### RPC スキーマ

- `FsReadDirEntry.realTarget`（`FsReadDirRealTarget`: `type` / `absPath` / `relPath?`）。実体が entry のパスと食い違うときだけ載る
- `relPath` は実体が `dir` 配下にあるときだけ定義される。「worktree 外は絶対パスでしか扱えない」制約が型に出る

### main（fsOps.readDir）

- symlink entry は `realpath` で実体を解決して `realTarget` に載せる。辿れない dangling / 循環（ELOOP）は `realTarget` 不在で「実体なし」を表す
- 列挙対象自身が symlink 越しか（`realpath(listing dir) !== realpath(dir) + 正規化相対パス`）を見て、entry 自身が link でなくても `realTarget` を付ける。この経路の entry は `listRealPath` が canonical なので realpath / stat を引き直さない
- `relPath` の包含判定は realpath 同士。macOS の `$TMPDIR` のように dir 自身が symlink 経由でも「実体は worktree 配下なのに外部扱い」にならない
- 判定に使う相対パスは resolve 済み target から導出する。入力 `path` の表記揺れ（`""` / `"."` / 末尾スラッシュ）が link 越し判定と gitignore prefix に漏れない
- gitignore の pathspec は常に **entry 自身**を指す。link 越し列挙で symlink 行にリンク先の path を渡すと、リンク先の ignored を行が引き継ぐ（git の管理対象は link blob 自身）。dangling 行も pathspec を失って判定されない
- `realpathSync` の失敗も `readdirSync` 失敗と同じ recheck に合流させる。列挙成功後に対象が消えると ENOENT が 500 → トーストになり、「不在は notFound」の契約を破る

### filer の表示

- ツリー reveal は `seq` で世代保護する。`loadChildren` の await 中に来た新しい要求が先に完走しても、古い要求の scrollIntoView が後から上書きしない
- `realTarget.type` を `FileEntry.kind` に写像する。dir symlink は kind `directory` で chevron + フォルダアイコンを持ち、ディレクトリ優先ソートに乗る
- `kind === "symlink"` は実体を解決できない行（dangling / 循環 / snapshot tree の blob）のみ
- バッジは `isSymlink`（link 自身の行）、名前の色は `realTarget` を持つ行（実体が別の場所にある行）。色は link ディレクトリの下層まで続き、実体向けの右クリック項目が出る集合と一致する
- 色の優先順位は git change > link > ignored。link は gitignore 対象が大半（worktree symlink 等）なので ignored の gray より上

### 右クリックメニュー

| 項目 | 条件 | 動作 |
| --- | --- | --- |
| `Select original file` | 実体が worktree 内の file | worktree 相対で preview（ツリー reveal と git 連動が効く） |
| `Select original folder` | 実体が worktree 内の directory | selection を動かさずツリーだけ実体へ移動（preview は保たれる） |
| `Copy original path` | 実体が worktree 外 | 実体の絶対パスを clipboard へ |

- 選択と path コピーは排他。判定軸は「filer で選択できるか」= 実体が worktree 配下かの 1 本
- 既存項目（Open in default app / Copy file / Copy path）は link path が対象
- 実体向け項目は worktree 相対パスを現在の store 基準で解決するため、dir 切替では menu を閉じる。右クリック時点の `dir` snapshot を menu が生き延びると、worktree A で算出した relPath が worktree B に適用され、同名パスが実在する並列 worktree で別ファイルが静かに開く
- 共通の `FileActionMenuItems`（preview ヘッダの ⋮ と共有）には入れない。共有先は実体情報を持たず、これらは filer の symlink 経路に固有

**ラベルの語彙**: 動詞 `Select` は filer のクリック操作の再現を指す（file 行の click は選択 → preview を開き、folder 行の click は展開）。kind 別の意味差が filer 側に既にあるため、surface 名を書き足さずに実装と対応が取れる。`original` は「link を経由しない元の場所」で、link 越しに列挙された行にも同じ意味で成立する（`man ln` もリンク先を "the original copy" と呼ぶ）。`real` は `realpath(3)` を知らないと何に対する real か伝わらず、`target` は同じ OS の語彙内で位置引数のロール名として逆向きにも使われる（BSD `ln` の `target_file` は作られる link 自身、`cp` / `mv` はコピー先）ため採らない。

### reveal と selection の分離

- `useWorktreeStore` は `revealRequest`（対象 relPath + 連番）と `revealRelPath()` を持つ。ディレクトリ実体の reveal を selection 経由でやると preview が "Directory" に落ちて開いていたファイルが消えるため、ツリー reveal を selection から独立させた
- `select*Path()` のカウンタは `selectPathVersion`。preview が「選択し直された」ことを検出して行スクロールをやり直す signal で、ツリー reveal は駆動しない（駆動するのは `revealRequest`）。prop 名も端点まで同名で流す
- `clearSelectedPath()` は reveal 要求も落とす。selection が無いのに要求だけ残ると、後から mount された行が stale な path を掘り出してツリーが自動展開される

## 検討して却下した案

**左クリックで実体へ選択を移す**（当初の要望）:

- worktree 外を指す link は移動先が無い。file は絶対パス preview に倒せるがツリーのハイライトが消え、directory は preview がディレクトリを表示できず、同じジェスチャの結果がリンク先の位置で分岐する
- `filer.copyFile`（cmd+c）は `selectedRelPath` 基準、右クリックは link path 基準になり、対象が gesture で割れる
- symlink は 1 つの実体に複数の名前がある構造で、UI が暗黙に実体へ正規化すると「どの名前で開いたか」が復元できなくなる（VS Code の同種の問題: microsoft/vscode issue100533、実体へのジャンプを context menu / modifier-click に置く要望: microsoft/vscode issue57873）

**選択項目と `Copy original path` の併記**: どちらを使うべきかの判断をユーザーに預けることになるため、実体の在り処 1 軸で排他にした。

## 既知の制約

- symlink 配下は FSEvents がリンクを辿らないため `fsChange` が届かない。リンク先の変更は折りたたみ → 再展開で反映される

## スコープの切り分け

| 作業内容 | やるべき理由 | この PR でやらない理由 |
| --- | --- | --- |
| worktree 外のディレクトリ実体をアプリ内で辿る | 実体が外部 repo にある symlink（`~/.claude/skills` 等）はアプリ内から中身を見られない | ツリーに対応ノードが無く、sidebar へ project として開く等の別機能が必要。`Copy original path` + Open in default app で当座を賄う |
| `checkIgnore` 失敗の観察ログ | silent drop 禁止の規律に照らせば失敗経路にログが欲しい | 非 git project では `git check-ignore` の失敗が正常系（`treatNonZeroExitAsSuccess` でも stderr 非空で reject）で、無条件のログは全 listing で出る恒常ノイズになる。分類を入れるなら失敗種別の判定から設計が要る |
| `absFileWatcher` テストの flake 調査 | `watch 中ファイルの変更で fsChangeAbsolute が push される` が本ブランチの検証中に 1 度 timeout した（再実行で pass） | 本 PR は `readDir` 経路のみで絶対パス単一ファイル監視に触れていない。FSEvents 到達待ちの既存 flake |

## 確認事項

- [ ] dir symlink（`.claude/skills/studio-review` 等）が展開でき、配下のファイルが preview で開けること
- [ ] バッジの見え方（アイコン右下、行の hover / 選択時にも矢印が読めるか）
- [ ] 名前の色が link 配下の下層まで続くこと
- [ ] worktree 内の実体で `Select original file` / `Select original folder`、外の実体で `Copy original path` が出ること
- [ ] `Select original folder` で preview の表示が保たれること（selection を動かさない）
- [ ] link 配下の gitignore 対象ファイル（`node_modules` を含む link 等）が gray で表示されること


