### PR TITLE
feat(filer): show submodules as pinned-commit leaves

### DIFF
--- a/apps/electron/src/fs/fsOps.test.ts
+++ b/apps/electron/src/fs/fsOps.test.ts
@@ -334,6 +334,10 @@ describe("FSOps", () => {
     const theirs = "3".repeat(40);
     const dir = makeTempDir();
     runFixtureGit(["init", "-b", "main"], dir);
+    // commit する fixture は identity を repo-local に固定する。未設定でも git は OS の
+    // gecos / ホスト名から自動導出するが、それが空になる環境では `empty ident name` で落ちる
+    runFixtureGit(["config", "user.email", "t@example.com"], dir);
+    runFixtureGit(["config", "user.name", "t"], dir);
     writeFileSync(join(dir, "seed.txt"), "x");
     runFixtureGit(["add", "seed.txt"], dir);
     runFixtureGit(["commit", "-m", "seed"], dir);

--- a/apps/electron/src/fs/fsOps.test.ts
+++ b/apps/electron/src/fs/fsOps.test.ts
@@ -281,26 +281,77 @@ describe("FSOps", () => {
     expect(byName.get("src")?.submoduleHash).toBeUndefined();
   });
 
-  test("gitlink 判定は列挙している 1 階層に閉じる", async () => {
+  test("孫の gitlink は列挙階層の同名 entry を submodule にしない", async () => {
     const dir = makeTempDir();
     runFixtureGit(["init"], dir);
-    mkdirSync(join(dir, "vendor"));
-    mkdirSync(join(dir, "vendor", "lib"));
+    mkdirSync(join(dir, "vendor", "lib"), { recursive: true });
+    // 孫 gitlink と basename が衝突するディレクトリを列挙階層に置く。1 階層に閉じていないと
+    // `vendor/lib` の gitlink がこの `lib` に載る
+    mkdirSync(join(dir, "lib"));
     addGitlink(dir, "vendor/lib");
-    // 親階層の列挙で `vendor` 自身が submodule に化けない（pathspec が孫を拾わない証拠）
     const root = await readDir(dir, "");
-    expect(root.entries.find((entry) => entry.name === "vendor")?.type).toBe("directory");
+    const byName = new Map(root.entries.map((entry) => [entry.name, entry]));
+    expect(byName.get("lib")?.type).toBe("directory");
+    expect(byName.get("vendor")?.type).toBe("directory");
     const nested = await readDir(dir, "vendor");
     expect(nested.entries.find((entry) => entry.name === "lib")?.type).toBe("submodule");
+  });
+
+  test("ディレクトリ名が glob メタ文字を含んでも判定がずれない", async () => {
+    // `[slug]` のような動的ルートは Next.js / Nuxt で実在する。ディレクトリ名を pathspec の
+    // パターンとして渡すと文字クラスに解釈され、`app/s/*` にも一致して兄弟の gitlink を拾い、
+    // 本物の gitlink を取り逃す
+    const dir = makeTempDir();
+    runFixtureGit(["init"], dir);
+    mkdirSync(join(dir, "app", "[slug]", "plain"), { recursive: true });
+    mkdirSync(join(dir, "app", "[slug]", "mod"), { recursive: true });
+    mkdirSync(join(dir, "app", "s", "plain"), { recursive: true });
+    addGitlink(dir, "app/[slug]/mod");
+    addGitlink(dir, "app/s/plain");
+    const result = await readDir(dir, "app/[slug]");
+    const byName = new Map(result.entries.map((entry) => [entry.name, entry]));
+    expect(byName.get("mod")?.type).toBe("submodule");
+    expect(byName.get("plain")?.type).toBe("directory");
+    expect(byName.get("plain")?.submoduleHash).toBeUndefined();
   });
 
   test("gitlink の path がディスク上 file なら実体の種別を優先する", async () => {
     const dir = makeTempDir();
     runFixtureGit(["init"], dir);
     writeFileSync(join(dir, "lib"), "");
+    // gitlink 問い合わせはディレクトリを含む階層でしか走らないため、無関係な dir を 1 つ置く
+    mkdirSync(join(dir, "src"));
     addGitlink(dir, "lib");
     const result = await readDir(dir, "");
     expect(result.entries.find((entry) => entry.name === "lib")?.type).toBe("file");
+  });
+
+  test("conflict 中の gitlink は working tree と同じ ours (stage 2) を返す", async () => {
+    // base / ours / theirs の 3 者が揃う形にして stage 1/2/3 をすべて出す。base を落とすと
+    // 「stage を見ずに先勝ち / 後勝ちで拾う」実装との差が出ない
+    const base = "1".repeat(40);
+    const ours = "2".repeat(40);
+    const theirs = "3".repeat(40);
+    const dir = makeTempDir();
+    runFixtureGit(["init", "-b", "main"], dir);
+    writeFileSync(join(dir, "seed.txt"), "x");
+    runFixtureGit(["add", "seed.txt"], dir);
+    runFixtureGit(["commit", "-m", "seed"], dir);
+    runFixtureGit(["update-index", "--add", "--cacheinfo", `160000,${base},conf`], dir);
+    runFixtureGit(["commit", "-m", "base"], dir);
+    runFixtureGit(["checkout", "-b", "other"], dir);
+    runFixtureGit(["update-index", "--add", "--cacheinfo", `160000,${theirs},conf`], dir);
+    runFixtureGit(["commit", "-m", "theirs"], dir);
+    runFixtureGit(["checkout", "main"], dir);
+    runFixtureGit(["update-index", "--add", "--cacheinfo", `160000,${ours},conf`], dir);
+    runFixtureGit(["commit", "-m", "ours"], dir);
+    // conflict する merge は非 0 終了する。conflict 状態を作るのが目的なので失敗は握る
+    tryCatch(() => runFixtureGit(["merge", "other"], dir));
+    mkdirSync(join(dir, "conf"), { recursive: true });
+    const result = await readDir(dir, "");
+    const conf = result.entries.find((entry) => entry.name === "conf");
+    expect(conf?.type).toBe("submodule");
+    expect(conf?.submoduleHash).toBe(ours);
   });
 
   test("symlink 越しの列挙でも実体側の path で gitignore 判定する", async () => {

--- a/apps/electron/src/fs/fsOps.test.ts
+++ b/apps/electron/src/fs/fsOps.test.ts
@@ -254,6 +254,55 @@ describe("FSOps", () => {
     expect(byName.get(".gitignore")).toBe(false);
   });
 
+  // submodule の working tree はディスク上ただのディレクトリなので、判定は index の gitlink
+  // （mode 160000）だけが根拠になる。`update-index --cacheinfo` は commit object の実在を
+  // 要求しないため、未初期化 submodule と同じ状態をネットワーク無しで作れる
+  const GITLINK_HASH = "1111111111111111111111111111111111111111";
+
+  function addGitlink(dir: string, relPath: string): void {
+    runFixtureGit(
+      ["update-index", "--add", "--cacheinfo", `160000,${GITLINK_HASH},${relPath}`],
+      dir,
+    );
+  }
+
+  test("index の gitlink はディレクトリではなく submodule として返る", async () => {
+    const dir = makeTempDir();
+    runFixtureGit(["init"], dir);
+    mkdirSync(join(dir, "lib"));
+    mkdirSync(join(dir, "src"));
+    addGitlink(dir, "lib");
+    const result = await readDir(dir, "");
+    const byName = new Map(result.entries.map((entry) => [entry.name, entry]));
+    expect(byName.get("lib")?.type).toBe("submodule");
+    expect(byName.get("lib")?.submoduleHash).toBe(GITLINK_HASH);
+    // gitlink でないディレクトリは巻き込まれない
+    expect(byName.get("src")?.type).toBe("directory");
+    expect(byName.get("src")?.submoduleHash).toBeUndefined();
+  });
+
+  test("gitlink 判定は列挙している 1 階層に閉じる", async () => {
+    const dir = makeTempDir();
+    runFixtureGit(["init"], dir);
+    mkdirSync(join(dir, "vendor"));
+    mkdirSync(join(dir, "vendor", "lib"));
+    addGitlink(dir, "vendor/lib");
+    // 親階層の列挙で `vendor` 自身が submodule に化けない（pathspec が孫を拾わない証拠）
+    const root = await readDir(dir, "");
+    expect(root.entries.find((entry) => entry.name === "vendor")?.type).toBe("directory");
+    const nested = await readDir(dir, "vendor");
+    expect(nested.entries.find((entry) => entry.name === "lib")?.type).toBe("submodule");
+  });
+
+  test("gitlink の path がディスク上 file なら実体の種別を優先する", async () => {
+    const dir = makeTempDir();
+    runFixtureGit(["init"], dir);
+    writeFileSync(join(dir, "lib"), "");
+    addGitlink(dir, "lib");
+    const result = await readDir(dir, "");
+    expect(result.entries.find((entry) => entry.name === "lib")?.type).toBe("file");
+  });
+
   test("symlink 越しの列挙でも実体側の path で gitignore 判定する", async () => {
     const dir = makeTempDir();
     runFixtureGit(["init"], dir);

--- a/apps/electron/src/fs/fsOps.ts
+++ b/apps/electron/src/fs/fsOps.ts
@@ -151,20 +151,19 @@ export async function readDir(dir: string, path: string): Promise<FsReadDirResul
       : prefix + entry.name;
     return { built, ignoreSpec };
   });
-  // submodule 判定の pathspec は listing 全体で 1 つなので、entry ごとの ignoreSpec とは別に
-  // 列挙対象自身の canonical な dir 相対パスを求める（link 越しの列挙で pathspec が
-  // `beyond a symbolic link` に落ちるのを避ける規律は ignoreSpec と同じ）。dir 外は当該 repo の
-  // index の管轄外なので問い合わせ自体を落とす。
-  // ディレクトリを 1 つも含まない階層に submodule はあり得ないため git を起動しない
-  // （working tree の submodule は初期化状態によらずディレクトリとして存在する）
-  const gitlinkDir = listCrossesLink ? relPathWithin(listRealPath, dirRealPath) : relDir;
-  const needsGitlinks = gitlinkDir !== undefined && dirents.some((entry) => entry.isDirectory());
+  // submodule 判定は列挙対象そのものを cwd にして引く（pathspec にディレクトリ名を混ぜず
+  // `:(glob)*` 固定に保つための契約。listGitlinks の docstring 参照）。symlink 越しに worktree
+  // 外を見ている列挙は当該 repo の index の管轄外なので問い合わせ自体を落とす（ignoreSpec が
+  // dir 外を落とすのと同じ規律）。ディレクトリを 1 つも含まない階層に submodule はあり得ないため
+  // git を起動しない（working tree の submodule は初期化状態によらずディレクトリとして存在する）
+  const needsGitlinks =
+    isWithinDir(listRealPath, dirRealPath) && dirents.some((entry) => entry.isDirectory());
   const [ignored, gitlinks] = await Promise.all([
     checkIgnore(
       dir,
       listing.flatMap(({ ignoreSpec }) => (ignoreSpec === undefined ? [] : [ignoreSpec])),
     ),
-    needsGitlinks ? listGitlinks(dir, gitlinkDir) : new Map<string, string>(),
+    needsGitlinks ? listGitlinks(listRealPath) : new Map<string, string>(),
   ]);
   const entries = listing
     .map(({ built, ignoreSpec }) => ({
@@ -309,6 +308,12 @@ function toRealTarget(
     absPath,
     relPath: relPathWithin(absPath, dirRealPath),
   };
+}
+
+/** realpath 済みの絶対パスが dir 配下（dir 自身を含む）にあるか。`relPathWithin` は dir 自身に
+ * 相対パスを与えられないため、包含だけを問う判定はこちらに分ける */
+function isWithinDir(absPath: string, dirRealPath: string): boolean {
+  return absPath === dirRealPath || relPathWithin(absPath, dirRealPath) !== undefined;
 }
 
 /** realpath 済みの絶対パスが dir 配下なら dir 相対パスを返す。dir 外なら undefined */

--- a/apps/electron/src/fs/fsOps.ts
+++ b/apps/electron/src/fs/fsOps.ts
@@ -19,7 +19,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, isAbsolute, join, relative, sep } from "node:path";
-import { checkIgnore } from "../git/gitOps";
+import { checkIgnore, listGitlinks } from "../git/gitOps";
 import { toWireBytes } from "../wireBytes";
 import { resolveContained } from "./pathContainment";
 
@@ -28,6 +28,8 @@ interface FsEntry {
   type: FsReadDirEntry["type"];
   /** 実体の在り処（FsReadDirRealTarget の契約） */
   realTarget?: FsReadDirRealTarget;
+  /** submodule が指す commit hash（FsReadDirEntry の契約） */
+  submoduleHash?: string;
   isIgnored: boolean;
 }
 
@@ -149,13 +151,24 @@ export async function readDir(dir: string, path: string): Promise<FsReadDirResul
       : prefix + entry.name;
     return { built, ignoreSpec };
   });
-  const ignored = await checkIgnore(
-    dir,
-    listing.flatMap(({ ignoreSpec }) => (ignoreSpec === undefined ? [] : [ignoreSpec])),
-  );
+  // submodule 判定の pathspec は listing 全体で 1 つなので、entry ごとの ignoreSpec とは別に
+  // 列挙対象自身の canonical な dir 相対パスを求める（link 越しの列挙で pathspec が
+  // `beyond a symbolic link` に落ちるのを避ける規律は ignoreSpec と同じ）。dir 外は当該 repo の
+  // index の管轄外なので問い合わせ自体を落とす。
+  // ディレクトリを 1 つも含まない階層に submodule はあり得ないため git を起動しない
+  // （working tree の submodule は初期化状態によらずディレクトリとして存在する）
+  const gitlinkDir = listCrossesLink ? relPathWithin(listRealPath, dirRealPath) : relDir;
+  const needsGitlinks = gitlinkDir !== undefined && dirents.some((entry) => entry.isDirectory());
+  const [ignored, gitlinks] = await Promise.all([
+    checkIgnore(
+      dir,
+      listing.flatMap(({ ignoreSpec }) => (ignoreSpec === undefined ? [] : [ignoreSpec])),
+    ),
+    needsGitlinks ? listGitlinks(dir, gitlinkDir) : new Map<string, string>(),
+  ]);
   const entries = listing
     .map(({ built, ignoreSpec }) => ({
-      ...built,
+      ...applyGitlink(built, gitlinks),
       isIgnored: ignoreSpec !== undefined && ignored.has(ignoreSpec),
     }))
     .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
@@ -218,6 +231,20 @@ function buildEntry(
     type,
     realTarget: toRealTarget(join(listRealPath, entry.name), isDirectory, dirRealPath),
   };
+}
+
+/**
+ * index の gitlink と突き合わせて、ディレクトリとして列挙された entry を submodule に倒す。
+ *
+ * 対象を directory に限るのは、gitlink の path が working tree では file / symlink になっている
+ * 食い違い状態を submodule として描かないため。ディスク上の実体の種別は常に lstat が SSOT で、
+ * index は「その実体が submodule として登録されているか」だけを足す。
+ */
+function applyGitlink(entry: FsEntryDraft, gitlinks: Map<string, string>): FsEntryDraft {
+  if (entry.type !== "directory") return entry;
+  const submoduleHash = gitlinks.get(entry.name);
+  if (submoduleHash === undefined) return entry;
+  return { ...entry, type: "submodule", submoduleHash };
 }
 
 /**

--- a/apps/electron/src/git/gitOps.ts
+++ b/apps/electron/src/git/gitOps.ts
@@ -72,20 +72,23 @@ const GITLINK_STAGE_RANK: Record<string, number> = { "0": 2, "2": 1 };
  * ファイルなので、ディスク側には初期化状態に依存しない手がかりが存在しない。`.gitmodules` は
  * 「設定」であって実体ではなく、index に gitlink が無い記述も、記述の無い gitlink もあり得る。
  *
- * `dir` は **列挙しているディレクトリそのもの**を渡す。pathspec を cwd 固定の `:(glob)*` に
- * 保つことで、ディレクトリ名がパターンとして解釈される経路を構造的に無くしている
- * （`:(glob)<name>/*` の形にすると、`app/[slug]` のようにディレクトリ名が glob メタ文字を
- * 含む場合に文字クラスとして解釈され、兄弟ディレクトリの gitlink を拾いつつ本物を取り逃す）。
- * `:(glob)` は `*` が `/` を跨がなくなる効果を持つため、これで 1 階層に閉じる。
+ * 引数は同ファイルの他の op（worktree root を受ける `dir`）と違い **列挙しているディレクトリ
+ * そのもの**。pathspec を cwd 固定の `:(glob)*` に保つことで、ディレクトリ名がパターンとして
+ * 解釈される経路を構造的に無くしている（`:(glob)<name>/*` の形にすると、`app/[slug]` のように
+ * ディレクトリ名が glob メタ文字を含む場合に文字クラスとして解釈され、兄弟ディレクトリの gitlink を
+ * 拾いつつ本物を取り逃す）。`:(glob)` は `*` が `/` を跨がなくなる効果を持つため、これで 1 階層に閉じる。
+ *
+ * anchor は cwd を所有する repo なので、worktree 内に独立した nested repo があればその index を
+ * 見る（ツリーが写しているディスクの実体としては妥当）。
  *
  * - `git ls-files --stage -z` の 1 レコードは `<mode> SP <object> SP <stage> TAB <path>`
  * - 出力 path は cwd 相対。1 階層 pathspec なので `/` を含まず、そのまま entry 名になる
  * - git 管理外 / git 不在は空 Map を返す（checkIgnore と同じく throw しない）
  */
-export async function listGitlinks(dir: string): Promise<Map<string, string>> {
-  const result = await tryCatch(runGit(["ls-files", "--stage", "-z", "--", ":(glob)*"], dir));
+export async function listGitlinks(listDir: string): Promise<Map<string, string>> {
+  const result = await tryCatch(runGit(["ls-files", "--stage", "-z", "--", ":(glob)*"], listDir));
   if (!result.ok) {
-    logGitlinkFailure(dir, result.error);
+    logGitlinkFailure(listDir, result.error);
     return new Map();
   }
   const ranked = new Map<string, { hash: string; rank: number }>();
@@ -108,12 +111,14 @@ export async function listGitlinks(dir: string): Promise<Map<string, string>> {
  * gitlink 列挙の失敗を観察可能にする。失敗の帰結は「submodule が普通のディレクトリとして出る」で、
  * 無音だと表示が退行したことに気づけない。
  *
- * 非 git プロジェクト（gozd は git 管理外の project も開ける）は列挙のたびに必ず失敗するため、
- * それだけはログを出さない。exit 128 は git の「not a git repository」の規約。
+ * 非 git プロジェクト（gozd は git 管理外の project も開ける）は列挙のたびに必ず失敗するので、
+ * これを黙らせるために exit 128 を除外する。ただし 128 は git の**汎用 fatal** で not-a-repo 専用
+ * ではないため、index 破損のような本物の障害もここで無音になる。stderr 文字列で絞る案は取らない:
+ * git のメッセージは翻訳対象で、`gozdGitEnv` はユーザーの locale をそのまま継承するため。
  */
-function logGitlinkFailure(dir: string, error: unknown): void {
+function logGitlinkFailure(listDir: string, error: unknown): void {
   if (error instanceof GitCommandError && error.exitCode === 128) return;
-  console.error(`[listGitlinks] ls-files failed: ${String(error)} dir=${dir}`);
+  console.error(`[listGitlinks] ls-files failed: ${String(error)} dir=${listDir}`);
 }
 
 /**

--- a/apps/electron/src/git/gitOps.ts
+++ b/apps/electron/src/git/gitOps.ts
@@ -3,7 +3,7 @@
 
 import { tryCatch } from "@gozd/shared";
 import { statSync } from "node:fs";
-import { basename, join } from "node:path";
+import { join } from "node:path";
 import { GitCommandError, runGit, runGitNonInteractive, runGitWithStdin } from "./gitRunner";
 import {
   parsePorcelainV2WithBranch,
@@ -56,42 +56,64 @@ export async function checkIgnore(dir: string, relPaths: string[]): Promise<Set<
 const GITLINK_MODE = "160000";
 
 /**
- * relDir 直下の submodule を「entry 名 → 指している commit hash」の Map で返す。
+ * 表示に採用する index stage と、その優先度（大きいほうが勝つ）。
+ *
+ * 通常の entry は stage 0 だけを持つ。conflict 中の gitlink は stage 1（base）/ 2（ours）/
+ * 3（theirs）が並ぶが、working tree に checkout されているのは ours なので、表示もそれに揃える。
+ * base / theirs は working tree のどこにも現れない値なので採用しない。
+ */
+const GITLINK_STAGE_RANK: Record<string, number> = { "0": 2, "2": 1 };
+
+/**
+ * `dir` 直下の submodule を「entry 名 → 指している commit hash」の Map で返す。
  *
  * 判定の SSOT は **index の gitlink**（mode `160000`）に置く。submodule の working tree は
  * 未初期化なら中身の無いディレクトリで、初期化済みでも `.git` は readDir が除外する gitlink
  * ファイルなので、ディスク側には初期化状態に依存しない手がかりが存在しない。`.gitmodules` は
  * 「設定」であって実体ではなく、index に gitlink が無い記述も、記述の無い gitlink もあり得る。
  *
- * pathspec の `:(glob)` 修飾子は `*` が `/` を跨がなくなる効果を持つため、`<relDir>/*` で
- * index 全体ではなく readDir が見ている 1 階層だけに絞れる。
+ * `dir` は **列挙しているディレクトリそのもの**を渡す。pathspec を cwd 固定の `:(glob)*` に
+ * 保つことで、ディレクトリ名がパターンとして解釈される経路を構造的に無くしている
+ * （`:(glob)<name>/*` の形にすると、`app/[slug]` のようにディレクトリ名が glob メタ文字を
+ * 含む場合に文字クラスとして解釈され、兄弟ディレクトリの gitlink を拾いつつ本物を取り逃す）。
+ * `:(glob)` は `*` が `/` を跨がなくなる効果を持つため、これで 1 階層に閉じる。
+ *
  * - `git ls-files --stage -z` の 1 レコードは `<mode> SP <object> SP <stage> TAB <path>`
- * - 出力 path は repo root 相対。`dir` は worktree root なので relDir 相対に読み替えられる
+ * - 出力 path は cwd 相対。1 階層 pathspec なので `/` を含まず、そのまま entry 名になる
  * - git 管理外 / git 不在は空 Map を返す（checkIgnore と同じく throw しない）
  */
-export async function listGitlinks(dir: string, relDir: string): Promise<Map<string, string>> {
-  const pathspec = relDir === "" ? ":(glob)*" : `:(glob)${relDir}/*`;
-  const result = await tryCatch(runGit(["ls-files", "--stage", "-z", "--", pathspec], dir));
-  // not a git repo / git 不在。submodule 無しとして扱う
-  if (!result.ok) return new Map();
-  const gitlinks = new Map<string, string>();
+export async function listGitlinks(dir: string): Promise<Map<string, string>> {
+  const result = await tryCatch(runGit(["ls-files", "--stage", "-z", "--", ":(glob)*"], dir));
+  if (!result.ok) {
+    logGitlinkFailure(dir, result.error);
+    return new Map();
+  }
+  const ranked = new Map<string, { hash: string; rank: number }>();
   for (const record of result.value.split("\0")) {
     if (!record.startsWith(`${GITLINK_MODE} `)) continue;
     const tabIndex = record.indexOf("\t");
-    // header と path を分ける TAB が無いレコードは想定外フォーマット。silent skip すると
-    // 「submodule なのに普通のディレクトリで出る」形で無音退行するため観察ログを残す
-    if (tabIndex < 0) {
-      console.error(`[listGitlinks] record missing TAB separator: ${record} dir=${dir}`);
-      continue;
-    }
-    const [, hash] = record.slice(0, tabIndex).split(" ");
-    if (hash === undefined) {
-      console.error(`[listGitlinks] record missing object hash: ${record} dir=${dir}`);
-      continue;
-    }
-    gitlinks.set(basename(record.slice(tabIndex + 1)), hash);
+    if (tabIndex < 0) continue;
+    const [, hash = "", stage = ""] = record.slice(0, tabIndex).split(" ");
+    const rank = GITLINK_STAGE_RANK[stage];
+    if (rank === undefined || hash === "") continue;
+    const name = record.slice(tabIndex + 1);
+    const current = ranked.get(name);
+    if (current !== undefined && current.rank >= rank) continue;
+    ranked.set(name, { hash, rank });
   }
-  return gitlinks;
+  return new Map(Array.from(ranked, ([name, { hash }]) => [name, hash]));
+}
+
+/**
+ * gitlink 列挙の失敗を観察可能にする。失敗の帰結は「submodule が普通のディレクトリとして出る」で、
+ * 無音だと表示が退行したことに気づけない。
+ *
+ * 非 git プロジェクト（gozd は git 管理外の project も開ける）は列挙のたびに必ず失敗するため、
+ * それだけはログを出さない。exit 128 は git の「not a git repository」の規約。
+ */
+function logGitlinkFailure(dir: string, error: unknown): void {
+  if (error instanceof GitCommandError && error.exitCode === 128) return;
+  console.error(`[listGitlinks] ls-files failed: ${String(error)} dir=${dir}`);
 }
 
 /**

--- a/apps/electron/src/git/gitOps.ts
+++ b/apps/electron/src/git/gitOps.ts
@@ -3,7 +3,7 @@
 
 import { tryCatch } from "@gozd/shared";
 import { statSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { GitCommandError, runGit, runGitNonInteractive, runGitWithStdin } from "./gitRunner";
 import {
   parsePorcelainV2WithBranch,
@@ -50,6 +50,48 @@ export async function checkIgnore(dir: string, relPaths: string[]): Promise<Set<
   // not a git repo / no .gitignore 等は exit code != 0。無視されたパス無しとして扱う
   if (!result.ok) return new Set();
   return new Set(result.value.split("\0").filter((path) => path !== ""));
+}
+
+/** index 1 行の先頭に立つ gitlink の mode。この mode を持つ entry が submodule。 */
+const GITLINK_MODE = "160000";
+
+/**
+ * relDir 直下の submodule を「entry 名 → 指している commit hash」の Map で返す。
+ *
+ * 判定の SSOT は **index の gitlink**（mode `160000`）に置く。submodule の working tree は
+ * 未初期化なら中身の無いディレクトリで、初期化済みでも `.git` は readDir が除外する gitlink
+ * ファイルなので、ディスク側には初期化状態に依存しない手がかりが存在しない。`.gitmodules` は
+ * 「設定」であって実体ではなく、index に gitlink が無い記述も、記述の無い gitlink もあり得る。
+ *
+ * pathspec の `:(glob)` 修飾子は `*` が `/` を跨がなくなる効果を持つため、`<relDir>/*` で
+ * index 全体ではなく readDir が見ている 1 階層だけに絞れる。
+ * - `git ls-files --stage -z` の 1 レコードは `<mode> SP <object> SP <stage> TAB <path>`
+ * - 出力 path は repo root 相対。`dir` は worktree root なので relDir 相対に読み替えられる
+ * - git 管理外 / git 不在は空 Map を返す（checkIgnore と同じく throw しない）
+ */
+export async function listGitlinks(dir: string, relDir: string): Promise<Map<string, string>> {
+  const pathspec = relDir === "" ? ":(glob)*" : `:(glob)${relDir}/*`;
+  const result = await tryCatch(runGit(["ls-files", "--stage", "-z", "--", pathspec], dir));
+  // not a git repo / git 不在。submodule 無しとして扱う
+  if (!result.ok) return new Map();
+  const gitlinks = new Map<string, string>();
+  for (const record of result.value.split("\0")) {
+    if (!record.startsWith(`${GITLINK_MODE} `)) continue;
+    const tabIndex = record.indexOf("\t");
+    // header と path を分ける TAB が無いレコードは想定外フォーマット。silent skip すると
+    // 「submodule なのに普通のディレクトリで出る」形で無音退行するため観察ログを残す
+    if (tabIndex < 0) {
+      console.error(`[listGitlinks] record missing TAB separator: ${record} dir=${dir}`);
+      continue;
+    }
+    const [, hash] = record.slice(0, tabIndex).split(" ");
+    if (hash === undefined) {
+      console.error(`[listGitlinks] record missing object hash: ${record} dir=${dir}`);
+      continue;
+    }
+    gitlinks.set(basename(record.slice(tabIndex + 1)), hash);
+  }
+  return gitlinks;
 }
 
 /**

--- a/apps/electron/src/git/gitTree.test.ts
+++ b/apps/electron/src/git/gitTree.test.ts
@@ -46,6 +46,22 @@ describe("parseLsTree / typeFromGitMode", () => {
     ]);
   });
 
+  test("gitlink は submoduleHash を持ち、blob / tree は持たない", () => {
+    const text = [
+      "160000 commit b43b8944bfba4113233ccfc090f373a6e869dff6\tvendor/lib",
+      "100644 blob abc\ta.ts",
+      "",
+    ].join("\0");
+    expect(parseLsTree(text)).toEqual([
+      { name: "a.ts", type: "file" },
+      {
+        name: "lib",
+        type: "submodule",
+        submoduleHash: "b43b8944bfba4113233ccfc090f373a6e869dff6",
+      },
+    ]);
+  });
+
   test("TAB 欠落レコードは silent skip せず throw する", () => {
     expect(() => parseLsTree("100644 blob abc src/a.ts\0")).toThrow(/TAB separator/);
   });

--- a/apps/electron/src/git/gitTree.ts
+++ b/apps/electron/src/git/gitTree.ts
@@ -19,6 +19,9 @@ export interface FileChangeInfo {
 export interface GitTreeEntryInfo {
   name: string;
   type: string;
+  /** submodule（gitlink）が指す commit hash。`type === "submodule"` のときだけ設定する。
+   * blob / tree の object hash は表示にも取得にも使わないため載せない。 */
+  submoduleHash?: string;
 }
 
 /** git の well-known empty tree object hash（`git hash-object -t tree </dev/null`）。
@@ -233,7 +236,10 @@ export function parseLsTree(text: string): GitTreeEntryInfo[] {
     if (name === "") {
       throw new Error(`git ls-tree: empty basename in record: ${record}`);
     }
-    result.push({ name, type: typeFromGitMode(headerParts[0]) });
+    const type = typeFromGitMode(headerParts[0]);
+    result.push(
+      type === "submodule" ? { name, type, submoduleHash: headerParts[2] } : { name, type },
+    );
   }
   return result.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
 }

--- a/apps/electron/src/git/submodule.test.ts
+++ b/apps/electron/src/git/submodule.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { parseGitmodulesConfig } from "./submodule";
+
+/** `git config -z` の 1 レコード（`<key> LF <value>` を NUL 区切り）を組む */
+function records(...pairs: [key: string, value: string][]): string {
+  return pairs.map(([key, value]) => `${key}\n${value}\0`).join("");
+}
+
+describe("parseGitmodulesConfig", () => {
+  test("path / url を submodule 名ごとに畳む", () => {
+    const text = records(
+      ["submodule.lib.path", "vendor/lib"],
+      ["submodule.lib.url", "https://github.com/owner/lib"],
+    );
+    expect(parseGitmodulesConfig(text)).toEqual(
+      new Map([["lib", { path: "vendor/lib", url: "https://github.com/owner/lib" }]]),
+    );
+  });
+
+  test("name にドットを含んでも property だけを末尾から切り出す", () => {
+    // `.gitmodules` の name は既定で path と同じ文字列なので、パスのドットがそのまま name に入る
+    const text = records(
+      ["submodule.tests/_fixtures/npmx.dev.path", "tests/_fixtures/npmx.dev"],
+      ["submodule.tests/_fixtures/npmx.dev.url", "https://github.com/npmx-dev/npmx.dev"],
+    );
+    expect(parseGitmodulesConfig(text)).toEqual(
+      new Map([
+        [
+          "tests/_fixtures/npmx.dev",
+          { path: "tests/_fixtures/npmx.dev", url: "https://github.com/npmx-dev/npmx.dev" },
+        ],
+      ]),
+    );
+  });
+
+  test("path / url 以外の property は捨てる", () => {
+    const text = records(
+      ["submodule.lib.path", "vendor/lib"],
+      ["submodule.lib.shallow", "true"],
+      ["submodule.lib.branch", "main"],
+    );
+    expect(parseGitmodulesConfig(text)).toEqual(new Map([["lib", { path: "vendor/lib" }]]));
+  });
+
+  test("値に改行を含んでも最初の LF だけを区切りにする", () => {
+    const text = records(["submodule.lib.url", "https://example.com/a\nb"]);
+    expect(parseGitmodulesConfig(text)).toEqual(
+      new Map([["lib", { url: "https://example.com/a\nb" }]]),
+    );
+  });
+
+  test("submodule 以外の section と空出力は無視する", () => {
+    expect(parseGitmodulesConfig(records(["remote.origin.url", "https://example.com"]))).toEqual(
+      new Map(),
+    );
+    expect(parseGitmodulesConfig("")).toEqual(new Map());
+  });
+});

--- a/apps/electron/src/git/submodule.test.ts
+++ b/apps/electron/src/git/submodule.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseGitmodulesConfig } from "./submodule";
+import { parseGitmodulesConfig, resolveRelativeOwnerRepo } from "./submodule";
 
 /** `git config -z` の 1 レコード（`<key> LF <value>` を NUL 区切り）を組む */
 function records(...pairs: [key: string, value: string][]): string {
@@ -54,5 +54,29 @@ describe("parseGitmodulesConfig", () => {
       new Map(),
     );
     expect(parseGitmodulesConfig("")).toEqual(new Map());
+  });
+});
+
+describe("resolveRelativeOwnerRepo", () => {
+  const origin = { owner: "acme", repo: "super" };
+
+  test("`../` は superproject の repo 成分を落として同じ owner 配下を指す", () => {
+    expect(resolveRelativeOwnerRepo(origin, "../lib.git")).toEqual({ owner: "acme", repo: "lib" });
+    expect(resolveRelativeOwnerRepo(origin, "../lib")).toEqual({ owner: "acme", repo: "lib" });
+  });
+
+  test("`../../` は owner まで遡って別 owner を指せる", () => {
+    expect(resolveRelativeOwnerRepo(origin, "../../other/lib.git")).toEqual({
+      owner: "other",
+      repo: "lib",
+    });
+  });
+
+  test("`./` は下位への降下になり GitHub の owner/repo に収まらない", () => {
+    expect(resolveRelativeOwnerRepo(origin, "./lib.git")).toBeUndefined();
+  });
+
+  test("遡りすぎて 2 成分に満たない場合は解決しない", () => {
+    expect(resolveRelativeOwnerRepo(origin, "../../../lib.git")).toBeUndefined();
   });
 });

--- a/apps/electron/src/git/submodule.ts
+++ b/apps/electron/src/git/submodule.ts
@@ -33,11 +33,14 @@ interface GitmodulesEntry {
  *
  * undefined を返すのは以下すべて。呼び出し側は「リンク先が無い」ことをユーザーに伝える責務を持つ
  * （無音で不発にしない）:
- * - `.gitmodules` が読めない（不在 / 指定 revision に無い / git 管理外）
+ * - `relPath` / `hash` が空（呼び出し側が submodule 行以外を渡した場合のガード）
+ * - `.gitmodules` を読めない（不在 / 指定 revision に無い / 権限・構文エラー等の git 実行失敗。
+ *   正常系と異常系が exit code で切り分けられないため一律ログに残す）
  * - その path に対応する記述が無い
- * - url が非 github.com host
- * - 相対 url（gitmodules(5) の `./` / `../` 形式）で、superproject の origin が未設定 or
- *   非 github.com host、あるいは解決結果が `owner/repo` の 2 成分にならない
+ * - `parseGitHubOwnerRepo` が owner / repo を取り出せない url（非 github.com host / 想定外の形式）
+ * - 相対 url（gitmodules(5) の `./` / `../` 形式）で superproject の origin を解決できない
+ *   （未設定 / 非 github.com host / git 実行失敗）、あるいは解決結果が `owner/repo` の
+ *   2 成分にならない
  */
 export async function submoduleBrowseUrl(
   dir: string,
@@ -63,11 +66,18 @@ async function readSubmoduleUrl(
 ): Promise<string | undefined> {
   if (rev !== undefined) validateRev(rev);
   const source = rev === undefined ? ["--file", ".gitmodules"] : ["--blob", `${rev}:.gitmodules`];
-  // `.gitmodules` 不在 / 指定 revision に無い / git 管理外は exit code != 0。URL 無しとして扱う
   const result = await tryCatch(
     runGit(["config", "-z", ...source, "--get-regexp", "^submodule\\."], dir),
   );
-  if (!result.ok) return undefined;
+  // `.gitmodules` 不在 / 指定 revision に無い / マッチ無しといった正常系と、権限エラーのような
+  // 異常系がどちらも exit 1 に潰れて exit code では切り分けられない。URL 無しとして扱いつつ
+  // 全失敗をログに残す（submodule 行の click でしか走らないので出力は増えない）
+  if (!result.ok) {
+    console.error(
+      `[readSubmoduleUrl] .gitmodules read failed: ${String(result.error)} dir=${dir} rev=${rev ?? "(worktree)"}`,
+    );
+    return undefined;
+  }
   for (const entry of parseGitmodulesConfig(result.value).values()) {
     if (entry.path === relPath) return entry.url;
   }
@@ -78,7 +88,16 @@ async function readSubmoduleUrl(
 async function resolveOwnerRepo(dir: string, url: string): Promise<OwnerRepo | undefined> {
   if (!isRelativeUrl(url)) return parseGitHubOwnerRepo(url);
   const origin = await repoOwnerName(dir);
-  if (origin.kind !== "ok") return undefined;
+  // `repoOwnerName` は git の失敗を一律 `unsetRemote` に潰すため、origin 未設定（正常系）と
+  // 権限エラー等の実障害が呼び出し側で区別できない。`.gitmodules` 読みと同じ失敗クラスなので
+  // kind 付きで記録する（分類の是正は shared 側の話なので、ログは caller に置く）。
+  // この分岐に来る url は相対形式だけなので credential を含み得ず、そのままログに載せてよい
+  if (origin.kind !== "ok") {
+    console.error(
+      `[resolveOwnerRepo] origin unresolved: kind=${origin.kind} dir=${dir} url=${url}`,
+    );
+    return undefined;
+  }
   return resolveRelativeOwnerRepo(origin, url);
 }
 

--- a/apps/electron/src/git/submodule.ts
+++ b/apps/electron/src/git/submodule.ts
@@ -8,9 +8,14 @@
 // submodule として表示されること自体は変わらない。
 
 import { tryCatch } from "@gozd/shared";
-import { parseGitHubOwnerRepo } from "./github";
+import { parseGitHubOwnerRepo, repoOwnerName } from "./github";
 import { runGit } from "./gitRunner";
 import { validateRelPath, validateRev } from "./gitValidate";
+
+interface OwnerRepo {
+  owner: string;
+  repo: string;
+}
 
 /** `.gitmodules` の 1 submodule 分の設定 */
 interface GitmodulesEntry {
@@ -21,27 +26,92 @@ interface GitmodulesEntry {
 /**
  * submodule が指す commit の GitHub 閲覧 URL を返す。解決できなければ undefined。
  *
- * undefined になるのは `.gitmodules` に記述が無い / url が非 github.com host の場合。
- * 呼び出し側は「リンク先が無い」ことをユーザーに伝える責務を持つ（無音で不発にしない）。
+ * `rev` を渡すとその revision の `.gitmodules` blob を読む。filer の snapshot mode では hash が
+ * 過去 commit 由来なので、url を working tree の `.gitmodules` から引くと、同じ path の submodule
+ * が commit 間で別 repo に差し替わっていた場合に「実在する別 repo の URL に過去の hash」という
+ * 誤リンクになる。
+ *
+ * undefined を返すのは以下すべて。呼び出し側は「リンク先が無い」ことをユーザーに伝える責務を持つ
+ * （無音で不発にしない）:
+ * - `.gitmodules` が読めない（不在 / 指定 revision に無い / git 管理外）
+ * - その path に対応する記述が無い
+ * - url が非 github.com host
+ * - 相対 url（gitmodules(5) の `./` / `../` 形式）で、superproject の origin が未設定 or
+ *   非 github.com host、あるいは解決結果が `owner/repo` の 2 成分にならない
  */
 export async function submoduleBrowseUrl(
   dir: string,
   relPath: string,
   hash: string,
+  rev?: string,
 ): Promise<string | undefined> {
   validateRelPath(relPath);
   validateRev(hash);
   if (relPath === "" || hash === "") return undefined;
-  // `.gitmodules` 不在 / git 管理外は exit code != 0。URL 無しとして扱う
+  const url = await readSubmoduleUrl(dir, relPath, rev);
+  if (url === undefined) return undefined;
+  const target = await resolveOwnerRepo(dir, url);
+  if (target === undefined) return undefined;
+  return `https://github.com/${target.owner}/${target.repo}/tree/${hash}`;
+}
+
+/** `.gitmodules` から path に対応する url を読む。読めなければ undefined */
+async function readSubmoduleUrl(
+  dir: string,
+  relPath: string,
+  rev: string | undefined,
+): Promise<string | undefined> {
+  if (rev !== undefined) validateRev(rev);
+  const source = rev === undefined ? ["--file", ".gitmodules"] : ["--blob", `${rev}:.gitmodules`];
+  // `.gitmodules` 不在 / 指定 revision に無い / git 管理外は exit code != 0。URL 無しとして扱う
   const result = await tryCatch(
-    runGit(["config", "-z", "--file", ".gitmodules", "--get-regexp", "^submodule\\."], dir),
+    runGit(["config", "-z", ...source, "--get-regexp", "^submodule\\."], dir),
   );
   if (!result.ok) return undefined;
-  const url = findSubmoduleUrl(parseGitmodulesConfig(result.value), relPath);
-  if (url === undefined) return undefined;
-  const parsed = parseGitHubOwnerRepo(url);
-  if (parsed === undefined) return undefined;
-  return `https://github.com/${parsed.owner}/${parsed.repo}/tree/${hash}`;
+  for (const entry of parseGitmodulesConfig(result.value).values()) {
+    if (entry.path === relPath) return entry.url;
+  }
+  return undefined;
+}
+
+/** url を GitHub の owner / repo に解決する。相対 url は superproject の origin を基準にする */
+async function resolveOwnerRepo(dir: string, url: string): Promise<OwnerRepo | undefined> {
+  if (!isRelativeUrl(url)) return parseGitHubOwnerRepo(url);
+  const origin = await repoOwnerName(dir);
+  if (origin.kind !== "ok") return undefined;
+  return resolveRelativeOwnerRepo(origin, url);
+}
+
+/** gitmodules(5) が定める相対 url か（superproject の origin からの相対位置を表す） */
+function isRelativeUrl(url: string): boolean {
+  return url.startsWith("./") || url.startsWith("../");
+}
+
+/**
+ * 相対 url を superproject の owner / repo に対して解決する。
+ *
+ * git 本体の `resolve_relative_url` と同じく `../` 1 つで末尾 1 成分を落とし、`./` は現在位置と
+ * して読み飛ばす。`owner/repo` の 2 成分に収まらない結果（`./lib` のような下位への降下や、
+ * `../` の行き過ぎ）は GitHub 上に対応するページが無いため undefined を返す。
+ */
+export function resolveRelativeOwnerRepo(
+  origin: OwnerRepo,
+  relativeUrl: string,
+): OwnerRepo | undefined {
+  const parts = [origin.owner, origin.repo];
+  for (const segment of relativeUrl.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      parts.pop();
+      continue;
+    }
+    parts.push(segment);
+  }
+  if (parts.length !== 2) return undefined;
+  const [owner = "", repo = ""] = parts;
+  const name = repo.endsWith(".git") ? repo.slice(0, -".git".length) : repo;
+  if (owner === "" || name === "") return undefined;
+  return { owner, repo: name };
 }
 
 /**
@@ -73,16 +143,4 @@ export function parseGitmodulesConfig(text: string): Map<string, GitmodulesEntry
     entries.set(name, { ...entry, [property]: value });
   }
   return entries;
-}
-
-/** path が一致する submodule の url を返す。name ではなく path で引くのは、filer が持つのが
- * ツリー上の相対パスであり、name は `.gitmodules` 側の任意ラベルでしかないため */
-function findSubmoduleUrl(
-  entries: Map<string, GitmodulesEntry>,
-  relPath: string,
-): string | undefined {
-  for (const entry of entries.values()) {
-    if (entry.path === relPath) return entry.url;
-  }
-  return undefined;
 }

--- a/apps/electron/src/git/submodule.ts
+++ b/apps/electron/src/git/submodule.ts
@@ -1,0 +1,88 @@
+// submodule の閲覧 URL 解決。filer の submodule 行から「その submodule の repo ページ」へ
+// 飛ぶために使う。
+//
+// path → url の対応は `.gitmodules` にしか無い（index の gitlink は commit hash しか持たない）。
+// 一方 filer の submodule 判定は index の gitlink が SSOT で、`.gitmodules` は参照しない。
+// 2 つの出所を分けているのは役割が違うため: index は「submodule か」と「どの commit か」、
+// `.gitmodules` は「どこから取ってくるか」を持つ。記述の無い gitlink は URL が解決できないだけで
+// submodule として表示されること自体は変わらない。
+
+import { tryCatch } from "@gozd/shared";
+import { parseGitHubOwnerRepo } from "./github";
+import { runGit } from "./gitRunner";
+import { validateRelPath, validateRev } from "./gitValidate";
+
+/** `.gitmodules` の 1 submodule 分の設定 */
+interface GitmodulesEntry {
+  path?: string;
+  url?: string;
+}
+
+/**
+ * submodule が指す commit の GitHub 閲覧 URL を返す。解決できなければ undefined。
+ *
+ * undefined になるのは `.gitmodules` に記述が無い / url が非 github.com host の場合。
+ * 呼び出し側は「リンク先が無い」ことをユーザーに伝える責務を持つ（無音で不発にしない）。
+ */
+export async function submoduleBrowseUrl(
+  dir: string,
+  relPath: string,
+  hash: string,
+): Promise<string | undefined> {
+  validateRelPath(relPath);
+  validateRev(hash);
+  if (relPath === "" || hash === "") return undefined;
+  // `.gitmodules` 不在 / git 管理外は exit code != 0。URL 無しとして扱う
+  const result = await tryCatch(
+    runGit(["config", "-z", "--file", ".gitmodules", "--get-regexp", "^submodule\\."], dir),
+  );
+  if (!result.ok) return undefined;
+  const url = findSubmoduleUrl(parseGitmodulesConfig(result.value), relPath);
+  if (url === undefined) return undefined;
+  const parsed = parseGitHubOwnerRepo(url);
+  if (parsed === undefined) return undefined;
+  return `https://github.com/${parsed.owner}/${parsed.repo}/tree/${hash}`;
+}
+
+/**
+ * `git config -z --get-regexp` の出力を submodule 名ごとの設定に畳む。
+ *
+ * `-z` の 1 レコードは `<key> LF <value>` で NUL 区切り。値に改行を含み得るため
+ * 最初の LF だけを区切りとして扱う。key は `submodule.<name>.<property>` で、**name 自身が
+ * `.` を含み得る**（`.gitmodules` の name は既定で path と同じ文字列なので、パスにドットが
+ * あればそのまま入る）ため、property は末尾の `.` から切り出す。
+ */
+export function parseGitmodulesConfig(text: string): Map<string, GitmodulesEntry> {
+  const entries = new Map<string, GitmodulesEntry>();
+  for (const record of text.split("\0")) {
+    if (record === "") continue;
+    const lineFeed = record.indexOf("\n");
+    // 値を持たない key（`.gitmodules` に `submodule.x.path` だけ書いて値が空等）は
+    // path / url のどちらにもならないので読み飛ばす
+    if (lineFeed < 0) continue;
+    const key = record.slice(0, lineFeed);
+    const value = record.slice(lineFeed + 1);
+    if (!key.startsWith("submodule.")) continue;
+    const rest = key.slice("submodule.".length);
+    const lastDot = rest.lastIndexOf(".");
+    if (lastDot < 0) continue;
+    const name = rest.slice(0, lastDot);
+    const property = rest.slice(lastDot + 1);
+    if (property !== "path" && property !== "url") continue;
+    const entry = entries.get(name) ?? {};
+    entries.set(name, { ...entry, [property]: value });
+  }
+  return entries;
+}
+
+/** path が一致する submodule の url を返す。name ではなく path で引くのは、filer が持つのが
+ * ツリー上の相対パスであり、name は `.gitmodules` 側の任意ラベルでしかないため */
+function findSubmoduleUrl(
+  entries: Map<string, GitmodulesEntry>,
+  relPath: string,
+): string | undefined {
+  for (const entry of entries.values()) {
+    if (entry.path === relPath) return entry.url;
+  }
+  return undefined;
+}

--- a/apps/electron/src/routes.ts
+++ b/apps/electron/src/routes.ts
@@ -795,7 +795,7 @@ async function handleGitLsTree(body: unknown): Promise<unknown> {
 async function handleGitSubmoduleUrl(body: unknown): Promise<unknown> {
   const req = body as GitSubmoduleUrlRequest;
   return {
-    url: await submoduleBrowseUrl(req.dir, req.path, req.hash),
+    url: await submoduleBrowseUrl(req.dir, req.path, req.hash, req.rev),
   } satisfies GitSubmoduleUrlResponse;
 }
 

--- a/apps/electron/src/routes.ts
+++ b/apps/electron/src/routes.ts
@@ -85,6 +85,8 @@ import type {
   GitShowFileResponse,
   GitStatusRequest,
   GitStatusResponse,
+  GitSubmoduleUrlRequest,
+  GitSubmoduleUrlResponse,
   GitViewerRequest,
   GitViewerResponse,
   GitWorktreeListRequest,
@@ -187,6 +189,7 @@ import { fetchRemotes, gitStatusFull, worktreeList } from "./git/gitOps";
 import { GitCommandError } from "./git/gitRunner";
 import type { StatusFull } from "./git/porcelain";
 import { issueList, prList, repoOwnerName, viewer } from "./git/github";
+import { submoduleBrowseUrl } from "./git/submodule";
 import { buildPtyEnv } from "./gozdEnv";
 import { buildGozdOpenPayload } from "./openTarget";
 import {
@@ -789,6 +792,13 @@ async function handleGitLsTree(body: unknown): Promise<unknown> {
   return { entries: await lsTree(req.dir, req.hash, req.path) } satisfies GitLsTreeResponse;
 }
 
+async function handleGitSubmoduleUrl(body: unknown): Promise<unknown> {
+  const req = body as GitSubmoduleUrlRequest;
+  return {
+    url: await submoduleBrowseUrl(req.dir, req.path, req.hash),
+  } satisfies GitSubmoduleUrlResponse;
+}
+
 async function handleGitLsFiles(body: unknown): Promise<unknown> {
   const req = body as GitLsFilesRequest;
   return { files: await lsFiles(req.dir) } satisfies GitLsFilesResponse;
@@ -1192,6 +1202,7 @@ export const routes: ReadonlyMap<string, RpcHandler> = new Map<string, RpcHandle
   ["/git/readBlob", handleGitReadBlob],
   ["/git/lsFiles", handleGitLsFiles],
   ["/git/lsTree", handleGitLsTree],
+  ["/git/submoduleUrl", handleGitSubmoduleUrl],
   ["/git/blameLine", handleGitBlameLine],
   ["/git/logLine", handleGitLogLine],
   ["/git/logFile", handleGitLogFile],

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -272,7 +272,6 @@ async function toggle(event: MouseEvent) {
     await openSubmoduleRepo();
     return;
   }
-  // gitShowCommitFile 等で内容を取れない葉は preview にも流さない
   if (isInertLeaf.value) return;
   emit("select", props.path);
 }

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -14,8 +14,9 @@
 - `symlink`: 実体を持たない symlink のみこの kind に来る（working tree の dangling / 循環、
   snapshot tree の symlink blob）。working tree では `select` emit（preview が not found を出す）、
   snapshot mode では blob 内容が target path 文字列でしかないため click を no-op に倒す
-- `submodule`: 常に no-op。gitlink object (`160000`) は `gitShowCommitFile` で内容を取得できないため
-  preview に流すとエラーになる。視覚的にも opacity を落として「click できない」ことを示す
+- `submodule`: gitlink (`160000`) が pin している commit の repo ページを外部ブラウザで開く。
+  展開はしない（配下は別 repo の管理下で、親 repo の status / gitignore では語れないため）。
+  右端に短縮 hash を出す（GitHub と同じ情報を、名前の truncate に飲まれない位置に置く）
 
 ## symlink
 
@@ -90,8 +91,8 @@ import {
   toFileEntriesFromGitTree,
 } from "./filerUtils";
 import type { FileEntry, FileEntryKind, FileRealTarget } from "./filerUtils";
-import { rpcFsReadDir, rpcGitLsTree } from "./rpc";
-import { getFileIconUrl, getFolderIconUrl } from "./useFileIcon";
+import { rpcFsReadDir, rpcGitLsTree, rpcGitSubmoduleUrl, rpcOpenExternal } from "./rpc";
+import { getFileIconUrl, getFolderIconUrl, getSubmoduleIconUrl } from "./useFileIcon";
 import { useFilerEventStore } from "./useFilerEventStore";
 import IconLucideChevronDown from "~icons/lucide/chevron-down";
 import IconLucideChevronRight from "~icons/lucide/chevron-right";
@@ -115,6 +116,8 @@ const props = defineProps<{
   isSymlink?: boolean;
   /** 実体の在り処。右クリック menu の実体向け項目の対象 */
   realTarget?: FileRealTarget;
+  /** submodule が指す commit hash。`kind === "submodule"` の行だけが持つ */
+  submoduleHash?: string;
   /** working tree モード由来の gitignore フラグ。snapshot mode では undefined */
   isIgnored?: boolean;
   /** ファイル自身の git 変更種別 */
@@ -157,16 +160,17 @@ const filerEventStore = useFilerEventStore();
 
 const isRoot = computed(() => isRootPath(props.path));
 const isDirectory = computed(() => props.kind === "directory");
+const isSubmodule = computed(() => props.kind === "submodule");
 const isSnapshot = computed(() => props.snapshotHash !== undefined);
 /**
- * click で何も起きない葉。`gitShowCommitFile` で内容を取得できない (submodule) / snapshot
- * 環境で意味のある内容を取れない (symlink in snapshot) ものを構造的に弾く。
+ * click で何も起きない葉。snapshot tree の symlink は blob の中身が target path 文字列でしか
+ * なく、preview に流しても意味のある内容にならない。
  */
-const isInertLeaf = computed(() => {
-  if (props.kind === "submodule") return true;
-  if (props.kind === "symlink" && isSnapshot.value) return true;
-  return false;
-});
+const isInertLeaf = computed(() => props.kind === "symlink" && isSnapshot.value);
+
+/** GitHub の submodule 表示に合わせた短縮 hash */
+const SHORT_HASH_LENGTH = 7;
+const shortSubmoduleHash = computed(() => props.submoduleHash?.slice(0, SHORT_HASH_LENGTH));
 
 const buttonRef = useTemplateRef<HTMLButtonElement>("button");
 const expanded = ref(isRoot.value);
@@ -234,7 +238,7 @@ const isDeleted = computed(() => !isSnapshot.value && props.gitChange === "delet
  * snapshot tree では blob が target path 文字列でしかないことを指す。
  */
 const rowTitle = computed(() => {
-  if (props.kind === "submodule") return "submodule (not previewable)";
+  if (isSubmodule.value) return `submodule @ ${props.submoduleHash} (open repository)`;
   if (props.kind === "symlink") return isSnapshot.value ? "symlink" : "broken symlink";
   if (props.isSymlink === true) return "symlink";
   return undefined;
@@ -242,6 +246,7 @@ const rowTitle = computed(() => {
 
 /** material-icon-theme のアイコン URL */
 const iconUrl = computed(() => {
+  if (isSubmodule.value) return getSubmoduleIconUrl();
   if (isDirectory.value) {
     return getFolderIconUrl(props.name, expanded.value);
   }
@@ -263,9 +268,39 @@ async function toggle(event: MouseEvent) {
     }
     return;
   }
+  if (isSubmodule.value) {
+    await openSubmoduleRepo();
+    return;
+  }
   // gitShowCommitFile 等で内容を取れない葉は preview にも流さない
   if (isInertLeaf.value) return;
   emit("select", props.path);
+}
+
+/**
+ * submodule 行の click。GitHub の submodule 表示と同じく、gitlink が pin している commit の
+ * repo ページを外部ブラウザで開く。
+ *
+ * URL の出所は `.gitmodules` で、submodule 判定に使う index の gitlink には含まれない。
+ * リンクを踏むときにしか要らないため列挙時ではなく click 時に引く。解決できないケース
+ * (`.gitmodules` に記述が無い / 非 github.com host) は無音の不発にせず通知で示す。
+ */
+async function openSubmoduleRepo() {
+  const dir = worktreeStore.dir;
+  if (dir === undefined || props.submoduleHash === undefined) return;
+  const result = await tryCatch(
+    rpcGitSubmoduleUrl({ dir, path: props.path, hash: props.submoduleHash }),
+  );
+  if (!result.ok) {
+    notify.error(`Failed to resolve submodule repository: ${props.path}`, result.error);
+    return;
+  }
+  const { url } = result.value;
+  if (url === undefined) {
+    notify.info(`No GitHub repository URL for submodule: ${props.path}`);
+    return;
+  }
+  void rpcOpenExternal({ url });
 }
 
 async function loadChildren() {
@@ -472,8 +507,10 @@ function onChildSelect(childPath: string) {
  * 右クリック。directory / file どちらも実体 path を持つ行は menu 対象にする。inert leaf のみ除外。
  *
  * - directory / file: menu 対象 (実 filesystem path として絶対 path を copy する)
- * - inert leaf (submodule / snapshot symlink): 早期 return (snapshot 時点と working tree の
- *   実体が一致しないため、working tree の絶対 path を誤って copy 可能にする UI を排除)
+ * - snapshot symlink: 早期 return (snapshot 時点と working tree の実体が一致しないため、
+ *   working tree の絶対 path を誤って copy 可能にする UI を排除)
+ * - submodule: 早期 return。行が指すのは別 repo の境界で、menu の項目はどれもツリー上の path を
+ *   親 repo 内のファイルとして扱うもの
  *
  * commitHash は navigator が `useGitGraphStore.contextMenuHash` で SSOT 解決するため payload
  * には乗せない (filer の `snapshotHash` は filer ツリー表示用なので copy 経路と分離する)。
@@ -482,7 +519,7 @@ function onChildSelect(childPath: string) {
  * payload を作って emit するだけ。
  */
 function onContextMenu(event: MouseEvent) {
-  if (isInertLeaf.value) return;
+  if (isInertLeaf.value || isSubmodule.value) return;
   if (!(event.currentTarget instanceof HTMLElement)) return;
   event.preventDefault();
   emit("contextMenu", {
@@ -533,7 +570,12 @@ function onContextMenu(event: MouseEvent) {
           class="absolute -right-0.5 -bottom-0.5 size-3 rounded-full bg-background text-info"
         />
       </span>
-      <span class="truncate">{{ name }}</span>
+      <span class="grow truncate">{{ name }}</span>
+      <!-- submodule が pin している commit。GitHub の `name @ hash` と同じ情報だが、幅の狭い
+           ツリーでは名前に続けると truncate に飲まれるため右端に固定する -->
+      <span v-if="isSubmodule" class="shrink-0 font-mono text-xs text-foreground-low">
+        {{ shortSubmoduleHash }}
+      </span>
     </button>
 
     <!-- 子エントリ -->
@@ -553,6 +595,7 @@ function onContextMenu(event: MouseEvent) {
         :kind="child.kind"
         :is-symlink="child.isSymlink"
         :real-target="child.realTarget"
+        :submodule-hash="child.submoduleHash"
         :is-ignored="child.isIgnored"
         :git-change="child.gitChange"
         :git-statuses="gitStatuses"

--- a/apps/renderer/src/features/filer/FileTreeItem.vue
+++ b/apps/renderer/src/features/filer/FileTreeItem.vue
@@ -282,25 +282,35 @@ async function toggle(event: MouseEvent) {
  * repo ページを外部ブラウザで開く。
  *
  * URL の出所は `.gitmodules` で、submodule 判定に使う index の gitlink には含まれない。
- * リンクを踏むときにしか要らないため列挙時ではなく click 時に引く。解決できないケース
- * (`.gitmodules` に記述が無い / 非 github.com host) は無音の不発にせず通知で示す。
+ * リンクを踏むときにしか要らないため列挙時ではなく click 時に引く。解決できないケースは
+ * 無音の不発にせず通知で示す (解決できない条件の SSOT は main 側 `submoduleBrowseUrl`)。
+ *
+ * snapshot mode では `rev` に表示中の commit を渡し、hash と同じ revision の `.gitmodules` から
+ * url を引かせる。path → url の対応は commit 間で変わり得るので、working tree の対応を過去の
+ * hash に重ねると別 repo を指す誤リンクになる。
  */
 async function openSubmoduleRepo() {
   const dir = worktreeStore.dir;
   if (dir === undefined || props.submoduleHash === undefined) return;
-  const result = await tryCatch(
-    rpcGitSubmoduleUrl({ dir, path: props.path, hash: props.submoduleHash }),
+  const resolved = await tryCatch(
+    rpcGitSubmoduleUrl({
+      dir,
+      path: props.path,
+      hash: props.submoduleHash,
+      rev: props.snapshotHash,
+    }),
   );
-  if (!result.ok) {
-    notify.error(`Failed to resolve submodule repository: ${props.path}`, result.error);
+  if (!resolved.ok) {
+    notify.error(`Failed to resolve submodule repository: ${props.path}`, resolved.error);
     return;
   }
-  const { url } = result.value;
+  const { url } = resolved.value;
   if (url === undefined) {
     notify.info(`No GitHub repository URL for submodule: ${props.path}`);
     return;
   }
-  void rpcOpenExternal({ url });
+  const opened = await tryCatch(rpcOpenExternal({ url }));
+  if (!opened.ok) notify.error(`Failed to open ${url}`, opened.error);
 }
 
 async function loadChildren() {
@@ -509,8 +519,9 @@ function onChildSelect(childPath: string) {
  * - directory / file: menu 対象 (実 filesystem path として絶対 path を copy する)
  * - snapshot symlink: 早期 return (snapshot 時点と working tree の実体が一致しないため、
  *   working tree の絶対 path を誤って copy 可能にする UI を排除)
- * - submodule: 早期 return。行が指すのは別 repo の境界で、menu の項目はどれもツリー上の path を
- *   親 repo 内のファイルとして扱うもの
+ * - submodule: 早期 return。行が表すのは親 repo 内のファイルではなく repo 境界の外にある別 repo
+ *   への参照で、click も外部コンテキストへ出る動作に倒してある (GitHub の submodule 行が
+ *   `<a>` であるのと同じ位置づけ)。行の対象が外部である以上、この repo のファイル操作は載せない
  *
  * commitHash は navigator が `useGitGraphStore.contextMenuHash` で SSOT 解決するため payload
  * には乗せない (filer の `snapshotHash` は filer ツリー表示用なので copy 経路と分離する)。

--- a/apps/renderer/src/features/filer/filerUtils.test.ts
+++ b/apps/renderer/src/features/filer/filerUtils.test.ts
@@ -39,10 +39,10 @@ describe("sortEntries", () => {
     expect(sorted[1]?.name).toBe("a.txt");
   });
 
-  test("symlink / submodule は file 同列扱い (directory より後)", () => {
+  test("submodule は directory 区画、実体なし symlink は file 同列", () => {
     const entries = [submodule("vendor"), symlink("link"), dir("src"), file("a.txt")];
     const sorted = sortEntries(entries);
-    expect(sorted.map((e) => e.name)).toEqual(["src", "a.txt", "link", "vendor"]);
+    expect(sorted.map((e) => e.name)).toEqual(["src", "vendor", "a.txt", "link"]);
   });
 
   test("同種内では名前順にソートする", () => {
@@ -240,6 +240,15 @@ describe("toFileEntries", () => {
     expect(result[0]?.realTarget).toBeUndefined();
   });
 
+  test("type === 'submodule' は kind と submoduleHash を引き継ぐ", () => {
+    const result = toFileEntries([
+      { name: "lib", type: "submodule", submoduleHash: "abc123", isIgnored: false },
+    ]);
+    expect(result[0]?.kind).toBe("submodule");
+    expect(result[0]?.submoduleHash).toBe("abc123");
+    expect(result[0]?.isSymlink).toBe(false);
+  });
+
   test("空配列を処理できる", () => {
     expect(toFileEntries([])).toEqual([]);
   });
@@ -263,9 +272,12 @@ describe("toFileEntriesFromGitTree", () => {
     expect(result[0]?.isSymlink).toBe(true);
   });
 
-  test("type === 'submodule' は kind: 'submodule' になる", () => {
-    const result = toFileEntriesFromGitTree([{ name: "vendor", type: "submodule" }]);
+  test("type === 'submodule' は kind: 'submodule' になり submoduleHash を引き継ぐ", () => {
+    const result = toFileEntriesFromGitTree([
+      { name: "vendor", type: "submodule", submoduleHash: "def456" },
+    ]);
     expect(result[0]?.kind).toBe("submodule");
+    expect(result[0]?.submoduleHash).toBe("def456");
   });
 
   test("未知の type は kind: 'file' に倒れる (forward compat)", () => {

--- a/apps/renderer/src/features/filer/filerUtils.ts
+++ b/apps/renderer/src/features/filer/filerUtils.ts
@@ -9,8 +9,8 @@ import type { GitChangeKind } from "../worktree";
  *   symlink は辿った先の種別でこの 2 つに解決される（dir symlink を leaf に潰さないため）
  * - `symlink`: 実体を持たない symlink。working tree では dangling / 循環、snapshot tree では
  *   blob 内容が target path 文字列でしかない（後者は click を no-op に倒す。FileTreeItem 側で判定）
- * - `submodule`: gitlink object (`160000`)。git show <hash>:<path> では内容を返せないため
- *   常に no-op
+ * - `submodule`: gitlink object (`160000`)。別 repo の実体を指すポインタでしかなく、親 repo の
+ *   status / gitignore で配下を語れないため展開させない葉として扱う（working / snapshot 共通）
  */
 type FileEntryKind = "file" | "directory" | "symlink" | "submodule";
 
@@ -41,6 +41,11 @@ interface FileEntry {
   /** 実体の在り処。ツリー上のパスと一致する / 実体を解決できない場合は undefined */
   realTarget?: FileRealTarget;
   /**
+   * submodule が指す commit hash。`kind === "submodule"` のときだけ持つ。
+   * working tree では index の gitlink、snapshot では tree の gitlink object。
+   */
+  submoduleHash?: string;
+  /**
    * gitignore に該当するか。working tree mode 由来のみ意味があり、snapshot mode では
    * 概念自体が存在しないため undefined になる。`isIgnored === true` のときだけ "ignored" の
    * 視覚処理を入れる比較規約 (`=== true` 明示) を呼び出し側で守る。
@@ -61,6 +66,7 @@ function fsEntryToKind(entry: FsReadDirEntry): FileEntryKind {
     if (entry.realTarget === undefined) return "symlink";
     return entry.realTarget.type === "directory" ? "directory" : "file";
   }
+  if (entry.type === "submodule") return "submodule";
   return entry.type === "directory" ? "directory" : "file";
 }
 
@@ -128,6 +134,7 @@ function toFileEntries(entries: FsReadDirEntry[]): FileEntry[] {
             relPath: e.realTarget.relPath,
             isDirectory: e.realTarget.type === "directory",
           },
+    submoduleHash: e.submoduleHash,
     isIgnored: e.isIgnored,
   }));
 }
@@ -141,6 +148,7 @@ function toFileEntriesFromGitTree(entries: GitTreeEntry[]): FileEntry[] {
     name: e.name,
     kind: gitTreeTypeToKind(e.type),
     isSymlink: e.type === "symlink",
+    submoduleHash: e.submoduleHash,
   }));
 }
 
@@ -185,14 +193,25 @@ function isDescendantOf(targetPath: string, ancestorPath: string): boolean {
   return targetPath.startsWith(ancestorPath + "/");
 }
 
-/** ディレクトリ優先 → 名前順 */
+/**
+ * ディレクトリ優先 → 名前順。
+ *
+ * submodule は展開できない葉だが、ディスク上はディレクトリが占める位置にあるため
+ * ディレクトリ群と同じ区画に置く（GitHub / VS Code の並びも同じ）。実体を解決できない
+ * symlink だけはディレクトリと断定できないので file 側に残す。
+ */
 function sortEntries(entries: FileEntry[]): FileEntry[] {
   return [...entries].sort((a, b) => {
-    const aDir = a.kind === "directory";
-    const bDir = b.kind === "directory";
+    const aDir = isDirectorySlot(a.kind);
+    const bDir = isDirectorySlot(b.kind);
     if (aDir !== bDir) return aDir ? -1 : 1;
     return a.name.localeCompare(b.name);
   });
+}
+
+/** 並び順でディレクトリ区画に属する kind か */
+function isDirectorySlot(kind: FileEntryKind): boolean {
+  return kind === "directory" || kind === "submodule";
 }
 
 export {

--- a/apps/renderer/src/features/filer/rpc.ts
+++ b/apps/renderer/src/features/filer/rpc.ts
@@ -23,6 +23,10 @@ import {
   FsWriteFileResponse,
   GitLsTreeRequest,
   GitLsTreeResponse,
+  GitSubmoduleUrlRequest,
+  GitSubmoduleUrlResponse,
+  OpenExternalRequest,
+  OpenExternalResponse,
   OpenFileRequest,
   OpenFileResponse,
 } from "@gozd/rpc";
@@ -34,6 +38,15 @@ export const rpcFsReadDir = (req: FsReadDirRequest) => rpc<FsReadDirResponse>("/
 // snapshot mode (git-graph でコミット選択中) の filer が呼ぶ。
 // hash 必須。空文字は main 側で reject される。
 export const rpcGitLsTree = (req: GitLsTreeRequest) => rpc<GitLsTreeResponse>("/git/lsTree", req);
+
+// submodule 行 click が呼ぶ。`.gitmodules` に記述が無い / 非 github.com host なら url 未設定で返る
+// （呼び出し側が「リンク先が無い」ことを通知する責務を持つ）。
+export const rpcGitSubmoduleUrl = (req: GitSubmoduleUrlRequest) =>
+  rpc<GitSubmoduleUrlResponse>("/git/submoduleUrl", req);
+
+/** URL を OS のデフォルトブラウザで開く。scheme allowlist は main 側の防壁。 */
+export const rpcOpenExternal = (req: OpenExternalRequest) =>
+  rpc<OpenExternalResponse>("/open/external", req);
 
 export const rpcFsReadFile = (req: FsReadFileRequest) =>
   rpc<FsReadFileResponse>("/fs/readFile", req);

--- a/apps/renderer/src/features/filer/useFileIcon.ts
+++ b/apps/renderer/src/features/filer/useFileIcon.ts
@@ -242,4 +242,17 @@ function getFolderIconUrl(folderName: string, isOpen: boolean): string {
   return requireIconUrl(maps.iconUrlByName, resolveFolderIconName(maps, folderName, isOpen));
 }
 
-export { getFileIconUrl, getFolderIconUrl };
+/**
+ * submodule 行のアイコン名。material-icon-theme は submodule を種別として持たない
+ * （VS Code 側は decoration provider が担うため）。テーマ内で最も近い語彙は `submodules` という
+ * 名前のフォルダに割り当てられた `folder-git` で、これを種別アイコンとして借用する。
+ */
+const SUBMODULE_ICON_NAME = "folder-git";
+
+/** submodule の SVG URL を返す。名前ではなく種別で決まるため引数を取らない */
+function getSubmoduleIconUrl(): string {
+  const maps = getIconMaps();
+  return requireIconUrl(maps.iconUrlByName, SUBMODULE_ICON_NAME);
+}
+
+export { getFileIconUrl, getFolderIconUrl, getSubmoduleIconUrl };

--- a/apps/renderer/src/features/filer/useFileIcon.ts
+++ b/apps/renderer/src/features/filer/useFileIcon.ts
@@ -243,16 +243,21 @@ function getFolderIconUrl(folderName: string, isOpen: boolean): string {
 }
 
 /**
- * submodule 行のアイコン名。material-icon-theme は submodule を種別として持たない
- * （VS Code 側は decoration provider が担うため）。テーマ内で最も近い語彙は `submodules` という
- * 名前のフォルダに割り当てられた `folder-git` で、これを種別アイコンとして借用する。
+ * submodule 行のアイコンとして借用する folder 名。material-icon-theme は submodule を種別として
+ * 持たない（VS Code 側は decoration provider が担うため）ので、テーマ内で最も近い語彙である
+ * この名前の folder 割り当てを引く。アイコン名を焼き込まず folder 名から引くことで、テーマが
+ * 割り当てを差し替えても追従する。
  */
-const SUBMODULE_ICON_NAME = "folder-git";
+const SUBMODULE_FOLDER_NAME = "submodules";
 
-/** submodule の SVG URL を返す。名前ではなく種別で決まるため引数を取らない */
+/** submodule の SVG URL を返す。entry 名ではなく種別で決まるため引数を取らない */
 function getSubmoduleIconUrl(): string {
   const maps = getIconMaps();
-  return requireIconUrl(maps.iconUrlByName, SUBMODULE_ICON_NAME);
+  const iconName = maps.folderNameMap.get(SUBMODULE_FOLDER_NAME);
+  if (iconName === undefined) {
+    throw new Error(`icon theme has no folder icon for "${SUBMODULE_FOLDER_NAME}"`);
+  }
+  return requireIconUrl(maps.iconUrlByName, iconName);
 }
 
 export { getFileIconUrl, getFolderIconUrl, getSubmoduleIconUrl };

--- a/docs/filer.md
+++ b/docs/filer.md
@@ -168,9 +168,8 @@ submodule は「別 repo を指すポインタ」であり、親 repo の filer 
 - gitlink の path がディスク上 file / symlink になっている食い違い状態は実体側の種別を優先する。ディスクの種別は常に lstat が SSOT で、index は「submodule として登録されているか」だけを足す
 - 列挙が symlink 越しに worktree 外を見ている場合は問い合わせを落とす（当該 repo の index の管轄外。`ignoreSpec` が dir 外を落とすのと同じ規律）
 - anchor は cwd を所有する repo なので、worktree 内に独立した nested repo があればその index を見る。ツリーが写しているディスクの実体としては妥当
-- 列挙の失敗を無音にする条件は exit 128。非 git project は列挙のたびに必ず失敗するため除いているが、128 は git の汎用 fatal で not-a-repo 専用ではなく、index 破損のような本物の障害もここで無音になる。stderr 文字列で絞る案は取らない（git のメッセージは翻訳対象で、git 実行 env はユーザーの locale をそのまま継承するため）
 - 並び順はディレクトリ区画に置く。展開できない葉だが、ディスク上はディレクトリが占める位置にある
-- 列挙の失敗は観察ログに残す。無音だと「submodule が普通のディレクトリとして出る」形で退行が見えないため。非 git project（gozd は git 管理外の project も開ける）は毎回失敗するので、exit 128 だけは除く
+- 列挙の失敗は観察ログに残す。無音だと「submodule が普通のディレクトリとして出る」形で退行が見えないため。無音にする条件は exit 128 で、非 git project（gozd は git 管理外の project も開ける）が列挙のたびに必ず失敗するのを黙らせるためだが、128 は git の汎用 fatal で not-a-repo 専用ではなく、index 破損のような本物の障害もここで無音になる。stderr 文字列で絞る案は取らない（git のメッセージは翻訳対象で、git 実行 env はユーザーの locale をそのまま継承するため）
 
 展開させないのは、配下が別 repo の管理下にあり親 repo の `git status` / `gitignore` では語れないため。VS Code は Explorer と git decoration が分離していて submodule 配下も普通に展開できるが、gozd の filer は git status を重ねる前提なので同じ切り方はしない。
 

--- a/docs/filer.md
+++ b/docs/filer.md
@@ -150,6 +150,31 @@ working tree の symlink は「link であること」と「実体としてど�
 - filer の click では folder 行は選択を発生させず展開だけを行う。したがって `Select original folder` も selection を動かさず、ツリーの展開 + スクロールだけを行う。ここを `selectRelPath` に倒すと preview がディレクトリ表示に落ちる（markdown link がディレクトリを指したときに起きる状態と同じ。`resolveMarkdownLink` は stat せず字句解決するため selection にディレクトリが入り得る）
 - 両方を同時に出さないのは、「どちらを使うべきか」の判断をユーザーに預けないため。実体の在り処で 1 つに定まる
 
+## submodule の表示
+
+submodule は「別 repo を指すポインタ」であり、親 repo の filer では展開しない葉として扱う。working tree モード / snapshot モードのどちらでも同じ契約になる。
+
+### 判定
+
+判定の SSOT は **index の gitlink**（mode `160000`）。
+
+- working tree 上の submodule は、未初期化なら中身の無いディレクトリ、初期化済みでも `.git` は除外対象の gitlink ファイルなので、**ディスク側に初期化状態に依存しない手がかりが存在しない**
+- `.gitmodules` は「設定」であって実体ではないため判定には使わない（記述の無い gitlink も、実体の無い記述もあり得る）
+- main の `readDir` は `git ls-files --stage -z -- ':(glob)<relDir>/*'` を `checkIgnore` と並列に 1 回実行する。`:(glob)` 修飾子は `*` が `/` を跨がなくなる効果を持つため、index 全体ではなく列挙中の 1 階層だけに絞れる。gitlink に一致した entry だけ `type` を `submodule` に倒し、commit hash を `submoduleHash` に載せる
+- ディレクトリを 1 つも含まない階層では git を起動しない（submodule は初期化状態によらずディレクトリとして存在するため）
+- gitlink の path がディスク上 file / symlink になっている食い違い状態は実体側の種別を優先する。ディスクの種別は常に lstat が SSOT で、index は「submodule として登録されているか」だけを足す
+- 並び順はディレクトリ区画に置く。展開できない葉だが、ディスク上はディレクトリが占める位置にある
+
+展開させないのは、配下が別 repo の管理下にあり親 repo の `git status` / `gitignore` では語れないため。VS Code は Explorer と git decoration が分離していて submodule 配下も普通に展開できるが、gozd の filer は git status を重ねる前提なので同じ切り方はしない。
+
+### 表示と click
+
+- 右端に短縮 hash（7 桁）を出す。GitHub の `name @ hash` と同じ情報だが、幅の狭いツリーでは名前に続けると truncate に飲まれるため右端に固定する（VS Code が `S` バッジを右端に置くのと同じ理由）
+- 名前の色は使わない。git change > link > ignored の優先順位を既に使い切っており、4 つ目の軸を足すと競合する
+- アイコンは material-icon-theme の `folder-git`。テーマは submodule を種別として持たない（VS Code 側は decoration provider が担う）ため、`submodules` という名前のフォルダに割り当てられたアイコンを種別アイコンとして借用する
+- click は gitlink が pin している commit の GitHub ページ（`/tree/<hash>`）を外部ブラウザで開く。URL は `.gitmodules` にしか無いため、列挙のたびに読まず click 時に `/git/submoduleUrl` で引く。`.gitmodules` に記述が無い / 非 github.com host は解決できないので、無音の不発にせず通知で示す
+- 右クリック menu は出さない。menu の項目はどれもツリー上の path を親 repo 内のファイルとして扱うもので、submodule の path は repo 境界そのものだから
+
 ## 削除ファイルの表示
 
 `git status` で `D` ステータスのファイル（index 側 / worktree 側のいずれの削除も含む）は、ディスク上に存在しないがツリーに仮想エントリとして表示する。ディレクトリ直下の削除ファイル / サブディレクトリを抽出し、ディスク上の既存エントリと重複しないものだけをツリーに追加する。
@@ -184,7 +209,7 @@ git-graph で UNCOMMITTED_HASH 以外の commit が選択されている間、fi
 
 - 「今 snapshot を見ている」ことと「working tree へ戻る」手段を、GitGraphPane 側を操作せず filer 側単独で完結させるため、NavigatorPane の Filer ヘッダーに状態表示と "Now" ボタンを持つ。実装詳細（表示分岐条件・データソース）は `NavigatorPane.vue` の `<doc>` ブロックを参照
 - データソースは `rpcGitLsTree(dir, hash, path)`。main 側（`gitTree.ts`）は `git ls-tree -z <hash> <path>/` で 1 階層分を返す。末尾 `/` は main 側で必ず付与する規約（外すとエントリ 1 件に倒れて lazy expand が成立しない）
-- `FileEntry.kind` は `"file" | "directory" | "symlink" | "submodule"`。`git mode` (`040000` / `120000` / `160000` / その他) を SSOT 写像する
+- `FileEntry.kind` は `"file" | "directory" | "symlink" | "submodule"`。snapshot mode では `git mode` (`040000` / `120000` / `160000` / その他) を SSOT 写像する（working tree モードは lstat + index の gitlink。[submodule の表示](#submodule-の表示)）
 - ルート FileTreeItem は `:key="dir"` のままで mode 切替では再マウントしない。子の `snapshotHash` watch が children を invalidate して再 load することで、展開状態 (`expanded`) と孫ノードの instance を保ったまま data だけ差し替える
 - mode 切替直後の `rpcGitLsTree` 完了前は children を先行 reset せず旧 mode の tree を表示し続ける設計。切替のたびに Loading フラッシュを見せると「今どこを見ているか」の continuity が壊れるため、データだけ後追いで差し替える経路に倒している (race は `loadSeq` でガード済み)。空フォルダ等で空 tree から空 tree への切替は視覚的に変化が出ないが、children 内のファイル / ディレクトリの kind や有無が変われば即座に反映される
 - `FileTreeItem` の子 `v-for :key` は `${child.name}-${child.kind}` で識別する。同名 path で kind が変わる稀なケース (file→directory への mv が commit に含まれて snapshot tree で別 kind になった等) では別 instance として再マウントされ、深いツリー展開状態は失われる。これは「kind 変化 = file ↔ directory の意味変化 = 展開可能性の変化」と捉えての意図的な分離
@@ -199,9 +224,8 @@ git-graph で UNCOMMITTED_HASH 以外の commit が選択されている間、fi
 - `symlink`: 実体を持たない symlink だけがこの kind に来る（working tree の dangling / 循環、
   snapshot tree の symlink blob）。working tree では `select` emit（preview が not found を出す）、
   snapshot mode では blob 内容が target path 文字列でしかないため click を no-op に倒す
-- `submodule`: 常に no-op。gitlink object (`160000`) は `gitShowCommitFile` で内容を取得できず
-  preview に流すとエラーになるため。UI 上は `cursor-not-allowed` + opacity 低下 + tooltip で
-  「click できない」ことを示す
+- `submodule`: 展開も preview もせず、gitlink が pin している commit の repo ページを開く
+  （[submodule の表示](#submodule-の表示)）
 
 ### selection の境界挙動
 
@@ -223,7 +247,6 @@ git-graph で UNCOMMITTED_HASH 以外の commit が選択されている間、fi
 
 - 範囲選択（`compareHash`）の扱い。`selectedHash` 単独で snapshot を表示する。範囲選択時は selectedHash 側（newer endpoint）の tree が表示される
 - snapshot mode 中のディレクトリのアイコン色やバッジ表示。working tree とは別の意味になるため将来検討
-- submodule（`160000`）配下への 1 階層降下。本 RPC では別 repo の commit を解決しないため葉として扱う
 
 ## ファイルアイコン
 

--- a/docs/filer.md
+++ b/docs/filer.md
@@ -160,20 +160,27 @@ submodule は「別 repo を指すポインタ」であり、親 repo の filer 
 
 - working tree 上の submodule は、未初期化なら中身の無いディレクトリ、初期化済みでも `.git` は除外対象の gitlink ファイルなので、**ディスク側に初期化状態に依存しない手がかりが存在しない**
 - `.gitmodules` は「設定」であって実体ではないため判定には使わない（記述の無い gitlink も、実体の無い記述もあり得る）
-- main の `readDir` は `git ls-files --stage -z -- ':(glob)<relDir>/*'` を `checkIgnore` と並列に 1 回実行する。`:(glob)` 修飾子は `*` が `/` を跨がなくなる効果を持つため、index 全体ではなく列挙中の 1 階層だけに絞れる。gitlink に一致した entry だけ `type` を `submodule` に倒し、commit hash を `submoduleHash` に載せる
+- main の `readDir` は **列挙しているディレクトリ自身を cwd にして** `git ls-files --stage -z -- ':(glob)*'` を `checkIgnore` と並列に 1 回実行する。gitlink に一致した entry だけ `type` を `submodule` に倒し、commit hash を `submoduleHash` に載せる
+- pathspec は cwd 固定の `:(glob)*` に保ち、**ディレクトリ名を pathspec に埋めない**。`:(glob)<name>/*` の形にすると、`app/[slug]` のようにディレクトリ名が glob メタ文字を含む場合に文字クラスとして解釈され、兄弟ディレクトリの gitlink を拾いつつ本物を取り逃す。`:(glob)` は `*` が `/` を跨がなくなる効果を持つため、cwd 相対の `*` で 1 階層に閉じる
+- 出力 path は cwd 相対で `/` を含まないため、そのまま entry 名として引き当てられる
+- conflict 中の gitlink は stage 1（base）/ 2（ours）/ 3（theirs）が並ぶ。working tree に checkout されているのは ours なので、表示も stage 2 に揃える（通常の entry は stage 0 のみ）
 - ディレクトリを 1 つも含まない階層では git を起動しない（submodule は初期化状態によらずディレクトリとして存在するため）
 - gitlink の path がディスク上 file / symlink になっている食い違い状態は実体側の種別を優先する。ディスクの種別は常に lstat が SSOT で、index は「submodule として登録されているか」だけを足す
+- 列挙が symlink 越しに worktree 外を見ている場合は問い合わせを落とす（当該 repo の index の管轄外。`ignoreSpec` が dir 外を落とすのと同じ規律）
 - 並び順はディレクトリ区画に置く。展開できない葉だが、ディスク上はディレクトリが占める位置にある
+- 列挙の失敗は観察ログに残す。無音だと「submodule が普通のディレクトリとして出る」形で退行が見えないため。非 git project（gozd は git 管理外の project も開ける）は毎回失敗するので、exit 128 だけは除く
 
 展開させないのは、配下が別 repo の管理下にあり親 repo の `git status` / `gitignore` では語れないため。VS Code は Explorer と git decoration が分離していて submodule 配下も普通に展開できるが、gozd の filer は git status を重ねる前提なので同じ切り方はしない。
 
 ### 表示と click
 
 - 右端に短縮 hash（7 桁）を出す。GitHub の `name @ hash` と同じ情報だが、幅の狭いツリーでは名前に続けると truncate に飲まれるため右端に固定する（VS Code が `S` バッジを右端に置くのと同じ理由）
-- 名前の色は使わない。git change > link > ignored の優先順位を既に使い切っており、4 つ目の軸を足すと競合する
-- アイコンは material-icon-theme の `folder-git`。テーマは submodule を種別として持たない（VS Code 側は decoration provider が担う）ため、`submodules` という名前のフォルダに割り当てられたアイコンを種別アイコンとして借用する
-- click は gitlink が pin している commit の GitHub ページ（`/tree/<hash>`）を外部ブラウザで開く。URL は `.gitmodules` にしか無いため、列挙のたびに読まず click 時に `/git/submoduleUrl` で引く。`.gitmodules` に記述が無い / 非 github.com host は解決できないので、無音の不発にせず通知で示す
-- 右クリック menu は出さない。menu の項目はどれもツリー上の path を親 repo 内のファイルとして扱うもので、submodule の path は repo 境界そのものだから
+- submodule 固有の色軸は足さない。名前の色は git change > link > ignored の優先順位を既に使い切っており、4 つ目を足すと競合する。gitlink の変更（pin 先の移動 / 配下の dirty）は `git status` が submodule の path そのものを報告するので、**既存の git change 色にそのまま乗る**（葉なので配下からの推論ではなく完全一致で引き当たる）
+- アイコンは material-icon-theme が `submodules` という名前のフォルダに割り当てているものを種別アイコンとして借用する。テーマは submodule を種別として持たない（VS Code 側は decoration provider が担う）ため、これが最も近い語彙になる。アイコン名を焼き込まず folder 名から引くので、テーマが割り当てを差し替えても追従する
+- click は gitlink が pin している commit の GitHub ページ（`/tree/<hash>`）を外部ブラウザで開く。URL は `.gitmodules` にしか無いため、列挙のたびに読まず click 時に `/git/submoduleUrl` で引く。解決できないケース（記述が無い / 非 github.com host / 相対 url を解決できない）は無音の不発にせず通知で示す
+- `.gitmodules` の相対 url（gitmodules(5) の `./` `../` 形式。superproject の origin からの相対位置）は origin の owner / repo を基準に解決する。`../` 1 つで末尾 1 成分を落とす git 本体と同じ規則
+- snapshot mode では hash と同じ revision の `.gitmodules` blob から url を引く。path → url の対応は commit 間で変わり得るので、working tree の対応を過去の hash に重ねると別 repo を指す誤リンクになる
+- 右クリック menu は出さない。行が表すのは親 repo 内のファイルではなく repo 境界の外にある別 repo への参照で、click も外部コンテキストへ出る動作に倒してある（GitHub の submodule 行が `<a>` であるのと同じ位置づけ）。行の対象が外部である以上、この repo のファイル操作は載せない
 
 ## 削除ファイルの表示
 

--- a/docs/filer.md
+++ b/docs/filer.md
@@ -167,6 +167,8 @@ submodule は「別 repo を指すポインタ」であり、親 repo の filer 
 - ディレクトリを 1 つも含まない階層では git を起動しない（submodule は初期化状態によらずディレクトリとして存在するため）
 - gitlink の path がディスク上 file / symlink になっている食い違い状態は実体側の種別を優先する。ディスクの種別は常に lstat が SSOT で、index は「submodule として登録されているか」だけを足す
 - 列挙が symlink 越しに worktree 外を見ている場合は問い合わせを落とす（当該 repo の index の管轄外。`ignoreSpec` が dir 外を落とすのと同じ規律）
+- anchor は cwd を所有する repo なので、worktree 内に独立した nested repo があればその index を見る。ツリーが写しているディスクの実体としては妥当
+- 列挙の失敗を無音にする条件は exit 128。非 git project は列挙のたびに必ず失敗するため除いているが、128 は git の汎用 fatal で not-a-repo 専用ではなく、index 破損のような本物の障害もここで無音になる。stderr 文字列で絞る案は取らない（git のメッセージは翻訳対象で、git 実行 env はユーザーの locale をそのまま継承するため）
 - 並び順はディレクトリ区画に置く。展開できない葉だが、ディスク上はディレクトリが占める位置にある
 - 列挙の失敗は観察ログに残す。無音だと「submodule が普通のディレクトリとして出る」形で退行が見えないため。非 git project（gozd は git 管理外の project も開ける）は毎回失敗するので、exit 128 だけは除く
 
@@ -179,6 +181,7 @@ submodule は「別 repo を指すポインタ」であり、親 repo の filer 
 - アイコンは material-icon-theme が `submodules` という名前のフォルダに割り当てているものを種別アイコンとして借用する。テーマは submodule を種別として持たない（VS Code 側は decoration provider が担う）ため、これが最も近い語彙になる。アイコン名を焼き込まず folder 名から引くので、テーマが割り当てを差し替えても追従する
 - click は gitlink が pin している commit の GitHub ページ（`/tree/<hash>`）を外部ブラウザで開く。URL は `.gitmodules` にしか無いため、列挙のたびに読まず click 時に `/git/submoduleUrl` で引く。解決できないケース（記述が無い / 非 github.com host / 相対 url を解決できない）は無音の不発にせず通知で示す
 - `.gitmodules` の相対 url（gitmodules(5) の `./` `../` 形式。superproject の origin からの相対位置）は origin の owner / repo を基準に解決する。`../` 1 つで末尾 1 成分を落とす git 本体と同じ規則
+- URL 解決は **開いている repo が宣言した submodule に対して定義される**。`.gitmodules` を読む cwd は worktree root で固定なので、判定側（列挙対象を cwd にする）と anchor がずれる nested repo 配下の submodule は解決できず、通知で終わる。誤った URL を出す組み合わせは構造的に起きない（親の `.gitmodules` に nested repo 内の path は載らない）
 - snapshot mode では hash と同じ revision の `.gitmodules` blob から url を引く。path → url の対応は commit 間で変わり得るので、working tree の対応を過去の hash に重ねると別 repo を指す誤リンクになる
 - 右クリック menu は出さない。行が表すのは親 repo 内のファイルではなく repo 境界の外にある別 repo への参照で、click も外部コンテキストへ出る動作に倒してある（GitHub の submodule 行が `<a>` であるのと同じ位置づけ）。行の対象が外部である以上、この repo のファイル操作は載せない
 

--- a/packages/rpc/src/fs.ts
+++ b/packages/rpc/src/fs.ts
@@ -34,8 +34,13 @@ export interface FsReadDirRealTarget {
 
 export interface FsReadDirEntry {
   name: string;
-  /** entry 自身の種別（lstat 由来。link は辿らず "symlink"） */
-  type: "file" | "directory" | "symlink";
+  /** entry 自身の種別。lstat 由来（link は辿らず "symlink"）だが、`submodule` だけは
+   * lstat では判別できないため index の gitlink（mode `160000`）を突き合わせて決める。
+   * 未初期化の submodule は working tree 上ただの空ディレクトリで、ディスク側に手がかりが
+   * 一切無い（初期化済みかどうかで種別が変わらないよう git を SSOT に置く）。 */
+  type: "file" | "directory" | "symlink" | "submodule";
+  /** submodule が指す commit hash（index の gitlink object）。`type === "submodule"` のときだけ設定。 */
+  submoduleHash?: string;
   /** 実体の在り処が entry のパス（`dir` + `path` + `name`）と食い違うときだけ設定する。
    * 該当するのは symlink 自身と、symlink 越しに列挙された entry（親 dir が link）の 2 経路。
    * 辿れない link（dangling / 循環 / 中間成分が非ディレクトリ）は未設定で「実体なし」を表す。 */

--- a/packages/rpc/src/gitOps.ts
+++ b/packages/rpc/src/gitOps.ts
@@ -476,10 +476,31 @@ export interface GitLsTreeRequest {
 export interface GitTreeEntry {
   name: string;
   type: string;
+  /** submodule（gitlink）が指す commit hash。`type === "submodule"` のときだけ設定する。 */
+  submoduleHash?: string;
 }
 
 export interface GitLsTreeResponse {
   entries: GitTreeEntry[];
+}
+
+// gitSubmoduleUrl: submodule が指す commit の GitHub 閲覧 URL を解決する。
+//
+// filer の submodule 行 click が呼ぶ。path → url の対応は `.gitmodules` にしか無いが、
+// submodule 判定そのものは index の gitlink が SSOT なので経路を分けてある（main 側
+// `submodule.ts` の SSOT）。readDir 応答に url を載せず click 時に引くのは、リンクを踏む
+// ときにしか要らない情報のために全列挙で `.gitmodules` を読まないため。
+export interface GitSubmoduleUrlRequest {
+  dir: string;
+  /** submodule の worktree 相対パス */
+  path: string;
+  /** submodule が指す commit hash。URL に埋めて pin する */
+  hash: string;
+}
+
+export interface GitSubmoduleUrlResponse {
+  /** 解決できた閲覧 URL。`.gitmodules` に記述が無い / 非 github.com host なら未設定 */
+  url?: string;
 }
 
 // gitLsFiles: worktree 内の全ファイル（tracked + untracked、gitignore 除外）の相対パスを返す。

--- a/packages/rpc/src/gitOps.ts
+++ b/packages/rpc/src/gitOps.ts
@@ -496,6 +496,10 @@ export interface GitSubmoduleUrlRequest {
   path: string;
   /** submodule が指す commit hash。URL に埋めて pin する */
   hash: string;
+  /** `.gitmodules` を読む revision。filer の snapshot mode が自身の commit hash を渡す。
+   * 未設定なら working tree の `.gitmodules` を読む（hash と url の出所を揃えるための指定で、
+   * path → url の対応は commit 間で変わり得る）。 */
+  rev?: string;
 }
 
 export interface GitSubmoduleUrlResponse {

--- a/packages/rpc/src/index.ts
+++ b/packages/rpc/src/index.ts
@@ -129,6 +129,8 @@ export type {
   GitShowCommitFileResponse,
   GitShowFileRequest,
   GitShowFileResponse,
+  GitSubmoduleUrlRequest,
+  GitSubmoduleUrlResponse,
   GitTreeEntry,
   GitViewerRequest,
   GitViewerResponse,


### PR DESCRIPTION
## 概要

filer で submodule が通常のディレクトリと区別できなかったのを、専用アイコン + 右端の短縮 commit hash を持つ「展開しない葉」として表示するようにした。行を click すると gitlink が pin している commit の GitHub ページが外部ブラウザで開く。

## 背景

submodule を多数持つリポジトリを filer で開くと、submodule がフォルダアイコンの普通のディレクトリとして並び、どれが submodule なのか判別できなかった。

原因は判定材料の在り処にある。submodule の working tree は、未初期化なら中身の無いディレクトリ、初期化済みでも `.git` は filer が除外している gitlink ファイルなので、**ディスク側には初期化状態に依存しない手がかりが存在しない**。`fsOps.readDir` は `Dirent.isDirectory()` しか見ていないため、構造的に `directory` へ潰れる。

`FileEntryKind` には以前から `submodule` があるが、生きているのは snapshot mode（`git ls-tree` 経由で mode `160000` を読む経路）だけで、working tree 側には届いていない。

### 先行実装の調査

実装方針を決めるにあたり VS Code と Orca のソースを読んだ。

- **VS Code**: Explorer 本体は submodule の概念を持たない（`src/vs/workbench/contrib/files` に言及ゼロ）。git 拡張の `GitDecorationProvider` が `{ tooltip: 'Submodule', badge: 'S', color: gitDecoration.submoduleResourceForeground }` を重ねるだけで、hash は表示せず、フォルダとして展開もできる。一覧の取得元は `.gitmodules` の生テキスト
- **Orca**: ファイルツリーを持たず、Source Control 側で submodule 行を展開して中の変更を見せる。path 集合は `git config --file .gitmodules --get-regexp '^submodule\..*\.path$'` で取り、コード上のコメントに `Read from .gitmodules to avoid an index-wide ls-files scan` と理由が明記されている。commit hash が要るときだけ `git ls-files -s -- <path>` を pathspec 1 個で叩く

両者が `.gitmodules` を起点にするのは、呼び出し文脈が worktree 全体で index 全走査を避けたいため。gozd の `readDir` は元から 1 階層 API なのでこの制約を継承する必要がなく、判定と hash 取得を 1 回で済ませられる。

## 変更内容

### submodule 判定（main）

- `listGitlinks(listDir)` を追加。**列挙しているディレクトリ自身を cwd にして** `git ls-files --stage -z -- ':(glob)*'` を実行し、mode `160000` の entry を `entry 名 → commit hash` の Map で返す
- `fsOps.readDir` が `checkIgnore` と並列にこれを実行し、gitlink に一致した entry の `type` を `submodule` に倒して `submoduleHash` を載せる
- pathspec は cwd 固定に保ち、**ディレクトリ名を pathspec に埋めない**。`:(glob)<name>/*` の形にすると、`app/[slug]` のようにディレクトリ名が glob メタ文字を含む場合に文字クラスとして解釈され、兄弟ディレクトリの gitlink を拾いつつ本物を取り逃す
- conflict 中の gitlink は stage 1（base）/ 2（ours）/ 3（theirs）が並ぶ。working tree に checkout されているのは ours なので stage 2 に揃える
- ディレクトリを 1 つも含まない階層では git を起動しない。列挙が symlink 越しに worktree 外を見ている場合も問い合わせを落とす
- 列挙の失敗は観察ログに残す。無音だと「submodule が普通のディレクトリとして出る」形で退行が見えないため。非 git project は列挙のたびに必ず失敗するので exit 128 を除外するが、128 は git の汎用 fatal で not-a-repo 専用ではなく、index 破損のような本物の障害もここで無音になる。stderr 文字列で絞る案は取らない（git のメッセージは翻訳対象で、`gozdGitEnv` はユーザーの locale をそのまま継承するため）

判定の SSOT は index の gitlink で、`.gitmodules` は使わない。`.gitmodules` は設定であって実体ではなく、記述の無い gitlink も、実体の無い記述もあり得るため。

### 閲覧 URL の解決（main）

- `/git/submoduleUrl` を追加。`.gitmodules` から path に対応する url を引き、`https://github.com/{owner}/{repo}/tree/{hash}` を返す
- 相対 url（gitmodules(5) の `./` `../` 形式。superproject の origin からの相対位置で、同一 org 内 submodule の定番）は origin の owner / repo を基準に解決する。`../` 1 つで末尾 1 成分を落とす git 本体と同じ規則
- snapshot mode では `rev` を受け取り、`git config --blob <rev>:.gitmodules` で hash と同じ revision の設定を読む。path → url の対応は commit 間で変わり得るので、working tree の対応を過去の hash に重ねると別 repo を指す誤リンクになる
- URL 解決は開いている repo が宣言した submodule に対して定義される。`.gitmodules` を読む cwd は worktree root で固定なので、判定側（列挙対象を cwd にする）と anchor がずれる nested repo 配下の submodule は解決できず通知で終わる。誤った URL を出す組み合わせは構造的に起きない
- 列挙のたびに `.gitmodules` を読まないよう、click 時にだけ引く経路として分離した

### 表示（renderer）

- working tree モードでも `kind === "submodule"` の行が出る
- アイコンは material-icon-theme が `submodules` という名前のフォルダに割り当てているものを借用する。テーマは submodule を種別として持たない（VS Code 側は decoration provider が担う）ためで、アイコン名を焼き込まず folder 名から引くのでテーマの差し替えに追従する
- 行の右端に短縮 hash（7 桁）を dimmed で表示。GitHub の `name @ hash` と同じ情報だが、幅の狭いツリーでは名前に続けると truncate に飲まれるため右端に固定した（VS Code が `S` バッジを右端に置くのと同じ理由）
- 並び順はディレクトリ区画。展開できない葉だが、ディスク上はディレクトリが占める位置にある
- click は展開でも preview でもなく、repo ページを外部ブラウザで開く。URL 解決の失敗も起動の失敗も無音の不発にせず通知で示す
- click が no-op になるのは snapshot mode の symlink だけ
- submodule 固有の色軸は足していないが、**gitlink の変更（pin 先の移動 / 配下の dirty）は既存の git change 色に乗る**。葉なので git change の解決は配下からの推論（prefix 一致）ではなく完全一致で、`git status` が報告する submodule の path そのものに引き当たる

### 検証

`git update-index --add --cacheinfo 160000,<sha>,<path>` は commit object の実在を要求しないため、未初期化 submodule と同じ index 状態をネットワーク無しで fixture 化できる。これを使い、判定・1 階層スコープ・glob メタ文字を含むディレクトリ名・実体種別の優先・conflict の stage 選択をテストにした。各テストはミューテーション（pathspec 注入形への差し戻し / type guard 削除 / stage 無視の last-wins）で落ちることを確認している。

加えて、submodule を 137 個持つ実リポジトリに対して `listGitlinks` / `readDir` / `submoduleBrowseUrl` を通しで実行し、137/137 が `submodule` として返ること、ルート直下の 41 entry が巻き込まれないこと、URL が pin された commit を指すことを確認している。

## 旧実装からの後退

- **初期化済み submodule の配下をツリーで閲覧できなくなる**。旧実装では submodule は普通のディレクトリだったため、checkout 済みなら展開して中のファイルを開けた。葉にしたことでこの経路が失われる。同じ理由で、submodule 配下の path を対象にした reveal もツリー上で到達できなくなる。代替は submodule 自体を gozd の repo として開くこと（マルチ repo 構成なので同一ウィンドウに並べられる）
- **submodule 行の右クリック menu が出なくなる**。旧実装では普通のディレクトリだったため Open in default app / Copy file / Copy path が使えた。行が表すのは親 repo 内のファイルではなく repo 境界の外にある別 repo への参照であり、click も外部コンテキストへ出る動作に倒してある（GitHub の submodule 行が `<a>` であるのと同じ位置づけ）。行の対象が外部である以上、この repo のファイル操作は載せない

## スコープの切り分け

| 作業内容 | やるべき理由 | この PR でやらない理由 |
| --- | --- | --- |
| 非 github.com host の閲覧 URL 解決 | GitLab / Gitea 等をホストにした submodule では click が通知だけで終わる | `parseGitHubOwnerRepo` が github.com 専用で、他ホストは URL 構造が異なる。GitHub 前提で運用する |
| `XtermTerminal.vue` の `openExternal` を通知付きにする | ターミナルのリンク起動が失敗しても無音で落ちる。renderer の「例外処理では必ず toast」規律に反する | 本 PR が持ち込んだものではない別 feature の既存欠陥で、filer の diff に混ぜると変更の境界がぼやける |
| `GitCommandError` / `gitDirs` が持つ「exit 128 = not a git repository」前提の見直し | 128 は git の汎用 fatal なので、`gitDirs` は index 破損を「git repo ではない」と報告し得る | 挙動の変更を伴い（破損時に throw するのか undefined を返すのか）、filer とは別の判断が要る。本 PR は新しく足した経路のコメントを正確にするに留める |

## 確認事項

- [ ] **初期化済み**（checkout 済み）の submodule を持つリポジトリでの見え方。検証に使ったリポジトリは 137 個すべて未初期化だったため、初期化済みのケースは実画面で未確認
- [ ] 非 github.com host の submodule を click したときに通知が出ること
