### PR TITLE
fix(terminal): keep the session preview popover hidden when closed

### DIFF
--- a/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
+++ b/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
@@ -136,7 +136,9 @@ DOM 構造は三段:
   クランプ内へ縮めてスクロール面に高さ制約を届けるための指定。display を
   `:popover-open` で条件づけるのは、素の `flex` が author origin として UA の
   `[popover]:not(:popover-open) { display: none }` に勝ち、閉じた popover を描画させて
-  しまうため。描画され続ければ上記の anchor 喪失に行き着く。padding は持たない
+  しまうため。閉じても描画され続けると、hide が `showPopover` の暗黙 anchor を外した
+  時点で上と同じ左上 fallback へ落ちる (proxy は生きたままなので、anchor 要素の
+  unmount とは別経路で同じ結末に至る)。padding は持たない
   (透明 padding があると keep-out clamp 時にタイトルバーとの間へスキマが出る。`p-0` は
   UA default の `[popover]` padding の打ち消し)。
   UA default の `[popover] { overflow: auto }` は

--- a/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
+++ b/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
@@ -130,9 +130,16 @@ no-drag` の切り抜きも敷く (Electron 公式の drag 帯プラクティス
 
 DOM 構造は三段:
 
-- 外側 popover element (`bg-transparent border-none overflow-visible p-0` + `flex flex-col`)
+- 外側 popover element (`bg-transparent border-none overflow-visible p-0` +
+  `[&:popover-open]:flex flex-col`)
   位置決めと max-height クランプの伝播を担う透明枠。flex-col は中間 box (min-h-0) を
-  クランプ内へ縮めてスクロール面に高さ制約を届けるための指定。padding は持たない
+  クランプ内へ縮めてスクロール面に高さ制約を届けるための指定。display は
+  `:popover-open` で条件づける — 素の `flex` は author origin なので UA の
+  `[popover]:not(:popover-open) { display: none }` に勝ってしまい、閉じた popover が
+  描画され続ける。表示中は暗黙 anchor が効いて元の場所に居座り、anchor 参照が切れた
+  時点で `position-area` が無効化して UA の `inset: 0` だけが残り、左上へ飛ぶ。
+  中身が外れるのは task-queued な `@toggle` 経由なので、その間に挟まったフレームで
+  左上のゴーストが見える。padding は持たない
   (透明 padding があると keep-out clamp 時にタイトルバーとの間へスキマが出る。`p-0` は
   UA default の `[popover]` padding の打ち消し)。
   UA default の `[popover] { overflow: auto }` は
@@ -655,7 +662,7 @@ watch([hasMain, hasSub], ([main, sub]) => {
        (popover 外 click / ESC) で閉じる。
        本文描画は SessionLogMessageBody に委譲 (assistant のみ markdown 解釈)。 -->
   <PreviewPopover
-    class="m-0 flex w-3xl max-w-[80vw] flex-col overflow-visible border-none bg-transparent p-0 text-base"
+    class="m-0 w-3xl max-w-[80vw] flex-col overflow-visible border-none bg-transparent p-0 text-base [&:popover-open]:flex"
     :style="previewPopoverStyle"
   >
     <template v-if="previewContext">

--- a/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
+++ b/apps/renderer/src/features/terminal/TerminalSessionPreview.vue
@@ -133,13 +133,10 @@ DOM 構造は三段:
 - 外側 popover element (`bg-transparent border-none overflow-visible p-0` +
   `[&:popover-open]:flex flex-col`)
   位置決めと max-height クランプの伝播を担う透明枠。flex-col は中間 box (min-h-0) を
-  クランプ内へ縮めてスクロール面に高さ制約を届けるための指定。display は
-  `:popover-open` で条件づける — 素の `flex` は author origin なので UA の
-  `[popover]:not(:popover-open) { display: none }` に勝ってしまい、閉じた popover が
-  描画され続ける。表示中は暗黙 anchor が効いて元の場所に居座り、anchor 参照が切れた
-  時点で `position-area` が無効化して UA の `inset: 0` だけが残り、左上へ飛ぶ。
-  中身が外れるのは task-queued な `@toggle` 経由なので、その間に挟まったフレームで
-  左上のゴーストが見える。padding は持たない
+  クランプ内へ縮めてスクロール面に高さ制約を届けるための指定。display を
+  `:popover-open` で条件づけるのは、素の `flex` が author origin として UA の
+  `[popover]:not(:popover-open) { display: none }` に勝ち、閉じた popover を描画させて
+  しまうため。描画され続ければ上記の anchor 喪失に行き着く。padding は持たない
   (透明 padding があると keep-out clamp 時にタイトルバーとの間へスキマが出る。`p-0` は
   UA default の `[popover]` padding の打ち消し)。
   UA default の `[popover] { overflow: auto }` は


### PR DESCRIPTION
## 概要

ターミナルのセッションログ全文 popover をドラッグして undock したとき、undock されたパネルとは別に、popover 本体が一瞬ウィンドウ左上（ゼロ位置）に現れる。外側 popover element の `display` を `:popover-open` で条件づけて解消する。

## 背景

`hidePopover()` を呼んでいるのに popover が消えていなかった。

外側 popover element が素の `flex` を持っており、これは author origin の宣言なので、UA スタイルシートの `[popover]:not(:popover-open) { display: none }` に詳細度と無関係に勝つ。結果として、閉じた popover が top layer の外にいる「ただの fixed 要素」として描画され続ける。

Electron（gozd の実行エンジンそのもの）で最小再現を組み、素の `flex` と `:popover-open` で条件づけたものを並べて測定した:

```text
bad  shown:        display=flex rect=(196,194) 768x400
bad  hidden(sync): display=flex rect=(196,194) 768x400
bad  hidden(task): display=flex rect=(0,0)     768x400
good shown:        display=flex rect=(196,194) 768x400
good hidden(sync): display=none rect=(0,0)     0x0
```

`showPopover({ source })` が張る暗黙 anchor は同期的な hide を跨いで残るため、hide 直後は元の位置に居座る。1 task 後に anchor 参照が切れると `position-area` が効かなくなり、残った UA の `inset: 0` と `m-0` で viewport 左上に落ちる。anchor 要素（proxy）は生きたままなので、これは proxy 方式が塞いでいる「anchor 要素の unmount」とは別経路。

見えている時間が「一瞬」なのは、中身を外すのが `@toggle` → open state クリア → `v-if` の経路で、`toggle` が task-queued なため。hide とその task の間にレンダリングが挟まったときだけゴーストが描かれる。ドラッグ経路で目立つのは、pointermove の合間にフレームが入りやすいため。

## 変更内容

### 外側 popover element の display

外側 popover element の `display` は `:popover-open` のときだけ `flex`。閉じている間は UA の `display: none` が残るため描画されない。`<doc>` にはこの条件づけの理由（素の `display` が UA 規則に勝つこと）と、hide 時の暗黙 anchor 解除が anchor 要素の unmount とは別経路であることを置く。

## スコープの切り分け

| 作業内容 | やるべき理由 | この PR でやらない理由 |
| --- | --- | --- |
| `NotificationToast.vue` の素の `flex` 除去 | 同じ欠陥クラスが残存している。`flex` と `[&:popover-open]:flex` を併記しており、無条件の方が勝つため閉じても描画され続ける | 本 PR の変更を revert しても残る既存の状態で、`popover="manual"` かつ pin 積み直しが同一タスク内で完結するため現時点で可視の症状はない |
| 「閉じた popover は描画されない」を CSS 1 箇所の default-deny にする | per-component class での担保は貼り忘れで静かに壊れる denylist。実際に本件で 1 回発火しており、Tailwind のビルド済み CSS と UA stylesheet のカスケードは単体テストで再現できないため回帰検出手段がない | `apps/renderer/CLAUDE.md` は Tier 3（element defaults）を `main.css` の `@layer base` と定めているが、`@layer base` の規則は Tailwind の `@layer utilities` に負けるため default-deny を実現できない（実測で確認）。layer 外の規則が必要で、token tier の契約改訂を伴う設計判断になる |

なお default-deny を採る場合、`[&:popover-open]:flex` を持つ 7 ファイル（`EventLogPanel` / `ServerListPanel` / `FloatingWindow` / `NotificationCenterPanel` / `MainLayout` / `NotificationToast` / `TerminalSessionPreview`）が素の `flex` に戻せる。

## 確認事項

- [ ] dev 起動で、popover ヘッダのドラッグ undock / undock ボタンクリック / light-dismiss のいずれでも左上にゴーストが出ないこと
- [ ] popover を開いた状態の見た目（max-height クランプ、中間 box のスクロール面の高さ）が変わっていないこと
