### PR TITLE
refactor(workspace): route wt-view dir selection through activateDir

### DIFF
--- a/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
+++ b/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
@@ -15,6 +15,7 @@ import {
   rpcCreateWorktree,
   rpcGitDefaultBranch,
   rpcTaskAdd,
+  selectDir,
 } from "../../../sidebar";
 import { useTerminalStore } from "../../../terminal";
 import { generateTimestamp, useWorktreeStore } from "../../../worktree";
@@ -93,8 +94,7 @@ export function registerIssueCommand(): () => void {
               errorLabel: "Failed to revive task for issue",
             });
             if (revived !== undefined) item.existingTask = revived;
-            terminalStore.viewMode = "wt";
-            worktreeStore.setOpen(existing.worktreeDir);
+            selectDir(existing.worktreeDir);
             return;
           }
           // 新規 worktree は default branch を起点に作る。main 側で `origin/HEAD` を
@@ -165,8 +165,7 @@ export function registerIssueCommand(): () => void {
           // issue URL を prefill で渡し、claude の入力欄に事前挿入する (送信はされない)。
           terminalStore.requestNewClaudeSession(result.value.dir, issue.url);
           terminalStore.setPreferredSetup(result.value.dir, result.value.setupScript);
-          terminalStore.viewMode = "wt";
-          worktreeStore.setOpen(result.value.dir);
+          selectDir(result.value.dir);
         };
 
         // viewer 取得失敗時は undefined。空文字に倒して picker dialog の "@me" filter UI

--- a/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
+++ b/apps/renderer/src/features/palette/features/issue-picker/registerIssueCommand.ts
@@ -15,7 +15,7 @@ import {
   rpcCreateWorktree,
   rpcGitDefaultBranch,
   rpcTaskAdd,
-  selectDir,
+  activateDir,
 } from "../../../sidebar";
 import { useTerminalStore } from "../../../terminal";
 import { generateTimestamp, useWorktreeStore } from "../../../worktree";
@@ -94,7 +94,7 @@ export function registerIssueCommand(): () => void {
               errorLabel: "Failed to revive task for issue",
             });
             if (revived !== undefined) item.existingTask = revived;
-            selectDir(existing.worktreeDir);
+            activateDir(existing.worktreeDir);
             return;
           }
           // 新規 worktree は default branch を起点に作る。main 側で `origin/HEAD` を
@@ -165,7 +165,7 @@ export function registerIssueCommand(): () => void {
           // issue URL を prefill で渡し、claude の入力欄に事前挿入する (送信はされない)。
           terminalStore.requestNewClaudeSession(result.value.dir, issue.url);
           terminalStore.setPreferredSetup(result.value.dir, result.value.setupScript);
-          selectDir(result.value.dir);
+          activateDir(result.value.dir);
         };
 
         // viewer 取得失敗時は undefined。空文字に倒して picker dialog の "@me" filter UI

--- a/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
+++ b/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
@@ -15,6 +15,7 @@ import {
   rpcCreateWorktree,
   rpcGitWorktreeList,
   rpcTaskAdd,
+  selectDir,
 } from "../../../sidebar";
 import { useTerminalStore } from "../../../terminal";
 import { generateTimestamp, useWorktreeStore } from "../../../worktree";
@@ -101,8 +102,7 @@ export function registerPrCommand(): () => void {
               errorLabel: "Failed to revive task for pull request",
             });
             if (revived !== undefined) item.existingTask = revived;
-            terminalStore.viewMode = "wt";
-            worktreeStore.setOpen(existingDir);
+            selectDir(existingDir);
             return;
           }
           // 新規 worktree 作成
@@ -154,8 +154,7 @@ export function registerPrCommand(): () => void {
           // PR URL を prefill で渡し、claude の入力欄に事前挿入する (送信はされない)。
           terminalStore.requestNewClaudeSession(result.value.dir, pr.url);
           terminalStore.setPreferredSetup(result.value.dir, result.value.setupScript);
-          terminalStore.viewMode = "wt";
-          worktreeStore.setOpen(result.value.dir);
+          selectDir(result.value.dir);
         };
 
         // viewer 取得失敗時は undefined。空文字に倒して picker dialog の "@me" filter UI

--- a/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
+++ b/apps/renderer/src/features/palette/features/pr-picker/registerPrCommand.ts
@@ -15,7 +15,7 @@ import {
   rpcCreateWorktree,
   rpcGitWorktreeList,
   rpcTaskAdd,
-  selectDir,
+  activateDir,
 } from "../../../sidebar";
 import { useTerminalStore } from "../../../terminal";
 import { generateTimestamp, useWorktreeStore } from "../../../worktree";
@@ -102,7 +102,7 @@ export function registerPrCommand(): () => void {
               errorLabel: "Failed to revive task for pull request",
             });
             if (revived !== undefined) item.existingTask = revived;
-            selectDir(existingDir);
+            activateDir(existingDir);
             return;
           }
           // 新規 worktree 作成
@@ -154,7 +154,7 @@ export function registerPrCommand(): () => void {
           // PR URL を prefill で渡し、claude の入力欄に事前挿入する (送信はされない)。
           terminalStore.requestNewClaudeSession(result.value.dir, pr.url);
           terminalStore.setPreferredSetup(result.value.dir, result.value.setupScript);
-          selectDir(result.value.dir);
+          activateDir(result.value.dir);
         };
 
         // viewer 取得失敗時は undefined。空文字に倒して picker dialog の "@me" filter UI

--- a/apps/renderer/src/features/palette/features/revive-picker/registerReviveCommand.ts
+++ b/apps/renderer/src/features/palette/features/revive-picker/registerReviveCommand.ts
@@ -18,7 +18,7 @@ import { tryCatch } from "@gozd/shared";
 import { useCommandRegistry } from "../../../../shared/command";
 import { useNotificationStore } from "../../../../shared/notification";
 import { useRepoStore } from "../../../../shared/repo";
-import { selectDir } from "../../../sidebar";
+import { activateDir } from "../../../sidebar";
 import { useTerminalStore } from "../../../terminal";
 import { useWorktreeStore } from "../../../worktree";
 import { rpcReviveSession, rpcReviveSessionList } from "./rpc";
@@ -65,7 +65,7 @@ export function registerReviveCommand(): () => void {
     // 明示ヒントとして渡す。作り直した worktree は未訪問なので、setOpen 起点の visit が
     // このヒントを消費して初期 leaf に `claude --resume <sessionId>` を仕込む。
     terminalStore.requestResumeSession(result.value.dir, session.sessionId);
-    selectDir(result.value.dir);
+    activateDir(result.value.dir);
   }
 
   /** loading で picker を開き、fetch 完了後に一覧を埋める。gen で stale 応答を捨てる。 */

--- a/apps/renderer/src/features/palette/features/revive-picker/registerReviveCommand.ts
+++ b/apps/renderer/src/features/palette/features/revive-picker/registerReviveCommand.ts
@@ -18,6 +18,7 @@ import { tryCatch } from "@gozd/shared";
 import { useCommandRegistry } from "../../../../shared/command";
 import { useNotificationStore } from "../../../../shared/notification";
 import { useRepoStore } from "../../../../shared/repo";
+import { selectDir } from "../../../sidebar";
 import { useTerminalStore } from "../../../terminal";
 import { useWorktreeStore } from "../../../worktree";
 import { rpcReviveSession, rpcReviveSessionList } from "./rpc";
@@ -64,8 +65,7 @@ export function registerReviveCommand(): () => void {
     // 明示ヒントとして渡す。作り直した worktree は未訪問なので、setOpen 起点の visit が
     // このヒントを消費して初期 leaf に `claude --resume <sessionId>` を仕込む。
     terminalStore.requestResumeSession(result.value.dir, session.sessionId);
-    terminalStore.viewMode = "wt";
-    worktreeStore.setOpen(result.value.dir);
+    selectDir(result.value.dir);
   }
 
   /** loading で picker を開き、fetch 完了後に一覧を埋める。gen で stale 応答を捨てる。 */

--- a/apps/renderer/src/features/server/ServerListPanel.vue
+++ b/apps/renderer/src/features/server/ServerListPanel.vue
@@ -22,7 +22,7 @@ click-to-front、ESC / Cmd+W はフォーカスがあるサーフェスを閉じ
 import { computed, useTemplateRef } from "vue";
 import { useRepoStore } from "../../shared/repo";
 import { useSurface } from "../../shared/surface";
-import { selectDir } from "../sidebar";
+import { activateDir } from "../sidebar";
 import { useTerminalStore } from "../terminal";
 import type { ServerAttributionKind } from "./rpc";
 import { useServerStore } from "./useServerStore";
@@ -116,7 +116,7 @@ const rows = computed<ServerRow[]>(() => {
 function onRowClick(row: ServerRow): void {
   // worktree が解決できない行 (external / 削除済み orphaned) は開けない。
   if (!row.openable) return;
-  selectDir(row.worktreePath);
+  activateDir(row.worktreePath);
   // live なら該当端末ペインへフォーカスする (ptyId は帰属先 PTY)。
   if (row.ptyId > 0) {
     const leafId = terminalStore.getLeafIdByPtyId(row.ptyId);

--- a/apps/renderer/src/features/server/ServerListPanel.vue
+++ b/apps/renderer/src/features/server/ServerListPanel.vue
@@ -22,8 +22,8 @@ click-to-front、ESC / Cmd+W はフォーカスがあるサーフェスを閉じ
 import { computed, useTemplateRef } from "vue";
 import { useRepoStore } from "../../shared/repo";
 import { useSurface } from "../../shared/surface";
+import { selectDir } from "../sidebar";
 import { useTerminalStore } from "../terminal";
-import { useWorktreeStore } from "../worktree";
 import type { ServerAttributionKind } from "./rpc";
 import { useServerStore } from "./useServerStore";
 import IconLucideServer from "~icons/lucide/server";
@@ -33,7 +33,6 @@ import IconLucideX from "~icons/lucide/x";
 const serverStore = useServerStore();
 const repoStore = useRepoStore();
 const terminalStore = useTerminalStore();
-const worktreeStore = useWorktreeStore();
 
 interface ServerRow {
   key: string;
@@ -117,8 +116,7 @@ const rows = computed<ServerRow[]>(() => {
 function onRowClick(row: ServerRow): void {
   // worktree が解決できない行 (external / 削除済み orphaned) は開けない。
   if (!row.openable) return;
-  terminalStore.viewMode = "wt";
-  worktreeStore.setOpen(row.worktreePath);
+  selectDir(row.worktreePath);
   // live なら該当端末ペインへフォーカスする (ptyId は帰属先 PTY)。
   if (row.ptyId > 0) {
     const leafId = terminalStore.getLeafIdByPtyId(row.ptyId);

--- a/apps/renderer/src/features/sidebar/SidebarPane.vue
+++ b/apps/renderer/src/features/sidebar/SidebarPane.vue
@@ -128,7 +128,7 @@ useSidebarData();
 
 const { confirmRef, confirmMessage, showConfirm, closeConfirm, executeConfirm } = useDialogs();
 
-const { isCreatingFor, selectDir, handleWorktreeSelect, addWorktree, handleWorktreeRemove } =
+const { isCreatingFor, activateDir, handleWorktreeSelect, addWorktree, handleWorktreeRemove } =
   useWorktreeActions({
     showConfirm,
   });
@@ -164,7 +164,7 @@ function onSelectWt(wt: WorktreeEntry) {
 
 // 非 git project ヘッダ経路。dir 選択プリミティブに委譲して rootDir を active にする。
 function onSelectRoot(rootDir: string) {
-  selectDir(rootDir);
+  activateDir(rootDir);
 }
 
 function onSelectTask(wt: WorktreeEntry, task: Task) {
@@ -177,7 +177,7 @@ function onSelectTask(wt: WorktreeEntry, task: Task) {
 //
 // 上段と違い viewMode を倒さない。下段のクリックは「動いているタイルへ focus を移す」
 // 操作で、docs/terminal.md の「横断ビュー（all / claude）では focus 追従のみ行い viewMode は
-// 変更しない」規律と同じ意味論になる。selectDir（= wt ビューへ移動する）を通すと、claude
+// 変更しない」規律と同じ意味論になる。activateDir（= wt ビューへ移動する）を通すと、claude
 // タイル表示中に下段を触った瞬間にタイルが畳まれ、常設ペインとして使えない。
 //
 // 下段の行は live session を持つ task だけなので（collectActiveSessionGroups が status で

--- a/apps/renderer/src/features/sidebar/activateDir.ts
+++ b/apps/renderer/src/features/sidebar/activateDir.ts
@@ -1,0 +1,19 @@
+import { useTerminalStore } from "../terminal";
+import { useWorktreeStore } from "../worktree";
+
+/**
+ * viewMode を wt に倒し setOpen で selectedDir を切り替える選択プリミティブ。
+ * wt ビューへ移動する dir 選択はこの関数を経由し、viewMode / setOpen の 2 行を直書きしない。
+ * viewMode と選択のどちらか一方だけを動かす操作は別物で、ここは通さない
+ * (viewMode 単独 = docs/terminal.md の「分割操作は意図を wt に戻す」、
+ *  setOpen 単独 = docs/terminal.md の「横断ビューでの選択追従」と docs/workspace.md の
+ *  アクティブセッションペイン)。
+ * setOpen は冪等で、同一 dir の再選択でも selectionVersion が発火し
+ * useTerminalStore 側の watch が done を消化する。
+ */
+export function activateDir(dir: string): void {
+  const terminalStore = useTerminalStore();
+  const worktreeStore = useWorktreeStore();
+  terminalStore.viewMode = "wt";
+  worktreeStore.setOpen(dir);
+}

--- a/apps/renderer/src/features/sidebar/activateDir.ts
+++ b/apps/renderer/src/features/sidebar/activateDir.ts
@@ -5,7 +5,7 @@ import { useWorktreeStore } from "../worktree";
  * viewMode を wt に倒し setOpen で selectedDir を切り替える選択プリミティブ。
  * wt ビューへ移動する dir 選択はこの関数を経由し、viewMode / setOpen の 2 行を直書きしない。
  * viewMode と選択のどちらか一方だけを動かす操作は別物で、ここは通さない
- * (viewMode 単独 = docs/terminal.md の「分割操作は意図を wt に戻す」、
+ * (例: viewMode 単独 = docs/terminal.md の「分割操作は意図を wt に戻す」、
  *  setOpen 単独 = docs/terminal.md の「横断ビューでの選択追従」と docs/workspace.md の
  *  アクティブセッションペイン)。
  * setOpen は冪等で、同一 dir の再選択でも selectionVersion が発火し

--- a/apps/renderer/src/features/sidebar/features/worktree/useWorktreeActions.ts
+++ b/apps/renderer/src/features/sidebar/features/worktree/useWorktreeActions.ts
@@ -5,7 +5,7 @@ import { useNotificationStore } from "../../../../shared/notification";
 import { useRepoStore } from "../../../../shared/repo";
 import { useTerminalStore } from "../../../terminal";
 import { generateTimestamp } from "../../../worktree";
-import { selectDir } from "../../openTaskSession";
+import { activateDir } from "../../activateDir";
 import { rpcCreateWorktree, rpcGitDefaultBranch, rpcGitWorktreeRemove } from "../../rpc";
 import { worktreeDisplayName } from "../../utils";
 
@@ -27,7 +27,7 @@ export function useWorktreeActions({ showConfirm }: UseWorktreeActionsOptions) {
   const creatingRootDirs = ref(new Set<string>());
 
   function handleWorktreeSelect(wt: WorktreeEntry) {
-    selectDir(wt.path);
+    activateDir(wt.path);
   }
 
   // --- store 更新 helpers ---
@@ -69,9 +69,9 @@ export function useWorktreeActions({ showConfirm }: UseWorktreeActionsOptions) {
       );
       if (result.ok && result.value.worktree !== undefined) {
         repoStore.appendWorktree(rootDir, result.value.worktree);
-        // setOpen（selectDir 内）が visit を駆動する前に setup ヒントを立てる
+        // setOpen（activateDir 内）が visit を駆動する前に setup ヒントを立てる
         terminalStore.setPreferredSetup(result.value.dir, result.value.setupScript);
-        selectDir(result.value.dir);
+        activateDir(result.value.dir);
       } else {
         notify.error("Failed to add worktree", result.ok ? undefined : result.error);
       }
@@ -110,7 +110,7 @@ export function useWorktreeActions({ showConfirm }: UseWorktreeActionsOptions) {
 
   return {
     isCreatingFor,
-    selectDir,
+    activateDir,
     handleWorktreeSelect,
     addWorktree,
     handleWorktreeRemove,

--- a/apps/renderer/src/features/sidebar/index.ts
+++ b/apps/renderer/src/features/sidebar/index.ts
@@ -1,4 +1,4 @@
-export { openTaskSession } from "./openTaskSession";
+export { openTaskSession, selectDir } from "./openTaskSession";
 export { default as SidebarPane } from "./SidebarPane.vue";
 export { rpcCreateWorktree, rpcGitDefaultBranch, rpcGitWorktreeList, rpcTaskAdd } from "./rpc";
 export type { BranchChangePayload, FsWatchReadyPayload, RemoteRefsChangePayload } from "./rpc";

--- a/apps/renderer/src/features/sidebar/index.ts
+++ b/apps/renderer/src/features/sidebar/index.ts
@@ -1,4 +1,5 @@
-export { openTaskSession, selectDir } from "./openTaskSession";
+export { activateDir } from "./activateDir";
+export { openTaskSession } from "./openTaskSession";
 export { default as SidebarPane } from "./SidebarPane.vue";
 export { rpcCreateWorktree, rpcGitDefaultBranch, rpcGitWorktreeList, rpcTaskAdd } from "./rpc";
 export type { BranchChangePayload, FsWatchReadyPayload, RemoteRefsChangePayload } from "./rpc";

--- a/apps/renderer/src/features/sidebar/openTaskSession.ts
+++ b/apps/renderer/src/features/sidebar/openTaskSession.ts
@@ -1,20 +1,6 @@
 import type { Task } from "@gozd/rpc";
 import { useTerminalStore } from "../terminal";
-import { useWorktreeStore } from "../worktree";
-
-/**
- * viewMode を wt に倒し setOpen で selectedDir を切り替える選択プリミティブ。
- * dir を active にする選択はこの関数を経由し、viewMode / setOpen の 2 行を直書きしない
- * (setOpen を伴わない viewMode 単独の切替 — terminal の split 系 — は別の操作で対象外)。
- * setOpen は冪等で、同一 dir の再選択でも selectionVersion が発火し
- * useTerminalStore 側の watch が done を消化する。
- */
-export function selectDir(dir: string): void {
-  const terminalStore = useTerminalStore();
-  const worktreeStore = useWorktreeStore();
-  terminalStore.viewMode = "wt";
-  worktreeStore.setOpen(dir);
-}
+import { activateDir } from "./activateDir";
 
 /**
  * task を選択して「dir を active にし、session へ到達する」分岐の SSOT。
@@ -32,16 +18,16 @@ export function openTaskSession(dir: string, task: Task): void {
   const terminalStore = useTerminalStore();
   if (task.sessionId === "") {
     terminalStore.requestNewClaudeSession(dir);
-    selectDir(dir);
+    activateDir(dir);
     return;
   }
   const ptyId = terminalStore.getPtyIdBySessionId(task.sessionId);
   if (ptyId === undefined) {
     terminalStore.requestResumeSession(dir, task.sessionId);
-    selectDir(dir);
+    activateDir(dir);
     return;
   }
-  selectDir(dir);
+  activateDir(dir);
   const leafId = terminalStore.getLeafIdByPtyId(ptyId);
   if (leafId === undefined) {
     // live PTY があるのに leaf が引けないのは paneRegistry の不整合。到達すると

--- a/apps/renderer/src/features/sidebar/openTaskSession.ts
+++ b/apps/renderer/src/features/sidebar/openTaskSession.ts
@@ -4,6 +4,8 @@ import { useWorktreeStore } from "../worktree";
 
 /**
  * viewMode を wt に倒し setOpen で selectedDir を切り替える選択プリミティブ。
+ * dir を active にする選択はこの関数を経由し、viewMode / setOpen の 2 行を直書きしない
+ * (setOpen を伴わない viewMode 単独の切替 — terminal の split 系 — は別の操作で対象外)。
  * setOpen は冪等で、同一 dir の再選択でも selectionVersion が発火し
  * useTerminalStore 側の watch が done を消化する。
  */

--- a/apps/renderer/src/features/terminal/registerTerminalCommands.ts
+++ b/apps/renderer/src/features/terminal/registerTerminalCommands.ts
@@ -77,8 +77,10 @@ export function registerTerminalCommands(
         if (active === undefined) return false;
         // split で増える新 pane は素の PTY（Claude 未起動）なので claude タイル対象外。
         // 既存 Claude leaf が残っていると claude ビュー実効値が解除されないため、
-        // ここでユーザー意図を wt へ明示的に切り替える。同 PR 設計上の既存パターン
-        // （useWorktreeActions / register*Command など）と同じ方針。
+        // ここでユーザー意図を wt へ明示的に切り替える（docs/terminal.md の「分割操作は
+        // 意図を wt に戻す」）。activateDir は通さない — ここは選択を動かさず表示意図
+        // だけを倒す操作で、setOpen を伴うと selectionVersion が発火して split のたびに
+        // done バッジが既読消化される。
         terminalStore.viewMode = "wt";
         terminalStore.splitPane(active.dir, "horizontal");
         return true;

--- a/apps/renderer/src/features/terminal/useTerminalStore.ts
+++ b/apps/renderer/src/features/terminal/useTerminalStore.ts
@@ -347,9 +347,6 @@ export const useTerminalStore = defineStore("terminal", () => {
    *  - claude ビュー中に split で素 PTY を増やしても、新 pane が見える wt として描画
    *  - Claude セッション全終了で空タイル（真っ黒）にならない
    *  - 各コマンド handler / store watch で「if claude then wt」を書く必要がない
-   * setter は `userViewMode` への代入を転送し、既存の `terminalStore.viewMode = "wt"`
-   * のような呼び出し（SidebarPane / useWorktreeActions / register*Command 等）を
-   * 改変なしで動かす。
    */
   const viewMode = computed<ViewMode>({
     get: () => {


### PR DESCRIPTION
## 概要

wt ビューへ移動する dir 選択 6 箇所を、選択プリミティブ `activateDir` の呼び出しに統一する。

## 背景

PR #1115 のスコープ外節「選択プリミティブを迂回する dir 選択の統一」の追跡。`terminalStore.viewMode = "wt"` + `worktreeStore.setOpen(dir)` の 2 行直書きが picker / server panel に分散しており、選択経路が増えるたびに複製が増える状態だった。プリミティブ関数自体（旧名 selectDir）が #1115 で追加されたため、この統一は #1115 の上に積む stacked PR とする。

当初 8 箇所とされたうち terminal の 2 箇所（split コマンド）は `setOpen` を伴わない viewMode 単独の切替 = 別の操作であり、置換すると挙動が変わる（selectionVersion 発火で done バッジが既読消化される）ため対象外。

## 変更内容

### プリミティブの契約

- `activateDir` に改名して専用ファイルへ切り出し、sidebar バレルから公開する。旧名 selectDir は `useRepoStore.selectDir`（選択値の書き込みのみ）・`ActiveSessionsPane` の emit 名（setOpen 単独経路）と衝突し、「唯一の入口」の誤読を誘発していた
- docstring は定義域を「wt ビューへ移動する dir 選択」に限定し、viewMode 単独（docs/terminal.md の分割操作）と setOpen 単独（横断ビューの選択追従 / アクティブセッションペイン）の両方向を対象外として docs の節名で規定する

### 置換（挙動不変）

- revive picker / issue picker ×2 / PR picker ×2 / server panel の 6 箇所を `activateDir(dir)` に置換
- terminal の split コマンドは `activateDir` を通さない理由（selectionVersion 発火で done バッジが既読消化される）をコメントで持つ

## スコープの切り分け

| 作業内容 | やるべき理由 | この PR でやらない理由 |
| --- | --- | --- |
| `activateDir` / `openTaskSession` の置き場（sidebar の共有層化） | 本 PR で sidebar バレルへの依存 feature が 3 → 5 に増え、#1121 の前提が進行する | feature 構成の変更として #1121 で扱う |
| 「直書きを増やさない」規範の ESLint ルール化 | prose の規範は機械検出されない | 統一 6 箇所の成果物と分離可能。自前 plugin への追加として独立に判断する |

## 確認事項

- [ ] revive / issue / PR picker、server panel からの選択で従来どおり worktree が切り替わる

