### PR TITLE
refactor(design-tokens): generate the age scale and validate its pair distinctness at build time

### DIFF
--- a/.claude/skills/gozd-ui/SKILL.md
+++ b/.claude/skills/gozd-ui/SKILL.md
@@ -25,7 +25,7 @@ Tier 3 (element defaults, @layer base)    ← renderer main.css
 SSOT:
 
 - Tier 1 primitives: `@gozd/design-tokens` package が prepare 時に `dist/tokens.generated.css` を生成。**手書き禁止**。brand を変えたいときは `packages/design-tokens/src/generateTokens.ts` の `BRAND` を編集して `pnpm install` (prepare で自動再生成)
-- Tier 1 brand-fixed (例外): Leonardo 生成パイプラインに載らない固定値 — theme 追従しない brand 色 (LINE 配色等) と、contrast 目標から導出しない個別設計値 (age scale 等) — は `main.css` の `:root` に手書きで定義する。命名規約 `--<scope>-<role>-primitive` で識別。例: `chat-incoming-primitive` / `age-week-primitive`
+- Tier 1 brand-fixed (例外): 固定値の置き場は**検証の有無**で分かれる。生成値との知覚不変条件を検証する必要がある設計値 (age scale 等) は `packages/design-tokens` の generator が持つ。検証を伴わない、theme 追従しない固定 brand 色 (LINE 配色等) は `main.css` の `:root` に手書きし、命名規約 `--<scope>-<role>-primitive` で識別する。例: `chat-incoming-primitive` 等
 - Tier 2/3: `apps/renderer/src/assets/main.css` (`@theme inline` semantic alias + `@layer base` element default)
 
 semantic alias / element default は `@theme inline` / `@layer base` 内。不足したら raw に逃げず token を追加する。
@@ -74,10 +74,12 @@ element-hover gray-4、ΔL 0.05) は人間に判別できない。**同一 scale
 VS Code が list 専用色 (`list.activeSelectionBackground` / `list.hoverBackground`) を別立てする
 理由でもある。
 
-- **keyboard カーソル行**: `bg-selection` (accent step 4)。上に乗せてよい text は contrast で
-  決める: `text-foreground` 約 9.3:1、`text-foreground-low` / `text-<intent>-text` 約 5.3:1 は
-  AA (4.5:1) を満たす。**`text-foreground-muted` は約 3.0:1 で AA を割るため、選択行に載る
-  セルには使わない** (foreground-low を下限にする)。step 5 は step-11 系 text が約 4.4:1 で
+- **keyboard カーソル行**: `bg-selection` (accent step 4)。この面はリスト行に text が載る
+  3 面 (panel / hover 行 / カーソル行) のうち最も contrast が厳しく、ここで AA (4.5:1) を
+  満たせば他 2 面も満たす。**載せる text token は計算で AA を確認してから使う**。
+  現行の最小は `text-age-week` 約 4.6:1、`text-foreground` 約 9.3:1、
+  `text-foreground-low` / `text-<intent>-text` 約 5.3:1。**`text-foreground-muted` は
+  約 3.0:1 で AA を割るため載せない**。step 5 は step-11 系 text が約 4.4:1 で
   AA をわずかに割るため使わない
 - **hover 行**: `hover:bg-element-hover` (無彩色 solid)。選択と色相で分かれるため薄める必要はなく、
   alpha modifier での希釈は Alpha 規律違反
@@ -187,8 +189,12 @@ SSOT。
 
 - 鮮度を塗る一覧はすべてこのスケールを使う。intent（success / warning 等）を鮮度に
   流用しない（経過時間はデータエンコーディングであって状態の意味ではない）
-- 生成 palette に無い値は brand-fixed primitive（`--age-<role>-primitive`）として
-  `main.css` の `:root` に置く（分類の定義は「3-tier token system」の brand-fixed 節）
+- 値（生成 primitive `--age-<role>`）と scale 内不変条件（全ペア ΔE ≥ 15）の SSOT は
+  `packages/design-tokens` の generator。違反は生成時にビルドが失敗する。載る面での
+  AA は利用側の知識のため機械検証を持たず、面や値の変更時に本 skill の規律で
+  設計時に計算検証する（CSS-first では検証入力のデータ化が成立しないため。
+  実地調査では token ペア検証の実例は Primer 1 件で、全 token を data 化した
+  構造が前提だった）
 
 ### Overlay / Focus ring
 

--- a/apps/renderer/CLAUDE.md
+++ b/apps/renderer/CLAUDE.md
@@ -3,11 +3,10 @@
 - 色は **semantic token** だけを使う。生 Tailwind palette (`zinc-*` / `blue-*` / `red-*` 等) と primitive 直参照 (`var(--gray-3)` / `var(--blue-9)` 等) は ESLint で error
 - Token system: 3-tier
   - Tier 1 (primitives): `@gozd/design-tokens` package が Adobe Leonardo で生成 → `dist/tokens.generated.css` を `main.css` が `@import`
-  - Tier 1 brand-fixed (例外): theme 追従しない固定 brand 色 (LINE 配色等) は `main.css` の `:root` に手書きで定義し、命名規約 `--<scope>-<role>-primitive` で識別する
+  - Tier 1 brand-fixed (例外): 知覚検証を伴わない固定 brand 色だけを `main.css` の `:root` に手書きし、命名規約 `--<scope>-<role>-primitive` で識別する (置き場の判定基準の SSOT は gozd-ui skill)。例: chat-\* (LINE ダークモード配色)。生成値との知覚検証が要る設計値 (age scale 等) は generator が持つ
   - Tier 2 (semantic aliases): `main.css` の `@theme inline` で role 名定義
   - Tier 3 (element defaults): `main.css` の `@layer base` で UA 上書き / scrollbar
 - Tier 1 primitives は **手書き禁止**。brand を変えるときは [`packages/design-tokens/src/generateTokens.ts`](../../packages/design-tokens/src/generateTokens.ts) の `BRAND` を編集し `pnpm install` (prepare で自動再生成)
-- Tier 1 brand-fixed primitives (`--<scope>-<role>-primitive`) は **例外的に `main.css` の `:root` への手書きを許可** する。theme 追従しない固定色は Adobe Leonardo 生成パイプラインに乗らないため。例: chat-\* (LINE ダークモード配色)
 - UI を書く / 直すときの規律一覧は project-local skill [`/.claude/skills/gozd-ui/SKILL.md`](../../.claude/skills/gozd-ui/SKILL.md) を参照 (Claude Code 自動適用)
 
 ## アイコン

--- a/apps/renderer/src/assets/main.css
+++ b/apps/renderer/src/assets/main.css
@@ -6,13 +6,12 @@
  * packages/design-tokens/src/generateTokens.ts を編集して pnpm install */
 @import "@gozd/design-tokens/tokens.css";
 
-/* Tier 1 (brand-fixed primitives): theme 追従しない固定 brand 色を独立 layer に隔離する。
+/* Tier 1 (brand-fixed primitives): 生成パイプラインに乗せない固定 brand 色の layer。
  *
- * 主 Tier 1 は `@gozd/design-tokens` package が Adobe Leonardo で theme 追従可能な形
- * (gray / intent × 12-step) として生成するが、LINE のブランド配色のように
- * 「dark/light theme に追従させたくない固定色」はその生成パイプラインに合わない。
- * design-tokens package に brand 固定 slot を増やす案もあるが、本 layer に集約する方が
- * 「theme 追従するか否か」の境界を一目で読める。
+ * 固定値の置き場は知覚検証の有無で分かれる (判定基準の SSOT は gozd-ui skill)。
+ * 生成値との知覚不変条件を検証する必要がある設計値 (age scale) は
+ * `@gozd/design-tokens` の generator が持ち、検証を伴わない theme 非追従の
+ * 固定 brand 色 (LINE 配色等) だけを本 layer に手書きする。
  *
  * 命名規約: `--<scope>-<role>-primitive`。Tier 2 (@theme inline) の semantic alias から
  * `var(--<scope>-<role>-primitive)` で参照される SSOT。
@@ -32,16 +31,6 @@
   --scroll-pill-primitive: oklch(0.48 0.11 250);
   --scroll-pill-hover-primitive: oklch(0.53 0.11 250);
   --scroll-pill-foreground-primitive: oklch(1 0 0);
-
-  /* age scale (相対日時の鮮度 4 段階のうち、生成 palette に無い 2 色)。
-     帯ごとに人間が候補比較で選んだ個別の色値であり、contrast 目標から scale を導く
-     Leonardo 生成では再現しないためここに置く。light theme 追加時は .light scope の
-     生成に乗らないので、この 2 値は再設計が必要。全値は選択カーソル行 (blue-4) 上で
-     不透明表示時に WCAG AA (4.5:1) を満たす明度帯域に収める (draft 行等の data state
-     dim は対象外)。hour 帯 (green-11) と date 帯 (gray-11) は生成 primitive を
-     Tier 2 が直接参照する */
-  --age-day-primitive: oklch(0.87 0.155 97);
-  --age-week-primitive: oklch(0.74 0.15 52);
 }
 
 /* layout 定数: カスタムタイトルバー（TitleBar.vue）の高さ。
@@ -84,8 +73,10 @@
   --color-element-hover: var(--gray-4);
   --color-element-active: var(--gray-5);
   /* keyboard カーソル行 (picker / list の選択)。無彩色の hover (element-hover) と色相で
-     分離するための低輝度 accent 面。上に乗せる text は foreground (約 9.3:1) /
-     foreground-low・intent-text (約 5.3:1) まで — foreground-muted (約 3.0:1) は載せない。
+     分離するための低輝度 accent 面。リスト行に text が載る 3 面 (panel / hover 行 /
+     カーソル行) のうち最も contrast が厳しく、ここで AA (4.5:1) を満たせば他 2 面も満たす。
+     上に乗せる text token は計算で AA を確認してから使う (現行の最小は age-week
+     約 4.6:1。foreground-muted 約 3.0:1 は AA を割るため載せない)。
      primary-subtle-hover と同値だが役割は別 (あちらは active row の hover で、focused list の
      カーソル行と同一リストに並ばない)。step 9 solid (primary) は前景色の全上書きとセットの
      戦略なのでリスト選択に使わない */
@@ -176,20 +167,19 @@
      (hour = 秒・分・時間表記、day = 日、week = 週、date = 絶対日付) で、色帯の境界と
      表示単位の切り替わりが一致する。帯の境界と token の対応は shared/time の
      formatRelativeAge が SSOT。経過時間はデータエンコーディングであって intent
-     (成功 / 警告) ではないため、intent token を借りず独立 role を持つ。散在する小さい
-     文字を凡例なしで見分ける絶対識別のため、同時に画面へ並びうる全ペアが「別の色名」
-     (ペア ΔE ≥ 15、OKLab ×100) になるよう hue で分離する。グレー階調や彩度差だけの
-     段分けは小サイズ文字で知覚できない (small-field effect) ため使わない。全段が
-     選択カーソル行 (bg-selection) 上で不透明表示時に AA (4.5:1) を満たす。 */
-  /* フレッシュ (24 時間未満)。green-11 と同値だが success (完了) とは独立した role */
-  --color-age-hour: var(--green-11);
+     (成功 / 警告) ではないため、intent token を借りず独立 role を持つ
+     (hour は green-11、date は gray-11 と同値だが、success / text 階層の restyle に
+     鮮度表示が追従しないよう primitive から独立)。値と全ペア ΔE 検証の SSOT は
+     @gozd/design-tokens の generator で、違反は生成時にビルドが失敗する。載る面での
+     AA は面の規律 (bg-selection 節) に従い設計時に計算で検証する。 */
+  /* フレッシュ (24 時間未満) */
+  --color-age-hour: var(--age-hour);
   /* 少し古い (24 時間〜7 日) */
-  --color-age-day: var(--age-day-primitive);
+  --color-age-day: var(--age-day);
   /* stale (7 日〜4 週間) */
-  --color-age-week: var(--age-week-primitive);
-  /* 陳腐化 (4 週間以上。絶対日付表記に切り替わった帯)。foreground-low と同値だが
-     独立 role (text 階層の restyle に鮮度表示が追従しないよう分離) */
-  --color-age-date: var(--gray-11);
+  --color-age-week: var(--age-week);
+  /* 陳腐化 (4 週間以上。絶対日付表記に切り替わった帯) */
+  --color-age-date: var(--age-date);
 
   /* chat (Tier 2 semantic alias): brand 固定 primitive (`:root` 配下) を `var()` で
      参照する。値の直書きは Tier 1 に集約し、Tier 2 は role 名のマッピングだけ持つ。 */

--- a/apps/renderer/src/shared/time/relativeAge.ts
+++ b/apps/renderer/src/shared/time/relativeAge.ts
@@ -26,7 +26,8 @@ const FOUR_WEEKS_SEC = 4 * WEEK_SEC;
 
 /** 鮮度 4 段階。最初に一致した帯を採る（境界は未満）。
  * 帯名は表示単位（hour = 秒・分・時間表記、day = 日、week = 週、date = 絶対日付）。
- * 各帯の意味と色は main.css の age-* token 定義コメントが SSOT。 */
+ * 各帯の意味は main.css の age-* token 定義コメント、値と知覚検証は
+ * `@gozd/design-tokens` の generator が SSOT。 */
 const AGE_BANDS = [
   { withinSec: DAY_SEC, color: "text-age-hour" },
   { withinSec: WEEK_SEC, color: "text-age-day" },

--- a/packages/design-tokens/README.md
+++ b/packages/design-tokens/README.md
@@ -3,60 +3,35 @@
 Tier 1（primitives）の design token を **contrast 駆動のアルゴリズムで生成**する。出力は
 CSS 変数。
 
+## 責務
+
+- **生成 scale**: 無彩色（solid + alpha）と intent hues の 12-step scale。step はコントラスト
+  比の昇順に並び、テキスト用の高 step は目標コントラスト比を満たすことが生成時に保証される
+- **検証済み設計値**: scale 内の知覚不変条件（全ペア ΔE）を要する固定値（age scale）。
+  値と検証はこの package が持ち、違反は生成失敗 = ビルド失敗になる
+
+token は `src/generateTokens.ts` から `dist/tokens.generated.css` に生成される。
+
 ## tier の分離
 
-| Tier                      | 責任                          | 配置               |
-| ------------------------- | ----------------------------- | ------------------ |
-| Tier 1 (primitives)       | 物理的な色値、12 段のスケール | この package       |
-| Tier 2 (semantic aliases) | role 名 → primitive の写像    | 利用側の entry CSS |
-| Tier 3 (element defaults) | UA スタイルシートの上書き     | 利用側の entry CSS |
+| Tier                      | 責任                       | 配置               |
+| ------------------------- | -------------------------- | ------------------ |
+| Tier 1 (primitives)       | 物理的な色値               | この package       |
+| Tier 2 (semantic aliases) | role 名 → primitive の写像 | 利用側の entry CSS |
+| Tier 3 (element defaults) | UA スタイルシートの上書き  | 利用側の entry CSS |
 
-**この package は role を知らない。** 「どの step をどの用途に使うか」は利用側の責務。
+**この package は semantic alias（Tier 2）を持たない。** step をどの用途に使うかの語彙は
+利用側（gozd-ui skill）が持つ。
 
 ## 利用側への要求
 
-公開するのは `@gozd/design-tokens/tokens.css` の 1 つだけ。中身は CSS 変数で、role 名は持たない。
-利用側はこれを読み込んだうえで **semantic alias（role 名 → primitive の写像）を自分で定義する**。
-
-## token 一覧
-
-| 名前             | 種別  | intent                     |
-| ---------------- | ----- | -------------------------- |
-| `--gray-1..12`   | solid | 中立（bg / border / text） |
-| `--gray-a1..a12` | alpha | overlay / chrome           |
-| `--blue-1..12`   | solid | primary / info             |
-| `--red-1..12`    | solid | destructive                |
-| `--green-1..12`  | solid | success                    |
-| `--amber-1..12`  | solid | warning                    |
-| `--orange-1..12` | solid | warning-strong             |
-
-step → 用途の写像は Radix の規約に従う。
-
-| step | 用途                                        |
-| ---- | ------------------------------------------- |
-| 1-2  | app / subtle な背景                         |
-| 3-5  | コンポーネント背景（通常 / hover / active） |
-| 6    | 非対話の境界線                              |
-| 7    | 対話可能な境界線                            |
-| 8    | 強い境界線 / フォーカスリング               |
-| 9-10 | 塗りつぶし背景（通常 / hover）              |
-| 11   | 低コントラストのテキスト                    |
-| 12   | 高コントラストのテキスト                    |
-
-**step 11 / 12 は目標コントラスト比を満たすことが生成時に保証される。**
-
-## なぜ生成するか
-
-contrast 駆動の生成器は **目標コントラストを入力に指定すると、それを満たす色を逆算する**。
-テキスト用の step が要求水準を確実に満たす。
-
-**手書きすると、色域上の彩度限界とコントラスト検証が手動になり破綻しやすい。**
-
-## brand の変更
-
-**primitives は手書きしない。** brand の変更は生成器への入力を変えることで行い、出力は必ず再生成
-された結果とする。
+- 公開するのは `@gozd/design-tokens/tokens.css` の 1 つだけ。利用側はこれを読み込み、
+  semantic alias を自分で定義する
+- **primitives は手書きしない。** brand の変更は生成器への入力（`BRAND`）を変えて再生成する。
+  手書きすると、色域上の彩度限界とコントラスト検証が手動になり破綻しやすい
 
 > [!NOTE]
-> テーマに追従しない固定の brand 色（外部サービスの指定配色など）は生成パイプラインに乗らないため、
-> 利用側で例外として手書きし、命名規約で識別できるようにする。
+> 固定値の置き場は知覚検証の有無で分かれる。生成値との知覚不変条件を検証する必要がある設計値
+> （age scale）はこの package の生成器が持つ。検証を伴わない、テーマに追従しない固定 brand 色
+> （外部サービスの指定配色など）は利用側で例外として手書きし、命名規約
+> `--<scope>-<role>-primitive` で識別できるようにする。

--- a/packages/design-tokens/src/colorMath.ts
+++ b/packages/design-tokens/src/colorMath.ts
@@ -1,0 +1,45 @@
+import chroma from "chroma-js";
+
+/* Leonardo 内蔵の chroma-js.d.ts shim が `@types/chroma-js` を shadow するため
+ * 型推論が unknown に倒れる（generateTokens.ts の chromaApi と同じ事情）。
+ * 必要な API を 1 箇所に集約して unknown cast を 1 度だけ書く。 */
+interface ChromaColor {
+  oklab: () => [number, number, number];
+  hex: () => string;
+  clipped: () => boolean;
+}
+const chromaApi = chroma as unknown as {
+  (input: string): ChromaColor;
+  oklch: (l: number, c: number, h: number) => ChromaColor;
+};
+
+/** sRGB gamut 外の設計値は clamp で画面と検証値が乖離するため、fallback せずエラーにする。
+ * chroma の clipped() は limit 前の生値を見るため、境界ちょうどの値 (純白等) も変換誤差で
+ * gamut 外判定になりうる */
+function toColor(c: Oklch): ChromaColor {
+  const color = chromaApi.oklch(...c);
+  if (color.clipped()) throw new Error(`out of sRGB gamut: oklch(${c.join(" ")})`);
+  return color;
+}
+
+/** 8bit 量子化後 (実際に描画される値) の色。判定は量子化後の値に対して行い、
+ * 境界近傍で「検証は通るが画面は割る」ずれを作らない */
+function quantized(c: Oklch): ChromaColor {
+  return chromaApi(toColor(c).hex());
+}
+
+/** oklch の成分 3 値（L, C, hue deg）。CSS の `oklch(L C h)` と同順 */
+export type Oklch = [number, number, number];
+
+/**
+ * OKLab ユークリッド距離 ×100。
+ *
+ * gozd-ui skill の「文字色で段階 / カテゴリを区別するときの知覚下限」が定める尺度で、
+ * 色名分離の下限はペア ΔE ≥ 15。色空間変換は chroma-js に委譲し、自前の変換行列を
+ * 持たない（検証器そのものが未検証の再実装になるのを避ける）。
+ */
+export function deltaEOk(a: Oklch, b: Oklch): number {
+  const [l1, a1, b1] = quantized(a).oklab();
+  const [l2, a2, b2] = quantized(b).oklab();
+  return Math.hypot(l1 - l2, a1 - a2, b1 - b2) * 100;
+}

--- a/packages/design-tokens/src/generateTokens.ts
+++ b/packages/design-tokens/src/generateTokens.ts
@@ -1,22 +1,7 @@
 /*
- * gozd design tokens Tier 1 (primitives) を Adobe Leonardo の contrast-driven
- * algorithm で生成し、CSS file (dist/tokens.generated.css) として出力する。
- *
- * Tailwind v4 の `@theme inline` semantic alias 層は consumer 側 (renderer の
- * main.css) が定義する。この package は primitive 層のみを責任範囲とする:
- *   - gray 12-step solid + 12-step alpha (overlay 用)
- *   - intent hues (blue/red/green/amber/orange) 各 12-step solid
- *
- * Radix step → role 写像に揃えた WCAG2 contrast ratios:
- *   1     bg 自身
- *   2-5   bg / component bg (rest/hover/active)        ← subtle chip / active row
- *   6-8   border (subtle/interactive/strong)
- *   9-10  solid bg (rest/hover)                         ← CTA / badge 本体
- *   11    low-contrast text (WCAG2 8.0+)
- *   12    high-contrast text (WCAG2 14.0+)
- *
- * 再生成: pnpm install (prepare で自動) または pnpm --filter @gozd/design-tokens
- *         build。brand identity を変えたいときは BRAND を編集して再生成。
+ * Tier 1 primitives を Adobe Leonardo の contrast-driven algorithm で生成し、
+ * dist/tokens.generated.css として出力する。package の契約 (責務 / 利用側への要求 /
+ * age scale の検証) は README.md。
  *
  * ## Leonardo の使い方 — colorKeys に複数 anchor を渡す
  *
@@ -43,6 +28,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { Color, BackgroundColor, Theme } from "@adobe/leonardo-contrast-colors";
 import chroma from "chroma-js";
+import { deltaEOk, type Oklch } from "./colorMath";
 
 const OUTPUT_FILE = path.resolve(import.meta.dir, "../dist/tokens.generated.css");
 
@@ -55,8 +41,30 @@ const BRAND = {
   orange: "#f97316",
 } as const;
 
+/* bg に対する WCAG2 目標コントラスト比。Radix step → role 写像
+ * (1 = bg 自身、2-5 = component bg rest/hover/active、6-8 = border、
+ *  9-10 = solid bg、11 = low text、12 = high text) に揃えた値で、
+ * step 11 / 12 のコントラスト保証はこの目標値から来る。
+ * BG 側は step 1 が bg 自身のため ratios は 11 点 */
 const STEP_RATIOS_BG = [1.1, 1.3, 1.5, 1.8, 2.2, 2.8, 3.5, 4.5, 5.5, 8, 14];
 const STEP_RATIOS_INTENT = [1.05, 1.15, 1.3, 1.5, 1.8, 2.2, 2.8, 3.5, 4.5, 5.5, 8, 14];
+
+/* age scale (相対日時の鮮度 4 帯) の個別設計値。hour / date 帯は生成 scale の step
+ * (green 11 / gray 11) と同値で、day / week は人間が候補比較で選んだ値。
+ * 帯の境界と表示単位は renderer の shared/time、role の意味は main.css が持ち、
+ * 値と知覚検証はここが SSOT。
+ *
+ * day / week は dark UI 前提の手選び値。light theme を追加するときは .light scope の
+ * 生成に乗らないため、この 2 値は再設計が必要。 */
+const AGE_DAY: Oklch = [0.87, 0.155, 97];
+const AGE_WEEK: Oklch = [0.74, 0.15, 52];
+
+/* age scale の scale 内不変条件 (gozd-ui skill「文字色で段階 / カテゴリを区別するときの
+ * 知覚下限」)。散在する小さい文字の絶対識別に必要な色名分離の下限で、違反は生成失敗 =
+ * ビルド失敗として現れる (Leonardo の contrast-driven 生成と同じ by-construction 方針)。
+ * 載る面での AA は利用側 (Tier 2 の配置) の知識であり、ここでは検証しない。面や値を
+ * 変えるときは skill の規律に従い設計時に計算で検証する。 */
+const AGE_MIN_PAIR_DELTA_E = 15;
 
 /* BackgroundColor scale 上で bg が位置する % (dark UI のため低い値) */
 const DARK_LIGHTNESS = 11;
@@ -80,13 +88,23 @@ function oklchOf(hex: string): [number, number, number] {
   return chromaApi(hex).oklch();
 }
 
-function toOklch(hex: string): string {
+/* 出力と同じ丸めの OKLCH triple。知覚検証は出荷される丸め後の値に対して行う */
+function roundedOklchOf(hex: string): Oklch {
   const [l, c, h] = oklchOf(hex);
-  const lr = (Math.round(l * 1000) / 1000).toString();
-  const cr = (Math.round(c * 1000) / 1000).toString();
-  /* chroma=0 (pure gray) は NaN hue を 0 に正規化 */
-  const hr = Number.isNaN(h) ? "0" : (Math.round(h * 10) / 10).toString();
-  return `oklch(${lr} ${cr} ${hr})`;
+  return [
+    Math.round(l * 1000) / 1000,
+    Math.round(c * 1000) / 1000,
+    /* chroma=0 (pure gray) は NaN hue を 0 に正規化 */
+    Number.isNaN(h) ? 0 : Math.round(h * 10) / 10,
+  ];
+}
+
+function oklchToCss([l, c, h]: Oklch): string {
+  return `oklch(${l} ${c} ${h})`;
+}
+
+function toOklch(hex: string): string {
+  return oklchToCss(roundedOklchOf(hex));
 }
 
 /* brand hex の hue を保ったまま L/C を差し替えた anchor hex を生成。
@@ -172,16 +190,46 @@ for (let i = 0; i < grayHexes.length; i++) {
   lines.push(`  --gray-a${i + 1}: ${alphaForGray(grayHexes[i], grayHexes[0])};`);
 }
 
+let greenHexes: string[] | undefined;
 for (const intent of intents) {
   const group = groups.find((g) => g.name === intent.name);
   if (group === undefined) throw new Error(`missing ${intent.name} group`);
   const hexes = group.values.map((v) => v.value);
   if (hexes.length !== 12) throw new Error(`expected 12 ${intent.name} steps, got ${hexes.length}`);
+  if (intent.name === "green") greenHexes = hexes;
   lines.push(``);
   lines.push(`  /* ${intent.name}: 12-step solid */`);
   for (let i = 0; i < hexes.length; i++) {
     lines.push(`  --${intent.name}-${i + 1}: ${toOklch(hexes[i])};`);
   }
+}
+
+/* age 帯の値を組み立て、scale 内不変条件を検証してから primitive として出力する */
+if (greenHexes === undefined) {
+  throw new Error("green scale missing for age bands");
+}
+const ageBands: Record<string, Oklch> = {
+  hour: roundedOklchOf(greenHexes[10]),
+  day: AGE_DAY,
+  week: AGE_WEEK,
+  date: roundedOklchOf(grayHexes[10]),
+};
+const bandEntries = Object.entries(ageBands);
+for (const [i, [nameA, a]] of bandEntries.entries()) {
+  for (const [nameB, b] of bandEntries.slice(i + 1)) {
+    const d = deltaEOk(a, b);
+    if (d < AGE_MIN_PAIR_DELTA_E) {
+      throw new Error(
+        `age scale: ${nameA}/${nameB} pair ΔE ${d.toFixed(1)} < ${AGE_MIN_PAIR_DELTA_E}`,
+      );
+    }
+  }
+}
+lines.push(``);
+lines.push(`  /* age scale: 相対日時の鮮度 4 帯 (hour = green-11、date = gray-11 と同値)。`);
+lines.push(`     全ペア ΔE >= ${AGE_MIN_PAIR_DELTA_E} を生成時に検証済み */`);
+for (const [name, triple] of bandEntries) {
+  lines.push(`  --age-${name}: ${oklchToCss(triple)};`);
 }
 
 lines.push(`}`);


### PR DESCRIPTION
## 概要

age scale（相対日時の鮮度 4 帯）の色値と scale 内不変条件（全ペア ΔE ≥ 15）の SSOT を `packages/design-tokens` の generator に移し、**生成時に検証してビルドを落とす**。`--age-{hour,day,week,date}` は tokens.generated.css に出力され、renderer の main.css は age の手書き primitive を持たなくなる（chat / scroll-pill の brand-fixed 手書き節は残る）。表示される色値は変更なし。

## 背景

( #1127 ) のスコープの切り分け節で追跡と決めた項目。age token は生成 primitive（green-11 / gray-11）と同値の帯を持つため、`packages/design-tokens` の BRAND や ratio を変えると値が動き、main.css のコメントが宣言する不変条件だけが残って無音で崩れる。

generator が検証するのは scale 内部の性質（全ペア ΔE）だけで、載る面（panel / hover 行 / 選択カーソル行）での AA は検証しない。面の選定は Tier 2 = 利用側の知識であり、generator が持つと Tier 1 が上位層の事実を読む層違反になって「機械強制されない合意値」という穴が要る。CSS を検証入力にする方式（main.css の parse）も採らない。主要 design system 7 件（Primer / Carbon / Spectrum / Polaris / USWDS / Radix Colors / Chakra）の実地調査で、CSS を検証入力にする実例は皆無、token ペアの contrast 検証を CI で行う実例は Primer の 1 件のみで、それも semantic 層まで全 token を data として持つ構造が前提だった。Tailwind v4 CSS-first を採る本 repo ではその前提が成立しないため、載る面での AA は他の全 text token と同じく skill の規律（面や値の変更時に設計時計算で検証。選択カーソル行が最も厳しい面で、そこで満たせば他 2 面も満たす）で統治する。

## 変更内容

### design-tokens

- `generateTokens.ts` に age scale のデータ（day / week の個別設計値、hour = green step 11・date = gray step 11 の参照）と全ペア ΔE（OKLab ×100）≥ 15 の検証を追加。違反は生成失敗 = ビルド失敗になる。検証は出荷される丸め後の値に対して行う
- `colorMath.ts`（package 内部モジュール）に ΔE を集約。色空間変換は chroma-js に委譲し、hex 経由の 8bit 量子化後（実際に描画される値）で判定、sRGB gamut 外は throw
- 生成 token 名は素の `--age-<band>`。`-primitive` suffix は main.css 手書き brand-fixed 専用の識別子として維持
- README は契約（責務 / 保証 / 利用側への要求）だけを述べ、個々の token の列挙表は持たない（token は `src/generateTokens.ts` から `dist/tokens.generated.css` に生成される、という関係だけを記す）
- 退行検出の実証: `AGE_WEEK` に `[0.76, 0.01, 52]` を注入すると `age scale: week/date pair ΔE 1.2 < 15` で生成が失敗する

### renderer

- main.css の手書き age primitive を削除し、Tier 2 の `--color-age-*` は生成された `--age-*` を参照する
- 固定値の置き場の判定基準（知覚検証の有無で分かれる）を gozd-ui skill を SSOT として統一し、renderer CLAUDE.md と main.css の brand-fixed 節の記述も揃えた
- bg-selection の規律（skill / main.css）を述語形に更新: 選択カーソル行は text が載る 3 面のうち最も contrast が厳しく、載せる text token は計算で AA を確認してから使う（現行の最小は `text-age-week` 約 4.6:1）
- generator に移った値の light theme 制約（day / week は dark 前提の手選び値で、`.light` scope 生成に乗らないため再設計が必要）は generator の age 節コメントへ移設

