### PR TITLE
fix(terminal): 半円のスピナータイトルを稼働中として扱う

### DIFF
--- a/apps/renderer/src/features/sidebar/useSidebarData.ts
+++ b/apps/renderer/src/features/sidebar/useSidebarData.ts
@@ -272,7 +272,8 @@ export function useSidebarData() {
     () => terminalStore.lastTitleUpdate,
     (update) => {
       if (!update?.title) return;
-      // Claude Code のステータスプレフィックス（✳ + Braille dots）を除去
+      // strip 後の値で同期する。スピナー文字を残すとコマが変わるたびに別タイトル扱いになり、
+      // syncTaskTitle の完全一致 dedupe を毎回すり抜けて RPC と tasks.json 書き込みが走り続ける
       const title = stripClaudeTitlePrefix(update.title);
       if (!title) return;
       if (title === CLAUDE_PLACEHOLDER_TITLE) return;

--- a/apps/renderer/src/features/terminal/claudeStatus.test.ts
+++ b/apps/renderer/src/features/terminal/claudeStatus.test.ts
@@ -11,8 +11,10 @@ import {
   type ClaudeStatus,
 } from "./claudeStatus";
 
-/** Claude が OSC タイトル先頭に出すプレフィックス（点字スピナー / ✳ + スペース） */
-const WORKING_TITLE = "⠋ project"; // U+280B = 点字スピナーの一種
+/** Claude が OSC タイトル先頭に出すプレフィックス（スピナー / ✳ + スペース） */
+const WORKING_TITLE = "⠋ project"; // U+280B = 2.1.227 以前の点字スピナー
+const WORKING_TITLE_HALF_CIRCLE = "◐ project"; // U+25D0 = 2.1.228 以降の半円スピナー
+const WORKING_TITLE_HALF_CIRCLE_ALT = "◑ project"; // U+25D1 = 半円スピナーのもう 1 コマ
 const IDLE_TITLE = "✳ project"; // U+2733 = ✳
 
 function setup() {
@@ -329,15 +331,24 @@ describe("handleHookEvent fx 発行（効果ストリームの単一発行点）
 
 describe("classifyClaudeTitle / stripClaudeTitlePrefix", () => {
   test("スピナープレフィックスは working、✳ は idle、それ以外は undefined", () => {
+    // 点字・半円のどちらの字形でも working。利用者の Claude Code バージョンは選べない
     expect(classifyClaudeTitle(WORKING_TITLE)).toBe("working");
+    expect(classifyClaudeTitle(WORKING_TITLE_HALF_CIRCLE)).toBe("working");
+    expect(classifyClaudeTitle(WORKING_TITLE_HALF_CIRCLE_ALT)).toBe("working");
     expect(classifyClaudeTitle(IDLE_TITLE)).toBe("idle");
     expect(classifyClaudeTitle("plain title")).toBeUndefined();
     // 矢印キー等のエスケープではなく通常タイトル。プレフィックス無しは状態シグナル無し
     expect(classifyClaudeTitle("⠋no-space")).toBeUndefined();
+    expect(classifyClaudeTitle("◐no-space")).toBeUndefined();
+    // タイトルに出る半円は 2 コマだけ。範囲記法 `◐-◓` への一般化で残り 2 つを巻き込まない
+    expect(classifyClaudeTitle("◒ project")).toBeUndefined();
+    expect(classifyClaudeTitle("◓ project")).toBeUndefined();
   });
 
   test("strip は working/idle 両プレフィックスを落とし、素のタイトルは触らない", () => {
     expect(stripClaudeTitlePrefix(WORKING_TITLE)).toBe("project");
+    expect(stripClaudeTitlePrefix(WORKING_TITLE_HALF_CIRCLE)).toBe("project");
+    expect(stripClaudeTitlePrefix(WORKING_TITLE_HALF_CIRCLE_ALT)).toBe("project");
     expect(stripClaudeTitlePrefix(IDLE_TITLE)).toBe("project");
     expect(stripClaudeTitlePrefix("project")).toBe("project");
   });

--- a/apps/renderer/src/features/terminal/claudeStatus.ts
+++ b/apps/renderer/src/features/terminal/claudeStatus.ts
@@ -209,12 +209,16 @@ const ASK_DEBOUNCE_MS = 150;
 
 /**
  * Claude Code が OSC タイトル先頭に付ける状態プレフィックス。working / idle をこの
- * プレフィックスで判定する（herdr 方式）。Claude は稼働中はタイトル先頭に点字スピナー
- * (U+2800–U+28FF)、プロンプト待ちでは `✳` (U+2733) を出す。いずれも直後に半角スペースが続く。
+ * プレフィックスで判定する（herdr 方式）。Claude は稼働中はタイトル先頭にスピナー、
+ * プロンプト待ちでは `✳` (U+2733) を出す。いずれも直後に半角スペースが続く。
+ *
+ * 稼働中スピナーの字形は Claude Code のバージョンで異なる。2.1.227 以前は点字
+ * (U+2800–U+28FF)、2.1.228 以降は半円 (`◐` U+25D0 / `◑` U+25D1) の 2 コマ。gozd の
+ * 利用者が使う Claude Code のバージョンは gozd が決められないため、両方を受ける。
  * `working` は「今まさに稼働している」確証、`idle` は「入力待ちに戻った」確証で、UserPromptSubmit /
  * PostToolUse hook や PTY 出力の中断メッセージに頼らず状態を導出できる。
  */
-const CLAUDE_TITLE_WORKING_RE = /^[⠀-⣿] /;
+const CLAUDE_TITLE_WORKING_RE = /^[⠀-⣿◐◑] /;
 const CLAUDE_TITLE_IDLE_RE = /^✳ /;
 
 /** OSC タイトルの状態プレフィックスを分類する。プレフィックスが無ければ undefined */


### PR DESCRIPTION
## 概要

Claude Code が稼働中に出す OSC タイトルのスピナーが半円字形になっても `working` を検知できるようにする。ターミナル leaf の状態バッジ・サイドバーの Task 行の状態バッジ・Task タイトルの 3 箇所が、Claude Code のバージョンによらず正しく出る状態にする。

## 背景

gozd は Claude の `working` / `idle` を hook ではなく OSC タイトル先頭の状態プレフィックスで判定している（`docs/claude-status.md` の「なぜ working / idle をタイトルで取るか」）。稼働中プレフィックスの照合は点字ブロック U+2800–U+28FF に限定していた。

Claude Code 2.1.228 でこのスピナーが点字から半円に変わった。CHANGELOG の記載は "Updated terminal title busy-spinner glyphs to reduce tab-bar jitter on some terminals"。結果として 2.1.228 以降を使う利用者の環境で 2 つの症状が出る。

- `observeTitle` が稼働中を分類できず、`working` に遷移しない。状態バッジが出ない
- `stripClaudeTitlePrefix` が同じ正規表現を共有しているため、サイドバーの Task タイトルにスピナー文字が付いたまま同期される。スピナーは 960ms ごとにコマが変わり、そのたびに `syncTaskTitle` の完全一致 dedupe をすり抜けるので、RPC と `tasks.json` 書き込みも走り続ける

待機中プレフィックス `✳` は 2.1.228 でも変わっていない。

## 変更内容

### 状態プレフィックスの定義

稼働中プレフィックスは点字ブロック U+2800–U+28FF と半円 U+25D0 / U+25D1 の和集合、待機中は `✳` U+2733。いずれも直後に半角スペースが 1 個続く。分類 `classifyClaudeTitle` と除去 `stripClaudeTitlePrefix` が同じ定数を見るため、状態バッジと Task タイトルの双方にこの 1 定数で効く。

### テスト

点字・半円の両字形が `working` に分類され、両方が除去されることを固定する。あわせて空白境界（`◐no-space`）とコードポイント境界（`◒` / `◓`）を押さえ、範囲記法への一般化でタイトルに出ないコマを巻き込む変更が入ったら落ちるようにする。

## 設計判断

### 点字を残す

先行実装 2 つとも点字を残している。herdr は検出 manifest に `Braille covers <= 2.1.227` と明記している。

gozd が相手にする Claude Code のバージョンは gozd が決められない。配布物であり、利用者の手元にどのバージョンがあるかは gozd の管理外にある。手元の環境が 2.1.229 であることは、点字を落としてよい根拠にならない。

### 半円は実測の 2 コマだけ受ける

先行実装で判断が割れている箇所で、gozd は herdr 側を採る。

| | 判定に使う集合 | 根拠 |
| --- | --- | --- |
| herdr | `\x{2800}-\x{28FF}` + `\x{25D0}-\x{25D1}` | 実測 |
| orca | `⠀-⣿` + `◐-◓` | 将来のコマ追加への予約 |

2.1.229 のバイナリには半円の配列が 2 つ実在し、タイトルに出るのは片方だけである。

- `yGi = ["◐","◑"]` — タイトル生成が参照する。`isAnimating` のとき `` `${yGi[frame]} ${title}` ``、そうでなければ `` `${"✳"} ${title}` `` を組み、`SET_TITLE_AND_ICON`（OSC 0）へ渡す。コマ間隔は 960ms
- `Wen = ["◐","◓","◑","◒"]` — セッション取得の進捗ステップ（`Validating session` / `Fetching session logs` ...）を画面に描く React コンポーネントが参照する。タイトル生成経路には接続していない

orca が範囲をブロック全体へ広げたのは stablyai/orca issue13889 の "reserving the full quarter-circle set is cheap" という提案を容れたもので、stablyai/orca pr13925 の Review 欄でも "Forward-looking: reserves the full U+25D0–U+25D3 quarter-circle block" と予約であることを明示している。herdrdev/herdr issue2707 が新フレームを `◐ ◓ ◑ ◒` と記しているのは 4 コマ配列の側を見たためと考えられるが、同 issue の evidence 欄に実際に現れるのは `◐` と `◑` だけで、herdr 本体も判定には 2 コマしか採っていない。

出ないコマを足さないのは、gozd では判定と除去が同じ定数を共有するため。herdr は判定を 2 コマ、表示用の除去を 4 コマと配分を分けられるが、gozd の 1 定数では検出の緩さがそのまま除去の緩さになる。

取り逃したときの損失も両者で違う。orca は状態を取れないと「エージェントが終了した」と解釈して Chat UI からターミナル表示へ蹴り出す経路を持ち、予防的に広げる実利があった。gozd の `observeTitle` は未知のプレフィックスを状態変化なしとして捨てるだけなので、損失は状態バッジが出ないことと Task タイトルにスピナーが残ることに留まる。

### 字形の変化そのものは検知できない

gozd が観測できるのはタイトル文字列が届いたところまでで、先頭の字形が稼働中を意味するかは Claude Code 側の実装にしかない。プレフィックスを持たない通常のタイトル（シェルの cwd、実行中コマンド）も同じ経路を流れるため、分類できないタイトルを異常として扱うこともできない。

先行実装 2 つとも、この検知を持たない。herdr は検出ルールをリモート配信して修正の配布を早める（`https://herdr.dev/agent-detection/index.toml` から取得し再起動なしで反映）が、変化に気づく起点は利用者の報告である。orca は穴の存在を pr13925 で認めたうえで着手していない。gozd も同じ前提に立ち、字形が変わったら報告を受けて定数を直す。

## スコープの切り分け

| 作業内容 | やるべき理由 | この PR でやらない理由 |
| --- | --- | --- |
| `. ` / `* ` の旧 Claude プレフィックス対応 | orca はこれらも稼働中プレフィックスとして受けている | gozd が対象とする範囲でこれらを出すバージョンが実在するか未確認 |

## 確認事項

- [ ] Claude が稼働中のあいだ、ターミナル leaf とサイドバー Task 行に working の状態バッジが出る
- [ ] サイドバーの Task タイトルにスピナー文字が残らない
