### PR TITLE
fix(repo): keep the fresher head when the worktree list lands late

### DIFF
--- a/apps/renderer/src/features/worktree/useRemoteFetchStore.ts
+++ b/apps/renderer/src/features/worktree/useRemoteFetchStore.ts
@@ -271,7 +271,12 @@ export const useRemoteFetchStore = defineStore("remoteFetch", () => {
   async function requestFollowUpFetch(dir: string): Promise<boolean> {
     const repo = repoStore.findRepoOwning(dir);
     if (repo === undefined || !repo.isGitRepo) {
-      logEvent("fetch", "skip", repo?.repoName ?? dir);
+      logEvent(
+        "fetch",
+        "skip",
+        repo?.repoName ?? dir,
+        repo === undefined ? `untracked dir: ${dir}` : "not a git repo",
+      );
       return false;
     }
     const outcome = await runFetch(repo.rootDir);

--- a/apps/renderer/src/features/worktree/useRemoteFetchStore.ts
+++ b/apps/renderer/src/features/worktree/useRemoteFetchStore.ts
@@ -275,7 +275,7 @@ export const useRemoteFetchStore = defineStore("remoteFetch", () => {
         "fetch",
         "skip",
         repo?.repoName ?? dir,
-        repo === undefined ? `untracked dir: ${dir}` : "not a git repo",
+        repo === undefined ? "untracked dir" : "not a git repo",
       );
       return false;
     }

--- a/apps/renderer/src/shared/repo/useRepoStore.test.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.test.ts
@@ -237,7 +237,32 @@ describe("updateRepoData", () => {
     expect(target?.latestMtime).toBe(42);
   });
 
-  test("世代が進んでいない wt はレスポンスの値をそのまま採用する", () => {
+  test("世代エントリを持つ wt でも、往復中に status が走らなければレスポンスを採る", () => {
+    setActivePinia(createPinia());
+    const store = useRepoStore();
+    store.addRepo({
+      rootDir: "/r1",
+      repoName: "r1",
+      isGitRepo: true,
+      worktrees: [{ ...wt("/r1/wt-1", "feat"), head: "old" }],
+    });
+    // 2 回目以降の fetchRepo と同じ状態。updateRepoData は末尾で全 wt の世代を進めるため、
+    // 定常状態では世代エントリが必ず存在する
+    store.setWorktreeGitStatuses("/r1/wt-1", {
+      statuses: {},
+      renameOldPaths: {},
+      upstream: undefined,
+      latestMtime: 0,
+      head: "current",
+    });
+
+    const genSnapshot = new Map([["/r1/wt-1", store.getGitStatusGen("/r1/wt-1")]]);
+    store.updateRepoData("/r1", [{ ...wt("/r1/wt-1", "feat"), head: "fetched" }], genSnapshot);
+
+    expect(store.repos["/r1"]?.worktrees[0]?.head).toBe("fetched");
+  });
+
+  test("世代エントリを持たない wt（hydrate 直後の初回 fetch）はレスポンスを採る", () => {
     setActivePinia(createPinia());
     const store = useRepoStore();
     store.addRepo({

--- a/apps/renderer/src/shared/repo/useRepoStore.test.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.test.ts
@@ -220,11 +220,13 @@ describe("updateRepoData", () => {
     });
 
     const genSnapshot = new Map([["/r1/wt-1", store.getGitStatusGen("/r1/wt-1")]]);
-    // rpcGitWorktreeList の往復中に status 経路が HEAD の移動を書く
+    // rpcGitWorktreeList の往復中に status 経路が HEAD の移動を書く。
+    // 全フィールドを wt() の既定値と区別できる値にする。既定値と同値だと、引き継ぎから
+    // そのフィールドを削っても ...wt が同じ値を埋めてしまい回帰を検出できない
     store.setWorktreeGitStatuses("/r1/wt-1", {
-      statuses: { "a.txt": ".M" },
-      renameOldPaths: {},
-      upstream: undefined,
+      statuses: { "b.txt": "R." },
+      renameOldPaths: { "b.txt": "a.txt" },
+      upstream: { ahead: 1, behind: 0 },
       latestMtime: 42,
       head: "new",
     });
@@ -233,7 +235,9 @@ describe("updateRepoData", () => {
 
     const target = store.repos["/r1"]?.worktrees[0];
     expect(target?.head).toBe("new");
-    expect(target?.gitStatuses).toEqual({ "a.txt": ".M" });
+    expect(target?.gitStatuses).toEqual({ "b.txt": "R." });
+    expect(target?.renameOldPaths).toEqual({ "b.txt": "a.txt" });
+    expect(target?.upstream).toEqual({ ahead: 1, behind: 0 });
     expect(target?.latestMtime).toBe(42);
   });
 

--- a/apps/renderer/src/shared/repo/useRepoStore.test.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.test.ts
@@ -208,6 +208,52 @@ describe("applyRepoTasks", () => {
   });
 });
 
+describe("updateRepoData", () => {
+  test("世代が進んだ wt は status 経路が書いた snapshot を丸ごと保持する（head も含む）", () => {
+    setActivePinia(createPinia());
+    const store = useRepoStore();
+    store.addRepo({
+      rootDir: "/r1",
+      repoName: "r1",
+      isGitRepo: true,
+      worktrees: [{ ...wt("/r1/wt-1", "feat"), head: "old" }],
+    });
+
+    const genSnapshot = new Map([["/r1/wt-1", store.getGitStatusGen("/r1/wt-1")]]);
+    // rpcGitWorktreeList の往復中に status 経路が HEAD の移動を書く
+    store.setWorktreeGitStatuses("/r1/wt-1", {
+      statuses: { "a.txt": ".M" },
+      renameOldPaths: {},
+      upstream: undefined,
+      latestMtime: 42,
+      head: "new",
+    });
+    // 往復前の HEAD を載せたレスポンスが後着する
+    store.updateRepoData("/r1", [{ ...wt("/r1/wt-1", "feat"), head: "old" }], genSnapshot);
+
+    const target = store.repos["/r1"]?.worktrees[0];
+    expect(target?.head).toBe("new");
+    expect(target?.gitStatuses).toEqual({ "a.txt": ".M" });
+    expect(target?.latestMtime).toBe(42);
+  });
+
+  test("世代が進んでいない wt はレスポンスの値をそのまま採用する", () => {
+    setActivePinia(createPinia());
+    const store = useRepoStore();
+    store.addRepo({
+      rootDir: "/r1",
+      repoName: "r1",
+      isGitRepo: true,
+      worktrees: [{ ...wt("/r1/wt-1", "feat"), head: "old" }],
+    });
+
+    const genSnapshot = new Map([["/r1/wt-1", store.getGitStatusGen("/r1/wt-1")]]);
+    store.updateRepoData("/r1", [{ ...wt("/r1/wt-1", "feat"), head: "fetched" }], genSnapshot);
+
+    expect(store.repos["/r1"]?.worktrees[0]?.head).toBe("fetched");
+  });
+});
+
 describe("setGithubIdentity", () => {
   test("既存 repo に identity を書き、updateRepoData（worktrees 差し替え）後も保持する", () => {
     setActivePinia(createPinia());

--- a/apps/renderer/src/shared/repo/useRepoStore.ts
+++ b/apps/renderer/src/shared/repo/useRepoStore.ts
@@ -388,7 +388,8 @@ export const useRepoStore = defineStore("repo", () => {
         if (beforeGen !== undefined && currentGen !== undefined && currentGen !== beforeGen) {
           // fetch 中に push / 単発更新が走っていた → 現値を保持。
           // `gitStatusFull` 出力の atomic snapshot 契約 (statuses / renameOldPaths /
-          // upstream / latestMtime を 1 セットで扱う) に合わせ、まとめて fresher 由来に倒す。
+          // upstream / latestMtime / head を 1 セットで扱う) に合わせ、まとめて fresher 由来に倒す。
+          // `head` は worktree 一覧側も書くが、往復前に読んだ OID なので採用すると巻き戻る。
           const fresher = current.worktrees.find((w) => w.path === wt.path);
           if (fresher !== undefined) {
             return {
@@ -397,6 +398,7 @@ export const useRepoStore = defineStore("repo", () => {
               renameOldPaths: fresher.renameOldPaths,
               upstream: fresher.upstream,
               latestMtime: fresher.latestMtime,
+              head: fresher.head,
             };
           }
         }

--- a/packages/rpc/src/common.ts
+++ b/packages/rpc/src/common.ts
@@ -10,7 +10,8 @@ export type EmptyMessage = Record<string, never>;
 export interface WorktreeEntry {
   path: string;
   /** HEAD が指す commit OID。unborn branch では空文字。
-   * **worktree 一覧の取得と git status の更新の両経路が書く**（同じ full sha なので後勝ちで収束）。
+   * **worktree 一覧の取得と git status の更新の両経路が書く**（観測時刻が違うため、より新しい
+   * 観測が優先される。RPC の往復前に読んだ値で、往復中に届いた観測を上書きしない）。
    * status 経路が書くのは、HEAD の移動を commit グラフの描画状態に依存せず観測するため。 */
   head: string;
   branch: string;


### PR DESCRIPTION
## 概要

`rpcGitWorktreeList` の往復中に git status 経路が書いた `head` が、往復前に読んだ古い OID で
上書きされる巻き戻りを止める。あわせて `head` の調停規則を型の SSOT に書き、追従 fetch の skip が
イベントログに原因を残すようにする。

影響範囲は renderer の repo store、remote fetch store、`@gozd/rpc` の `WorktreeEntry` doc。
HEAD が動いた直後に PR diff / Stack diff を操作したときの取りこぼし（トグルの無反応、空撃ちの再解決）が
消える。

## 背景

`updateRepoData` は RPC 往復中に status が更新された worktree について、レスポンスの古い値を捨てて
store の現値を保持する世代ガードを持つ。**この引き継ぎ対象はフィールドの手作業の列挙で、型に載っていない。**
`WorktreeEntry` に新しいフィールドが増えても、引き継ぎから漏れたことは型エラーにならない
（`...wt` が既に全フィールドを埋めている）。

結果として、フィールド追加のたびに引き継ぎ側が追随を要求され、既に一度取りこぼしている。

| 時期 | 出来事 | 出典 |
| --- | --- | --- |
| 2026-05-10 | 世代ガード付きの fresher 引き継ぎを導入。引き継ぐのは `gitStatuses` 1 つ | 0bba6fc6 |
| 2026-05-17 | `upstream` を引き継ぎに追加（フィールド追加と同一 commit） | 6c50df23 |
| 2026-06-08 | `latestMtime` を `WorktreeEntry` に追加。引き継ぎ側は追随せず | 395d29d2 |
| 2026-06-08 | `latestMtime` の巻き戻りを後追いで修正。commit body に、引き継ぎが patch の型を迂回するため手作業で同じ束を写す必要があると記録 | 533bfad2 |
| 2026-06-10 | `renameOldPaths` を引き継ぎに追加（フィールド追加と同一 commit） | 2e516668 |
| 2026-08-17 | `WorktreeStatusPatch` に `head` を追加し、commit グラフではなく git status 経由で HEAD を観測する形にした。引き継ぎ側は追随せず | 52a2d22d |
| 2026-08-17 | 上記を含む PR がマージ | ( #1154 ) |

放置した場合、以下が commit のたびに起こりうる。

```text
T0  fs watch (git dir) → fetchRepo が rpcGitWorktreeList を発射（head=A を読む）
T1  HEAD が移動 → gitStatusChange push が head=B を書く（世代が進む）
T2  T0 のレスポンスが着弾 → 世代ガードは効くが head だけ A に巻き戻る
```

`useGitStatusStore.headHash` を読むのは `usePrDiffToggleStore` だけで、読む箇所は 2 つある。

- `watch([liveBaseOid, headHash])` — B → A → B の往復ごとに `reresolveOrigin()` が走り、
  merge-base RPC と（base commit が未取得なら）follow-up fetch が余計に飛ぶ
- `enable()` の起点 snapshot と、`resolveDiffBase()` を await した後の `isPrDiffOriginStale` 判定 —
  この await 窓の中で巻き戻ると起点が動いたと判定され、**通知なしで return** する。ユーザーから見ると
  PR diff / Stack diff のトグルが無反応で終わる

`head` の値自体は次の status push で収束するため、恒久的なずれにはならない。

`packages/rpc/src/common.ts` の `head` doc は調停規則を「後勝ちで収束」と宣言している。これは
往復前に読んだ古い観測が新しい観測を上書きすることを許す規則で、上記の巻き戻りをそのまま追認する。

`requestFollowUpFetch` の skip は `notifyBackgroundFailure` すら通らない完全な無通知経路で、
イベントログが唯一の観察点になる。detail が無いと「未追跡 dir だったのか、非 git repo だったのか」を
事後に再構築できない。

## 変更内容

### `head` の引き継ぎ

- `updateRepoData` の fresher 引き継ぎに `head: fresher.head` を追加
- 既存コメントの atomic snapshot 契約の列挙に `head` を追加し、一覧側も書くフィールドをなぜ採らないかを
  1 行添えた

### 調停規則の契約化

`WorktreeEntry.head` の doc から「後勝ちで収束」を落とし、より新しい観測が優先されること、
往復前に読んだ値で往復中に届いた観測を上書きしないことを書く。

### 回帰テスト

`updateRepoData` の describe を新設し 3 件追加。

- 世代が進んだ wt は status 経路の snapshot を丸ごと（`head` 含め）保持する
- 世代エントリを持つが往復中に status が走らなかった wt はレスポンスを採る
- 世代エントリを持たない wt（hydrate 直後の初回 fetch）はレスポンスを採る

### イベントログ

`requestFollowUpFetch` の skip に detail を追加し、`untracked dir` と `not a git repo` を分ける。
書式は同一関数内の `runFetch` の error 行に揃えた。

## 設計判断

**`head` を last-write-wins のまま据え置かない。** 旧 doc の「後勝ちで収束」は、両経路が同じ full sha を
書くという値の形式の話であって、観測時刻の前後を問わない調停規則としては成立しない。世代ガードは
「古い値で新しい値を上書きさせない」ために存在するので、`head` を例外にするとガードの存在意義が消える。

**防波堤をコメントではなく契約文に置いた。** 型の SSOT にある doc が旧規則を宣言したままだと、
`head: fresher.head` を将来の編集者が「doc に後勝ちと書いてあるから不要」と削る導線になる。

**回帰テストは世代ガードの 3 状態を分けて置いた。** `getGitStatusGen` は未登録 dir に 0 を返すが、
ガードが読む Map は `undefined` を返すため、「世代エントリが無い」と「世代エントリがあり同値」は
別経路になる。後者は `updateRepoData` が末尾で全 wt の世代を進める都合上、2 回目以降の `fetchRepo` が
必ず通る本番の定常状態で、これを踏まないとガード条件が固定できない。
`currentGen !== beforeGen` を `currentGen !== undefined` に置換した実装を注入し、定常状態のケースだけが
落ちることを確認した。

**引き継ぎのテストは、全フィールドを helper の既定値と異なる値にした。** 既定値と同値だと、引き継ぎから
そのフィールドを削っても `...wt` が同じ値を埋めるため回帰を検出できない。5 フィールドを 1 つずつ削る
検証を行い、全件でテストが落ちることを確認した。

**`requestFollowUpFetch` の 2 原因の分岐は、片方が現在の呼び出し元から到達しなくても残す。**
これは store の public method で、到達性は呼び出し元に依存する。スコープ切り分け節で defer した
`usePrDiffToggleStore` の分岐は、同一 store 内の watcher 登録順と `enable()` の early return から
module 内で到達不能を示せる。到達性を module 内で閉じて証明できるかどうかが線引きで、
public API 境界の guard に caller 依存の仮定を焼き込まない。

## 旧実装からの変更点

| 種別 | 変化 | 内容 |
| --- | --- | --- |
| 改善 | worktree 一覧の後着で `head` が巻き戻らない | 旧実装は世代が進んだ wt でも `head` だけレスポンス由来の古い OID を採用していた |
| 改善 | PR diff / Stack diff の ON 操作が黙って失われなくなる | 旧実装は `resolveDiffBase()` の await 窓で巻き戻りが起きると起点が動いたと判定し、通知なしでトグルを無反応のまま終えていた |
| 改善 | 再解決の空撃ちが減る | 旧実装は巻き戻りのたびに `reresolveOrigin()` を起こし、merge-base RPC と follow-up fetch を余計に発射していた |
| 改善 | 追従 fetch 経路の `fetch skip` 行に原因が残る | 旧実装は未追跡 dir と非 git repo を detail 無しの同一行に潰していた。detail 列が付くのは `requestFollowUpFetch` 由来の行だけで、`fetchIfDue` 由来の `fetch skip` 行は detail 無しのまま残る |

いずれも旧実装の誤った挙動に依存する経路は無い。`head` は次の status push で収束していたため、
巻き戻り中の値を読んで永続化する箇所は存在しない。

## スコープの切り分け

| 作業内容 | やるべき理由 | この PR でやらない理由 |
| --- | --- | --- |
| 引き継ぎフィールドの列挙を `Pick<WorktreeEntry, ...>` で型化し、`updateRepoData` と `setWorktreeGitStatuses` が同じ集合を参照する | 手作業の列挙が同型欠陥を 2 度生んでいる（背景の表）。型化すればフィールド追加が漏れた時点でコンパイルエラーになる | main 基準で単独に書ける変更で、本 PR に依存しない。`useGitStatusStore` / `useGitStatusSync` の呼び出し 2 箇所のリネームを伴い、触る feature が増える |
| `requestImmediateFetch` にも skip の `logEvent` を入れ、`notify.info` の文言を原因に対応させる | 抑止がイベントログに一切現れず、文言も非 git repo に対して偽。本 PR で follow-up 側だけが原因を分けたため、2 経路の観測粒度が揃っていない | `logEvent` 自体の欠落は本 PR 以前からで、本 PR を revert しても残る |
| `handleGitWorktreeList` が `head` を `worktreeList()` 由来にせず `StatusFull.head` を使う | 生産者側で `head` だけが他 4 フィールドより古い観測になり、レスポンス内で atomic snapshot が成立していない | main 側の変更で、renderer の世代ガードが先に効くため本 PR の巻き戻りには寄与しない |
| atomic snapshot 契約の列挙を 1 箇所に寄せる | 同じ契約が `useRepoStore`（3 箇所）/ `useGitStatusStore` / `common.ts` の計 5 箇所で 3 通りに割れている | 上記の型化と同じ追跡先。散文の列挙は型化すれば消える |
| `updateRepoData` で消えた path の `gitStatusGenByDir` エントリを掃除する | `removeRepo` は同じ理由で掃除しているのに、worktree 単体の削除経路では残り続ける | 本 PR の巻き戻りとは別軸のリーク |
| `fetchIfDue` の in-flight early return と skip に原因を残す | in-flight は `logEvent` が 1 行も出ず、skip は非 git repo と backoff 中が潰れている | 原因の分解は `isRepoFetchDue` の戻り値の設計から要る。真偽値 1 個では原因を返せない |
| `usePrDiffToggleStore` の `dir` 消失分岐の原因分離 | `dir === undefined` と `baseOid === undefined` が同じ通知文言（PR 起因）を出す | この分岐に到達できない。`enable()` は `dir` 未定義なら `lockedBase` を設定せず、`dir` の変化は先に登録された専用 watcher が必ず先に OFF にする |

## 確認事項

- [ ] commit 直後に PR diff / Stack diff を ON にしたとき、トグルが無反応で終わらないこと（`resolveDiffBase` の await 窓と `fetchRepo` の着弾が重なる実行時レースで、静的検証では再現できない）
- [ ] イベントログの `fetch skip` 行に原因が表示されること（追従 fetch の対象が非 git repo のとき）
