### PR TITLE
fix(git-graph): ずれた branch にも PR バッジを出し、CI ドットは origin の行だけに描く

### DIFF
--- a/apps/renderer/src/features/git-graph/features/commit-list/RefBadge.vue
+++ b/apps/renderer/src/features/git-graph/features/commit-list/RefBadge.vue
@@ -7,6 +7,19 @@
 PR 番号バッジの後ろに CI ドットとコメント数を並べる。何を出さないかの契約は
 docs/git.md の「PR 一覧が運ぶ情報の範囲」。
 
+PR 番号とコメント数は **PR 単位**の値なので、branch を指す ref にはすべて出す（tag は対象外）。
+local と origin が別コミットに分かれていても出す — stack を積み替える運用ではずれている状態が
+常態で、「同じコミットに居るときだけ出す」にすると PR を持つ branch からバッジが消える。
+
+**CI ドットだけは commit 単位**の値で、PR head ref に対する結果を指す。`origin/<branch>` が
+載っている行にだけ描く（判定とその限界は `graphRefs.ts` の `hasOriginRef`）。
+
+ずれていること自体はこのバッジでは示せない。link アイコンは local と origin の両方がグラフに
+載っているときしか判定できず、載っていない scope ではどちらのアイコンも付かない。**PR バッジは
+出るがずれは見えない**状態になる。
+
+PR バッジが出ている行でドットが無いのは、origin が載っていないか、check が未登録かのどちらか。
+
 `checkState` が undefined なのは **check が 1 つも登録されていない commit** であって、失敗でも
 取得漏れでもない。CI を持たない repo に加え、push 直後に GitHub が check を作るまでの過渡状態も
 ここに落ちるため、push のたびにドットが一瞬消えてから復帰する。
@@ -32,6 +45,7 @@ import type { GitPullRequest } from "@gozd/rpc";
 import { computed } from "vue";
 import { activateExternalLink, CHECK_STATE_DISPLAY } from "../../../github-item";
 import type { DisplayRef } from "./displayRef";
+import { hasOriginRef, prLookupBranch } from "./graphRefs";
 import IconLucideGitPullRequest from "~icons/lucide/git-pull-request";
 import IconLucideLink from "~icons/lucide/link";
 import IconLucideLink2Off from "~icons/lucide/link-2-off";
@@ -44,11 +58,8 @@ const props = defineProps<{
 
 /** DisplayRef からブランチ名を抽出し、対応する PR を返す */
 const pr = computed(() => {
-  if (props.displayRef.type === "tag" || props.displayRef.type === "local") return undefined;
-  const branchName =
-    props.displayRef.type === "remote"
-      ? props.displayRef.label.slice("origin/".length)
-      : props.displayRef.label;
+  const branchName = prLookupBranch(props.displayRef);
+  if (branchName === undefined) return undefined;
   return props.prByBranch.get(branchName);
 });
 
@@ -70,8 +81,12 @@ const CURRENT_REMOTE_CLASS = "bg-warning text-warning-foreground opacity-50";
 /** default branch decoration。type 色の上に ring を重ねる */
 const DEFAULT_CLASS = "ring-1 ring-inset ring-current";
 
-/** CI ドットの表示。check 未登録 (`checkState` undefined) ならドットごと出さない */
+/**
+ * CI ドットの表示。check 未登録 (`checkState` undefined) ならドットごと出さない。
+ * `origin/<branch>` が載っていない行にも出さない（`hasOriginRef` の doc 参照）。
+ */
 const checkDot = computed(() => {
+  if (!hasOriginRef(props.displayRef)) return undefined;
   const state = pr.value?.checkState;
   return state === undefined ? undefined : CHECK_STATE_DISPLAY[state];
 });

--- a/apps/renderer/src/features/git-graph/features/commit-list/graphRefs.test.ts
+++ b/apps/renderer/src/features/git-graph/features/commit-list/graphRefs.test.ts
@@ -1,6 +1,12 @@
 import type { GitCommit } from "@gozd/rpc";
 import { describe, expect, test } from "bun:test";
-import { computeDisplayRefs, computeOutOfSyncBranches } from "./graphRefs";
+import type { DisplayRef } from "./displayRef";
+import {
+  computeDisplayRefs,
+  computeOutOfSyncBranches,
+  hasOriginRef,
+  prLookupBranch,
+} from "./graphRefs";
 
 /** テスト用 commit を最小フィールドで生成する */
 function commit(hash: string, refs: string[]): GitCommit {
@@ -113,5 +119,49 @@ describe("computeOutOfSyncBranches", () => {
   test("origin 側のみ (ローカル不在) は out-of-sync にしない", () => {
     const commits = [commit("a", ["origin/feat"])];
     expect(computeOutOfSyncBranches(commits)).toEqual(new Set());
+  });
+});
+
+/** DisplayRef の snapshot。検証したいフィールドだけ上書きする */
+function displayRef(over: Partial<DisplayRef> = {}): DisplayRef {
+  return {
+    label: "feat/a",
+    type: "local",
+    isSynced: false,
+    isOutOfSync: false,
+    isCurrent: false,
+    isDefault: false,
+    ...over,
+  };
+}
+
+describe("prLookupBranch", () => {
+  test("local と synced はラベルがそのまま branch 名", () => {
+    expect(prLookupBranch(displayRef({ type: "local" }))).toBe("feat/a");
+    expect(prLookupBranch(displayRef({ type: "synced" }))).toBe("feat/a");
+  });
+
+  test("remote は origin/ を剥がして local と同じ名前に寄せる", () => {
+    expect(prLookupBranch(displayRef({ type: "remote", label: "origin/feat/a" }))).toBe("feat/a");
+  });
+
+  test("tag は branch ではないので引かない", () => {
+    expect(prLookupBranch(displayRef({ type: "tag", label: "v1.0.0" }))).toBeUndefined();
+  });
+});
+
+describe("hasOriginRef", () => {
+  test("synced と remote は origin が載っている", () => {
+    expect(hasOriginRef(displayRef({ type: "synced" }))).toBe(true);
+    expect(hasOriginRef(displayRef({ type: "remote", label: "origin/feat/a" }))).toBe(true);
+  });
+
+  // local は未 push と「origin が別 commit」の 2 系統を含む。どちらも origin は載っていない
+  test("local には origin が載っていない", () => {
+    expect(hasOriginRef(displayRef({ type: "local" }))).toBe(false);
+  });
+
+  test("tag には origin が無い", () => {
+    expect(hasOriginRef(displayRef({ type: "tag", label: "v1.0.0" }))).toBe(false);
   });
 });

--- a/apps/renderer/src/features/git-graph/features/commit-list/graphRefs.ts
+++ b/apps/renderer/src/features/git-graph/features/commit-list/graphRefs.ts
@@ -96,3 +96,41 @@ export function computeDisplayRefs(
 
   return result;
 }
+
+/**
+ * ref バッジが PR を引くときの branch 名。tag は branch ではないので undefined。
+ *
+ * PR は branch 名 (`headRefName`) に紐づくので、local と origin は同じ名前へ寄せる。ref が
+ * どちらの側かは PR の有無と無関係。
+ */
+export function prLookupBranch(displayRef: DisplayRef): string | undefined {
+  if (displayRef.type === "tag") return undefined;
+  if (displayRef.type === "remote") return displayRef.label.slice("origin/".length);
+  return displayRef.label;
+}
+
+/** 種別の追加を型で強制するためのテーブル。意味は `hasOriginRef` の doc。 */
+const HAS_ORIGIN_REF: Record<DisplayRef["type"], boolean> = {
+  synced: true,
+  remote: true,
+  local: false,
+  tag: false,
+};
+
+/**
+ * この ref と同じ branch の `origin/<branch>` が、同じ commit に載っているか。判定は ref 単位で、
+ * 同じ行にある別の ref は見ない。`synced` は local と origin が同一 commit に居ることの定義その
+ * もの、`remote` は origin ref 自身。`local` は載っていない状態で、**未 push と、origin が別
+ * commit に居るという 2 系統を含む**。
+ *
+ * CI の総合結果は **PR head ref の commit** に対する値なので、origin が載っている ref にだけ
+ * 描く。それ以外に描くと「head ではない commit の CI 結果」という存在しない事実になる（`local` には
+ * origin より後ろに居る = push 済みの状態も含まれるので、理由は push の有無ではない）。
+ *
+ * **origin ref が PR head を指しているかまでは見ない。**origin ref も PR の取得結果もそれぞれ
+ * 取得時点のスナップショットなので、branch の指す先が動いた直後は両者がずれ、その間は別 commit
+ * の CI が描かれる。commit で判定するには PR head の OID が要る。
+ */
+export function hasOriginRef(displayRef: DisplayRef): boolean {
+  return HAS_ORIGIN_REF[displayRef.type];
+}


### PR DESCRIPTION
## 概要

Git Graph の ref バッジで、PR 番号とコメント数を **tag 以外のすべての branch ref** に出す。local branch と `origin/<branch>` が別コミットを指していても出る。

CI ドットだけは扱いを分け、**`origin/<branch>` が載っている行にのみ**描く。ドットが描かれる行の集合は変わらず、これまで PR の引き当て側が担っていた条件をドット側の明示的な条件へ移す。

## 背景

stacked PR を積み替えている worktree で、PR を持つ branch にバッジが出ない状態だった。

ref バッジは PR バッジを `synced` / `remote` の ref にだけ出し、`local` を除外していた。この `local` は「未 push」だけでなく **local と origin が別コミットを指す状態**も含む（`graphRefs.ts` の `computeDisplayRefs` が、同一コミットに両方あるときだけ `synced` に統合する）。

stack を積み替えると全段の local が origin より先へ進むため、後者は常態になる。さらに Current スコープのグラフは HEAD から到達しない ref を載せないため、`origin/<branch>` 側の行自体がグラフに現れず、バッジの出る場所がどこにも無くなる。

観測例（`origin` は push 済みで PR が存在する）:

```text
fix/sdk-type-accuracy            local=2c4e025cd8f remote=6c61503fb60
test/studio-editor-client-bun    local=60fdf31d7ef remote=465684b4757
test/studio-ui-bun               local=7cab8ae1a02 remote=993269b42f0
```

除外は 2026-03-26 に ref バッジを導入した PR ( #246 ) で入った。同 PR の確認事項は「synced ブランチで PR バッジが重複表示されないか」も挙げており、除外は「未 push に出さない」と「同じ PR を二重に出さない」の 2 つを兼ねていた。

## 変更内容

### `graphRefs.ts`

- `prLookupBranch(displayRef)` — ref から引き当てる branch 名を返す。tag は undefined、remote は `origin/` を剥がす
- `hasOriginRef(displayRef)` — その ref と同じ branch の `origin/<branch>` が同じコミットに載っているかを返す

### `RefBadge.vue`

- PR の引き当ては `prLookupBranch` の結果に従う。branch を指す ref はすべて対象になる
- CI ドットは `hasOriginRef` が true の ref にのみ描く

## 設計判断

**バッジが運ぶ 3 つの値は粒度が違う。** PR 番号とコメント数は PR 単位の事実で、その branch を指す ref ならどこに描いても正しい。CI の総合結果 (`statusCheckRollup`) は **PR head ref の commit** に対する値なので、行のコミットが head と一致するときしか意味を持たない。1 つの条件で 3 つとも出し分けると、条件を緩めたときに粒度の違う値が一緒に漏れる。

**ドットの条件は「その ref と同じ branch の origin が同じコミットに載っているか」で表す。**判定は ref 単位で、同じ行にある別の ref は見ない。 `synced` は local と origin が同一コミットに居ることの定義そのもの、`remote` は origin ref 自身。`local` は origin が載っていない状態で、**未 push と、origin が別コミットに居るという 2 系統を含む**。そこに head の CI を描くと「head ではないコミットの CI 結果」という存在しない事実になる。理由は push の有無ではない — `local` には origin より後ろに居る（＝ push 済み）状態も含まれる。

この判定は **origin ref が実際に PR head を指しているかまでは見ない**。origin ref も PR の取得結果もそれぞれ取得時点のスナップショットなので、branch の指す先が動いた直後は両者がずれる（fetch していない `origin/<branch>` が古いコミットを指す場合と、force-push で origin は動いたが PR の取得が追いつかない場合の両方がある）。その間は別コミットの CI が描かれる。commit 単位で判定するには PR head の OID を運ぶ必要があり、本 PR では扱わない（スコープの切り分け）。

**未 push branch にバッジを出さないための除外は不要。** 引き当ては `prByBranch.get(branchName)` で行い、未 push の branch は、**同名の open PR が他に無い限り**空を返す。除外が兼ねていた 2 つの保証のうち、こちらは引き当て自体で満たされる。

## 旧実装からの変更点

| 種別 | 変化 | 内容 |
| --- | --- | --- |
| 改善 | ずれた branch に PR 番号とコメント数が出る | 旧実装は「同一コミットに居ること」を PR 表示の条件にしていた。PR は commit ではなく branch 名（`headRefName`）に紐づくため、位置の一致を条件にすると位置がずれた瞬間に紐づけごと消えていた |
| 後退 | 同じ PR が 2 行に出ることがある | local と origin の両方がグラフに載る場合、両方の行に同じ PR バッジが付く。#246 の確認事項が挙げていた重複表示と同じ形 |
| 後退 | ずれていることが画面から分からない | link アイコン (`isOutOfSync`) は local と origin の両方がグラフに載っているときしか判定できない。載らない scope では **PR バッジは出るがずれは見えない**状態になる。未 push の local と同じ見た目で、両者は区別できない |
| 後退 | 未 push の local branch に、同名の他人の open PR が紐づきうる | 引き当ては branch 名の一致だけで行う。旧実装の除外はこの誤紐づけも塞いでいた。fork 由来の PR は取得側で除外済みなので、同一 repo 内で branch 名が衝突した場合に限る |

CI ドットが描かれる行の集合は前後で一致する。旧実装は `local` / `tag` で PR の引き当て自体が空になるためドットも出ず、新実装は引き当てを広げたうえで `hasOriginRef` で同じ集合に落としている。

## スコープの切り分け

| 作業内容 | やるべき理由 | この PR でやらない理由 |
| --- | --- | --- |
| PR head の OID を運び、行のコミットと直接比較する | ref 種別は head 一致の代理でしかなく、origin ref と PR の取得結果がずれている間は別コミットの CI が描かれる（fetch 前で origin が古い場合と、force-push で origin だけ動いた場合の両方）。`docs/git.md` は stack の base 端について「ref 名ではなく commit で持つ」と定めており、対称な head 端だけが ref 種別のままになっている | 型（`packages/rpc`）・取得（query と変換）・描画（行の commit を渡す経路）の 3 パッケージにまたがる。この症状は本 PR を revert しても残る |
| `DisplayRef` に bare な branch 名を持たせる | `computeDisplayRefs` が `origin/` を付けて組み立てたラベルを `prLookupBranch` が剥がして読み戻しており、表記を変えると例外を出さずに引き当てが空になる | `DisplayRef` は commit-list 全体が読む共有の型で、変更は本 PR の主張と独立に評価できる |
| ずれの判定を commit 窓から切り離す | `computeOutOfSyncBranches` が「ref の事実」を描画中のコミット列から復元しており、`maxCount` や scope を変えると同じ状態で答えが変わる。本 PR は「PR バッジは出るがずれは見えない」状態を新たに作るため、判定の正確さが効く場面が増える | 本 PR を revert しても残る既存の構造で、独立に評価できる |
| PR 一覧が 100 件で切れる問題の解消 | 母集合が切れると、バッジの欠落が「PR を持たない branch」と同じ見た目になる | 原因が別（取得の上限）。上位 PR で扱う |

## 確認事項

- [ ] local と origin がずれた branch に PR 番号とコメント数が出る
- [ ] そのずれた行に **CI ドットが出ない**（push 済みで同期している行には出る）
- [ ] tag には PR バッジが出ない
- [ ] local と origin の両方がグラフに載る場面で、同じ PR が 2 行に出ることを許容できるか



